### PR TITLE
Print where weights are loaded from when no auto discover.

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -181,6 +181,8 @@ void EngineController::UpdateNetwork() {
   std::string net_path = network_path;
   if (net_path == kAutoDiscover) {
     net_path = DiscoverWeightsFile();
+  } else {
+    std::cerr << "Loading weights file from: " << net_path << std::endl;
   }
   Weights weights = LoadWeightsFromFile(net_path);
 


### PR DESCRIPTION
Currently the weights file is only printed when found through auto discovery.  With config files, it would also be nice to see it always printed as a sanity check.