### PR TITLE
Per UCI protocol example, `isready` directly initializes network (fixes startup lag)

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -146,6 +146,7 @@ void EngineController::SetCacheSize(int size) { cache_.SetCapacity(size); }
 
 void EngineController::EnsureReady() {
   GarbageCollectNodePool();
+  UpdateNetwork();
   std::unique_lock<RpSharedMutex> lock(busy_mutex_);
 }
 


### PR DESCRIPTION
http://wbec-ridderkerk.nl/html/UCIProtocol.html

Note that it is ambiguous in the specification if options may be set/reset after isready, but it is clear that isready should finish all expensive initialization, options or not (quoting the link):

// the engine has sent all parameters and is ready
		uciok

// Note: here the GUI can already send a "quit" command if it just wants to find out
//       details about the engine, so the engine should not initialize its internal
//       parameters before here.
// now the GUI sets some values in the engine
// set hash to 32 MB
setoption name Hash value 32

// init tbs
setoption name NalimovCache value 1
setoption name NalimovPath value d:\tb;c\tb

// waiting for the engine to finish initializing
// this command and the answer is required here!
isready

// engine has finished setting up the internal values
		readyok

// now we are ready to go

// if the GUI is supporting it, tell the engine that is is
// searching on a game that is hasn't searched on before
ucinewgame

// if the engine supports the "UCI_AnalyseMode" option and the next search is supposted to
// be an analysis, the GUI should set "UCI_AnalyseMode" to true if it is currently
// set to false with this engine
setoption name UCI_AnalyseMode value true

// tell the engine to search infinite from the start position after 1.e4 e5
position startpos moves e2e4 e7e5
go infinite