### PR TITLE
Remove depth from Node (-4 bytes in Node, depth now in NodeTree)

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -227,7 +227,7 @@ void EngineController::Go(const GoParams& params) {
                                      tree_->IsBlackToMove(), params);
 
   search_ =
-      std::make_unique<Search>(*tree_, network_.get(), best_move_callback_,
+      std::make_unique<Search>(tree_.get(), network_.get(), best_move_callback_,
                                info_callback_, limits, options_, &cache_);
 
   search_->StartThreads(options_.Get<int>(kThreadsOption));

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -33,6 +33,7 @@
 #include <cstring>
 #include <iostream>
 #include <sstream>
+#include <stack>
 #include <thread>
 #include "neural/encoder.h"
 #include "neural/network.h"
@@ -193,24 +194,6 @@ void Node::FinalizeScoreUpdate(float v) {
   --n_in_flight_;
 }
 
-void Node::UpdateMaxDepth(int depth) {
-  if (depth > max_depth_) max_depth_ = depth;
-}
-
-bool Node::UpdateFullDepth(uint16_t* depth) {
-  // TODO(crem) If this function won't be needed, consider also killing
-  //            ChildNodes/NodeRange/Nodes_Iterator.
-  if (full_depth_ > *depth) return false;
-  for (Node* child : ChildNodes()) {
-    if (*depth > child->full_depth_) *depth = child->full_depth_;
-  }
-  if (*depth >= full_depth_) {
-    full_depth_ = ++*depth;
-    return true;
-  }
-  return false;
-}
-
 Node::NodeRange Node::ChildNodes() const { return child_.get(); }
 
 void Node::ReleaseChildren() { gNodeGc.AddToGcQueue(std::move(child_)); }
@@ -322,12 +305,66 @@ void NodeTree::MakeMove(Move move) {
   history_.Append(move);
 }
 
+// This function examines the tree to recalculate the already searched depth. At
+// first glance this might seem excessive, but, even aside from the memory
+// savings of not caching depths in Nodes, this is actually in sum a
+// computational savings as well. The simple reason is that for the old per-Node
+// depths, they are recalculated d times for *every* node, where d is the depth.
+// This recalculates *once* per node (and only the reused nodes at that), so
+// this replaces O(N log(N)) ops with 2*O(N) ops (N is the number of nodes,
+// d ~ log(N)). And, as if that wasn't cool enough, this actually moves some of
+// the computation out of the otherwise-critical search code/cpu time, and moves
+// it into the pre-search initialization which doesn't count against move-search
+// time. The only drawback is that this computational effort is changed from
+// spread-over-the-search to all-at-once-in-initializtion, but it's a very
+// simple and efficient loop, and even with dozens of millions of nodes, only
+// takes on the order of milliseconds (and UCI sends an `isready` command
+// between `position` and `go` anyways).
+void NodeTree::RecalculateDepth() {
+  // This is the iterative translation of the most obvious and simple recursive
+  // implementation of a traversal of the tree. Basically the wo choices for
+  // this are depth first and breadth first; the former is far more obvious from
+  // a recursive standpoint, and also has the advantage that the intermediate
+  // storage need only be logarithmically long relative to the number of nodes.
+  // (The latter, using a queue rather than a stack, would have an intermediate
+  // length much closer to linear in the number of nodes rather than
+  // logarithmic.) The recursive implementation looks like this:
+  // void RecalculateDepth(node, depth) {
+  //   Process(node, depth);
+  //   for (child : node) {
+  //     RecalculateDepth(child, depth+1);
+  //   }
+  // }
+  std::stack<Node*> stack;
+  cumulative_depth_ = max_depth_ = 0;
+
+  stack.push(current_head_);
+
+  while (!stack.empty()) {
+    auto& node = stack.top(); // stack::top returns a reference!
+    if (node) {
+      if (node->GetN() > 0) {
+        auto depth = stack.size() - 1;
+        cumulative_depth_ += depth;
+        if (max_depth_ < depth) max_depth_ = depth;
+
+        stack.push(node->child_.get());
+      }
+      node = node->sibling_.get(); // Modifies the stack entry inplace!
+    } else {
+      stack.pop();
+    }
+  }
+}
+
 void NodeTree::TrimTreeAtHead() {
   auto tmp = std::move(current_head_->sibling_);
   // Send dependent nodes for GC instead of destroying them immediately.
   gNodeGc.AddToGcQueue(std::move(current_head_->child_));
   *current_head_ = Node(current_head_->GetParent(), current_head_->index_);
   current_head_->sibling_ = std::move(tmp);
+
+  cumulative_depth_ = max_depth_ = 0;
 }
 
 void NodeTree::ResetToPosition(const std::string& starting_fen,
@@ -361,6 +398,8 @@ void NodeTree::ResetToPosition(const std::string& starting_fen,
   if (!seen_old_head) {
     assert(!current_head_->sibling_);
     TrimTreeAtHead();
+  } else {
+    RecalculateDepth();
   }
 }
 
@@ -370,6 +409,23 @@ void NodeTree::DeallocateTree() {
   gNodeGc.AddToGcQueue(std::move(gamebegin_node_));
   gamebegin_node_ = nullptr;
   current_head_ = nullptr;
+  cumulative_depth_ = max_depth_ = 0;
+}
+
+// Not thread safe!
+void NodeTree::UpdateDepth(uint16_t new_node_depth) {
+  if (new_node_depth > max_depth_) max_depth_ = new_node_depth;
+  cumulative_depth_ += new_node_depth;
+}
+
+uint16_t NodeTree::GetMaxDepth() const {
+  return max_depth_;
+}
+
+uint16_t NodeTree::GetAverageDepth() const {
+  float ret = static_cast<float>(cumulative_depth_) /
+              static_cast<float>(current_head_->n_ - 1); // Exclude root node.
+  return static_cast<uint16_t>(std::ceil(ret));
 }
 
 }  // namespace lczero

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -88,13 +88,13 @@ void Search::PopulateUciParams(OptionsParser* options) {
                           "allowed-node-collisions") = 0;
 }
 
