### PR TITLE
Add no tree reuse option for tournaments.

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -370,7 +370,7 @@ V3TrainingData Node::GetV3TrainingData(GameResult game_result,
   return result;
 }
 
-void NodeTree::MakeMove(Move move) {
+void NodeTree::MakeMove(Move move, bool no_tree_reuse) {
   if (HeadPosition().IsBlackToMove()) move.Mirror();
 
   Node* new_head = nullptr;
@@ -382,6 +382,10 @@ void NodeTree::MakeMove(Move move) {
   }
   gNodePool.ReleaseAllChildrenExceptOne(current_head_, new_head);
   current_head_ = new_head ? new_head : current_head_->CreateChild(move);
+  if (no_tree_reuse) {
+    gNodePool.ReleaseChildren(current_head_);
+    current_head_->ResetStats();
+  }
   history_.Append(move);
 }
 

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -370,7 +370,7 @@ V3TrainingData Node::GetV3TrainingData(GameResult game_result,
   return result;
 }
 
-void NodeTree::MakeMove(Move move, bool no_tree_reuse) {
+void NodeTree::MakeMove(Move move) {
   if (HeadPosition().IsBlackToMove()) move.Mirror();
 
   Node* new_head = nullptr;
@@ -382,11 +382,12 @@ void NodeTree::MakeMove(Move move, bool no_tree_reuse) {
   }
   gNodePool.ReleaseAllChildrenExceptOne(current_head_, new_head);
   current_head_ = new_head ? new_head : current_head_->CreateChild(move);
-  if (no_tree_reuse) {
-    gNodePool.ReleaseChildren(current_head_);
-    current_head_->ResetStats();
-  }
   history_.Append(move);
+}
+
+void NodeTree::TrimTreeAtHead() {
+  gNodePool.ReleaseChildren(current_head_);
+  current_head_->ResetStats();
 }
 
 void NodeTree::ResetToPosition(const std::string& starting_fen,

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -195,6 +195,8 @@ class NodeTree {
   ~NodeTree() { DeallocateTree(); }
   // Adds a move to current_head_.
   void MakeMove(Move move);
+  // Resets the current head to ensure it doesn't carry over details from a
+  // previous search.
   void TrimTreeAtHead();
   // Sets the position in a tree, trying to reuse the tree.
   // If @auto_garbage_collect, old tree is garbage collected immediately. (may

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -194,7 +194,8 @@ class NodeTree {
  public:
   ~NodeTree() { DeallocateTree(); }
   // Adds a move to current_head_.
-  void MakeMove(Move move);
+  // If no_tree_reuse is true, ensures the new head is pristine.
+  void MakeMove(Move move, bool no_tree_reuse = false);
   // Sets the position in a tree, trying to reuse the tree.
   // If @auto_garbage_collect, old tree is garbage collected immediately. (may
   // take some milliseconds)

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -194,8 +194,8 @@ class NodeTree {
  public:
   ~NodeTree() { DeallocateTree(); }
   // Adds a move to current_head_.
-  // If no_tree_reuse is true, ensures the new head is pristine.
-  void MakeMove(Move move, bool no_tree_reuse = false);
+  void MakeMove(Move move);
+  void TrimTreeAtHead();
   // Sets the position in a tree, trying to reuse the tree.
   // If @auto_garbage_collect, old tree is garbage collected immediately. (may
   // take some milliseconds)

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -24,8 +24,8 @@
 namespace lczero {
 
 SelfPlayGame::SelfPlayGame(PlayerOptions player1, PlayerOptions player2,
-                           bool shared_tree)
-    : options_{player1, player2} {
+                           bool shared_tree, bool no_tree_reuse)
+    : options_{player1, player2}, no_tree_reuse_(no_tree_reuse) {
   tree_[0] = std::make_shared<NodeTree>();
   tree_[0]->ResetToPosition(ChessBoard::kStartingFen, {});
 
@@ -68,8 +68,8 @@ void SelfPlayGame::Play(int white_threads, int black_threads) {
 
     // Add best move to the tree.
     Move move = search_->GetBestMove().first;
-    tree_[0]->MakeMove(move);
-    if (tree_[0] != tree_[1]) tree_[1]->MakeMove(move);
+    tree_[0]->MakeMove(move, no_tree_reuse_);
+    if (tree_[0] != tree_[1]) tree_[1]->MakeMove(move, no_tree_reuse_);
     blacks_move = !blacks_move;
   }
 }

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -24,8 +24,8 @@
 namespace lczero {
 
 SelfPlayGame::SelfPlayGame(PlayerOptions player1, PlayerOptions player2,
-                           bool shared_tree, bool no_tree_reuse)
-    : options_{player1, player2}, no_tree_reuse_(no_tree_reuse) {
+                           bool shared_tree, bool reuse_tree)
+    : options_{player1, player2}, reuse_tree_(reuse_tree) {
   tree_[0] = std::make_shared<NodeTree>();
   tree_[0]->ResetToPosition(ChessBoard::kStartingFen, {});
 
@@ -68,8 +68,16 @@ void SelfPlayGame::Play(int white_threads, int black_threads) {
 
     // Add best move to the tree.
     Move move = search_->GetBestMove().first;
-    tree_[0]->MakeMove(move, no_tree_reuse_);
-    if (tree_[0] != tree_[1]) tree_[1]->MakeMove(move, no_tree_reuse_);
+    tree_[0]->MakeMove(move);
+    if (!reuse_tree_) {
+      tree_[0]->TrimTreeAtHead();
+    }
+    if (tree_[0] != tree_[1]) {
+      tree_[1]->MakeMove(move);
+      if (!reuse_tree_) {
+        tree_[1]->TrimTreeAtHead();
+      }
+    }
     blacks_move = !blacks_move;
   }
 }

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -23,9 +23,17 @@
 
 namespace lczero {
 
+namespace{
+const char* kReuseTreeeStr = "Reuse the node statistics between moves";
+}
+
+void SelfPlayGame::PopulateUciParams(OptionsParser* options) {
+  options->Add<BoolOption>(kReuseTreeeStr, "reuse-tree") = true;
+}
+
 SelfPlayGame::SelfPlayGame(PlayerOptions player1, PlayerOptions player2,
-                           bool shared_tree, bool reuse_tree)
-    : options_{player1, player2}, reuse_tree_(reuse_tree) {
+                           bool shared_tree)
+    : options_{player1, player2} {
   tree_[0] = std::make_shared<NodeTree>();
   tree_[0]->ResetToPosition(ChessBoard::kStartingFen, {});
 
@@ -49,6 +57,9 @@ void SelfPlayGame::Play(int white_threads, int black_threads) {
 
     // Initialize search.
     const int idx = blacks_move ? 1 : 0;
+    if (!options_[idx].uci_options->Get<bool>(kReuseTreeeStr)) {
+      tree_[idx]->TrimTreeAtHead();
+    }
     {
       std::lock_guard<std::mutex> lock(mutex_);
       if (abort_) break;
@@ -69,15 +80,7 @@ void SelfPlayGame::Play(int white_threads, int black_threads) {
     // Add best move to the tree.
     Move move = search_->GetBestMove().first;
     tree_[0]->MakeMove(move);
-    if (!reuse_tree_) {
-      tree_[0]->TrimTreeAtHead();
-    }
-    if (tree_[0] != tree_[1]) {
-      tree_[1]->MakeMove(move);
-      if (!reuse_tree_) {
-        tree_[1]->TrimTreeAtHead();
-      }
-    }
+    if (tree_[0] != tree_[1]) tree_[1]->MakeMove(move);
     blacks_move = !blacks_move;
   }
 }

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -49,9 +49,10 @@ class SelfPlayGame {
   // If shared_tree is true, search tree is reused between players.
   // (useful for training games). Otherwise the tree is separate for black
   // and white (useful i.e. when they use different networks).
-  // If no_tree_reuse is true, each move resets the tree.
+  // If reuse_tree is false, each move clears the status and children of the
+  // new node corresponding to the move.
   SelfPlayGame(PlayerOptions player1, PlayerOptions player2, bool shared_tree,
-               bool no_tree_reuse);
+               bool reuse_tree);
 
   // Starts the game and blocks until the game is finished.
   void Play(int white_threads, int black_threads);
@@ -71,7 +72,7 @@ class SelfPlayGame {
   // Node tree for player1 and player2. If the tree is shared between players,
   // tree_[0] == tree_[1].
   std::shared_ptr<NodeTree> tree_[2];
-  const bool no_tree_reuse_;
+  const bool reuse_tree_;
 
   // Search that is currently in progress. Stored in members so that Abort()
   // can stop it.

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -49,7 +49,9 @@ class SelfPlayGame {
   // If shared_tree is true, search tree is reused between players.
   // (useful for training games). Otherwise the tree is separate for black
   // and white (useful i.e. when they use different networks).
-  SelfPlayGame(PlayerOptions player1, PlayerOptions player2, bool shared_tree);
+  // If no_tree_reuse is true, each move resets the tree.
+  SelfPlayGame(PlayerOptions player1, PlayerOptions player2, bool shared_tree,
+               bool no_tree_reuse);
 
   // Starts the game and blocks until the game is finished.
   void Play(int white_threads, int black_threads);
@@ -69,6 +71,7 @@ class SelfPlayGame {
   // Node tree for player1 and player2. If the tree is shared between players,
   // tree_[0] == tree_[1].
   std::shared_ptr<NodeTree> tree_[2];
+  const bool no_tree_reuse_;
 
   // Search that is currently in progress. Stored in members so that Abort()
   // can stop it.

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -49,10 +49,10 @@ class SelfPlayGame {
   // If shared_tree is true, search tree is reused between players.
   // (useful for training games). Otherwise the tree is separate for black
   // and white (useful i.e. when they use different networks).
-  // If reuse_tree is false, each move clears the status and children of the
-  // new node corresponding to the move.
-  SelfPlayGame(PlayerOptions player1, PlayerOptions player2, bool shared_tree,
-               bool reuse_tree);
+  SelfPlayGame(PlayerOptions player1, PlayerOptions player2, bool shared_tree);
+
+  // Populate command line options that it uses.
+  static void PopulateUciParams(OptionsParser* options);
 
   // Starts the game and blocks until the game is finished.
   void Play(int white_threads, int black_threads);
@@ -72,7 +72,6 @@ class SelfPlayGame {
   // Node tree for player1 and player2. If the tree is shared between players,
   // tree_[0] == tree_[1].
   std::shared_ptr<NodeTree> tree_[2];
-  const bool reuse_tree_;
 
   // Search that is currently in progress. Stored in members so that Abort()
   // can stop it.

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -28,7 +28,7 @@ namespace lczero {
 
 namespace {
 const char* kShareTreesStr = "Share game trees for two players";
-const char* kNoTreeReuseStr = "Clear tree after every move.";
+const char* kReuseTreeeStr = "Reuse the node statistics between moves.";
 const char* kTotalGamesStr = "Number of games to play";
 const char* kParallelGamesStr = "Number of games to play in parallel";
 const char* kThreadsStr = "Number of CPU threads for every game";
@@ -52,7 +52,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   options->AddContext("player2");
 
   options->Add<BoolOption>(kShareTreesStr, "share-trees") = false;
-  options->Add<BoolOption>(kNoTreeReuseStr, "disable-tree-reuse") = false;
+  options->Add<BoolOption>(kReuseTreeeStr, "reuse-tree") = true;
   options->Add<IntOption>(kTotalGamesStr, -1, 999999, "games") = -1;
   options->Add<IntOption>(kParallelGamesStr, 1, 256, "parallelism") = 8;
   options->Add<IntOption>(kThreadsStr, 1, 8, "threads", 't') = 1;
@@ -94,7 +94,7 @@ SelfPlayTournament::SelfPlayTournament(const OptionsDict& options,
       },
       kTotalGames(options.Get<int>(kTotalGamesStr)),
       kShareTree(options.Get<bool>(kShareTreesStr)),
-      kNoTreeReuse(options.Get<bool>(kNoTreeReuseStr)),
+      kReuseTree(options.Get<bool>(kReuseTreeeStr)),
       kParallelism(options.Get<int>(kParallelGamesStr)),
       kTraining(options.Get<bool>(kTrainingStr)) {
   // If playing just one game, the player1 is white, otherwise randomize.
@@ -230,7 +230,7 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
   {
     Mutex::Lock lock(mutex_);
     games_.emplace_front(
-        std::make_unique<SelfPlayGame>(options[0], options[1], kShareTree, kNoTreeReuse));
+        std::make_unique<SelfPlayGame>(options[0], options[1], kShareTree, kReuseTree));
     game_iter = games_.begin();
   }
   auto& game = **game_iter;

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -143,7 +143,7 @@ SelfPlayTournament::SelfPlayTournament(const OptionsDict& options,
   // Initializing cache.
   cache_[0] = std::make_shared<NNCache>(
       options.GetSubdict("player1").Get<int>(kNnCacheSizeStr));
-  if (kShareTree || networks_[0] == networks_[1]) {
+  if (kShareTree) {
     cache_[1] = cache_[0];
   } else {
     cache_[1] = std::make_shared<NNCache>(

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -28,7 +28,6 @@ namespace lczero {
 
 namespace {
 const char* kShareTreesStr = "Share game trees for two players";
-const char* kReuseTreeeStr = "Reuse the node statistics between moves.";
 const char* kTotalGamesStr = "Number of games to play";
 const char* kParallelGamesStr = "Number of games to play in parallel";
 const char* kThreadsStr = "Number of CPU threads for every game";
@@ -52,7 +51,6 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   options->AddContext("player2");
 
   options->Add<BoolOption>(kShareTreesStr, "share-trees") = false;
-  options->Add<BoolOption>(kReuseTreeeStr, "reuse-tree") = true;
   options->Add<IntOption>(kTotalGamesStr, -1, 999999, "games") = -1;
   options->Add<IntOption>(kParallelGamesStr, 1, 256, "parallelism") = 8;
   options->Add<IntOption>(kThreadsStr, 1, 8, "threads", 't') = 1;
@@ -69,6 +67,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   options->Add<BoolOption>(kVerboseThinkingStr, "verbose-thinking") = false;
 
   Search::PopulateUciParams(options);
+  SelfPlayGame::PopulateUciParams(options);
   auto defaults = options->GetMutableDefaultsOptions();
   defaults->Set<int>(Search::kMiniBatchSizeStr, 32);     // Minibatch size
   defaults->Set<bool>(Search::kSmartPruningStr, false);  // No smart pruning
@@ -94,7 +93,6 @@ SelfPlayTournament::SelfPlayTournament(const OptionsDict& options,
       },
       kTotalGames(options.Get<int>(kTotalGamesStr)),
       kShareTree(options.Get<bool>(kShareTreesStr)),
-      kReuseTree(options.Get<bool>(kReuseTreeeStr)),
       kParallelism(options.Get<int>(kParallelGamesStr)),
       kTraining(options.Get<bool>(kTrainingStr)) {
   // If playing just one game, the player1 is white, otherwise randomize.
@@ -230,7 +228,7 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
   {
     Mutex::Lock lock(mutex_);
     games_.emplace_front(
-        std::make_unique<SelfPlayGame>(options[0], options[1], kShareTree, kReuseTree));
+        std::make_unique<SelfPlayGame>(options[0], options[1], kShareTree));
     game_iter = games_.begin();
   }
   auto& game = **game_iter;

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -87,7 +87,7 @@ class SelfPlayTournament {
   const int kThreads[2];
   const int kTotalGames;
   const bool kShareTree;
-  const bool kNoTreeReuse;
+  const bool kReuseTree;
   const size_t kParallelism;
   const bool kTraining;
 };

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -87,6 +87,7 @@ class SelfPlayTournament {
   const int kThreads[2];
   const int kTotalGames;
   const bool kShareTree;
+  const bool kNoTreeReuse;
   const size_t kParallelism;
   const bool kTraining;
 };

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -87,7 +87,6 @@ class SelfPlayTournament {
   const int kThreads[2];
   const int kTotalGames;
   const bool kShareTree;
-  const bool kReuseTree;
   const size_t kParallelism;
   const bool kTraining;
 };


### PR DESCRIPTION
To close #26.

This option should work regardless of kShareTrees - but in case share trees is also disabled I made cache sharing automatic if networks are equal even if share trees is not true. It looks like a safe performance improvement for that scenario... I think.