### PR TITLE
Track false positive resign thresholds for non-resign tournament games.

### DIFF
--- a/src/chess/callbacks.h
+++ b/src/chess/callbacks.h
@@ -88,6 +88,10 @@ struct GameInfo {
   int game_id = -1;
   // The color of the player1, if known.
   optional<bool> is_black;
+  // Minimum resign threshold which would have resulted in a false positive
+  // if resign had of been enabled.
+  // Only provided if the game wasn't played with resign enabled.
+  optional<float> min_false_positive_threshold;
 
   using Callback = std::function<void(const GameInfo&)>;
 };

--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -201,6 +201,15 @@ void UciLoop::SendResponse(const std::string& response) {
   std::cout << response << std::endl;
 }
 
+void UciLoop::SendResponses(const std::vector<std::string>& responses) {
+  static std::mutex output_mutex;
+  std::lock_guard<std::mutex> lock(output_mutex);
+  for (auto& response : responses) {
+    if (debug_log_) debug_log_ << '<' << response << std::endl << std::flush;
+    std::cout << response << std::endl;
+  }
+}
+
 // TODO: remove these monstrosities
 #define LC0V_STR_INNER(a) #a
 #define LC0V_STR(a) LC0V_STR_INNER(a)

--- a/src/chess/uciloop.h
+++ b/src/chess/uciloop.h
@@ -47,6 +47,8 @@ class UciLoop {
 
   // Sends response to host.
   virtual void SendResponse(const std::string& response);
+  // Sends responses to host ensuring they are received as a block.
+  virtual void SendResponses(const std::vector<std::string>& responses);
   void SendBestMove(const BestMoveInfo& move);
   void SendInfo(const ThinkingInfo& info);
   void SendId();

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -120,7 +120,6 @@ float SelfPlayGame::GetWorstEvalForWinnerOrDraw() const {
   return std::min(min_eval_[0], min_eval_[1]);
 }
 
-
 void SelfPlayGame::Abort() {
   std::lock_guard<std::mutex> lock(mutex_);
   abort_ = true;

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -50,6 +50,7 @@ SelfPlayGame::SelfPlayGame(PlayerOptions player1, PlayerOptions player2,
 
 void SelfPlayGame::Play(int white_threads, int black_threads, bool enable_resign) {
   bool blacks_move = false;
+  min_eval_[0] = min_eval_[1] = 1.0f;
 
   // Do moves while not end of the game. (And while not abort_)
   while (!abort_) {
@@ -80,11 +81,12 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool enable_resign
     training_data_.push_back(tree_[idx]->GetCurrentHead()->GetV3TrainingData(
         GameResult::UNDECIDED, tree_[idx]->GetPositionHistory()));
 
+    float eval = search_->GetBestEval();
+    eval = (eval + 1) / 2;
+    if (eval < min_eval_[idx]) min_eval_[idx] = eval;
     if (enable_resign) {
       const float resignpct =
               options_[idx].uci_options->Get<float>(kResignPercentageStr) / 100;
-      float eval = search_->GetBestEval();
-      eval = (eval + 1) / 2;
       if (eval < resignpct) { // always false when resignpct == 0
         game_result_ = blacks_move ? GameResult::WHITE_WON
                                    : GameResult::BLACK_WON;
@@ -111,6 +113,13 @@ std::vector<Move> SelfPlayGame::GetMoves() const {
   std::reverse(moves.begin(), moves.end());
   return moves;
 }
+
+float SelfPlayGame::GetWorstEvalForWinnerOrDraw() const {
+  if (game_result_ == GameResult::WHITE_WON) return min_eval_[0];
+  if (game_result_ == GameResult::BLACK_WON) return min_eval_[1];
+  return std::min(min_eval_[0], min_eval_[1]);
+}
+
 
 void SelfPlayGame::Abort() {
   std::lock_guard<std::mutex> lock(mutex_);

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -50,7 +50,6 @@ SelfPlayGame::SelfPlayGame(PlayerOptions player1, PlayerOptions player2,
 
 void SelfPlayGame::Play(int white_threads, int black_threads, bool enable_resign) {
   bool blacks_move = false;
-  min_eval_[0] = min_eval_[1] = 1.0f;
 
   // Do moves while not end of the game. (And while not abort_)
   while (!abort_) {

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -65,6 +65,9 @@ class SelfPlayGame {
 
   GameResult GetGameResult() const { return game_result_; }
   std::vector<Move> GetMoves() const;
+  // Gets the eval which required the biggest swing up to get the final outcome.
+  // Eval is the expected outcome in the range 0<->1.
+  float GetWorstEvalForWinnerOrDraw() const;
 
  private:
   // options_[0] is for white player, [1] for black.
@@ -78,6 +81,9 @@ class SelfPlayGame {
   std::unique_ptr<Search> search_;
   bool abort_ = false;
   GameResult game_result_ = GameResult::UNDECIDED;
+  // Track minimum eval for each player so that GetWorstEvalForWinnerOrDraw()
+  // can be calculated after end of game.
+  float min_eval_[2];
   std::mutex mutex_;
 
   // Training data to send.

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -83,7 +83,7 @@ class SelfPlayGame {
   GameResult game_result_ = GameResult::UNDECIDED;
   // Track minimum eval for each player so that GetWorstEvalForWinnerOrDraw()
   // can be calculated after end of game.
-  float min_eval_[2];
+  float min_eval_[2] = {1.0f, 1.0f};
   std::mutex mutex_;
 
   // Training data to send.

--- a/src/selfplay/loop.cc
+++ b/src/selfplay/loop.cc
@@ -75,6 +75,15 @@ void SelfPlayLoop::CmdStart() {
 }
 
 void SelfPlayLoop::SendGameInfo(const GameInfo& info) {
+  // Send separate resign report before gameready as client gameready parsing
+  // will easily get confused by adding new parameters as both training file
+  // and move list potentially contain spaces.
+  if (info.min_false_positive_threshold) {
+    std::string resign_res = "resign_report";
+    resign_res += 
+        " fp_threshold " + std::to_string(*info.min_false_positive_threshold);
+    SendResponse(resign_res);
+  }
   std::string res = "gameready";
   if (!info.training_filename.empty())
     res += " trainingfile " + info.training_filename;

--- a/src/selfplay/loop.cc
+++ b/src/selfplay/loop.cc
@@ -75,6 +75,7 @@ void SelfPlayLoop::CmdStart() {
 }
 
 void SelfPlayLoop::SendGameInfo(const GameInfo& info) {
+  std::vector<std::string> responses;
   // Send separate resign report before gameready as client gameready parsing
   // will easily get confused by adding new parameters as both training file
   // and move list potentially contain spaces.
@@ -82,7 +83,7 @@ void SelfPlayLoop::SendGameInfo(const GameInfo& info) {
     std::string resign_res = "resign_report";
     resign_res += 
         " fp_threshold " + std::to_string(*info.min_false_positive_threshold);
-    SendResponse(resign_res);
+    responses.push_back(resign_res);
   }
   std::string res = "gameready";
   if (!info.training_filename.empty())
@@ -101,7 +102,8 @@ void SelfPlayLoop::SendGameInfo(const GameInfo& info) {
     res += " moves";
     for (const auto& move : info.moves) res += " " + move.as_string();
   }
-  SendResponse(res);
+  responses.push_back(res);
+  SendResponses(responses);
 }
 
 void SelfPlayLoop::CmdSetOption(const std::string& name,

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -252,6 +252,10 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
     game_info.is_black = player1_black;
     game_info.game_id = game_number;
     game_info.moves = game.GetMoves();
+    if (!enable_resign) {
+      game_info.min_false_positive_threshold =
+          game.GetWorstEvalForWinnerOrDraw();
+    }
     if (kTraining) {
       TrainingDataWriter writer(game_number);
       game.WriteTrainingData(&writer);


### PR DESCRIPTION
This is untested right now as I'm still making the changes to the client.