-Search::Search(const NodeTree& tree, Network* network,
+Search::Search(NodeTree* tree, Network* network,
                BestMoveInfo::Callback best_move_callback,
                ThinkingInfo::Callback info_callback, const SearchLimits& limits,
                const OptionsDict& options, NNCache* cache)
-    : root_node_(tree.GetCurrentHead()),
+    : tree_(tree),
+      root_node_(tree_->GetCurrentHead()),
       cache_(cache),
-      played_history_(tree.GetPositionHistory()),
       network_(network),
       limits_(limits),
       start_time_(std::chrono::steady_clock::now()),
@@ -138,8 +138,8 @@ void ApplyDirichletNoise(Node* node, float eps, double alpha) {
 void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
   if (!best_move_edge_) return;
   last_outputted_best_move_edge_ = best_move_edge_.edge();
-  uci_info_.depth = root_node_->GetFullDepth();
-  uci_info_.seldepth = root_node_->GetMaxDepth();
+  uci_info_.depth = tree_->GetAverageDepth();
+  uci_info_.seldepth = tree_->GetMaxDepth();
   uci_info_.time = GetTimeSinceStart();
   uci_info_.nodes = total_playouts_ + initial_visits_;
   uci_info_.hashfull =
@@ -149,7 +149,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
   uci_info_.score = 290.680623072 * tan(1.548090806 * best_move_edge_.GetQ(0));
   uci_info_.pv.clear();
 
-  bool flip = played_history_.IsBlackToMove();
+  bool flip = tree_->GetPositionHistory().IsBlackToMove();
   for (auto iter = best_move_edge_; iter;
        iter = GetBestChildNoTemperature(iter.node()), flip = !flip) {
     uci_info_.pv.push_back(iter.GetMove(flip));
@@ -166,8 +166,8 @@ void Search::MaybeOutputInfo() {
   Mutex::Lock counters_lock(counters_mutex_);
   if (!responded_bestmove_ && best_move_edge_ &&
       (best_move_edge_.edge() != last_outputted_best_move_edge_ ||
-       uci_info_.depth != root_node_->GetFullDepth() ||
-       uci_info_.seldepth != root_node_->GetMaxDepth() ||
+       uci_info_.depth != tree_->GetAverageDepth() ||
+       uci_info_.seldepth != tree_->GetMaxDepth() ||
        uci_info_.time + kUciInfoMinimumFrequencyMs < GetTimeSinceStart())) {
     SendUciInfo();
   }
@@ -197,7 +197,7 @@ void Search::SendMovesStats() const {
                                            b.GetQ(parent_q) + b.GetU(U_coeff));
             });
 
-  const bool is_black_to_move = played_history_.IsBlackToMove();
+  const bool is_black_to_move = tree_->GetPositionHistory().IsBlackToMove();
   ThinkingInfo info;
   for (const auto& edge : edges) {
     std::ostringstream oss;
@@ -249,8 +249,9 @@ NNCacheLock Search::GetCachedFirstPlyResult(EdgeAndNode edge) const {
   // It would be relatively straightforward to generalize this to fetch NN
   // results for an abitrary move.
   optional<float> retval;
-  PositionHistory history(played_history_);  // Is it worth it to move this
-  // initialization to SendMoveStats, reducing n memcpys to 1? Probably not.
+  PositionHistory history(tree_->GetPositionHistory());
+  // Is it worth it to move this initialization to SendMoveStats, reducing
+  // n memcpys to 1? Probably not.
   history.Append(edge.GetMove());
   auto hash = history.HashLast(kCacheHistoryLength + 1);
   NNCacheLock nneval(cache_, hash);
@@ -356,7 +357,7 @@ std::pair<Move, Move> Search::GetBestMoveInternal() const
 
   float temperature = kTemperature;
   if (temperature && kTempDecayMoves) {
-    int moves = played_history_.Last().GetGamePly() / 2;
+    int moves = tree_->GetPositionHistory().Last().GetGamePly() / 2;
     if (moves >= kTempDecayMoves) {
       temperature = 0.0;
     } else {
@@ -371,7 +372,8 @@ std::pair<Move, Move> Search::GetBestMoveInternal() const
 
   Move ponder_move;  // Default is "null move" which means "don't display
                      // anything".
-  return {best_node.GetMove(played_history_.IsBlackToMove()), ponder_move};
+  return {best_node.GetMove(tree_->GetPositionHistory().IsBlackToMove()),
+          ponder_move};
 }
 
 // Returns a child with most visits.
@@ -570,7 +572,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend() {
   Node* node = search_->root_node_;
   Node::Iterator best_edge;
   // Initialize position sequence with pre-move position.
-  history_.Trim(search_->played_history_.GetLength());
+  history_.Trim(search_->tree_->GetPositionHistory().GetLength());
 
   SharedMutex::Lock lock(search_->nodes_mutex_);
 
@@ -727,7 +729,7 @@ void SearchWorker::MaybePrefetchIntoCache() {
   // nodes which are likely useful in future.
   if (computation_->GetCacheMisses() > 0 &&
       computation_->GetCacheMisses() < search_->kMaxPrefetchBatch) {
-    history_.Trim(search_->played_history_.GetLength());
+    history_.Trim(search_->tree_->GetPositionHistory().GetLength());
     SharedMutex::SharedLock lock(search_->nodes_mutex_);
     PrefetchIntoCache(search_->root_node_, search_->kMaxPrefetchBatch -
                                                computation_->GetCacheMisses());
@@ -881,12 +883,9 @@ void SearchWorker::DoBackupUpdate() {
 
     // Backup V value up to a root. After 1 visit, V = Q.
     float v = node_to_process.v;
-    // Maximum depth the node is explored.
+    // This node's depth in the tree relative to root_node_.
     uint16_t depth = 0;
-    // If the node is terminal, mark it as fully explored to an "infinite"
-    // depth.
-    uint16_t cur_full_depth = node->IsTerminal() ? 999 : 0;
-    bool full_depth_updated = true;
+
     for (Node* n = node; n != search_->root_node_->GetParent();
          n = n->GetParent()) {
       ++depth;
@@ -894,12 +893,6 @@ void SearchWorker::DoBackupUpdate() {
       // Q will be flipped for opponent.
       v = -v;
 
-      // Update the stats.
-      // Max depth.
-      n->UpdateMaxDepth(depth);
-      // Full depth.
-      if (full_depth_updated)
-        full_depth_updated = n->UpdateFullDepth(&cur_full_depth);
       // Best move.
       if (n->GetParent() == search_->root_node_ &&
           search_->best_move_edge_.GetN() <= n->GetN()) {
@@ -907,6 +900,8 @@ void SearchWorker::DoBackupUpdate() {
             search_->GetBestChildNoTemperature(search_->root_node_);
       }
     }
+    --depth; // Loop counts relative to root_node_->GetParent().
+    search_->tree_->UpdateDepth(depth);
     ++search_->total_playouts_;
   }
 }

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -52,7 +52,7 @@ struct SearchLimits {
 
 class Search {
  public:
-  Search(const NodeTree& tree, Network* network,
+  Search(NodeTree* tree, Network* network,
          BestMoveInfo::Callback best_move_callback,
          ThinkingInfo::Callback info_callback, const SearchLimits& limits,
          const OptionsDict& options, NNCache* cache);
@@ -140,10 +140,11 @@ class Search {
   Mutex threads_mutex_;
   std::vector<std::thread> threads_ GUARDED_BY(threads_mutex_);
 
+  // The node tree is stored for depth computation purposes. root_node_ ==
+  // tree_->current_head_, but is so oft used that we store it for convenience.
+  NodeTree* tree_;
   Node* root_node_;
   NNCache* cache_;
-  // Fixed positions which happened before the search.
-  const PositionHistory& played_history_;
 
   Network* const network_;
   const SearchLimits limits_;
@@ -184,7 +185,7 @@ class Search {
 class SearchWorker {
  public:
   SearchWorker(Search* search)
-      : search_(search), history_(search_->played_history_) {}
+      : search_(search), history_(search_->tree_->GetPositionHistory()) {}
 
   // Runs iterations while needed.
   void RunBlocking() {

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -77,9 +77,10 @@ void SelfPlayGame::Play(int white_threads, int black_threads,
       std::lock_guard<std::mutex> lock(mutex_);
       if (abort_) break;
       search_ = std::make_unique<Search>(
-          *tree_[idx], options_[idx].network, options_[idx].best_move_callback,
-          options_[idx].info_callback, options_[idx].search_limits,
-          *options_[idx].uci_options, options_[idx].cache);
+          tree_[idx].get(), options_[idx].network,
+          options_[idx].best_move_callback, options_[idx].info_callback,
+          options_[idx].search_limits, *options_[idx].uci_options,
+          options_[idx].cache);
     }
 
     // Do search.


### PR DESCRIPTION
This also replaces the "full" depth (which was useless) with the average depth of every node in the tree.
(This is considered superior to "average depth of recently added nodes" and "average depth of leaf nodes", per the testing data recorded in the now-superseded #124.)

In addition to the memory savings, this is also computationally faster (though negligibly so, on the whole). This removes O(N log(N)) operations from pseudo-critical `Search`/`go ...` code, and replaces it with O(N) operations in `Search`/`go ...` code in addition to O(N) non-critical `NodeTree`/`position` code.

Non-regression-of-performance is supported by the following, two tests of each command:

```
time ./lc0-edge-node selfplay --games=100 --parallelism=8 --movetime=30 --backend=random --weights=/home/bill/leela/weights/weights_t9_9155.txt.gz --reuse-tree --share-trees
real    1m17.833s
user    8m14.924s
sys     0m8.156s

real    1m17.675s
user    7m59.168s
sys     0m7.876s


time ./lc0-depth selfplay --games=100 --parallelism=8 --movetime=30 --backend=random --weights=/home/bill/leela/weights/weights_t9_9155.txt.gz --reuse-tree --share-trees
real    1m15.590s
user    8m8.440s
sys     0m8.264s

real    1m9.253s
user    7m16.568s
sys     0m7.152s
```