### PR TITLE
fix data race condition

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -724,7 +724,7 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget) {
   // n = 0 and n_in_flight_ > 0, that means the node is being extended.
   if (node->GetN() == 0) return 0;
   // The node is terminal; don't prefetch it.
-  if (!node->HasChildren()) return 0;
+  if (node->IsTerminal()) return 0;
 
   // Populate all subnodes and their scores.
   typedef std::pair<float, Node*> ScoredNode;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -721,7 +721,9 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget) {
     return 1;
   }
 
-  // If it's a node in process of expansion or is terminal, don't prefetch it.
+  // n = 0 and n_in_flight_ > 0, that means the node is being extended.
+  if (node->GetN() == 0) return 0;
+  // The node is terminal; don't prefetch it.
   if (!node->HasChildren()) return 0;
 
   // Populate all subnodes and their scores.


### PR DESCRIPTION
This PR fixed a data race condition that was discovered when investigating #98. The fix is by @mooskagh, who analyzed the thread sanitizer output. It currently appears the race condition is unrelated to the crashes that issue pertains to.