### PR TITLE
Update engine.cc time management to slower CLOP tune

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -77,14 +77,14 @@ void EngineController::PopulateOptions(OptionsParser* options) {
   options->Add<ChoiceOption>(kNnBackendStr, backends, "backend") =
       backends.empty() ? "<none>" : backends[0];
   options->Add<StringOption>(kNnBackendOptionsStr, "backend-opts");
-  options->Add<FloatOption>(kSlowMoverStr, 0.0f, 100.0f, "slowmover") = 1.93f;
+  options->Add<FloatOption>(kSlowMoverStr, 0.0f, 100.0f, "slowmover") = 1.95f;
   options->Add<IntOption>(kMoveOverheadStr, 0, 10000, "move-overhead") = 100;
   options->Add<FloatOption>(kTimeCurvePeak, -1000.0f, 1000.0f,
-                            "time-curve-peak") = 26.0f;
+                            "time-curve-peak") = 26.2f;
   options->Add<FloatOption>(kTimeCurveLeftWidth, 0.0f, 1000.0f,
-                            "time-curve-left-width") = 67.0f;
+                            "time-curve-left-width") = 82.0f;
   options->Add<FloatOption>(kTimeCurveRightWidth, 0.0f, 1000.0f,
-                            "time-curve-right-width") = 76.0f;
+                            "time-curve-right-width") = 74.0f;
 
   Search::PopulateUciParams(options);
 


### PR DESCRIPTION
Updated to 1.95 and 26.2 from over 5000 games of clop at 30+.17. retuned left and right for close to 1000 games at 60+1. And got these values. ZZ tested this compared to equal with less increment as well.

```
TC 192s+0.8s/move match running, 28/100 games played
   # PLAYER                                      :  RATING  ERROR   GAMES
   1 LC0_Id9149_SM1.95_TCP26.2_TCLW82_TCRW74     :       0     35      28
   2 LC0_Id9149_SM1.8_TCP41_TCLW1000_TCRW39.5    :       0   ----      28`
```

This shows even though I tuned for a 60/1 ratio (wheras tcec is 180 ratio) it works just as good as original even with a 240 ratio. (Although likely would be stronger saving a tiny bit more time for end compared to tune)