### PR TITLE
Out of order eval for terminal nodes and cache hits.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -57,11 +57,8 @@ const char* Search::kCacheHistoryLengthStr =
 const char* Search::kPolicySoftmaxTempStr = "Policy softmax temperature";
 const char* Search::kAllowedNodeCollisionsStr =
     "Allowed node collisions, per batch";
-<<<<<<< HEAD
 const char* Search::kOutOfOrderEvalStr = "Out-of-order cache backpropagation";
-=======
 const char* Search::kStickyCheckmateStr = "Ignore alternatives to checkmate";
->>>>>>> upstream/master
 
 namespace {
 const int kSmartPruningToleranceNodes = 100;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -586,8 +586,7 @@ void SearchWorker::GatherMinibatch() {
     // doesn't require NN eval (i.e. it's a cache hit or terminal node), do
     // out of order eval for it.
     if (search_->kOutOfOrderEval) {
-      const bool is_terminal = node->IsTerminal();
-      if (is_terminal || minibatch_.back().is_cache_hit) {
+      if (node->IsTerminal() || minibatch_.back().is_cache_hit) {
         // Perform out of order eval for the last entry in minibatch_.
         FetchSingleNodeResult(&minibatch_.back(),
                               computation_->GetBatchSize() - 1);
@@ -596,7 +595,7 @@ void SearchWorker::GatherMinibatch() {
         // Remove last entry in minibatch_, as it has just been
         // processed.
         // If NN eval was already processed out of order, remove it.
-        if (minibatch_.back().nn_queried) computation_->PopInput();
+        if (minibatch_.back().nn_queried) computation_->PopCacheHit();
         minibatch_.pop_back();
         --minibatch_size;
       }

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -133,7 +133,7 @@ class Search {
   // There is already one thread that responded bestmove, other threads
   // should not do that.
   bool responded_bestmove_ GUARDED_BY(counters_mutex_) = false;
-  // Becomes true when smart pruning decides
+  // Becomes true when smart pruning decides that no better move can be found.
   bool found_best_move_ GUARDED_BY(counters_mutex_) = false;
   // Stored so that in the case of non-zero temperature GetBestMove() returns
   // consistent results.
@@ -255,11 +255,7 @@ class SearchWorker {
 
   Search* const search_;
   // List of nodes to process.
-  std::vector<NodeToProcess> nodes_to_process_;
-  // How many of the nodes in a batch are collisions.
-  int collisions_found_;
-  // If true, pipeline should only eval the last entry in the cache.
-  bool out_of_order_eval_ = false;
+  std::vector<NodeToProcess> minibatch_;
   std::unique_ptr<CachingComputation> computation_;
   // History is reset and extended by PickNodeToExtend().
   PositionHistory history_;

--- a/src/neural/blas/winograd_convolution3.cc
+++ b/src/neural/blas/winograd_convolution3.cc
@@ -108,8 +108,6 @@ void WinogradConvolution3::Forward(const size_t batch_size,
   TransformOut(batch_size, output, output_channels);
 }
 
-
-
 void WinogradConvolution3::TransformIn(const size_t batch_size,
                                        const float* input,
                                        const size_t channels) {
@@ -149,7 +147,6 @@ void WinogradConvolution3::TransformIn(const size_t batch_size,
                 }
               }
             }
-          
 
             // Calculates transpose(B).x.B
             // B = [[ 1.0,  0.0,  0.0,  0.0],
@@ -191,7 +188,6 @@ void WinogradConvolution3::TransformIn(const size_t batch_size,
             R[14][ch] = T1[3][2] - T1[3][1];
             R[15][ch] = T1[3][1] - T1[3][3];
           }
-          const size_t channel = channel_long;
           float* V_channel = V_batch + channel_long;
           const auto V_incr = channels * kTiles * batch_size;
           float* wTile_V = V_channel + channels * (block_y * kWtiles + block_x);
@@ -206,15 +202,12 @@ void WinogradConvolution3::TransformIn(const size_t batch_size,
     }
   }
 
-#else // USE_ISPC
+#else  // USE_ISPC
 
-  ispc::winograd_TransformIn_ispc( batch_size, input,channels,&V_[0]);
+  ispc::winograd_TransformIn_ispc(batch_size, input, channels, &V_[0]);
 
-#endif // USE_ISPC
-
+#endif  // USE_ISPC
 }
-
-
 
 void WinogradConvolution3::Sgemm(const size_t batch_size, const float* weights,
                                  const size_t input_channels,
@@ -293,7 +286,6 @@ void WinogradConvolution3::Sgemm(const size_t batch_size, const float* weights,
 #endif
 }
 
-
 void WinogradConvolution3::TransformOut(const size_t batch_size, float* output,
                                         const size_t channels) {
 #ifndef USE_ISPC
@@ -353,11 +345,11 @@ void WinogradConvolution3::TransformOut(const size_t batch_size, float* output,
     }
   }
 
-#else // USE_ISPC
+#else  // USE_ISPC
 
-  ispc::winograd_TransformOut_ispc( batch_size, &M_[0],channels,output);
+  ispc::winograd_TransformOut_ispc(batch_size, &M_[0], channels, output);
 
-#endif // USE_ISPC
+#endif  // USE_ISPC
 }
 
 }  // namespace lczero

--- a/src/neural/cache.cc
+++ b/src/neural/cache.cc
@@ -48,7 +48,7 @@ bool CachingComputation::AddInputByHash(uint64_t hash) {
   return true;
 }
 
-void CachingComputation::PopInput() {
+void CachingComputation::PopCacheHit() {
   assert(!batch_.empty());
   assert(batch_.back().lock);
   assert(batch_.back().idx_in_parent == -1);

--- a/src/neural/cache.cc
+++ b/src/neural/cache.cc
@@ -48,6 +48,13 @@ bool CachingComputation::AddInputByHash(uint64_t hash) {
   return true;
 }
 
+void CachingComputation::PopInput() {
+  assert(!batch_.empty());
+  assert(batch_.back().lock);
+  assert(batch_.back().idx_in_parent == -1);
+  batch_.pop_back();
+}
+
 void CachingComputation::AddInput(
     uint64_t hash, InputPlanes&& input,
     std::vector<uint16_t>&& probabilities_to_cache) {

--- a/src/neural/cache.h
+++ b/src/neural/cache.h
@@ -75,7 +75,7 @@ class CachingComputation {
   float GetPVal(int sample, int move_id) const;
   // Pops last input from the computation. Only allowed for inputs which were
   // cached.
-  void PopInput();
+  void PopCacheHit();
 
  private:
   struct WorkItem {

--- a/src/neural/cache.h
+++ b/src/neural/cache.h
@@ -73,7 +73,8 @@ class CachingComputation {
   float GetQVal(int sample) const;
   // Returns P value @move_id of @sample.
   float GetPVal(int sample, int move_id) const;
-  // Pops last input from the computation. Only allowed for inputs from cache.
+  // Pops last input from the computation. Only allowed for inputs which were
+  // cached.
   void PopInput();
 
  private:

--- a/src/neural/cache.h
+++ b/src/neural/cache.h
@@ -73,6 +73,8 @@ class CachingComputation {
   float GetQVal(int sample) const;
   // Returns P value @move_id of @sample.
   float GetPVal(int sample, int move_id) const;
+  // Pops last input from the computation. Only allowed for inputs from cache.
+  void PopInput();
 
  private:
   struct WorkItem {


### PR DESCRIPTION
Currently if the first node in a batch turns out to be a cache hit, it's back-propagated immediately without gathering full batch and without querying NN.

This PR extends that (behind `--out-of-order-eval` flag) to:
- Cache hit at any index in the batch
- Also to terminal nodes

When during the batch collection such node is encountered, it's processed out of order. On the next iteration, batch gathering continues from where previous attempt stopped.

Gives +8% nps.
(Having `--cache-history-length=0` with that change gives +12% nps on top of that, may be worth to reconsider using it, maybe it will translate to Elo gain this time)