### PR TITLE
Fix the improper handling of terminal V values. 

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -250,8 +250,9 @@ float Node::GetVisitedPolicy() const {
 void Node::ResetStats() {
   n_in_flight_ = 0;
   n_ = 0;
-  q_ = 0.0;
-  p_ = 0.0;
+  v_ = 0.0f;
+  q_ = 0.0f;
+  p_ = 0.0f;
   max_depth_ = 0;
   full_depth_ = 0;
   is_terminal_ = false;
@@ -287,8 +288,6 @@ bool Node::TryStartScoreUpdate() {
 void Node::CancelScoreUpdate() { --n_in_flight_; }
 
 void Node::FinalizeScoreUpdate(float v, float gamma, float beta) {
-  // Update v;
-  if (n_ == 0) v_ = v;
   // Recompute Q.
   q_ += (v - q_) / (std::pow(static_cast<float>(n_), gamma) * beta + 1);
   // Increment N.

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -86,10 +86,11 @@ class Node {
   float GetP() const { return p_; }
   // Returns whether the node is known to be draw/lose/win.
   bool IsTerminal() const { return is_terminal_; }
-  float GetTerminalNodeValue() const { return q_; }
   uint16_t GetFullDepth() const { return full_depth_; }
   uint16_t GetMaxDepth() const { return max_depth_; }
 
+  // Sets node own value (from neural net or win/draw/lose adjudication).
+  void SetV(float val) { v_ = val; }
   // Sets move probability.
   void SetP(float val) { p_ = val; }
   // Makes the node terminal and sets it's score.
@@ -144,7 +145,8 @@ class Node {
   // Root node contains move a1a1.
   Move move_;
 
-  // Q value fetched from neural network. Only used for debug output.
+  // Q value fetched from neural network. It's not strictly necessary to have in
+  // Node, but it's useful for debug output.
   float v_;
   // Average value (from value head of neural network) of all visited nodes in
   // subtree. For terminal nodes, eval is stored.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -796,13 +796,10 @@ void SearchWorker::FetchNNResults() {
   // Copy NN results into nodes.
   int idx_in_computation = 0;
   for (auto& node_to_process : nodes_to_process_) {
-    if (!node_to_process.nn_queried) {
-      node_to_process.v = node_to_process.node->GetTerminalNodeValue();
-      continue;
-    }
+    if (!node_to_process.nn_queried) continue;
     Node* node = node_to_process.node;
     // Populate V value.
-    node_to_process.v = -computation_->GetQVal(idx_in_computation);
+    node->SetV(-computation_->GetQVal(idx_in_computation));
     // Populate P values.
     float total = 0.0;
     for (Node* n : node->Children()) {
@@ -844,7 +841,7 @@ void SearchWorker::DoBackupUpdate() {
     }
 
     // Backup V value up to a root. After 1 visit, V = Q.
-    float v = node_to_process.v;
+    float v = node->GetV();
     // Maximum depth the node is explored.
     uint16_t depth = 0;
     // If the node is terminal, mark it as fully explored to an "infinite"

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -225,8 +225,6 @@ class SearchWorker {
     Node* node;
     bool is_collision = false;
     bool nn_queried = false;
-    // Value from NN's value head, or -1/0/1 for terminal nodes.
-    float v;
   };
 
   NodeToProcess PickNodeToExtend();


### PR DESCRIPTION
This is a selective reversion of cda3a4e4281b84ce38a472e99f03e9f57bad7d9f.

Fixes #91.

Credit to Tilps for spotting it. I was reviewing, and would have found it eventually, but it probably would have taken me several hours in my... less than fully awake state right now.