### PR TITLE
Node::GetVisitedPolicy uses cached value to avoid expensive recalcula…

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -184,8 +184,9 @@ void Node::FinalizeScoreUpdate(float v) {
   // Recompute Q.
   q_ += (v - q_) / (n_ + 1);
   // If first visit, update parent's sum of policies visited at least once.
-  if (n_ == 0 && parent_ != nullptr)
+  if (n_ == 0 && parent_ != nullptr) {
     parent_->visited_policy_ += parent_->edges_[index_].GetP();
+  }
   // Increment N.
   ++n_;
   // Decrement virtual loss.

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -149,13 +149,8 @@ void Node::CreateEdges(const MoveList& moves) {
 Node::ConstIterator Node::Edges() const { return {edges_, &child_}; }
 Node::Iterator Node::Edges() { return {edges_, &child_}; }
 
-float Node::GetVisitedPolicy() const {
-  float res = 0.0f;
-  for (const auto* node = child_.get(); node; node = node->sibling_.get()) {
-    if (node->n_ > 0) res += edges_[node->index_].GetP();
-  }
-  return res;
-}
+float Node::GetVisitedPolicy() const { return visited_policy_;  }
+
 
 Edge* Node::GetEdgeToNode(const Node* node) const {
   assert(node->parent_ == this);
@@ -188,6 +183,9 @@ void Node::CancelScoreUpdate() { --n_in_flight_; }
 void Node::FinalizeScoreUpdate(float v) {
   // Recompute Q.
   q_ += (v - q_) / (n_ + 1);
+  // If first visit, update parent's sum of policies visited at least once.
+  if (n_ == 0 && parent_ != nullptr)
+    parent_->visited_policy_ += parent_->edges_[index_].GetP();
   // Increment N.
   ++n_;
   // Decrement virtual loss.

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -222,6 +222,8 @@ class Node {
   // but not finished). This value is added to n during selection which node
   // to pick in MCTS, and also when selecting the best move.
   uint16_t n_in_flight_ = 0;
+  // Sum of policy priors which have had at least one playout.
+  float visited_policy_ = 0.0f;
 
   // Maximum depth any subnodes of this node were looked at.
   uint16_t max_depth_ = 0;


### PR DESCRIPTION
Severe slowdown in nodes per second (nps) has been commonly seen in high-end multi-GPU systems (starting notably after a few seconds to a few minutes). Analysis under a debugger shows the CPU threads become the bottleneck, with only one thread making progress at any given time as it traverses and updates the increasingly deep large tree (and other threads waiting on the single tree mutex held by the active thread). Aggregate GPU utilization often drops from near 100% to 25% or less.

As GPUs become increasingly faster, (but CPUs much less so) the ultimate scalability of LeelaChessZero will be increasingly by gated by the efficiency of the search code. Thus incremental improvements in this area would seem to be important. 

Analysis under a debugger revealed considerable CPU time being spent in the method Node::GetVisitedPolicy, which does a lot of pointer chasing as it accumulates the visited policy statistic. This method executes approximately 100,000,000 times for each 5,000,000 nodes visited. 

This PR proposes an enhancement whereby the Node::GetVisitedPolicy method now just returns a cached value. This new cached value is stored in a new member variable at Node (at a cost of 4 bytes). The cached value is easily kept up to date (needing a potential update in only one place, at Node::FinalizeScoreUpdate).

Analysis from the starting position using a 3-GPU (Titan V) system showed a aggregate nps improvement of 13% when run for 60 seconds (73.6 to 83.3 knps), and about 15% (51.6 to 59.4 knps) when run for 15 minutes.

**SAMPLE TEST COMMAND LINE** 
lc0 -t 8 -w d:\weights\big.txt --no-smart-pruning --nncache=20000000 --minibatch-size=512 --backend=multiplexing "--backend-opts=(backend=cudnn-fp16,gpu=0),(backend=cudnn-fp16,gpu=1),(backend=cudnn-fp16,gpu=2)"