### PR TITLE
Use system zlib if available...

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -297,7 +297,7 @@ endif
   ## ~~~~
   # Pick latest from https://wrapdb.mesonbuild.com/zlib and put into
   # subprojects/zlib.wrap
-  deps += subproject('zlib').get_variable('zlib_dep')
+  deps += dependency('zlib', fallback: ['zlib', 'zlib_dep'])
 
   ## ~~~~~~~~
   ## Profiler


### PR DESCRIPTION
...and only use the zlib submodule as a fallback.