### PR TITLE
make protobuf paths configurable and build/cache on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,15 +33,20 @@ install:
 - cmd: pip3 install --upgrade meson
 - cmd: call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
 - cmd: set PKG_FOLDER="C:\cache"
+- cmd: IF NOT EXIST c:\cache\protobuf\ git clone -b v3.5.1 --single-branch --depth 1 https://github.com/google/protobuf.git
+- cmd: IF NOT EXIST c:\cache\protobuf\ mkdir protobuf\build_msvc
+- cmd: IF NOT EXIST c:\cache\protobuf\ cd protobuf\build_msvc
+- cmd: IF NOT EXIST c:\cache\protobuf\ cmake -G "Visual Studio 14 2015 Win64" -Dprotobuf_BUILD_SHARED_LIBS=NO -Dprotobuf_MSVC_STATIC_RUNTIME=NO -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=c:/cache/protobuf ../cmake
+- cmd: IF NOT EXIST c:\cache\protobuf\ msbuild INSTALL.vcxproj /p:Configuration=Release /p:Platform=x64 /m
+- cmd: set PATH=c:\cache\protobuf\bin;%PATH%
+- cmd: cd C:\projects\lc0
 cache:
-  - C:\cache
-  - C:\Python36\scripts
-  - C:\Python36\Lib\site-packages
-  - 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.2'
-  - C:\projects\lc0\subprojects\packagecache
+  - C:\cache -> appveyor.yml
+  - 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.2 -> appveyor.yml'
+  - C:\projects\lc0\subprojects\packagecache -> appveyor.yml
 before_build:
 - cmd: git submodule update --init --recursive
-- cmd: meson.py build --backend vs2015 --buildtype release -Dgtest=%GTEST% -Dopencl=%OPENCL% -Dblas=%BLAS% -Dcudnn=%CUDA% -Dcudnn_include="%PKG_FOLDER%\cuda\include" -Dcudnn_libdirs="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.2\lib\x64","%PKG_FOLDER%\cuda\lib\x64" -Dopenblas_include="%PKG_FOLDER%\OpenBLAS.0.2.14.1\lib\native\include" -Dopenblas_libdirs="%PKG_FOLDER%\OpenBLAS.0.2.14.1\lib\native\lib\x64" -Dopencl_include="%PKG_FOLDER%\opencl-nug.0.777.12\build\native\include" -Dopencl_libdirs="%PKG_FOLDER%\opencl-nug.0.777.12\build\native\lib\x64" -Ddefault_library=static
+- cmd: meson.py build --backend vs2015 --buildtype release -Dgtest=%GTEST% -Dopencl=%OPENCL% -Dblas=%BLAS% -Dcudnn=%CUDA% -Dcudnn_include="%PKG_FOLDER%\cuda\include" -Dcudnn_libdirs="%CUDA_PATH%\lib\x64","%PKG_FOLDER%\cuda\lib\x64" -Dprotobuf_include="%PKG_FOLDER%\protobuf\include" -Dprotobuf_libdir="%PKG_FOLDER%\protobuf\lib" -Dopenblas_include="%PKG_FOLDER%\OpenBLAS.0.2.14.1\lib\native\include" -Dopenblas_libdirs="%PKG_FOLDER%\OpenBLAS.0.2.14.1\lib\native\lib\x64" -Dopencl_include="%PKG_FOLDER%\opencl-nug.0.777.12\build\native\include" -Dopencl_libdirs="%PKG_FOLDER%\opencl-nug.0.777.12\build\native\lib\x64" -Ddefault_library=static
 build:
   parallel: true
   project: build/lc0.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,8 +24,8 @@ install:
 - cmd: IF %CUDA%==false nuget install OpenBLAS -Version 0.2.14.1 -OutputDirectory C:\cache
 - cmd: IF %CUDA%==false nuget install opencl-nug -Version 0.777.12 -OutputDirectory C:\cache
 - cmd: set "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.2"
-- cmd: IF %CUDA%==true IF NOT EXIST "%CUDA_PATH%" appveyor DownloadFile https://developer.nvidia.com/compute/cuda/9.2/Prod2/network_installers/cuda_9.2.148_win10_network
-- cmd: IF %CUDA%==true IF NOT EXIST "%CUDA_PATH%" cuda_9.2.148_win10_network -s nvcc_9.2 cublas_dev_9.2 cublas_9.2 cudart_9.2
+- cmd: IF %CUDA%==true IF NOT EXIST "%CUDA_PATH%" appveyor DownloadFile https://developer.nvidia.com/compute/cuda/9.2/Prod2/local_installers/cuda_9.2.148_win10
+- cmd: IF %CUDA%==true IF NOT EXIST "%CUDA_PATH%" cuda_9.2.148_win10 -s nvcc_9.2 cublas_dev_9.2 cublas_9.2 cudart_9.2
 - cmd: IF %CUDA%==true set PATH=%CUDA_PATH%\bin;%PATH%
 - cmd: IF %CUDA%==true IF NOT EXIST C:\cache\cuda appveyor DownloadFile http://developer.download.nvidia.com/compute/redist/cudnn/v7.1.4/cudnn-9.2-windows10-x64-v7.1.zip
 - cmd: IF %CUDA%==true IF NOT EXIST C:\cache\cuda 7z x cudnn-9.2-windows10-x64-v7.1.zip -oC:\cache
