### PR TITLE
Pruning rename

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -49,7 +49,8 @@ const char* Search::kTemperatureStr = "Initial temperature";
 const char* Search::kTempDecayMovesStr = "Moves with temperature decay";
 const char* Search::kNoiseStr = "Add Dirichlet noise at root node";
 const char* Search::kVerboseStatsStr = "Display verbose move stats";
-const char* Search::kAggressiveTimePruningStr = "Aggressive smart pruning threshold";
+const char* Search::kTimePruningStr = "Time pruning aggression";
+const char* Search::kNodePruningStr = "Node pruning";
 const char* Search::kFpuReductionStr = "First Play Urgency Reduction";
 const char* Search::kCacheHistoryLengthStr =
     "Length of history to include in cache";
@@ -78,8 +79,9 @@ void Search::PopulateUciParams(OptionsParser* options) {
   options->Add<IntOption>(kTempDecayMovesStr, 0, 100, "tempdecay-moves") = 0;
   options->Add<BoolOption>(kNoiseStr, "noise", 'n') = false;
   options->Add<BoolOption>(kVerboseStatsStr, "verbose-move-stats") = false;
-  options->Add<FloatOption>(kAggressiveTimePruningStr, 0.0f, 10.0f,
-                            "smart-pruning-aggresiveness") = 0.68f;
+  options->Add<FloatOption>(kTimePruningStr, 0.0f, 10.0f,
+                            "time-pruning") = 0.68f;
+  options->Add<BoolOption>(kNodePruningStr, "node-pruning") = false;
   options->Add<FloatOption>(kFpuReductionStr, -100.0f, 100.0f,
                             "fpu-reduction") = 0.0f;
   options->Add<IntOption>(kCacheHistoryLengthStr, 0, 7,
@@ -111,7 +113,8 @@ Search::Search(const NodeTree& tree, Network* network,
       kTempDecayMoves(options.Get<int>(kTempDecayMovesStr)),
       kNoise(options.Get<bool>(kNoiseStr)),
       kVerboseStats(options.Get<bool>(kVerboseStatsStr)),
-      kAggressiveTimePruning(options.Get<float>(kAggressiveTimePruningStr)),
+      kTimePruning(options.Get<float>(kTimePruningStr)),
+      kNodePruning(options.Get<bool>(kNodePruningStr)),
       kFpuReduction(options.Get<float>(kFpuReductionStr)),
       kCacheHistoryLength(options.Get<int>(kCacheHistoryLengthStr)),
       kPolicySoftmaxTemp(options.Get<float>(kPolicySoftmaxTempStr)),
@@ -297,11 +300,11 @@ void Search::MaybeTriggerStop() {
 }
 
 void Search::UpdateRemainingMoves() {
-  if (kAggressiveTimePruning <= 0.0f) return;
+  if (kTimePruning <= 0.0f && !kNodePruning) return;
   SharedMutex::Lock lock(nodes_mutex_);
   remaining_playouts_ = std::numeric_limits<int>::max();
   // Check for how many playouts there is time remaining.
-  if (limits_.time_ms >= 0) {
+  if (kTimePruning > 0.0f && limits_.time_ms >= 0) {
     auto time_since_start = GetTimeSinceStart();
     if (time_since_start > kSmartPruningToleranceMs) {
       auto nps = (1000LL * total_playouts_ + kSmartPruningToleranceNodes) /
@@ -309,14 +312,14 @@ void Search::UpdateRemainingMoves() {
                  1;
       int64_t remaining_time = limits_.time_ms - time_since_start;
       // Put early_exit scaler here so calculation doesn't have to be done on every node.
-      int64_t remaining_playouts = kAggressiveTimePruning * remaining_time * nps / 1000;
+      int64_t remaining_playouts = kTimePruning * remaining_time * nps / 1000;
       // Don't assign directly to remaining_playouts_ as overflow is possible.
       if (remaining_playouts < remaining_playouts_)
         remaining_playouts_ = remaining_playouts;
     }
   }
   // Check how many visits are left.
-  if (limits_.visits >= 0) {
+  if (kNodePruning && limits_.visits >= 0) {
     // Add kMiniBatchSize, as it's possible to exceed visits limit by that
     // number.
     auto remaining_visits =
@@ -325,7 +328,7 @@ void Search::UpdateRemainingMoves() {
     if (remaining_visits < remaining_playouts_)
       remaining_playouts_ = remaining_visits;
   }
-  if (limits_.playouts >= 0) {
+  if (kNodePruning && limits_.playouts >= 0) {
     // Add kMiniBatchSize, as it's possible to exceed visits limit by that
     // number.
     auto remaining_playouts =

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -650,7 +650,8 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend() {
     }
 
     history_.Append(best_edge.GetMove());
-    if (is_root_node && possible_moves <= 1 && !search_->limits_.infinite) {
+    if (search_->kNodePruning && is_root_node &&
+        possible_moves <= 1 && !search_->limits_.infinite) {
       // If there is only one move theoretically possible within remaining time,
       // output it.
       Mutex::Lock counters_lock(search_->counters_mutex_);

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -97,7 +97,8 @@ class Search {
   static const char* kTempDecayMovesStr;
   static const char* kNoiseStr;
   static const char* kVerboseStatsStr;
-  static const char* kAggressiveTimePruningStr;
+  static const char* kTimePruningStr;
+  static const char* kNodePruningStr;
   static const char* kFpuReductionStr;
   static const char* kCacheHistoryLengthStr;
   static const char* kPolicySoftmaxTempStr;
@@ -170,7 +171,8 @@ class Search {
   const int kTempDecayMoves;
   const bool kNoise;
   const bool kVerboseStats;
-  const float kAggressiveTimePruning;
+  const float kTimePruning;
+  const bool kNodePruning;
   const float kFpuReduction;
   const bool kCacheHistoryLength;
   const float kPolicySoftmaxTemp;

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -83,10 +83,11 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   SelfPlayGame::PopulateUciParams(options);
   auto defaults = options->GetMutableDefaultsOptions();
   defaults->Set<int>(Search::kMiniBatchSizeStr, 32);     // Minibatch size
-  defaults->Set<float>(Search::kAggressiveTimePruningStr, 0.0f);  // No smart pruning
-  defaults->Set<float>(Search::kTemperatureStr, 1.0f);    // Temperature = 1.0
+  defaults->Set<float>(Search::kTimePruningStr, 0.0f);   // No smart pruning
+  defaults->Set<bool>(Search::kNodePruningStr, false);   // Ditto
+  defaults->Set<float>(Search::kTemperatureStr, 1.0f);   // Temperature = 1.0
   defaults->Set<bool>(Search::kNoiseStr, true);          // Dirichlet noise
-  defaults->Set<float>(Search::kFpuReductionStr, 0.0f);   // No FPU reduction.
+  defaults->Set<float>(Search::kFpuReductionStr, 0.0f);  // No FPU reduction.
 }
 
 SelfPlayTournament::SelfPlayTournament(const OptionsDict& options,


### PR DESCRIPTION
Alternative to #230 , separating time pruning from node pruning.

Things I'm not sure about: the name "node pruning", perhaps "visit pruning" would be better?; the description string for this option is in need of help too

Things I'm more sure about but willing to change: node pruning default off.

This would also "fix" the behavior of not searching forced moves, which might mess with resign.