### PR TITLE
Clop time managment update

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -77,14 +77,14 @@ void EngineController::PopulateOptions(OptionsParser* options) {
   options->Add<ChoiceOption>(kNnBackendStr, backends, "backend") =
       backends.empty() ? "<none>" : backends[0];
   options->Add<StringOption>(kNnBackendOptionsStr, "backend-opts");
-  options->Add<FloatOption>(kSlowMoverStr, 0.0f, 100.0f, "slowmover") = 1.97f;
+  options->Add<FloatOption>(kSlowMoverStr, 0.0f, 100.0f, "slowmover") = 1.94f;
   options->Add<IntOption>(kMoveOverheadStr, 0, 10000, "move-overhead") = 100;
   options->Add<FloatOption>(kTimeCurvePeak, -1000.0f, 1000.0f,
-                            "time-curve-peak") = 24.0f;
+                            "time-curve-peak") = 26.6f;
   options->Add<FloatOption>(kTimeCurveLeftWidth, 0.0f, 1000.0f,
-                            "time-curve-left-width") = 52.8f;
+                            "time-curve-left-width") = 65.8f;
   options->Add<FloatOption>(kTimeCurveRightWidth, 0.0f, 1000.0f,
-                            "time-curve-right-width") = 71.7f;
+                            "time-curve-right-width") = 77.2f;
 
   Search::PopulateUciParams(options);
 

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -77,14 +77,14 @@ void EngineController::PopulateOptions(OptionsParser* options) {
   options->Add<ChoiceOption>(kNnBackendStr, backends, "backend") =
       backends.empty() ? "<none>" : backends[0];
   options->Add<StringOption>(kNnBackendOptionsStr, "backend-opts");
-  options->Add<FloatOption>(kSlowMoverStr, 0.0f, 100.0f, "slowmover") = 1.94f;
+  options->Add<FloatOption>(kSlowMoverStr, 0.0f, 100.0f, "slowmover") = 1.93f;
   options->Add<IntOption>(kMoveOverheadStr, 0, 10000, "move-overhead") = 100;
   options->Add<FloatOption>(kTimeCurvePeak, -1000.0f, 1000.0f,
-                            "time-curve-peak") = 26.6f;
+                            "time-curve-peak") = 26.0f;
   options->Add<FloatOption>(kTimeCurveLeftWidth, 0.0f, 1000.0f,
-                            "time-curve-left-width") = 65.8f;
+                            "time-curve-left-width") = 67.0f;
   options->Add<FloatOption>(kTimeCurveRightWidth, 0.0f, 1000.0f,
-                            "time-curve-right-width") = 77.2f;
+                            "time-curve-right-width") = 76.0f;
 
   Search::PopulateUciParams(options);
 


### PR DESCRIPTION
2267 games update. 
left peak 65. right peak 80. peak ply 27. scale 1.95 was tested around 1900 games, first result of actually beating the initial time management according to ZZ.
```   # PLAYER                                      :  RATING  ERROR   GAMES
   1 LC0_Id9149_SM1.95_TCP27_TCLW65_TCRW80       :      11     43     100
   2 LC0_Id9149_SM1.8_TCP41_TCLW1000_TCRW39.5    :       0   ----     100
```
11 elo ahead instead of 28 behind for a gain of about 40 elo since last commit. at 48s+0.2