### PR TITLE
try to deploy appveyor packaged zips to github

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,3 +55,10 @@ artifacts:
     name: lc0-$(NAME)
   - path: lc0-$(NAME).zip
     name: lc0-$(NAME)-zip
+deploy:
+  - provider: GitHub
+    artifact: lc0-$(NAME).zip
+    auth_token:
+      secure: xlw/7zqX2zEfNwrEr3/oaZ4FIREcdYgvMbWolZz4sUtzUfxrlyFoAvVj/I4FNlIN
+    on:
+      appveyor_repo_tag: true


### PR DESCRIPTION
If I created the correct encrypted authentication token this will upload the following generated zip files to the github release page on each release: lc0-blas.zip, lc0-openl.zip and lc0-cudnn.zip
If it doesn't work we'll need to figure out how to generate the correct token.