### PR TITLE
Remove use of popcnt, fixes #174.

### DIFF
--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -709,14 +709,14 @@ bool ChessBoard::HasMatingMaterial() const {
     return true;
   }
 
-#ifdef _MSC_VER
-  int our = _mm_popcnt_u64(our_pieces_.as_int());
-  int their = _mm_popcnt_u64(their_pieces_.as_int());
-#else
-  int our = __builtin_popcountll(our_pieces_.as_int());
-  int their = __builtin_popcountll(their_pieces_.as_int());
-#endif
-  if (our + their < 4) {
+  // All the pieces together.
+  uint64_t x = our_pieces_.as_int() | their_pieces_.as_int();
+  // x &= x - 1 clears the rigthmost bit.
+  x &= x - 1;
+  x &= x - 1;
+  x &= x - 1;
+  // If x zero we started with 3 or less bits set.
+  if (x == 0) {
     // K v K, K+B v K, K+N v K.
     return false;
   }

--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -711,7 +711,7 @@ bool ChessBoard::HasMatingMaterial() const {
 
   // All the pieces together.
   uint64_t x = our_pieces_.as_int() | their_pieces_.as_int();
-  // x &= x - 1 clears the rigthmost bit.
+  // x &= x - 1 clears the rigthmost set bit (if any).
   x &= x - 1;
   x &= x - 1;
   x &= x - 1;


### PR DESCRIPTION
The popcnt instruction is not supported on older core processors. The fact that even on those this is only rarely encountered shows this is not a speed critical piece of code. However since it was used just to check for less than 4 pieces on the board, the replacement code can be very efficient. Microbenchmarks show the new code to be slightly faster than a single popcnt call, but it replaces two of them so it should be a win regardless. 