### PR TITLE
Filesystem_posix: GetFileList to include non-broken soft links.

### DIFF
--- a/src/neural/loader.cc
+++ b/src/neural/loader.cc
@@ -94,7 +94,7 @@ Weights LoadWeightsFromFile(const std::string& filename) {
   FloatVectors vecs = LoadFloatsFromFile(filename);
 
   if (vecs.size() <= 19)
-    throw Exception("Weithts file " + filename +
+    throw Exception("Weights file " + filename +
                     " should have at least 19 lines");
   if (vecs[0][0] != 2) throw Exception("Weights version 2 expected");
 

--- a/src/utils/filesystem.posix.cc
+++ b/src/utils/filesystem.posix.cc
@@ -36,9 +36,20 @@ std::vector<std::string> GetFileList(const std::string& directory) {
   DIR* dir = opendir(directory.c_str());
   if (!dir) return result;
   while (auto* entry = readdir(dir)) {
-    if (entry->d_type == DT_REG) {
-      result.push_back(entry->d_name);
+    bool exists=false;
+    switch (entry->d_type) {
+      case DT_REG:
+        exists=true;
+        break;
+      case DT_LNK:
+        // check that the soft link actually points to a regular file.
+        const std::string filename = directory + "/" + entry->d_name;
+        struct stat s;
+        exists=stat(filename.c_str(), &s)==0 && (s.st_mode&S_IFMT)==S_IFREG;
+        break;
     }
+    if (exists)
+      result.push_back(entry->d_name);
   }
   closedir(dir);
   return result;


### PR DESCRIPTION
This development makes GetFileList to include soft link *when they actually resolve to a regular file*.

The same simple development with just including  DT_LNK  is the allowed types could prevent lc0 to list the directory if a broken link was present in the directory.

Alternatively, we could add a "bool FileExists(cont char*)" in the filesystem interface and call the function. 