### PR TITLE
Fix crash where uci command "go nodes" is entered.

### DIFF
--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -96,10 +96,18 @@ int GetNumeric(
   	throw Exception("Unexpected error");
   }
   std::string str=iter->second.c_str();
-  if (str.empty()) {
-    throw Exception("expected value after "+key);
+  try {
+    if (str.empty()) {
+      throw Exception("expected value after "+key);
+    }
+    return stoi(str);
   }
-  return stoi(str);
+  catch(std::invalid_argument& e){
+    throw Exception("invalid value "+str);
+  }
+ 
+  
+ 
 }
 
 

--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -88,28 +88,22 @@ std::string GetOrEmpty(
   return iter->second;
 }
 
-int GetNumeric(
-    const std::unordered_map<std::string, std::string>& params,
-    const std::string& key) {
+int GetNumeric(const std::unordered_map<std::string, std::string>& params,
+               const std::string& key) {
   auto iter = params.find(key);
   if (iter == params.end()) {
-  	throw Exception("Unexpected error");
+    throw Exception("Unexpected error");
   }
-  std::string str=iter->second.c_str();
+  std::string str = iter->second;
   try {
     if (str.empty()) {
-      throw Exception("expected value after "+key);
+      throw Exception("expected value after " + key);
     }
     return stoi(str);
+  } catch (std::invalid_argument& e) {
+    throw Exception("invalid value " + str);
   }
-  catch(std::invalid_argument& e){
-    throw Exception("invalid value "+str);
-  }
- 
-  
- 
 }
-
 
 bool ContainsKey(const std::unordered_map<std::string, std::string>& params,
                  const std::string& key) {

--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -94,12 +94,12 @@ int GetNumeric(const std::unordered_map<std::string, std::string>& params,
   if (iter == params.end()) {
     throw Exception("Unexpected error");
   }
-  std::string str = iter->second;
+  const std::string& str = iter->second;
   try {
     if (str.empty()) {
       throw Exception("expected value after " + key);
     }
-    return stoi(str);
+    return std::stoi(str);
   } catch (std::invalid_argument& e) {
     throw Exception("invalid value " + str);
   }

--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -88,6 +88,21 @@ std::string GetOrEmpty(
   return iter->second;
 }
 
+int GetNumeric(
+    const std::unordered_map<std::string, std::string>& params,
+    const std::string& key) {
+  auto iter = params.find(key);
+  if (iter == params.end()) {
+  	throw Exception("Unexpected error");
+  }
+  std::string str=iter->second.c_str();
+  if (str.empty()) {
+    throw Exception("expected value after "+key);
+  }
+  return stoi(str);
+}
+
+
 bool ContainsKey(const std::unordered_map<std::string, std::string>& params,
                  const std::string& key) {
   return params.find(key) != params.end();
@@ -138,9 +153,9 @@ bool UciLoop::DispatchCommand(
       }
       go_params.infinite = true;
     }
-#define OPTION(x)                                    \
-  if (ContainsKey(params, #x)) {                     \
-    go_params.x = std::stoi(GetOrEmpty(params, #x)); \
+#define OPTION(x)                         \
+  if (ContainsKey(params, #x)) {          \
+    go_params.x = GetNumeric(params, #x); \
   }
     OPTION(wtime);
     OPTION(btime);


### PR DESCRIPTION
The UCI loop is try-catched but atoi (an old std-c routine **crashes**).

> ./lc0 --backend="blas"
       _
|   _ | |
|_ |_ |_| built Jun  2 2018
go nodes
libc++abi.dylib: terminating with uncaught exception of type std::invalid_argument: stoi: no conversion
Abort trap: 6

Now:

go nodes xyz
error invalid value xyz
go nodes
error expected value after nodes


