### PR TITLE
Reduce Move size from 4 bytes to 2 (take two)

### DIFF
--- a/src/chess/bitboard.cc
+++ b/src/chess/bitboard.cc
@@ -275,26 +275,26 @@ const int kQueenCastleIndex =
 
 Move::Move(const std::string& str, bool black) {
   if (str.size() < 4) throw Exception("Bad move: " + str);
-  from_ = BoardSquare(str.substr(0, 2), black);
-  to_ = BoardSquare(str.substr(2, 2), black);
+  SetFrom(BoardSquare(str.substr(0, 2), black));
+  SetTo(BoardSquare(str.substr(2, 2), black));
   if (str.size() != 4) {
     if (str.size() != 5) throw Exception("Bad move: " + str);
     switch (str[4]) {
       case 'q':
       case 'Q':
-        promotion_ = Promotion::Queen;
+        SetPromotion(Promotion::Queen);
         break;
       case 'r':
       case 'R':
-        promotion_ = Promotion::Rook;
+        SetPromotion(Promotion::Rook);
         break;
       case 'b':
       case 'B':
-        promotion_ = Promotion::Bishop;
+        SetPromotion(Promotion::Bishop);
         break;
       case 'n':
       case 'N':
-        promotion_ = Promotion::Knight;
+        SetPromotion(Promotion::Knight);
         break;
       default:
         throw Exception("Bad move: " + str);
@@ -303,17 +303,17 @@ Move::Move(const std::string& str, bool black) {
 }
 
 uint16_t Move::as_packed_int() const {
-  if (promotion_ == Promotion::Knight) {
-    return from_.as_int() * 64 + to_.as_int();
+  if (promotion() == Promotion::Knight) {
+    return from().as_int() * 64 + to().as_int();
   } else {
-    return static_cast<int>(promotion_) * 64 * 64 + from_.as_int() * 64 +
-           to_.as_int();
+    return static_cast<int>(promotion()) * 64 * 64 + from().as_int() * 64 +
+           to().as_int();
   }
 }
 
 uint16_t Move::as_nn_index() const {
-  if (!castling_) return kMoveToIdx[as_packed_int()];
-  if (from_.col() < to_.col()) return kKingCastleIndex;
+  if (!castling()) return kMoveToIdx[as_packed_int()];
+  if (from().col() < to().col()) return kKingCastleIndex;
   return kQueenCastleIndex;
 }
 

--- a/src/chess/bitboard.h
+++ b/src/chess/bitboard.h
@@ -72,7 +72,7 @@ class BoardSquare {
   }
 
  private:
-  std::uint8_t square_ = 0;
+  std::uint8_t square_ = 0; // Only lower six bits should be set.
 };
 
 // Represents a board as an array of 64 bits.
@@ -190,40 +190,43 @@ class Move {
  public:
   enum class Promotion : std::uint8_t { None, Queen, Rook, Bishop, Knight };
   Move() = default;
-  Move(BoardSquare from, BoardSquare to) : from_(from), to_(to) {}
+  Move(BoardSquare from, BoardSquare to)
+          : data_(to.as_int() + (from.as_int() << 6)) {}
   Move(BoardSquare from, BoardSquare to, Promotion promotion)
-      : from_(from), to_(to), promotion_(promotion) {}
-  Move(const std::string& str, bool black = false);
-  Move(const char* str, bool black = false) : Move(std::string(str), black) {}
+          : data_(to.as_int() + (from.as_int() << 6) +
+                  (static_cast<uint8_t>(promotion) << 12)) {}
+  Move(const std::string &str, bool black = false);
+  Move(const char *str, bool black = false) : Move(std::string(str), black) {}
 
-  BoardSquare from() const { return from_; }
-  BoardSquare to() const { return to_; }
-  Promotion promotion() const { return promotion_; }
-  bool IsCastling() const { return castling_; }
-  void SetCastling() { castling_ = true; }
+  BoardSquare to() const { return {data_ & kToMask}; }
+  BoardSquare from() const { return {(data_ & kFromMask) >> 6}; }
+  Promotion promotion() const { return Promotion((data_ & kPromoMask) >> 12); }
+  bool castling() const { return (data_ & kCastleMask) != 0; }
+  void SetCastling() { data_ |= kCastleMask; }
 
+  void SetTo(BoardSquare to) { data_ = (data_ & ~kToMask) | to.as_int(); }
+  void SetFrom(BoardSquare from) {
+    data_ = (data_ & ~kFromMask) | (from.as_int() << 6);
+  }
+  void SetPromotion(Promotion promotion) {
+    data_ = (data_ & ~kPromoMask) | (static_cast<uint8_t>(promotion) << 12);
+  }
   // 0 .. 16384, knight promotion and no promotion is the same.
   uint16_t as_packed_int() const;
 
   // 0 .. 1857, to use in neural networks.
   uint16_t as_nn_index() const;
 
-  bool operator==(const Move& other) const {
-    return from_ == other.from_ && to_ == other.to_ &&
-           promotion_ == other.promotion_;
-  }
+  bool operator==(const Move& other) const { return data_ == other.data_; }
 
   bool operator!=(const Move& other) const { return !operator==(other); }
-  operator bool() const { return from_.as_int() != 0 || to_.as_int() != 0; }
+  operator bool() const { return data_ != 0; }
 
-  void Mirror() {
-    from_.Mirror();
-    to_.Mirror();
-  }
+  void Mirror() { data_ ^= 0b111000111000; }
 
   std::string as_string() const {
-    std::string res = from_.as_string() + to_.as_string();
-    switch (promotion_) {
+    std::string res = from().as_string() + to().as_string();
+    switch (promotion()) {
       case Promotion::None:
         return res;
       case Promotion::Queen:
@@ -240,10 +243,19 @@ class Move {
   }
 
  private:
-  BoardSquare from_;
-  BoardSquare to_;
-  Promotion promotion_ = Promotion::None;
-  bool castling_ = false;
+    uint16_t data_ = 0;
+    // Move, using the following encoding:
+    // bits 0..5 "to"-square
+    // bits 6..11 "from"-square
+    // bits 12..14 promotion value
+    // bit 15 whether move is a castling
+
+    enum Masks : uint16_t {
+        kToMask = 0b0000000000111111,
+        kFromMask = 0b0000111111000000,
+        kPromoMask = 0b0111000000000000,
+        kCastleMask = 0b1000000000000000,
+    };
 };
 
 using MoveList = std::vector<Move>;

--- a/src/chess/bitboard.h
+++ b/src/chess/bitboard.h
@@ -198,8 +198,8 @@ class Move {
   Move(const std::string& str, bool black = false);
   Move(const char* str, bool black = false) : Move(std::string(str), black) {}
 
-  BoardSquare to() const { return {data_ & kToMask}; }
-  BoardSquare from() const { return {(data_ & kFromMask) >> 6}; }
+  BoardSquare to() const { return BoardSquare(data_ & kToMask); }
+  BoardSquare from() const { return BoardSquare((data_ & kFromMask) >> 6); }
   Promotion promotion() const { return Promotion((data_ & kPromoMask) >> 12); }
   bool castling() const { return (data_ & kCastleMask) != 0; }
   void SetCastling() { data_ |= kCastleMask; }

--- a/src/chess/bitboard.h
+++ b/src/chess/bitboard.h
@@ -72,7 +72,7 @@ class BoardSquare {
   }
 
  private:
-  std::uint8_t square_ = 0; // Only lower six bits should be set.
+  std::uint8_t square_ = 0;  // Only lower six bits should be set.
 };
 
 // Represents a board as an array of 64 bits.
@@ -104,7 +104,7 @@ class BitBoard {
 
   // Sets value of given square to 0.
   void reset(BoardSquare square) { reset(square.as_int()); }
-  void reset(std ::uint8_t pos) { board_ &= ~(std::uint64_t(1) << pos); }
+  void reset(std::uint8_t pos) { board_ &= ~(std::uint64_t(1) << pos); }
   void reset(int row, int col) { reset(BoardSquare(row, col)); }
 
   // Gets value of a square.
@@ -191,12 +191,12 @@ class Move {
   enum class Promotion : std::uint8_t { None, Queen, Rook, Bishop, Knight };
   Move() = default;
   Move(BoardSquare from, BoardSquare to)
-          : data_(to.as_int() + (from.as_int() << 6)) {}
+      : data_(to.as_int() + (from.as_int() << 6)) {}
   Move(BoardSquare from, BoardSquare to, Promotion promotion)
-          : data_(to.as_int() + (from.as_int() << 6) +
-                  (static_cast<uint8_t>(promotion) << 12)) {}
-  Move(const std::string &str, bool black = false);
-  Move(const char *str, bool black = false) : Move(std::string(str), black) {}
+      : data_(to.as_int() + (from.as_int() << 6) +
+              (static_cast<uint8_t>(promotion) << 12)) {}
+  Move(const std::string& str, bool black = false);
+  Move(const char* str, bool black = false) : Move(std::string(str), black) {}
 
   BoardSquare to() const { return {data_ & kToMask}; }
   BoardSquare from() const { return {(data_ & kFromMask) >> 6}; }
@@ -243,19 +243,19 @@ class Move {
   }
 
  private:
-    uint16_t data_ = 0;
-    // Move, using the following encoding:
-    // bits 0..5 "to"-square
-    // bits 6..11 "from"-square
-    // bits 12..14 promotion value
-    // bit 15 whether move is a castling
+  uint16_t data_ = 0;
+  // Move, using the following encoding:
+  // bits 0..5 "to"-square
+  // bits 6..11 "from"-square
+  // bits 12..14 promotion value
+  // bit 15 whether move is a castling
 
-    enum Masks : uint16_t {
-        kToMask = 0b0000000000111111,
-        kFromMask = 0b0000111111000000,
-        kPromoMask = 0b0111000000000000,
-        kCastleMask = 0b1000000000000000,
-    };
+  enum Masks : uint16_t {
+    kToMask = 0b0000000000111111,
+    kFromMask = 0b0000111111000000,
+    kPromoMask = 0b0111000000000000,
+    kCastleMask = 0b1000000000000000,
+  };
 };
 
 using MoveList = std::vector<Move>;


### PR DESCRIPTION
Turns out that the reason for the extraneous queen promotions was because Mirror was using 0x instead of 0b for the bitmask, so it was setting the wrong bits