### PR TITLE
Fix smart pruning, which was broken by improper implicit comparison

### DIFF
--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -242,7 +242,9 @@ class EdgeAndNode {
  public:
   EdgeAndNode() = default;
   EdgeAndNode(Edge* edge, Node* node) : edge_(edge), node_(node) {}
-  operator bool() const { return edge_ != nullptr; }
+  explicit operator bool() const { return edge_ != nullptr; }
+  bool operator==(const EdgeAndNode& other) const { return edge_ == other.edge_; }
+  bool operator!=(const EdgeAndNode& other) const { return edge_ != other.edge_; }
   bool HasNode() const { return node_ != nullptr; }
   Edge* edge() const { return edge_; }
   Node* node() const { return node_; }
@@ -315,8 +317,7 @@ class Edge_Iterator : public EdgeAndNode {
   Edge_Iterator<is_const> end() { return {}; }
 
   // Functions to support iterator interface.
-  bool operator==(Edge_Iterator& other) { return edge_ == other.edge_; }
-  bool operator!=(Edge_Iterator& other) { return edge_ != other.edge_; }
+  // Equality comparison operators are inherited from EdgeAndNode.
   void operator++() {
     // If it was the last edge in array, become end(), otherwise advance.
     if (++current_idx_ == total_count_) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -783,7 +783,10 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget) {
           std::min(scores.size(), budget < 2 ? first_unsorted_index + 2
                                              : first_unsorted_index + 3);
       std::partial_sort(scores.begin() + first_unsorted_index,
-                        scores.begin() + new_unsorted_index, scores.end());
+                        scores.begin() + new_unsorted_index, scores.end(),
+                        [](const ScoredEdge& a, const ScoredEdge& b) {
+                          return a.first < b.first;
+                        });
       first_unsorted_index = new_unsorted_index;
     }
 


### PR DESCRIPTION
Moved the comparison from Edge_Iterator to its parent EdgeAndNode, which should operate identically.
Also, the implicit bool conversion was apparently being used in the sorting in PrefetchIntoCache, so that had to be fixed as well.

search.cc:614 was the comparison in question; it always came up false (except when best_move_edge_ was null), thus preventing smart pruning, thus totally screwing up Leela's time usage. (First noticed on TCEC bonus matches)

Fixed output:

```
child b1a3 best move e2e4 differ? 1
child b1c3 best move e2e4 differ? 1
child g1f3 best move e2e4 differ? 1
child g1h3 best move e2e4 differ? 1
child a2a3 best move e2e4 differ? 1
child a2a4 best move e2e4 differ? 1
child b2b3 best move e2e4 differ? 1
child b2b4 best move e2e4 differ? 1
child c2c3 best move e2e4 differ? 1
child c2c4 best move e2e4 differ? 1
child d2d3 best move e2e4 differ? 1
child d2d4 best move e2e4 differ? 1
child e2e3 best move e2e4 differ? 1
child e2e4 best move e2e4 differ? 0
child f2f3 best move e2e4 differ? 1
child f2f4 best move e2e4 differ? 1
child g2g3 best move e2e4 differ? 1
child g2g4 best move e2e4 differ? 1
child h2h3 best move e2e4 differ? 1
child h2h4 best move e2e4 differ? 1
```
(previously these were all 0, incorrectly)


```
./lc0 --minibatch-size=1 --max-prefetch=0 --backend=blas -t 1 --verbose-move-stats -w ../../../weights/weights_t9_9155.txt.gz --fpu-reduction=0 --policy-softmax-temp=1 --cpuct=1.2
       _
|   _ | |
|_ |_ |_| built Jul 10 2018
go nodes 1000
Creating backend [blas]...
BLAS vendor: OpenBlas.
OpenBlas [NO_LAPACKE DYNAMIC_ARCH NO_AFFINITY Sandybridge].
OpenBlas found 8 Sandybridge core(s).
OpenBLAS using 1 core(s) for this backend.
BLAS max batch size is 256.
info depth 2 seldepth 2 time 12 nodes 2 score cp 6 hashfull 0 nps 166 pv d2d4 d7d5
info depth 2 seldepth 3 time 24 nodes 4 score cp 5 hashfull 0 nps 166 pv d2d4 d7d5 c2c4
info depth 2 seldepth 4 time 73 nodes 11 score cp 6 hashfull 0 nps 150 pv d2d4 d7d5 c2c4 e7e6
info depth 2 seldepth 5 time 86 nodes 13 score cp 6 hashfull 0 nps 151 pv d2d4 d7d5 c2c4 e7e6 b1c3
info depth 3 seldepth 5 time 141 nodes 21 score cp 8 hashfull 0 nps 148 pv d2d4 d7d5 c2c4 e7e6 b1c3
info depth 3 seldepth 6 time 149 nodes 22 score cp 8 hashfull 0 nps 147 pv d2d4 d7d5 c2c4 e7e6 b1c3 g8f6
info depth 3 seldepth 7 time 209 nodes 30 score cp 8 hashfull 0 nps 143 pv d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5
info depth 3 seldepth 8 time 255 nodes 37 score cp 8 hashfull 0 nps 145 pv d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7
info depth 3 seldepth 9 time 352 nodes 51 score cp 8 hashfull 0 nps 144 pv d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3
info depth 3 seldepth 10 time 528 nodes 77 score cp 9 hashfull 0 nps 145 pv d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8
info depth 3 seldepth 11 time 858 nodes 135 score cp 9 hashfull 0 nps 157 pv d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3
info depth 3 seldepth 12 time 1280 nodes 214 score cp 8 hashfull 0 nps 167 pv d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 h7h6 g5h4
info depth 3 seldepth 13 time 1759 nodes 301 score cp 8 hashfull 1 nps 171 pv d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 h7h6 g5h4 e8g8
info depth 3 seldepth 14 time 2215 nodes 390 score cp 8 hashfull 1 nps 176 pv d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 h7h6 g5h4
info depth 3 seldepth 15 time 2921 nodes 538 score cp 8 hashfull 2 nps 184 pv d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 h7h6 g5h4
info depth 3 seldepth 16 time 3696 nodes 704 score cp 8 hashfull 2 nps 190 pv d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 h7h6 g5h4
info depth 3 seldepth 17 time 4028 nodes 778 score cp 8 hashfull 3 nps 193 pv d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 h7h6 g5h4
info depth 3 seldepth 18 time 4171 nodes 816 score cp 8 hashfull 3 nps 195 pv d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 h7h6 g5h4
info depth 3 seldepth 19 time 4450 nodes 882 score cp 7 hashfull 3 nps 198 pv d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 h7h6 g5h4 b8d7
info depth 3 seldepth 19 time 4463 nodes 885 score cp 7 hashfull 3 nps 198 pv d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 e2e3 e8g8 g1f3 h7h6 g5h4 b8d7
info string g2g4  (378 ) N:       1 (+ 0) (P:  0.36%) (Q: -0.07096) (U: 0.06419) (Q+U: -0.00677) (V: -0.0710) 
info string f2f3  (346 ) N:       2 (+ 0) (P:  0.51%) (Q: -0.03599) (U: 0.06113) (Q+U:  0.02514) (V: -0.0141) 
info string g1h3  (161 ) N:       2 (+ 0) (P:  0.56%) (Q: -0.03797) (U: 0.06640) (Q+U:  0.02843) (V: -0.0115) 
info string f2f4  (351 ) N:       2 (+ 0) (P:  0.56%) (Q: -0.03595) (U: 0.06626) (Q+U:  0.03031) (V: -0.0264) 
info string h2h4  (403 ) N:       2 (+ 0) (P:  0.63%) (Q: -0.03720) (U: 0.07511) (Q+U:  0.03791) (V: -0.0115) 
info string b1a3  (34  ) N:       2 (+ 0) (P:  0.67%) (Q: -0.02871) (U: 0.07911) (Q+U:  0.05040) (V: -0.0115) 
info string a2a4  (207 ) N:       4 (+ 0) (P:  1.11%) (Q: -0.01868) (U: 0.07948) (Q+U:  0.06080) (V: -0.0115) 
info string b2b4  (234 ) N:       4 (+ 0) (P:  1.15%) (Q: -0.01470) (U: 0.08222) (Q+U:  0.06752) (V: -0.0115) 
info string d2d3  (288 ) N:       5 (+ 0) (P:  1.28%) (Q: -0.00954) (U: 0.07631) (Q+U:  0.06676) (V: -0.0115) 
info string g2g3  (374 ) N:       6 (+ 0) (P:  1.42%) (Q: -0.01039) (U: 0.07253) (Q+U:  0.06213) (V: -0.0115) 
info string c2c3  (259 ) N:       7 (+ 0) (P:  1.55%) (Q: -0.00278) (U: 0.06925) (Q+U:  0.06647) (V: -0.0115) 
info string a2a3  (204 ) N:       9 (+ 0) (P:  1.82%) (Q:  0.00072) (U: 0.06508) (Q+U:  0.06580) (V: -0.0115) 
info string b2b3  (230 ) N:       9 (+ 0) (P:  1.96%) (Q: -0.00339) (U: 0.06986) (Q+U:  0.06647) (V: -0.0115) 
info string b1c3  (36  ) N:      13 (+ 0) (P:  2.17%) (Q:  0.00818) (U: 0.05536) (Q+U:  0.06354) (V: -0.0096) 
info string h2h3  (400 ) N:      20 (+ 0) (P:  3.26%) (Q:  0.00765) (U: 0.05542) (Q+U:  0.06307) (V: -0.0042) 
info string e2e3  (317 ) N:      54 (+ 0) (P:  7.25%) (Q:  0.01454) (U: 0.04704) (Q+U:  0.06158) (V:  0.0147) 
info string e2e4  (322 ) N:      76 (+ 0) (P: 10.20%) (Q:  0.01381) (U: 0.04728) (Q+U:  0.06109) (V:  0.0337) 
info string c2c4  (264 ) N:      81 (+ 0) (P:  8.88%) (Q:  0.02139) (U: 0.03866) (Q+U:  0.06004) (V:  0.0234) 
info string g1f3  (159 ) N:     233 (+ 0) (P: 19.11%) (Q:  0.02399) (U: 0.02914) (Q+U:  0.05313) (V:  0.0265) 
info string d2d4  (293 ) N:     352 (+ 0) (P: 35.52%) (Q:  0.01709) (U: 0.03590) (Q+U:  0.05299) (V:  0.0147) 
bestmove d2d4
```