### PR TITLE
Update README.md with build instructions for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,12 @@ Then either:
 Or.
 
 7. Opten generated solution `build/lc0.sln` in Visual Studio and build yourself.
+
+## Mac
+
+1. Install brew as per the instructions at https://brew.sh/
+2. Install python3: `brew install python3`
+3. Install meson: `brew install meson`
+4. Install ninja: `brew install ninja`
+5. Run `./build.sh`
+6. The resulting binary will be in build/release


### PR DESCRIPTION
Build instructions for mac added. Uses OpenCL backend.

Best if someone with a virgin Mac system tests this to see if I have got all the prerequisits in.