### PR TITLE
Bug fix: biases used twice in conv1x1 in network_blas

### DIFF
--- a/src/neural/blas/convolution1.cc
+++ b/src/neural/blas/convolution1.cc
@@ -23,8 +23,7 @@ namespace lczero {
 
 void Convolution1::Forward(const size_t batch_size, const size_t input_channels,
                            const size_t output_channels, const float* input,
-                           const float* weights, const float* biases,
-                           float* output) {
+                           const float* weights, float* output) {
   for (size_t i = 0; i < batch_size; i++) {
     // C←αAB + βC
     // M Number of rows in matrices A and C.
@@ -61,13 +60,6 @@ void Convolution1::Forward(const size_t batch_size, const size_t input_channels,
                 batch_output,          // C
                 kSquares);             // ldc, leading rank of B
 
-    auto index = 0;
-    for (size_t o = 0; o < output_channels; o++) {
-      const auto bias = biases[o];
-      for (size_t b = 0; b < kSquares; b++) {
-        batch_output[index++] += bias;
-      }
-    }
   }
 }
 

--- a/src/neural/blas/convolution1.h
+++ b/src/neural/blas/convolution1.h
@@ -31,7 +31,7 @@ class Convolution1 {
   // Batched forward inference.
   static void Forward(const size_t batch_size, const size_t input_channels,
                       const size_t output_channels, const float* input,
-                      const float* weights, const float* biases, float* output);
+                      const float* weights, float* output);
 
  private:
   static constexpr auto kWidth = 8;

--- a/src/neural/network_blas.cc
+++ b/src/neural/network_blas.cc
@@ -184,11 +184,11 @@ void BlasComputation::ComputeBlocking() {
 
     Convolution1::Forward(batch_size, output_channels, num_policy_input_planes,
                           conv_out, weights_.policy.weights.data(),
-                          weights_.policy.biases.data(), policy_buffer.data());
+                          policy_buffer.data());
 
     Convolution1::Forward(batch_size, output_channels, num_value_input_planes,
                           conv_out, weights_.value.weights.data(),
-                          weights_.value.biases.data(), value_buffer.data());
+                          value_buffer.data());
 
     Batchnorm::Apply(batch_size, num_policy_input_planes, &policy_buffer[0],
                      weights_.policy.bn_means.data(),


### PR DESCRIPTION
This bug existed since the port of BLAS.