### PR TITLE
Meson: added search for OpenBLAS include directories

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -153,22 +153,22 @@ if get_option('build_backends')
     elif get_option('openblas') and openblas_lib.found()
       add_project_arguments('-DUSE_OPENBLAS', language : 'cpp')
 
-      openblas_headers_found = false
-      if cc.has_header('cblas.h')
-        openblas_headers_found = true
-      else
+      if not cc.has_header('openblas_config.h')
+        openblas_headers_found = false
+        
         foreach d : get_option('openblas_include')
           if not openblas_headers_found
-            if cc.has_header('cblas.h', args: '-I' + d)
-      	      includes += include_directories(d)
+            if cc.has_header('openblas_config.h', args: '-I' + d)
+              # add the first valid include directory
+              includes += include_directories(d)
               openblas_headers_found = true
             endif
           endif
         endforeach
-      endif
-      
-      if not openblas_headers_found
-        error('Openblas headers are required but not found!')
+        
+        if not openblas_headers_found
+          error('Failed to detect OpenBLAS headers. Did you install libopenblas-dev?')
+        endif
       endif
 
       deps += [ openblas_lib ]

--- a/meson.build
+++ b/meson.build
@@ -153,16 +153,15 @@ if get_option('build_backends')
     elif get_option('openblas') and openblas_lib.found()
       add_project_arguments('-DUSE_OPENBLAS', language : 'cpp')
 
-      if not cc.has_header('openblas_config.h')
+      required_openblas_header = 'openblas_config.h'
+      if not cc.has_header(required_openblas_header)
         openblas_headers_found = false
         
+        # add the first valid include directory
         foreach d : get_option('openblas_include')
-          if not openblas_headers_found
-            if cc.has_header('openblas_config.h', args: '-I' + d)
-              # add the first valid include directory
-              includes += include_directories(d)
-              openblas_headers_found = true
-            endif
+          if not openblas_headers_found and cc.has_header(required_openblas_header, args: '-I' + d)
+            includes += include_directories(d)
+            openblas_headers_found = true
           endif
         endforeach
         

--- a/meson.build
+++ b/meson.build
@@ -152,7 +152,25 @@ if get_option('build_backends')
 
     elif get_option('openblas') and openblas_lib.found()
       add_project_arguments('-DUSE_OPENBLAS', language : 'cpp')
-      includes += include_directories(get_option('openblas_include'))
+
+      openblas_headers_found = false
+      if cc.has_header('cblas.h')
+        openblas_headers_found = true
+      else
+        foreach d : get_option('openblas_include')
+          if not openblas_headers_found
+            if cc.has_header('cblas.h', args: '-I' + d)
+      	      includes += include_directories(d)
+              openblas_headers_found = true
+            endif
+          endif
+        endforeach
+      endif
+      
+      if not openblas_headers_found
+        error('Openblas headers are required but not found!')
+      endif
+
       deps += [ openblas_lib ]
       has_blas = true
 


### PR DESCRIPTION
Search for OpenBLAS headers in array `get_option('openblas_include')`. Add the first directory that contains `cblas.h` to `includes`.

This fixes following build meson build error on Ubuntu 18.04 with `libopenblas-dev` installed

> meson.build:155:6: ERROR:  Include dir /usr/include/openblas/ does not exist.

