### PR TITLE
[CircleCI] Use a previous docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: danieluranga/leela_chess_zero-lc0_ubuntu_builder:0.0.4
+      - image: danieluranga/leela_chess_zero-lc0_ubuntu_builder:0.0.2
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Use a previous docker image that should use the protobuf versions from the Ubuntu repos.