### PR TITLE
BLAS backend build system usability improvements

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -202,7 +202,7 @@ if get_option('build_backends')
     ]
 
     if not get_option('blas')
-      opencl_files += 'src/neural/transforms.cc'
+      opencl_files += 'src/neural/BLAS/transforms.cc'
     endif
 
     files += opencl_files

--- a/meson.build
+++ b/meson.build
@@ -138,18 +138,18 @@ if get_option('build_backends')
   openblas_lib = cc.find_library('openblas', required: false)
 
   if get_option('blas') or get_option('opencl')
-    if mkl_lib.found()
+    if get_option('mkl') and mkl_lib.found()
       add_project_arguments('-DUSE_MKL', language : 'cpp')
       includes += include_directories(get_option('mkl_include'))
       deps += [ mkl_lib ]
       has_blas = true
 
-    elif accelerate_lib.found()
+    elif get_option('accelerate') and accelerate_lib.found()
       includes += include_directories('/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Headers')
       deps += [ accelerate_lib ]
       has_blas = true
 
-    elif openblas_lib.found()
+    elif get_option('openblas') and openblas_lib.found()
       add_project_arguments('-DUSE_OPENBLAS', language : 'cpp')
       includes += include_directories(get_option('openblas_include'))
       deps += [ openblas_lib ]

--- a/meson.build
+++ b/meson.build
@@ -193,20 +193,24 @@ if get_option('build_backends')
   endif
   
 
-  if get_option('opencl') and has_opencl and has_blas
+  if get_option('opencl') and has_opencl
 
-    opencl_files = [
-    'src/neural/CL/OpenCL.cc',
-    'src/neural/CL/OpenCLTuner.cc',
-    'src/neural/network_opencl.cc',
-    ]
+    if has_blas
+      opencl_files = [
+      'src/neural/CL/OpenCL.cc',
+      'src/neural/CL/OpenCLTuner.cc',
+      'src/neural/network_opencl.cc',
+      ]
 
-    if not get_option('blas')
-      opencl_files += 'src/neural/BLAS/transforms.cc'
+      if not get_option('blas')
+        opencl_files += 'src/neural/BLAS/transforms.cc'
+      endif
+
+      files += opencl_files
+      has_backends = true
+    else
+      warning('The OpenCL backend requires a BLAS library')
     endif
-
-    files += opencl_files
-    has_backends = true
 
   endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -62,3 +62,18 @@ option('tf',
        type: 'boolean',
        value: true,
        description: 'Enable TensorFlow backend')
+
+option('openblas',
+       type: 'boolean',
+       value: true,
+       description: 'Enable OpenBLAS support')
+
+option('mkl',
+       type: 'boolean',
+       value: true,
+       description: 'Enable MKL BLAS support')
+
+option('accelerate',
+       type: 'boolean',
+       value: true,
+       description: 'Enable Accelerate BLAS support')


### PR DESCRIPTION
Improvements discussed in #58: 
1. Each BLAS library can be enabled/disabled individually;
2. A warning is generated if building the OpenCL backend but no BLAS library is detected.

Also fixes the location of transform.cc (that was moved) when building the OpenCL backend but not the BLAS backend.