### PR TITLE
Add adjustable peaking time curve

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -89,7 +89,7 @@ void EngineController::PopulateOptions(OptionsParser* options) {
 
 double move_weight(int ply, float peak, float left_width, float right_width) {
   const float width = ply > peak ? right_width : left_width;
-  constexpr float width_scaler = 2 / std::log(2 + std::sqrt(3));
+  constexpr float width_scaler = 1.518651485; // 2 / log(2 + sqrt(3))
   return std::pow(std::cosh((ply - peak) / width / width_scaler), -2);
 }
 


### PR DESCRIPTION
Weighs the time to give each move by a parameterised peaking function.

This has the effect of changing the time curve to adjustably spend less time on earlier moves and more time in the midgame.

The weightings are parameterised by:

- Peak: The ply to peak the weightings given to each move
- Width: How wide the time curve is (I think this is approximately how far after the peak the inflection point will be)

Note: The parameters change the shape of the weights given to each move, not the time curve directly.

Because `Scale thinking time`effectively changes the time curve, I've just removed it since you should be able to get similar effects by changing parameters of the weighting function.

- Example of weights given with _peak=30_ and _width=30_
  <img width="320" alt="screen shot 2018-06-07 at 7 04 45 am" src="https://user-images.githubusercontent.com/313295/41066697-eaedea6c-6a21-11e8-9d11-3fd57a192f3a.png">
- Example of weights given with _peak=45_ and _width=60_
   <img width="322" alt="screen shot 2018-06-07 at 7 32 04 am" src="https://user-images.githubusercontent.com/313295/41067488-eeb6375a-6a24-11e8-82a5-d67297eadec2.png">

Here are different move times between the current time curve vs SF's time curve (adjusted to try to offset smart-pruning) vs the proposed time curve (with peak=28, width=25).
![tpm3 2](https://user-images.githubusercontent.com/313295/41193998-1ec11e2a-6c54-11e8-8722-6f5f5a0f6d57.png)

The shape of the peaking function was determined by analysing training games and weighing moves in proportion to _average_winrate_loss_<sub>ply</sub> * _p_game_undecided_<sub>ply</sub>. Where  _p_game_undecided_ adjudicated games if both players saw >85% winrate.

I'm still in the process of tuning peak and width but the default values given should provide an ELO boost. Here are the results of peak=28, width=28 (I meant to do 25) vs the current time curve.

```
Score of lc0-newtm vs lc0-oldtm: 109 - 32 - 69  [0.683] 210
Elo difference: 133.61 +/- 39.97
```

Both players have temp-decay-moves=25 for variety and are playing with 15s+.1s.