### PR TITLE
add gtest option and fallback in meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -300,10 +300,10 @@ executable('lc0', 'src/main.cc',
 
 
 ### Tests
-gtest = dependency('gtest', required: false)
+gtest = dependency('gtest', fallback: ['gtest', 'gtest_dep'], required: false)
 
 test_deps = deps
-if gtest.found()
+if get_option('gtest') and gtest.found()
   test_deps += gtest
 
   test('ChessBoard',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -87,3 +87,8 @@ option('accelerate',
        type: 'boolean',
        value: true,
        description: 'Enable Accelerate BLAS support')
+
+option('gtest',
+       type: 'boolean',
+       value: true,
+       description: 'Build gtest tests')

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = googletest-release-1.8.0
+
+source_url = https://github.com/google/googletest/archive/release-1.8.0.zip
+source_filename = gtest-1.8.0.zip
+source_hash = f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf
+
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/gtest/1.8.0/5/get_zip
+patch_filename = gtest-1.8.0-5-wrap.zip
+patch_hash = 7eeaede4aa2610a403313b74e04baf91ccfbaef03203d8f56312e22df1834ec5


### PR DESCRIPTION
Adds a fallback gtest submodule to be built in case gtest is not installed, and an option to disable the building of tests.