### PR TITLE
Change Edge::p_ from float to uint16_t

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -115,7 +115,7 @@ Move Edge::GetMove(bool as_opponent) const {
 
 std::string Edge::DebugString() const {
   std::ostringstream oss;
-  oss << "Move: " << move_.as_string() << " P:" << p_;
+  oss << "Move: " << move_.as_string() << " P: " << GetP();
   return oss.str();
 }
 

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -115,7 +115,7 @@ Move Edge::GetMove(bool as_opponent) const {
 
 std::string Edge::DebugString() const {
   std::ostringstream oss;
-  oss << "Move: " << move_.as_string() << " P: " << GetP();
+  oss << "Move: " << move_.as_string() << " p_: " << p_ << " GetP: " << GetP();
   return oss.str();
 }
 

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -139,12 +139,13 @@ Move Edge::GetMove(bool as_opponent) const {
 // they add up to 1).
 
 // If the two assumed-on exponent bits (3<<28) are in fact off, the input is
-// rounded up to the smallest value with them on. We verify this by subtracting
-// the two bits from the input and checking for a negative result. This is
-// combined with the round-to-nearest addition (1<<11).
+// rounded up to the smallest value with them on. We accomplish this by
+// subtracting the two bits from the input and checking for a negative result
+// (the subtraction works despite crossing from exponent to significand). This
+// is combined with the round-to-nearest addition (1<<11) into one op.
 void Edge::SetP(float p) {
-  constexpr int32_t roundings = (1 << 11) - (3 << 28);
   assert(0.0f <= p && p <= 1.0f);
+  constexpr int32_t roundings = (1 << 11) - (3 << 28);
   int32_t tmp;
   std::memcpy(&tmp, &p, sizeof(float));
   tmp += roundings;

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -128,20 +128,20 @@ Move Edge::GetMove(bool as_opponent) const {
 // by half the precision that is ultimately kept (addition overflow into the 7
 // exponent bits is possible, but also works correctly).
 
-// Toss the sign and 2 highest bits of the exponent (assuming them to be 01),
-// take the next 16 bits, that leaves the 13 trailing LSB of the significand to
-// be lost as well. Round-to-nearest by adding a 1 in that 13th bit before
-// truncating.
+// Toss the sign and 3 highest bits of the exponent (assuming them to be 011),
+// take the next 16 bits, that leaves the 12 trailing LSB of the significand to
+// be lost as well. Round-to-nearest by adding a 1 in that 12th bit before
+// truncating. The minimum number that can be represented is 4.656613E-10.
 void Edge::SetP(float p) {
   assert(0.0f <= p);
-  uint32_t tmp;
+  int32_t tmp;
   std::memcpy(&tmp, &p, sizeof(float));
-  assert((tmp & (3 << 29)) == (1 << 29));
-  p_ = static_cast<uint16_t>((tmp - (1 << 29) + (1 << 12)) >> 13);
+  tmp -= (3 << 28) - (1 << 11);
+  p_ = (tmp < 0) ? 0 : static_cast<uint16_t>(tmp >> 12);
 }
 
 float Edge::GetP() const {
-  uint32_t tmp = (static_cast<uint32_t>(p_) << 13) + (1 << 29);
+  uint32_t tmp = (static_cast<uint32_t>(p_) << 12) + (3 << 28);
   float tmpf;
   std::memcpy(&tmpf, &tmp, sizeof(uint32_t));
   return tmpf;

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -128,18 +128,20 @@ Move Edge::GetMove(bool as_opponent) const {
 // by half the precision that is ultimately kept (addition overflow into the 7
 // exponent bits is possible, but also works correctly).
 
-// Toss the sign and MSB of the exponent, take the next 16 bits, that leaves
-// the 14 trailing LSB of the significand to be lost as well. Round-to-nearest
-// by adding a 1 in that 14th bit before truncating.
+// Toss the sign and 2 highest bits of the exponent (assuming them to be 01),
+// take the next 16 bits, that leaves the 13 trailing LSB of the significand to
+// be lost as well. Round-to-nearest by adding a 1 in that 13th bit before
+// truncating.
 void Edge::SetP(float p) {
-  assert(0.0f <= p && p < 2.0f);
+  assert(0.0f <= p);
   uint32_t tmp;
   std::memcpy(&tmp, &p, sizeof(float));
-  p_ = static_cast<uint16_t>((tmp + (1 << 13)) >> 14);
+  assert((tmp & (3 << 29)) == (1 << 29));
+  p_ = static_cast<uint16_t>((tmp - (1 << 29) + (1 << 12)) >> 13);
 }
 
 float Edge::GetP() const {
-  uint32_t tmp = static_cast<uint32_t>(p_) << 14;
+  uint32_t tmp = (static_cast<uint32_t>(p_) << 13) + (1 << 29);
   float tmpf;
   std::memcpy(&tmpf, &tmp, sizeof(uint32_t));
   return tmpf;

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -80,13 +80,9 @@ class Edge {
   Move GetMove(bool as_opponent = false) const;
 
   // Returns or sets value of Move policy prior returned from the neural net
-  // (but can be changed by adding Dirichlet noise). We use a 16 bit significand
-  // for storage savings in memory-critical Edges. Priors are floored at
-  // 1/0xFFFF, since we use priors multiplicatively to calculate U.
-  float GetP() const { return   static_cast<float>(p_)
-                              / static_cast<float>(0xFFFF); }
-  void SetP(float val) { p_ = std::max(static_cast<uint16_t>(1),
-                                       static_cast<uint16_t>(val * 0xFFFF)); }
+  // (but can be changed by adding Dirichlet noise).
+  float GetP() const;
+  void SetP(float val);
 
   // Debug information about the edge.
   std::string DebugString() const;

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -95,8 +95,8 @@ class Edge {
   // Root node contains move a1a1.
   Move move_;
 
-  // Probability that this move will be made. From policy head of the neural
-  // network. Stored with a 16 bit significand in the form of a uint16_t.
+  // Probability that this move will be made, from the policy head of the neural
+  // network; compressed to a 16 bit format (5 bits exp, 11 bits significand).
   uint16_t p_ = 0;
 
   friend class EdgeList;

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -80,7 +80,7 @@ class Edge {
   Move GetMove(bool as_opponent = false) const;
 
   // Returns or sets value of Move policy prior returned from the neural net
-  // (but can be changed by adding Dirichlet noise).
+  // (but can be changed by adding Dirichlet noise). Must be in [0,1].
   float GetP() const;
   void SetP(float val);
 


### PR DESCRIPTION
This saves 2 actual bytes, or 4 aligned bytes after the Move savings, resulting in roughly 40% savings in total tree size:
35\*8 + 64 = 344  bytes per node --> 35\*4 + 64 = 204 bytes per node

```
# with new policy

|   _ | |
|_ |_ |_| built Jul 14 2018
Move size 2 for estimated Edge size 4 vs actual Edge size 4 Node size 64 for total estimated bytes/Node of 204
go nodes 5
Creating backend [blas]...
BLAS vendor: OpenBlas.
OpenBlas [NO_LAPACKE DYNAMIC_ARCH NO_AFFINITY Sandybridge].
OpenBlas found 8 Sandybridge core(s).
OpenBLAS using 1 core(s) for this backend.
BLAS max batch size is 256.
info depth 2 seldepth 2 time 33 nodes 2 score cp 6 hashfull 0 nps 60 pv d2d4 d7d5
info depth 2 seldepth 3 time 60 nodes 4 score cp 5 hashfull 0 nps 66 pv d2d4 d7d5 c2c4
info depth 2 seldepth 3 time 74 nodes 5 score cp 5 hashfull 0 nps 67 pv d2d4 d7d5 c2c4
info string g2g4  (378 ) N:       0 (+ 0) (P:  0.36%) (Q:  0.01514) (U: 0.00861) (Q+U:  0.02375) (V:  -.----) 
info string f2f3  (346 ) N:       0 (+ 0) (P:  0.51%) (Q:  0.01514) (U: 0.01230) (Q+U:  0.02745) (V:  -.----) 
info string f2f4  (351 ) N:       0 (+ 0) (P:  0.56%) (Q:  0.01514) (U: 0.01333) (Q+U:  0.02847) (V:  -.----) 
info string g1h3  (161 ) N:       0 (+ 0) (P:  0.56%) (Q:  0.01514) (U: 0.01337) (Q+U:  0.02851) (V:  -.----) 
info string h2h4  (403 ) N:       0 (+ 0) (P:  0.63%) (Q:  0.01514) (U: 0.01512) (Q+U:  0.03027) (V:  -.----) 
info string b1a3  (34  ) N:       0 (+ 0) (P:  0.66%) (Q:  0.01514) (U: 0.01593) (Q+U:  0.03107) (V:  -.----) 
info string a2a4  (207 ) N:       0 (+ 0) (P:  1.11%) (Q:  0.01514) (U: 0.02670) (Q+U:  0.04184) (V:  -.----) 
info string b2b4  (234 ) N:       0 (+ 0) (P:  1.15%) (Q:  0.01514) (U: 0.02761) (Q+U:  0.04276) (V:  -.----) 
info string d2d3  (288 ) N:       0 (+ 0) (P:  1.28%) (Q:  0.01514) (U: 0.03076) (Q+U:  0.04591) (V:  -.----) 
info string g2g3  (374 ) N:       0 (+ 0) (P:  1.42%) (Q:  0.01514) (U: 0.03413) (Q+U:  0.04928) (V:  -.----) 
info string c2c3  (259 ) N:       0 (+ 0) (P:  1.55%) (Q:  0.01514) (U: 0.03721) (Q+U:  0.05235) (V:  -.----) 
info string a2a3  (204 ) N:       0 (+ 0) (P:  1.82%) (Q:  0.01514) (U: 0.04373) (Q+U:  0.05887) (V:  -.----) 
info string b2b3  (230 ) N:       0 (+ 0) (P:  1.96%) (Q:  0.01514) (U: 0.04699) (Q+U:  0.06213) (V:  -.----) 
info string b1c3  (36  ) N:       0 (+ 0) (P:  2.17%) (Q:  0.01514) (U: 0.05211) (Q+U:  0.06726) (V:  -.----) 
info string h2h3  (400 ) N:       0 (+ 0) (P:  3.26%) (Q:  0.01514) (U: 0.07826) (Q+U:  0.09340) (V:  -.----) 
info string e2e3  (317 ) N:       0 (+ 0) (P:  7.25%) (Q:  0.01514) (U: 0.17399) (Q+U:  0.18913) (V:  -.----) 
info string c2c4  (264 ) N:       0 (+ 0) (P:  8.88%) (Q:  0.01514) (U: 0.21317) (Q+U:  0.22832) (V:  -.----) 
info string e2e4  (322 ) N:       0 (+ 0) (P: 10.20%) (Q:  0.01514) (U: 0.24485) (Q+U:  0.26000) (V:  -.----) 
info string g1f3  (159 ) N:       1 (+ 0) (P: 19.11%) (Q:  0.02653) (U: 0.22934) (Q+U:  0.25587) (V:  0.0265) 
info string d2d4  (293 ) N:       3 (+ 0) (P: 35.52%) (Q:  0.01257) (U: 0.21311) (Q+U:  0.22568) (V:  0.0147) 
bestmove d2d4
quit

# with old policy
       _
|   _ | |
|_ |_ |_| built Jul 10 2018
go nodes 5
Creating backend [blas]...
BLAS vendor: OpenBlas.
OpenBlas [NO_LAPACKE DYNAMIC_ARCH NO_AFFINITY Sandybridge].
OpenBlas found 8 Sandybridge core(s).
OpenBLAS using 1 core(s) for this backend.
BLAS max batch size is 256.
info depth 1 seldepth 1 time 22 nodes 2 score cp 6 hashfull 0 nps 90 pv d2d4 d7d5
info depth 1 seldepth 2 time 43 nodes 4 score cp 5 hashfull 0 nps 93 pv d2d4 d7d5 c2c4
info depth 1 seldepth 2 time 52 nodes 5 score cp 5 hashfull 0 nps 96 pv d2d4 d7d5 c2c4
info string g2g4  (378 ) N:       0 (+ 0) (P:  0.36%) (Q:  0.01514) (U: 0.00864) (Q+U:  0.02378) (V:  -.----) 
info string f2f3  (346 ) N:       0 (+ 0) (P:  0.51%) (Q:  0.01514) (U: 0.01234) (Q+U:  0.02748) (V:  -.----) 
info string f2f4  (351 ) N:       0 (+ 0) (P:  0.56%) (Q:  0.01514) (U: 0.01337) (Q+U:  0.02852) (V:  -.----) 
info string g1h3  (161 ) N:       0 (+ 0) (P:  0.56%) (Q:  0.01514) (U: 0.01340) (Q+U:  0.02854) (V:  -.----) 
info string h2h4  (403 ) N:       0 (+ 0) (P:  0.63%) (Q:  0.01514) (U: 0.01516) (Q+U:  0.03030) (V:  -.----) 
info string b1a3  (34  ) N:       0 (+ 0) (P:  0.67%) (Q:  0.01514) (U: 0.01596) (Q+U:  0.03111) (V:  -.----) 
info string a2a4  (207 ) N:       0 (+ 0) (P:  1.11%) (Q:  0.01514) (U: 0.02673) (Q+U:  0.04188) (V:  -.----) 
info string b2b4  (234 ) N:       0 (+ 0) (P:  1.15%) (Q:  0.01514) (U: 0.02765) (Q+U:  0.04280) (V:  -.----) 
info string d2d3  (288 ) N:       0 (+ 0) (P:  1.28%) (Q:  0.01514) (U: 0.03080) (Q+U:  0.04594) (V:  -.----) 
info string g2g3  (374 ) N:       0 (+ 0) (P:  1.42%) (Q:  0.01514) (U: 0.03415) (Q+U:  0.04929) (V:  -.----) 
info string c2c3  (259 ) N:       0 (+ 0) (P:  1.55%) (Q:  0.01514) (U: 0.03727) (Q+U:  0.05241) (V:  -.----) 
info string a2a3  (204 ) N:       0 (+ 0) (P:  1.82%) (Q:  0.01514) (U: 0.04378) (Q+U:  0.05892) (V:  -.----) 
info string b2b3  (230 ) N:       0 (+ 0) (P:  1.96%) (Q:  0.01514) (U: 0.04699) (Q+U:  0.06213) (V:  -.----) 
info string b1c3  (36  ) N:       0 (+ 0) (P:  2.17%) (Q:  0.01514) (U: 0.05214) (Q+U:  0.06728) (V:  -.----) 
info string h2h3  (400 ) N:       0 (+ 0) (P:  3.26%) (Q:  0.01514) (U: 0.07829) (Q+U:  0.09344) (V:  -.----) 
info string e2e3  (317 ) N:       0 (+ 0) (P:  7.25%) (Q:  0.01514) (U: 0.17403) (Q+U:  0.18918) (V:  -.----) 
info string c2c4  (264 ) N:       0 (+ 0) (P:  8.88%) (Q:  0.01514) (U: 0.21322) (Q+U:  0.22836) (V:  -.----) 
info string e2e4  (322 ) N:       0 (+ 0) (P: 10.20%) (Q:  0.01514) (U: 0.24490) (Q+U:  0.26005) (V:  -.----) 
info string g1f3  (159 ) N:       1 (+ 0) (P: 19.11%) (Q:  0.02653) (U: 0.22935) (Q+U:  0.25588) (V:  0.0265) 
info string d2d4  (293 ) N:       3 (+ 0) (P: 35.52%) (Q:  0.01257) (U: 0.21312) (Q+U:  0.22569) (V:  0.0147) 
bestmove d2d4

```

Only one move has a different rounded decimal digit, all the rest are identical. Remains to be tested in gameplay. Should probably be tested with actual 16bit weights as well.