### PR TITLE
Remove v_ from Node, take 2

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -250,7 +250,6 @@ float Node::GetVisitedPolicy() const {
 void Node::ResetStats() {
   n_in_flight_ = 0;
   n_ = 0;
-  v_ = 0.0f;
   q_ = 0.0f;
   p_ = 0.0f;
   max_depth_ = 0;
@@ -276,7 +275,7 @@ Move Node::GetMove(bool flip) const {
 
 void Node::MakeTerminal(GameResult result) {
   is_terminal_ = true;
-  v_ = q_ = (result == GameResult::DRAW) ? 0.0f : 1.0f;
+  q_ = (result == GameResult::DRAW) ? 0.0f : 1.0f;
 }
 
 bool Node::TryStartScoreUpdate() {

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -79,18 +79,16 @@ class Node {
   // Returns p / N, which is equal to U / (cpuct * sqrt(N[parent])) by the MCTS
   // equation. So it's really more of a "reduced U" than raw U.
   float GetU() const { return p_ / (1 + n_ + n_in_flight_); }
-  // Returns value of Value Head returned from the neural net.
-  float GetV() const { return v_; }
   // Returns value of Move probability returned from the neural net
   // (but can be changed by adding Dirichlet noise).
   float GetP() const { return p_; }
   // Returns whether the node is known to be draw/lose/win.
   bool IsTerminal() const { return is_terminal_; }
+  // Unlike GetQ, this is works when n_ == 0
+  float GetTerminalNodeValue() const { return q_; }
   uint16_t GetFullDepth() const { return full_depth_; }
   uint16_t GetMaxDepth() const { return max_depth_; }
 
-  // Sets node own value (from neural net or win/draw/lose adjudication).
-  void SetV(float val) { v_ = val; }
   // Sets move probability.
   void SetP(float val) { p_ = val; }
   // Makes the node terminal and sets it's score.
@@ -145,9 +143,6 @@ class Node {
   // Root node contains move a1a1.
   Move move_;
 
-  // Q value fetched from neural network. It's not strictly necessary to have in
-  // Node, but it's useful for debug output.
-  float v_;
   // Average value (from value head of neural network) of all visited nodes in
   // subtree. For terminal nodes, eval is stored.
   float q_;

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -84,7 +84,6 @@ class Node {
   float GetP() const { return p_; }
   // Returns whether the node is known to be draw/lose/win.
   bool IsTerminal() const { return is_terminal_; }
-  // Returns q_ unconditionally (unlike GetQ).
   float GetTerminalNodeValue() const { return q_; }
   uint16_t GetFullDepth() const { return full_depth_; }
   uint16_t GetMaxDepth() const { return max_depth_; }

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -84,7 +84,7 @@ class Node {
   float GetP() const { return p_; }
   // Returns whether the node is known to be draw/lose/win.
   bool IsTerminal() const { return is_terminal_; }
-  // Unlike GetQ, this is works when n_ == 0
+  // Returns q_ unconditionally (unlike GetQ).
   float GetTerminalNodeValue() const { return q_; }
   uint16_t GetFullDepth() const { return full_depth_; }
   uint16_t GetMaxDepth() const { return max_depth_; }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -227,11 +227,10 @@ void Search::SendMovesStats() const {
 
 std::string Search::GetCachedFirstPlyValue(const Node* node) const {
   assert(node->GetParent() == root_node_);
-  static PositionHistory history(played_history_); // A bit of a hack.
-  // It's not really worth making a fully fledged member variable, but also no
-  // sense recopying it for every call to this function.
   std::ostringstream oss;
   oss << std::fixed;
+  PositionHistory history(played_history_); // Is it worth it to move this
+  // initialization to SendMoveStats, reducing n memcpys to 1? Probably not.
   history.Append(node->GetMove());
   auto hash = history.HashLast(kCacheHistoryLength + 1);
   auto nneval = cache_->Lookup(hash); // "Pins" the node, but no big deal
@@ -240,7 +239,6 @@ std::string Search::GetCachedFirstPlyValue(const Node* node) const {
   } else {
     oss << std::setw(6) << std::setprecision(2) << -nneval->q * 100;
   }
-  history.Pop();
   return oss.str();
 }
 

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -215,7 +215,9 @@ void Search::SendMovesStats() const {
         << std::setw(2) << node->GetNInFlight() << ") ";
 
     oss << "(V: ";
+    // Handrolled optional only has a few overloads available, simple usage only
     optional<float> v = GetCachedFirstPlyValue(node);
+    if (!v && node->IsTerminal()) v = node->GetTerminalNodeValue();
     if (v) {
       oss << std::setw(6) << std::setprecision(2) << *v * 100;
     } else {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -238,11 +238,12 @@ std::string Search::GetCachedFirstPlyValue(const Node* node) const {
   // initialization to SendMoveStats, reducing n memcpys to 1? Probably not.
   history.Append(node->GetMove());
   auto hash = history.HashLast(kCacheHistoryLength + 1);
-  auto nneval = cache_->Lookup(hash); // "Pins" the node, but no big deal
+  auto nneval = cache_->Lookup(hash);
   if (nneval == nullptr) {
     oss << " --.--";
   } else {
     oss << std::setw(6) << std::setprecision(2) << -nneval->q * 100;
+    cache_->Unpin(hash, nneval);
   }
   return oss.str();
 }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -238,12 +238,11 @@ std::string Search::GetCachedFirstPlyValue(const Node* node) const {
   // initialization to SendMoveStats, reducing n memcpys to 1? Probably not.
   history.Append(node->GetMove());
   auto hash = history.HashLast(kCacheHistoryLength + 1);
-  auto nneval = cache_->Lookup(hash);
-  if (nneval == nullptr) {
-    oss << " --.--";
-  } else {
+  NNCacheLock nneval(cache_, hash);
+  if (nneval) {
     oss << std::setw(6) << std::setprecision(2) << -nneval->q * 100;
-    cache_->Unpin(hash, nneval);
+  } else {
+    oss << " --.--";
   }
   return oss.str();
 }

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -112,7 +112,7 @@ class Search {
   void SendUciInfo();  // Requires nodes_mutex_ to be held.
 
   void SendMovesStats() const;
-  // An ugly name, but this function currently has very limited use
+  // This function serves only as a helper to SendMovesStats for debug output.
   optional<float> GetCachedFirstPlyValue(const Node* node) const;
 
   mutable Mutex counters_mutex_ ACQUIRED_AFTER(nodes_mutex_);
@@ -191,9 +191,9 @@ class SearchWorker {
   // 2. Gather minibatch.
   // 3. Prefetch into cache.
   // 4. Run NN computation.
-  // 5. Populate computed nodes with results of the NN computation.
-  // 6. Update nodes.
-  // 7. Update status/counters.
+  // 5. Retrieve NN computations (and terminal values) into nodes.
+  // 6. Propogate a new node's information to all its parents in the tree.
+  // 7. Update the Search's status and progress information.
   void ExecuteOneIteration();
 
   // Returns whether another search iteration is needed (false means exit).
@@ -213,13 +213,13 @@ class SearchWorker {
   // 4. Run NN computation.
   void RunNNComputation();
 
-  // 5. Populate computed nodes with results of the NN computation.
+  // 5. Retrieve NN computations (and terminal values) into nodes.
   void FetchMinibatchResults();
 
-  // 6. Update nodes.
+  // 6. Propogate a new node's information to all its parents in the tree.
   void DoBackupUpdate();
 
-  // 7. Update status/counters.
+  // 7. Update the Search's status and progress information.
   void UpdateCounters();
 
  private:

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -108,8 +108,10 @@ class Search {
   void UpdateRemainingMoves();
   void MaybeTriggerStop();
   void MaybeOutputInfo();
-  void SendMovesStats() const;
   void SendUciInfo();  // Requires nodes_mutex_ to be held.
+
+  void SendMovesStats() const;
+  std::string GetCachedFirstPlyValue(const Node* node) const;
 
   mutable Mutex counters_mutex_ ACQUIRED_AFTER(nodes_mutex_);
   // Tells all threads to stop.

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -214,7 +214,7 @@ class SearchWorker {
   void RunNNComputation();
 
   // 5. Populate computed nodes with results of the NN computation.
-  void FetchNNResults();
+  void FetchMinibatchResults();
 
   // 6. Update nodes.
   void DoBackupUpdate();

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -27,6 +27,7 @@
 #include "neural/cache.h"
 #include "neural/network.h"
 #include "utils/mutex.h"
+#include "utils/optional.h"
 #include "utils/optionsdict.h"
 #include "utils/optionsparser.h"
 
@@ -111,7 +112,8 @@ class Search {
   void SendUciInfo();  // Requires nodes_mutex_ to be held.
 
   void SendMovesStats() const;
-  std::string GetCachedFirstPlyValue(const Node* node) const;
+  // An ugly name, but this function currently has very limited use
+  optional<float> GetCachedFirstPlyValue(const Node* node) const;
 
   mutable Mutex counters_mutex_ ACQUIRED_AFTER(nodes_mutex_);
   // Tells all threads to stop.

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -225,6 +225,8 @@ class SearchWorker {
     Node* node;
     bool is_collision = false;
     bool nn_queried = false;
+    // Value from NN's value head, or -1/0/1 for terminal nodes.
+    float v;
   };
 
   NodeToProcess PickNodeToExtend();

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -112,8 +112,9 @@ class Search {
   void SendUciInfo();  // Requires nodes_mutex_ to be held.
 
   void SendMovesStats() const;
-  // This function serves only as a helper to SendMovesStats for debug output.
-  optional<float> GetCachedFirstPlyValue(const Node* node) const;
+
+  // We only need first ply for debug output, but could be easily generalized.
+  NNCacheLock GetCachedFirstPlyResult(const Node* node) const;
 
   mutable Mutex counters_mutex_ ACQUIRED_AFTER(nodes_mutex_);
   // Tells all threads to stop.
@@ -192,7 +193,7 @@ class SearchWorker {
   // 3. Prefetch into cache.
   // 4. Run NN computation.
   // 5. Retrieve NN computations (and terminal values) into nodes.
-  // 6. Propogate a new node's information to all its parents in the tree.
+  // 6. Propagate the new nodes' information to all their parents in the tree.
   // 7. Update the Search's status and progress information.
   void ExecuteOneIteration();
 
@@ -216,7 +217,7 @@ class SearchWorker {
   // 5. Retrieve NN computations (and terminal values) into nodes.
   void FetchMinibatchResults();
 
-  // 6. Propogate a new node's information to all its parents in the tree.
+  // 6. Propagate the new nodes' information to all their parents in the tree.
   void DoBackupUpdate();
 
   // 7. Update the Search's status and progress information.

--- a/src/utils/cache.h
+++ b/src/utils/cache.h
@@ -28,8 +28,8 @@ namespace lczero {
 
 // Generic LRU cache. Thread-safe. Takes ownership of all values, which are
 // deleted upon eviction; thus, using values stored requires pinning them, which
-// in turn requires Unpin()ing them before cache destruction. The use of
-// LruCacheLock is recommend to automate this element-memory management.
+// in turn requires Unpin()ing them after use. The use of LruCacheLock is
+// recommend to automate this element-memory management.
 template <class K, class V>
 class LruCache {
   static const double constexpr kLoadFactor = 1.33;

--- a/src/utils/cache.h
+++ b/src/utils/cache.h
@@ -88,6 +88,7 @@ class LruCache {
   // Looks up and pins the element by key. Returns nullptr if not found.
   // If found, brings the element to the head of the queue (makes it last to
   // evict); furthermore, a call to Unpin must be made for each such element.
+  // Use of LruCacheLock is recommended to automate this pin management.
   V* LookupAndPin(K key) {
     Mutex::Lock lock(mutex_);
 
@@ -102,7 +103,8 @@ class LruCache {
     return nullptr;
   }
 
-  // Unpins the element given key and value.
+  // Unpins the element given key and value. Use of LruCacheLock is recommended
+  // to automate this pin management.
   void Unpin(K key, V* value) {
     Mutex::Lock lock(mutex_);
 
@@ -120,7 +122,7 @@ class LruCache {
       cur = &el->next_in_hash;
     }
 
-    // Now lookup in actve list.
+    // Now lookup in active list.
     auto hash = hasher_(key) % hash_.size();
     for (Item* iter = hash_[hash]; iter; iter = iter->next_in_hash) {
       if (key == iter->key && value == iter->value.get()) {


### PR DESCRIPTION
Half for reference relative to the bug fix, half serious to get that max mem savings. As far as debug usefulness goes, is there a debug macro defined by meson that we can use to conditionally include V outputs? (By which I mean we could have a conditionally-compiled std::vector<evals> in the `Search` for printing purposes)