### PR TITLE
discover gzipped files

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -171,7 +171,7 @@ void EngineController::UpdateNetwork() {
 
   std::string net_path = network_path;
   if (net_path == kAutoDiscover) {
-    net_path = DiscoveryWeightsFile();
+    net_path = DiscoverWeightsFile();
   }
   Weights weights = LoadWeightsFromFile(net_path);
 

--- a/src/neural/loader.cc
+++ b/src/neural/loader.cc
@@ -101,7 +101,8 @@ void DenormConvBlock(const pblczero::Weights_ConvBlock& conv,
 FloatVectors LoadFloatsFromPbFile(const std::string& buffer) {
   auto net = pblczero::Net();
   FloatVectors vecs;
-  net.ParseFromString(buffer);
+  if (!net.ParseFromString(buffer))
+    throw Exception("Invalid weight file: parse error.");
 
   if (net.magic() != kWeightMagic)
     throw Exception("Invalid weight file: bad header.");
@@ -192,7 +193,7 @@ Weights LoadWeightsFromFile(const std::string& filename) {
   PopulateLastIntoVector(&vecs, &result.ip_pol_w);
   PopulateConvBlockWeights(&vecs, &result.policy);
 
-  // Version, Input + all the residual should be left.
+  // Input + all the residual should be left.
   if ((vecs.size() - 4) % 8 != 0)
     throw Exception("Invalid weight file: parse error.");
 
@@ -246,7 +247,7 @@ std::string DiscoverWeightsFile() {
       return candidate.second;
     }
 
-    // first byte of the protobuf stream is 0x0d for fixed32, so we ignore it as
+    // First byte of the protobuf stream is 0x0d for fixed32, so we ignore it as
     // our own magic should suffice.
     auto magic = reinterpret_cast<std::uint32_t*>(buf+1);
     if (*magic == kWeightMagic) {

--- a/src/neural/loader.cc
+++ b/src/neural/loader.cc
@@ -244,6 +244,8 @@ std::string DiscoverWeightsFile() {
       return candidate.second;
     }
 
+    // first byte of the protobuf stream is 0x0d for fixed32, so we ignore it as
+    // our own magic should suffice.
     auto magic = reinterpret_cast<std::uint32_t*>(buf+1);
     if (*magic == kWeightMagic) {
       std::cerr << "Found pb network file: " << candidate.second << std::endl;

--- a/src/neural/loader.cc
+++ b/src/neural/loader.cc
@@ -220,7 +220,7 @@ std::string DiscoveryWeightsFile() {
 
   std::sort(time_and_filename.rbegin(), time_and_filename.rend());
 
-  // Open all candidates, from newest to oldest, possibly gzipped, and try to
+  // Open all candidates, from newest to oldest, possibly gzipped, and try to 
   // read version for it. If version is 2 or if the file is gzipped, return it.
   std::ifstream compressed_file;
   std::uint16_t header;

--- a/src/neural/loader.h
+++ b/src/neural/loader.h
@@ -40,6 +40,6 @@ Weights LoadWeightsFromFile(const std::string& filename);
 // Tries to find a file which looks like a weights file, and located in
 // directory of binary_name or one of subdirectories. If there are several such
 // files, returns one which has the latest modification date.
-std::string DiscoveryWeightsFile();
+std::string DiscoverWeightsFile();
 
 }  // namespace lczero

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -128,7 +128,7 @@ SelfPlayTournament::SelfPlayTournament(const OptionsDict& options,
     std::string path =
         options.GetSubdict(kPlayerNames[idx]).Get<std::string>(kNetFileStr);
     if (path == kAutoDiscover) {
-      path = DiscoveryWeightsFile();
+      path = DiscoverWeightsFile();
     }
     Weights weights = LoadWeightsFromFile(path);
     std::string backend =


### PR DESCRIPTION
The DiscoveryWeightsFile() function for protobuf compressed files didn't work. This PR makes sure it works again by checking the file header of a gzipped file. Unfortunately gzopen() doesn't distinguish between opening a regular file or a gzipped file.

Furthermore, binary protobuf does not contain some kind of header but goes straight into serialized data. I don't know of a better way to check for these type of files.