### PR TITLE
Remove redundant compiler flag

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,6 @@ if cc.get_id() == 'clang' or cc.get_id() == 'gcc'
 
   if get_option('buildtype') == 'release'
     add_project_arguments('-march=native', language : 'cpp')
-    add_project_arguments('-mtune=native', language : 'cpp')
   endif
 endif
 


### PR DESCRIPTION
Specifying -march=native implies -mtune=native (see https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html). I removed the latter from the build config.