### PR TITLE
Fix two minor bugs in best_move_edge_ tracking

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -401,6 +401,7 @@ EdgeAndNode Search::GetBestChildNoTemperature(Node* parent) const {
 // Returns a child chosen according to weighted-by-temperature visit count.
 EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
                                                 float temperature) const {
+  assert(parent->GetN() > 1);
   std::vector<float> cumulative_sums;
   float sum = 0.0;
   const float n_parent = parent->GetN();
@@ -573,8 +574,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend() {
   SharedMutex::Lock lock(search_->nodes_mutex_);
 
   // Fetch the current best root node visits for possible smart pruning.
-  int best_node_n = 0;
-  if (search_->best_move_edge_) best_node_n = search_->best_move_edge_.GetN();
+  int best_node_n = search_->best_move_edge_.GetN();
 
   // True on first iteration, false as we dive deeper.
   bool is_root_node = true;
@@ -901,12 +901,10 @@ void SearchWorker::DoBackupUpdate() {
       if (full_depth_updated)
         full_depth_updated = n->UpdateFullDepth(&cur_full_depth);
       // Best move.
-      if (n->GetParent() == search_->root_node_) {
-        if (!search_->best_move_edge_ ||
-            search_->best_move_edge_.GetN() < n->GetN()) {
-          search_->best_move_edge_ =
-              EdgeAndNode(search_->root_node_->GetEdgeToNode(n), n);
-        }
+      if (n->GetParent() == search_->root_node_ &&
+          search_->best_move_edge_.GetN() <= n->GetN()) {
+            search_->best_move_edge_ =
+                search_->GetBestChildNoTemperature(search_->root_node_);
       }
     }
     ++search_->total_playouts_;

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -101,6 +101,8 @@ class Search {
   std::pair<Move, Move> GetBestMoveInternal() const;
 
   // Returns a child with most visits, with or without temperature.
+  // NoTemperature is safe to use on non-extended nodes, while WithTemperature
+  // accepts only nodes with at least 1 visited child.
   EdgeAndNode GetBestChildNoTemperature(Node* parent) const;
   EdgeAndNode GetBestChildWithTemperature(Node* parent,
                                           float temperature) const;


### PR DESCRIPTION
These two were visible in the UCI PV in certain situtations, where the putative PV differed from what was later reported as the best move.
This commit fixes #167, which is the corresponding bug report.

Both bugs arose from circumstances where best_move_edge_ differed from what GetBestChildNoTemperature(root_node_) would report.

One such circumstance was that, after tree reuse, when starting a second Search, best_move_edge_ was null, which means if the subsequent search failed to playout the previous/actual best node (from the reused tree), then by the updates in DoBackupNode, best_move_edge_ would be incorrectly set to recently searched nodes, which didn't include the previous most searched node, and thus disagree with GBCNT.
(Such a circumstance can arise either by contrived FPUR hacks, or in certain super long tactical searches, each as reported in the issue by apleasantillusion.)

The other circumstance was from the updates in DoBackupUpdates: if the "best" move had the *same* number of visits as the "current" move, no further updating was done, which meant that if the "current" move had better tiebreakers in GBCNT, it would be chosen by GBCNT even though best_move_edge_ wasn't updated to "current".

The former circumstance could lead to incorrect search behavior (especially relating to smart pruning), and the latter technically could, though I expect it makes no practical difference, and frankly even the former circumstance is quite rare anyways. Even so, it's best to correct these behaviors.

The implementation of fixes is up for debate. The tiebreaker updates in DBU could be simplified to always use GBCNT, even without temperature, but that's more CPU time (but is it trivial cpu time in exchange for cleaner code?). It might also be possible to optimize away certain boolean checks of best_move_edge_ as well, though for now I decided that fewer changes is better. LMKWYT.