### PR TITLE
Implement Configuration Files

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,7 @@ files += [
   'src/selfplay/loop.cc',
   'src/selfplay/tournament.cc',
   'src/utils/commandline.cc',
+  'src/utils/configfile.cc',
   'src/utils/optionsdict.cc',
   'src/utils/optionsparser.cc',
   'src/utils/random.cc',

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -254,7 +254,7 @@ EngineLoop::EngineLoop()
 }
 
 void EngineLoop::RunLoop() {
-  if (!options_.ProcessAllFlags()) return;
+  if (!ConfigFile::Init(&options_) || !options_.ProcessAllFlags()) return;
   UciLoop::RunLoop();
 }
 

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -33,6 +33,7 @@
 #include "mcts/search.h"
 #include "neural/factory.h"
 #include "neural/loader.h"
+#include "utils/configfile.h"
 
 namespace lczero {
 namespace {
@@ -96,6 +97,8 @@ void EngineController::PopulateOptions(OptionsParser* options) {
                             "time-curve-right-width") = 74.0f;
 
   Search::PopulateUciParams(options);
+
+  ConfigFile::PopulateOptions(options);
 
   auto defaults = options->GetMutableDefaultsOptions();
 

--- a/src/selfplay/loop.cc
+++ b/src/selfplay/loop.cc
@@ -27,6 +27,7 @@
 
 #include "selfplay/loop.h"
 #include "selfplay/tournament.h"
+#include "utils/configfile.h"
 
 namespace lczero {
 
@@ -45,7 +46,7 @@ void SelfPlayLoop::RunLoop() {
   options_.Add<BoolOption>(kInteractive, "interactive") = false;
   SelfPlayTournament::PopulateOptions(&options_);
 
-  if (!options_.ProcessAllFlags()) return;
+  if (!ConfigFile::Init(&options_) || !options_.ProcessAllFlags()) return;
   if (options_.GetOptionsDict().Get<bool>(kInteractive)) {
     UciLoop::RunLoop();
   } else {

--- a/src/utils/configfile.cc
+++ b/src/utils/configfile.cc
@@ -1,0 +1,49 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#include "utils/configfile.h"
+#include "utils/optionsparser.h"
+
+namespace lczero {
+  namespace {
+    const char* kConfigFileStr = "Configuration file path";
+    const char* kDefaultConfigFile = ".config";
+  }
+
+std::vector<std::string> ConfigFile::arguments_;
+
+void ConfigFile::Init() {
+  arguments_.clear();
+  //for (int i = 1; i < argc; ++i) arguments_.push_back(argv[i]);
+}
+
+void ConfigFile::PopulateOptions(OptionsParser* options) {
+  options->Add<StringOption>(kConfigFileStr, "config", 'c') = kDefaultConfigFile;
+  auto parser = *options;
+}
+
+}  // namespace lczero

--- a/src/utils/configfile.cc
+++ b/src/utils/configfile.cc
@@ -25,6 +25,10 @@
   Program grant you additional permission to convey the resulting work.
 */
 
+#include <iostream>
+#include <string>
+
+#include "utils/commandline.h"
 #include "utils/configfile.h"
 #include "utils/optionsparser.h"
 
@@ -36,14 +40,34 @@ namespace lczero {
 
 std::vector<std::string> ConfigFile::arguments_;
 
-void ConfigFile::Init() {
-  arguments_.clear();
-  //for (int i = 1; i < argc; ++i) arguments_.push_back(argv[i]);
-}
-
 void ConfigFile::PopulateOptions(OptionsParser* options) {
   options->Add<StringOption>(kConfigFileStr, "config", 'c') = kDefaultConfigFile;
-  auto parser = *options;
+}
+
+bool ConfigFile::Init(OptionsParser* options) {
+  arguments_.clear();
+  //for (int i = 1; i < argc; ++i) arguments_.push_back(argv[i]);
+
+  // Process flags to get the config file parameter.
+  if (!options->ProcessAllFlags()) return false;
+  
+  // Get the config file parameter passed on the command line or the default.
+  OptionsDict dict = options->GetOptionsDict();
+  std::string filename = dict.Get<std::string>(kConfigFileStr);
+  filename = CommandLine::BinaryDirectory() + "/" + filename;
+
+  std::cout << "debug: config=" << filename << std::endl;
+
+  // Read the file into the args string.
+  std::string args;
+  if (!ParseFile(filename, args)) return false;
+
+  return true;
+}
+
+bool ConfigFile::ParseFile(std::string filename, std::string& args) {
+
+  return true;
 }
 
 }  // namespace lczero

--- a/src/utils/configfile.h
+++ b/src/utils/configfile.h
@@ -49,7 +49,7 @@ class ConfigFile {
 
  private:
   // Reads the config file into a 1 line string.
-  static bool ParseFile(std::string filename, std::string& args);
+  static bool ParseFile(std::string filename, std::string& args, bool def);
 
   static std::vector<std::string> arguments_;
 };

--- a/src/utils/configfile.h
+++ b/src/utils/configfile.h
@@ -1,0 +1,54 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace lczero {
+
+class OptionsParser;
+
+class ConfigFile {
+ public:
+  ConfigFile() = delete;
+
+  // This function must be called before any other.
+  static void Init();
+
+  // Config file arguments.
+  static const std::vector<std::string>& Arguments() { return arguments_; }
+
+  // Add the config file parameter to the options dictionary
+  static void PopulateOptions(OptionsParser* options);
+
+ private:
+  static std::vector<std::string> arguments_;
+};
+
+}  // namespace lczero

--- a/src/utils/configfile.h
+++ b/src/utils/configfile.h
@@ -38,16 +38,19 @@ class ConfigFile {
  public:
   ConfigFile() = delete;
 
-  // This function must be called before any other.
-  static void Init();
+  // This function must be called after PopulateOptions.
+  static bool Init(OptionsParser* options);
 
   // Config file arguments.
   static const std::vector<std::string>& Arguments() { return arguments_; }
 
-  // Add the config file parameter to the options dictionary
+  // Add the config file parameter to the options dictionary.
   static void PopulateOptions(OptionsParser* options);
 
  private:
+  // Reads the config file into a 1 line string.
+  static bool ParseFile(std::string filename, std::string& args);
+
   static std::vector<std::string> arguments_;
 };
 

--- a/src/utils/optionsparser.cc
+++ b/src/utils/optionsparser.cc
@@ -31,6 +31,7 @@
 #include <iostream>
 #include <sstream>
 #include "utils/commandline.h"
+#include "utils/configfile.h"
 
 namespace lczero {
 
@@ -89,10 +90,14 @@ const OptionsDict& OptionsParser::GetOptionsDict(const std::string& context) {
 }
 
 bool OptionsParser::ProcessAllFlags() {
+  if (!ProcessFlags(ConfigFile::Arguments()) 
+    || !ProcessFlags(CommandLine::Arguments())) return false;
+  return true;
+}  
+
+bool OptionsParser::ProcessFlags(const std::vector<std::string>& args) {
   std::string context;
-  for (auto iter = CommandLine::Arguments().begin(),
-            end = CommandLine::Arguments().end();
-       iter != end; ++iter) {
+  for (auto iter = args.begin(), end = args.end(); iter != end; ++iter) {
     std::string param = *iter;
     if (param == "-h" || param == "--help") {
       ShowHelp();

--- a/src/utils/optionsparser.h
+++ b/src/utils/optionsparser.h
@@ -101,7 +101,7 @@ class OptionsParser {
   // Call option setter all options.
   void SendAllOptions();
   // Processes all flags from the command line and an optional
-  // configuration file. Returns false if should exit.
+  // configuration file. Returns false if there is an invalid flag.
   bool ProcessAllFlags();
   // Processes either the command line or configuration file flags.
   bool ProcessFlags(const std::vector<std::string>& args);

--- a/src/utils/optionsparser.h
+++ b/src/utils/optionsparser.h
@@ -100,8 +100,11 @@ class OptionsParser {
   void SendOption(const std::string& name);
   // Call option setter all options.
   void SendAllOptions();
-  // Processes all flags. Returns false if should exit.
+  // Processes all flags from the command line and an optional
+  // configuration file. Returns false if should exit.
   bool ProcessAllFlags();
+  // Processes either the command line or configuration file flags.
+  bool ProcessFlags(const std::vector<std::string>& args);
 
   // Get the options dict for given context.
   const OptionsDict& GetOptionsDict(const std::string& context = {});

--- a/src/utils/string.cc
+++ b/src/utils/string.cc
@@ -27,6 +27,7 @@
 
 #include "utils/string.h"
 
+#include <algorithm>
 #include <sstream>
 #include <vector>
 
@@ -68,6 +69,22 @@ std::vector<int> ParseIntList(const std::string& str) {
     result.push_back(std::stoi(x));
   }
   return result;
+}
+
+std::string& LeftTrim(std::string& s) {
+  s.erase(s.begin(), std::find_if(s.begin(),
+    s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+  return s;
+}
+
+std::string& RightTrim(std::string& s) {
+  s.erase(std::find_if(s.rbegin(), s.rend(), 
+    std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+  return s;
+}
+
+std::string& Trim(std::string& s) {
+  return LeftTrim(RightTrim(s));
 }
 
 }  // namespace lczero

--- a/src/utils/string.h
+++ b/src/utils/string.h
@@ -46,4 +46,13 @@ std::vector<std::string> StrSplit(const std::string& str,
 // Parses comma-separated list of integers.
 std::vector<int> ParseIntList(const std::string& str);
 
+// Trim string from the start.
+std::string& LeftTrim(std::string& s);
+
+// Trim string froml the end.
+std::string& RightTrim(std::string& s);
+
+// Trim the string from both ends.
+std::string& Trim(std::string& s);
+
 }  // namespace lczero

--- a/src/utils/string.h
+++ b/src/utils/string.h
@@ -49,7 +49,7 @@ std::vector<int> ParseIntList(const std::string& str);
 // Trim string from the start.
 std::string& LeftTrim(std::string& s);
 
-// Trim string froml the end.
+// Trim string from the end.
 std::string& RightTrim(std::string& s);
 
 // Trim the string from both ends.


### PR DESCRIPTION
This PR will hopefully satisfy the https://github.com/LeelaChessZero/lc0/issues/19 help request.

The configuration file layout in the PR simply uses the same command syntax that you would use on the command line.  You also have the option to put each flag on a different line if you choose.  An "#" symbol at the beginning of the line is treated like a comment.  For example:

```
#this line is a comment
       #this line is also a comment
-t 1
--minibatch-size=128
#--minibatch-size=256
--max-prefetch=0
```
Will be the same as a command line that looks like:

`-t 1 --minibatch-size=128 --max-prefetch=0`

Parameters on the command line override parameters in the config file.  For instance:

`./lc0 -t 2`

This will cause two threads to be used instead of the one specified in the config file.

The default configuration file is currently set to .config.  This can be changed by using the new -c/--config command line option.

This has not been tested on Windows or Mac.