### PR TITLE
Fix lc0 + Arena ponder issue

### DIFF
--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -181,7 +181,7 @@ void UciLoop::SendResponse(const std::string& response) {
 
 void UciLoop::SendBestMove(const BestMoveInfo& move) {
   std::string res = "bestmove " + move.bestmove.as_string();
-  if (move.ponder) res += " ponder " + move.ponder.as_string();
+/*  if (move.ponder) res += " ponder " + move.ponder.as_string(); */
   if (move.player != -1) res += " player " + std::to_string(move.player);
   if (move.game_id != -1) res += " gameid " + std::to_string(move.game_id);
   if (move.is_black)


### PR DESCRIPTION
Commented out line 184 in an attempt to fix the issues that present when using lc0 with Arena and the GUI thinks the engine is ponder-capable after getting `bestmove <move> ponder <pondermove>` string. 
With this change, we avoid the `ponder <pondermove>` part, hopefully.