### PR TITLE
Replace "full" depth with average-branching-factor depth

### DIFF
--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -159,19 +159,19 @@ bool UciLoop::DispatchCommand(
       go_params.searchmoves =
           StrSplitAtWhitespace(GetOrEmpty(params, "searchmoves"));
     }
-#define OPTION(x)                         \
+#define UCIGOOPTION(x)                    \
   if (ContainsKey(params, #x)) {          \
     go_params.x = GetNumeric(params, #x); \
   }
-    OPTION(wtime);
-    OPTION(btime);
-    OPTION(winc);
-    OPTION(binc);
-    OPTION(movestogo);
-    OPTION(depth);
-    OPTION(nodes);
-    OPTION(movetime);
-#undef OPTION
+    UCIGOOPTION(wtime);
+    UCIGOOPTION(btime);
+    UCIGOOPTION(winc);
+    UCIGOOPTION(binc);
+    UCIGOOPTION(movestogo);
+    UCIGOOPTION(depth);
+    UCIGOOPTION(nodes);
+    UCIGOOPTION(movetime);
+#undef UCIGOOPTION
     CmdGo(go_params);
   } else if (command == "stop") {
     CmdStop();

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -81,6 +81,7 @@ SearchLimits EngineController::PopulateSearchLimits(int /*ply*/, bool is_black,
                                                     const GoParams& params) {
   SearchLimits limits;
   limits.visits = params.nodes;
+  limits.depth = params.depth;
   limits.time_ms = params.movetime;
   int64_t time = (is_black ? params.btime : params.wtime);
   limits.infinite = params.infinite;

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -264,8 +264,7 @@ std::string Node::DebugString() const {
   oss << "Move: " << move_.as_string() << " Term:" << is_terminal_
       << " This:" << this << " Parent:" << parent_ << " child:" << child_
       << " sibling:" << sibling_ << " P:" << p_ << " Q:" << q_ << " W:" << w_
-      << " N:" << n_ << " N_:" << n_in_flight_ << " nleaves:" << num_leaves_ << "\n";
-  //for (Node* child : Children()) { oss << child->DebugString(); }
+      << " N:" << n_ << " N_:" << n_in_flight_ << " nleaves:" << num_leaves_;
   return oss.str();
 }
 
@@ -323,7 +322,8 @@ uint16_t Node::GetAverageDepth() const {
   assert(n_ > 0);
   double branchfactor = (double)(n_ - 1) / (double)(n_ - num_leaves_);
   double depth = std::log((double)n_) / std::log(branchfactor);
-  std::cerr << "Branch factor: " << branchfactor << " Depth: " << depth << "\n";
+  // TODO: return a pair of depth and branch factor?
+  //std::cerr << "Branch factor: " << branchfactor << " Depth: " << depth << "\n";
   // at small tree sizes, whacky stuff happens with the log
   return std::min((uint16_t)std::floor(depth), GetMaxDepth());
 }

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstring>
 #include <iostream>
 #include <sstream>
@@ -254,7 +255,7 @@ void Node::ResetStats() {
   w_ = 0.0;
   p_ = 0.0;
   max_depth_ = 0;
-  full_depth_ = 0;
+  num_leaves_ = 0;
   is_terminal_ = false;
 }
 
@@ -263,7 +264,8 @@ std::string Node::DebugString() const {
   oss << "Move: " << move_.as_string() << " Term:" << is_terminal_
       << " This:" << this << " Parent:" << parent_ << " child:" << child_
       << " sibling:" << sibling_ << " P:" << p_ << " Q:" << q_ << " W:" << w_
-      << " N:" << n_ << " N_:" << n_in_flight_;
+      << " N:" << n_ << " N_:" << n_in_flight_ << " nleaves:" << num_leaves_ << "\n";
+  //for (Node* child : Children()) { oss << child->DebugString(); }
   return oss.str();
 }
 
@@ -302,16 +304,28 @@ void Node::UpdateMaxDepth(int depth) {
   if (depth > max_depth_) max_depth_ = depth;
 }
 
-bool Node::UpdateFullDepth(uint16_t* depth) {
-  if (full_depth_ > *depth) return false;
-  for (Node* child : Children()) {
-    if (*depth > child->full_depth_) *depth = child->full_depth_;
+void Node::UpdateNumLeaves() {
+  if (n_ > 1 && HasChildren()) {
+    num_leaves_ = 0;
+    for (Node* child : Children()) {
+      num_leaves_ += child->num_leaves_;
+    }
+  } else {
+    num_leaves_ = n_; // assume that n_ > 1 and !HasChildren() never happens
   }
-  if (*depth >= full_depth_) {
-    full_depth_ = ++*depth;
-    return true;
-  }
-  return false;
+}
+
+// We calculate the average branching factor, then use that as the base of the
+// logarithm of the total tree size.
+// ABF = (sum of bfactors) / (total non-leaf nodes)
+//     = (number of non-root nodes) / (total nodes - leaf nodes)
+uint16_t Node::GetAverageDepth() const {
+  assert(n_ > 0);
+  double branchfactor = (double)(n_ - 1) / (double)(n_ - num_leaves_);
+  double depth = std::log((double)n_) / std::log(branchfactor);
+  std::cerr << "Branch factor: " << branchfactor << " Depth: " << depth << "\n";
+  // at small tree sizes, whacky stuff happens with the log
+  return std::min((uint16_t)std::floor(depth), GetMaxDepth());
 }
 
 namespace {

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -65,6 +65,7 @@ class Node {
 
   // Returns sum of policy priors which have had at least one playout.
   float GetVisitedPolicy() const;
+
   uint32_t GetN() const { return n_; }
   uint32_t GetNInFlight() const { return n_in_flight_; }
   uint32_t GetChildrenVisits() const { return n_ > 0 ? n_ - 1 : 1; }
@@ -90,13 +91,12 @@ class Node {
   float GetP() const { return p_; }
   // Returns whether the node is known to be draw/lose/win.
   bool IsTerminal() const { return is_terminal_; }
-  uint16_t GetFullDepth() const { return full_depth_; }
-  uint16_t GetMaxDepth() const { return max_depth_; }
 
   // Sets node own value (from neural net or win/draw/lose adjudication).
   void SetV(float val) { v_ = val; }
   // Sets move probability.
   void SetP(float val) { p_ = val; }
+
   // Makes the node terminal and sets it's score.
   void MakeTerminal(GameResult result);
 
@@ -105,8 +105,10 @@ class Node {
   // "being updated" by incrementing n-in-flight, and return true.
   // Otherwise return false.
   bool TryStartScoreUpdate();
+
   // Decrements n-in-flight back.
   void CancelScoreUpdate();
+
   // Updates the node with newly computed value v.
   // Updates:
   // * N (+=1)
@@ -117,10 +119,11 @@ class Node {
 
   // Updates max depth, if new depth is larger.
   void UpdateMaxDepth(int depth);
+  // Non-recursively sums child leaves into this node
+  void UpdateNumLeaves();
+  uint16_t GetMaxDepth() const { return max_depth_; }
+  uint16_t GetAverageDepth() const;
 
-  // Calculates the full depth if new depth is larger, updates it, returns
-  // in depth parameter, and returns true if it was indeed updated.
-  bool UpdateFullDepth(uint16_t* depth);
 
   V3TrainingData GetV3TrainingData(GameResult result,
                                    const PositionHistory& history) const;
@@ -171,14 +174,14 @@ class Node {
 
   // Maximum depth any subnodes of this node were looked at.
   uint16_t max_depth_;
-  // Complete depth all subnodes of this node were fully searched.
-  uint16_t full_depth_;
+  // How many nodes have at most 1 playout in this subtree (including self).
+  uint32_t num_leaves_;
   // Does this node end game (with a winning of either sides or draw).
   bool is_terminal_;
 
   // Pointer to a parent node. nullptr for the root.
   Node* parent_;
-  // Pointer to a first child. nullptr for leave node.
+  // Pointer to a first child. nullptr for leaf node.
   Node* child_;
   // Pointer to a next sibling. nullptr if there are no further siblings.
   Node* sibling_;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -213,8 +213,6 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
        iter = GetBestChild(iter), flip = !flip) {
     uci_info_.pv.push_back(iter->GetMove(flip));
   }
-  //std::ostringstream comment;
-  //comment << "branchfactor " << TODO; // todo: top 5 moves visits and value
   uci_info_.comment.clear();
   info_callback_(uci_info_);
 }
@@ -281,7 +279,6 @@ void Search::SendMovesStats() const {
     info.comment = oss.str();
     info_callback_(info);
   }
-  //std::cout << root_node_->DebugString();
 }
 
 void Search::MaybeTriggerStop() {
@@ -302,6 +299,10 @@ void Search::MaybeTriggerStop() {
       total_playouts_ + initial_visits_ >= limits_.visits) {
     stop_ = true;
   }
+  // Stop if reached depth limit.
+  if (limits_.depth >= 0 && root_node_->GetAverageDepth() > limits_.depth) {
+    stop_ = true;
+  }
   // Stop if reached time limit.
   if (limits_.time_ms >= 0 && GetTimeSinceStart() >= limits_.time_ms) {
     stop_ = true;
@@ -312,7 +313,6 @@ void Search::MaybeTriggerStop() {
     if (kVerboseStats) SendMovesStats();
     best_move_ = GetBestMoveInternal();
     best_move_callback_({best_move_.first, best_move_.second});
-    //std::cout << root_node_->DebugString();
     responded_bestmove_ = true;
     best_move_node_ = nullptr;
   }
@@ -354,6 +354,7 @@ void Search::UpdateRemainingMoves() {
     if (remaining_playouts < remaining_playouts_)
       remaining_playouts_ = remaining_playouts;
   }
+  // TODO: create estimated remaining_playouts if limits_.depth >= 0?
   // Even if we exceeded limits, don't go crazy by not allowing any playouts.
   if (remaining_playouts_ <= 1) remaining_playouts_ = 1;
 }
@@ -853,7 +854,6 @@ void SearchWorker::DoBackupUpdate() {
       }
     }
     ++search_->total_playouts_;
-    //std::cout << node->DebugString();
   }
 }
 

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -35,6 +35,7 @@ namespace lczero {
 struct SearchLimits {
   std::int64_t visits = -1;
   std::int64_t playouts = -1;
+  std::int16_t depth = -1;
   std::int64_t time_ms = -1;
   bool infinite = false;
   MoveList searchmoves;


### PR DESCRIPTION
It is +2 bytes per node, but I think the much more useful UCI output (plus the activation of obeying "go depth n") is worth the extra 2MB per million nodes. And maybe in the future we can examine doing it in a nonrecursive way as well