@@ -41,9 +41,9 @@ install:
 - cmd: set PATH=c:\cache\protobuf\bin;%PATH%
 - cmd: cd C:\projects\lc0
 cache:
-  - C:\cache -> appveyor.yml
-  - 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.2 -> appveyor.yml'
-  - C:\projects\lc0\subprojects\packagecache -> appveyor.yml
+  - C:\cache
+  - 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.2'
+  - C:\projects\lc0\subprojects\packagecache
 before_build:
 - cmd: git submodule update --init --recursive
 - cmd: meson.py build --backend vs2015 --buildtype release -Dgtest=%GTEST% -Dopencl=%OPENCL% -Dblas=%BLAS% -Dcudnn=%CUDA% -Dcudnn_include="%PKG_FOLDER%\cuda\include" -Dcudnn_libdirs="%CUDA_PATH%\lib\x64","%PKG_FOLDER%\cuda\lib\x64" -Dprotobuf_include="%PKG_FOLDER%\protobuf\include" -Dprotobuf_libdir="%PKG_FOLDER%\protobuf\lib" -Dopenblas_include="%PKG_FOLDER%\OpenBLAS.0.2.14.1\lib\native\include" -Dopenblas_libdirs="%PKG_FOLDER%\OpenBLAS.0.2.14.1\lib\native\lib\x64" -Dopencl_include="%PKG_FOLDER%\opencl-nug.0.777.12\build\native\include" -Dopencl_libdirs="%PKG_FOLDER%\opencl-nug.0.777.12\build\native\lib\x64" -Ddefault_library=static

--- a/meson.build
+++ b/meson.build
@@ -73,7 +73,7 @@ if not protobuf_dep.found() or not protoc.found()
   protoc = subproject('protobuf').get_variable('protoc')
 else
   deps += protobuf_dep
-  if not protobuf_lib.found()
+  if protobuf_lib.found()
     includes += include_directories(get_option('protobuf_include'))
   endif
 endif

--- a/meson.build
+++ b/meson.build
@@ -62,13 +62,20 @@ has_backends = false
 
 # Both protobuf and protoc must be the same version, so couple them together.
 protobuf_lib = cc.find_library('libprotobuf', dirs : get_option('protobuf_libdir'), required : false)
+if not protobuf_lib.found()
+  protobuf_dep = dependency('protobuf', required : false)
+else
+  protobuf_dep = protobuf_lib
+endif
 protoc = find_program('protoc', required : false)
-if not protobuf_lib.found() or not protoc.found()
+if not protobuf_dep.found() or not protoc.found()
   deps += subproject('protobuf').get_variable('protobuf_dep')
   protoc = subproject('protobuf').get_variable('protoc')
 else
-  deps += protobuf_lib
-  includes += include_directories(get_option('protobuf_include'))
+  deps += protobuf_dep
+  if not protobuf_lib.found()
+    includes += include_directories(get_option('protobuf_include'))
+  endif
 endif
 
 gen = generator(protoc, output: ['@BASENAME@.pb.cc', '@BASENAME@.pb.h'],

--- a/meson.build
+++ b/meson.build
@@ -61,13 +61,14 @@ includes = []
 has_backends = false
 
 # Both protobuf and protoc must be the same version, so couple them together.
-protobuf_dep = dependency('protobuf', required : false)
+protobuf_lib = cc.find_library('libprotobuf', dirs : get_option('protobuf_libdir'), required : false)
 protoc = find_program('protoc', required : false)
-if not protobuf_dep.found() or not protoc.found()
+if not protobuf_lib.found() or not protoc.found()
   deps += subproject('protobuf').get_variable('protobuf_dep')
   protoc = subproject('protobuf').get_variable('protoc')
 else
-  deps += protobuf_dep
+  deps += protobuf_lib
+  includes += include_directories(get_option('protobuf_include'))
 endif
 
 gen = generator(protoc, output: ['@BASENAME@.pb.cc', '@BASENAME@.pb.h'],

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,6 +3,11 @@ option('tensorflow_include',
        value: ['/usr/local/include/tensorflow/'],
        description: 'Paths to tensorflow include directories')
 
+option('protobuf_include',
+       type: 'array',
+       value: ['/usr/local/include/'],
+       description: 'Paths to protobuf include directories')
+
 option('openblas_include',
        type: 'array',
        value: ['/usr/include/openblas/'],
@@ -17,6 +22,11 @@ option('tensorflow_libdir',
        type: 'array',
        value: ['/usr/local/lib/tensorflow_cc/'],
        description: 'Paths to tensorflow libraries')
+
+option('protobuf_libdir',
+       type: 'array',
+       value: ['/usr/lib/x86_64-linux-gnu/'],
+       description: 'Paths to protobuf libraries')
 
 option('openblas_libdirs',
        type: 'array',


### PR DESCRIPTION
The objective of this patch is to allow a precompiled protobuf to be used on windows/appveyor. This requires the protobuf library and include paths to be configurable for the build, which is achieved by replacing the dependency() with a cc.find_library() and include_directories() pair, together with the relevant meson options.

The appveyor.yml change builds and installs protobuf on a path that is cached for subsequent builds. Also the caching of meson is removed since it turns out to be slower than a fresh install.

This has been tested on ubuntu 16.04, windows and appveyor. Additional testing, in particular on osx is welcome.