### PR TITLE
Disable cuda builds for the time being

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,11 @@ image:
 - Previous Visual Studio 2017
 environment:
   matrix:
-  - NAME: cuda
-    OPENCL: false
-    BLAS: false
-    CUDA: true
-    GTEST: false
+#  - NAME: cuda
+#    OPENCL: false
+#    BLAS: false
+#    CUDA: true
+#    GTEST: false
   - NAME: opencl
     OPENCL: true
     BLAS: true


### PR DESCRIPTION
Appveyor updated their VS2017 image to the latest one, that cuda complains about, so disable the cuda build until a solution is found (I'm looking for one).