### PR TITLE
Use submodule if either protobuf or protoc not found

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -60,11 +60,14 @@ files = []
 includes = []
 has_backends = false
 
-deps += dependency('protobuf', fallback : ['protobuf', 'protobuf_dep'], required: true)
+# Both protobuf and protoc must be the same version, so couple them together.
+protobuf_dep = dependency('protobuf', required : false)
 protoc = find_program('protoc', required : false)
-if not protoc.found()
-  message('protoc will be built from the subproject')
+if not protobuf_dep.found() or not protoc.found()
+  deps += subproject('protobuf').get_variable('protobuf_dep')
   protoc = subproject('protobuf').get_variable('protoc')
+else
+  deps += protobuf_dep
 endif
 
 gen = generator(protoc, output: ['@BASENAME@.pb.cc', '@BASENAME@.pb.h'],


### PR DESCRIPTION
It turns out that there are many systems with only protobuf or protoc installed. Since both have to be available and the same version, this patch couples their detection and uses the fallback submodule if either is missing.