### PR TITLE
Change "full" depth to average depth

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstring>
 #include <iostream>
 #include <sstream>

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -193,22 +193,10 @@ void Node::FinalizeScoreUpdate(float v) {
   --n_in_flight_;
 }
 
-void Node::UpdateMaxDepth(int depth) {
-  if (depth > max_depth_) max_depth_ = depth;
-}
-
-bool Node::UpdateFullDepth(uint16_t* depth) {
-  // TODO(crem) If this function won't be needed, consider also killing
-  //            ChildNodes/NodeRange/Nodes_Iterator.
-  if (full_depth_ > *depth) return false;
-  for (Node* child : ChildNodes()) {
-    if (*depth > child->full_depth_) *depth = child->full_depth_;
-  }
-  if (*depth >= full_depth_) {
-    full_depth_ = ++*depth;
-    return true;
-  }
-  return false;
+uint16_t Node::GetAverageDepth() const {
+  float ret =   static_cast<float>(cumulative_depth_)
+              / static_cast<float>(n_ - 1); // Exclude "this" node.
+  return static_cast<uint16_t>(std::round(ret));
 }
 
 Node::NodeRange Node::ChildNodes() const { return child_.get(); }

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -29,7 +29,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cmath>
 #include <cstring>
 #include <iostream>
 #include <sstream>
@@ -191,12 +190,6 @@ void Node::FinalizeScoreUpdate(float v) {
   ++n_;
   // Decrement virtual loss.
   --n_in_flight_;
-}
-
-uint16_t Node::GetAverageDepth() const {
-  float ret =   static_cast<float>(cumulative_depth_)
-              / static_cast<float>(n_ - 1); // Exclude "this" node.
-  return static_cast<uint16_t>(std::round(ret));
 }
 
 Node::NodeRange Node::ChildNodes() const { return child_.get(); }

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -175,10 +175,10 @@ class Node {
   void FinalizeScoreUpdate(float v);
 
   // Depth tracking and retrieval functions.
-  void UpdateMaxDepth(const uint16_t& depth) {
+  void UpdateMaxDepth(const uint16_t depth) {
     if (depth > max_depth_) max_depth_ = depth;
   }
-  void UpdateAverageDepth(const uint16_t& depth) {
+  void UpdateAverageDepth(const uint16_t depth) {
     // Denominator should be total+1, but we exclude the root from the average.
     average_depth_ += (depth - average_depth_) / n_;
   }

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -177,9 +178,15 @@ class Node {
   void UpdateMaxDepth(const uint16_t& depth) {
     if (depth > max_depth_) max_depth_ = depth;
   }
+  void UpdateAverageDepth(const uint16_t& depth) {
+    // Denominator should be total+1, but we exclude the root from the average.
+    average_depth_ += (depth - average_depth_) / n_;
+  }
+
   uint16_t GetMaxDepth() const { return max_depth_; }
-  void UpdateAverageDepth(const uint16_t& depth) { cumulative_depth_ += depth; }
-  uint16_t GetAverageDepth() const;
+  uint16_t GetAverageDepth() const {
+    return static_cast<uint16_t>(std::round(average_depth_));
+  }
 
   V3TrainingData GetV3TrainingData(GameResult result,
                                    const PositionHistory& history) const;
@@ -227,7 +234,7 @@ class Node {
   // Maximum depth any subnodes of this node were looked at.
   uint16_t max_depth_ = 0;
   // Running total depth of all searched nodes.
-  uint32_t cumulative_depth_ = 0;
+  float average_depth_ = 0.0f;
 
   // Does this node end game (with a winning of either sides or draw).
   bool is_terminal_ = false;

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -156,10 +156,6 @@ class Node {
 
   // Returns whether the node is known to be draw/lose/win.
   bool IsTerminal() const { return is_terminal_; }
-  uint16_t GetFullDepth() const { return full_depth_; }
-  uint16_t GetMaxDepth() const { return max_depth_; }
-  uint16_t GetNumEdges() const { return edges_.size(); }
-
   // Makes the node terminal and sets it's score.
   void MakeTerminal(GameResult result);
 
@@ -177,15 +173,18 @@ class Node {
   // * N-in-flight (-=1)
   void FinalizeScoreUpdate(float v);
 
-  // Updates max depth, if new depth is larger.
-  void UpdateMaxDepth(int depth);
-
-  // Calculates the full depth if new depth is larger, updates it, returns
-  // in depth parameter, and returns true if it was indeed updated.
-  bool UpdateFullDepth(uint16_t* depth);
+  // Depth tracking and retrieval functions.
+  void UpdateMaxDepth(const uint16_t& depth) {
+    if (depth > max_depth_) max_depth_ = depth;
+  }
+  uint16_t GetMaxDepth() const { return max_depth_; }
+  void UpdateAverageDepth(const uint16_t& depth) { cumulative_depth_ += depth; }
+  uint16_t GetAverageDepth() const;
 
   V3TrainingData GetV3TrainingData(GameResult result,
                                    const PositionHistory& history) const;
+
+  uint16_t GetNumEdges() const { return edges_.size(); }
 
   // Returns range for iterating over edges.
   ConstIterator Edges() const;
@@ -227,8 +226,9 @@ class Node {
 
   // Maximum depth any subnodes of this node were looked at.
   uint16_t max_depth_ = 0;
-  // Complete depth all subnodes of this node were fully searched.
-  uint16_t full_depth_ = 0;
+  // Running total depth of all searched nodes.
+  uint32_t cumulative_depth_ = 0;
+
   // Does this node end game (with a winning of either sides or draw).
   bool is_terminal_ = false;
 

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include <cmath>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -185,7 +184,7 @@ class Node {
 
   uint16_t GetMaxDepth() const { return max_depth_; }
   uint16_t GetAverageDepth() const {
-    return static_cast<uint16_t>(std::round(average_depth_));
+    return static_cast<uint16_t>(average_depth_ + 0.5f);
   }
 
   V3TrainingData GetV3TrainingData(GameResult result,


### PR DESCRIPTION
Since there remain major disagreements about the performance of recalculating reused-tree depths outside of the Search code, this patch instead leaves the updated depth inside the Node structure, as currently exists in master. Even so, it's still technically less cpu cycles, although probably trivially so. It is also +2 bytes in Node, but it seems that these +2 bytes are already wasted by alignment, so at least on g++/x86 compiles, this is memory neutral. With this patch: `Move size 2 for estimated Edge size 6 vs actual Edge size 8 Node size 72 for total estimated bytes/Node of 352` and on master: `Move size 2 for estimated Edge size 6 vs actual Edge size 8 Node size 72 for total estimated bytes/Node of 352`. I'm pretty sure it didn't used to be this way until the introduction of the cached TotalVisitedPolicy thing, I guess that extra float is causing the alignment problem. (And yes, I double-triple checked I was actually using master when running the comparison.)

So it seems that this patch is strictly better than status quo, being identical memory and trivially less cpu, and also having the benefit that "full" depth is replaced with something much more [useful](https://github.com/LeelaChessZero/lc0/pull/124#issue-198461389) yet which also satisfies my "one move analysis, one depth" [criterion](https://github.com/LeelaChessZero/lc0/issues/86#issuecomment-408179482). (In particular, full depth is bugged with having sometimes depth > 1000 output, but most importantly, it always shows the ~same value for nearly all searches of any sort, including trees that are order of magnitudes different in size, or trees which are the same size but wildly different shape. Average depth fixes all these problems.)

Although I haven't had time to investigate further about the performance of my old PR #160, which I still provisionally believe to be superior pending further investigation (several bytes fewer memory, less total cpu time, less cpu time in search code), I'm willing to close that one if this one is approved.