### PR TITLE
ispc  fix linking error

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -199,7 +199,7 @@ if get_option('build_backends')
     endif
 
     ispc = find_program('ispc', required: false)
-
+    ispc_extra_args = []
     if has_blas and get_option('ispc') and ispc.found()
       ispc_native_only = get_option('ispc_native_only')
       if host_machine.system() == 'windows'
@@ -210,7 +210,8 @@ if get_option('build_backends')
 			    '@BASENAME@_avx2.obj' ]
 	endif
       else
-        outputnames = [ '@BASENAME@.o']
+	ispc_extra_args += ['--pic']
+	outputnames = [ '@BASENAME@.o']
 	if not ispc_native_only
 	   outputnames += ['@BASENAME@_sse2.o', '@BASENAME@_sse4.o', 
                            '@BASENAME@_avx.o', '@BASENAME@_avx11.o',
@@ -224,9 +225,10 @@ if get_option('build_backends')
       endif
       iscp_gen = generator(ispc,
         output: [ '@BASENAME@_ispc.h', outputnames ],
-        arguments: [ '-O2', '--arch=x86-64', '--pic',
+        arguments: [ '-O2', '--arch=x86-64',
                      '--target=' + ispc_target,
                      '@INPUT@', '-o', '@OUTPUT1@' ,'-h', '@OUTPUT0@' ]
+                     + ispc_extra_args
       )
     endif
 

--- a/meson.build
+++ b/meson.build
@@ -224,7 +224,7 @@ if get_option('build_backends')
       endif
       iscp_gen = generator(ispc,
         output: [ '@BASENAME@_ispc.h', outputnames ],
-        arguments: [ '-O2', '--arch=x86-64',
+        arguments: [ '-O2', '--arch=x86-64', '--pic',
                      '--target=' + ispc_target,
                      '@INPUT@', '-o', '@OUTPUT1@' ,'-h', '@OUTPUT0@' ]
       )

--- a/meson.build
+++ b/meson.build
@@ -204,18 +204,18 @@ if get_option('build_backends')
       ispc_native_only = get_option('ispc_native_only')
       if host_machine.system() == 'windows'
         outputnames = [ '@BASENAME@.obj']
-	if not ispc_native_only
-	    outputnames += ['@BASENAME@_sse2.obj', '@BASENAME@_sse4.obj',
-                            '@BASENAME@_avx.obj', '@BASENAME@_avx11.obj',
-			    '@BASENAME@_avx2.obj' ]
-	endif
+        if not ispc_native_only
+          outputnames += ['@BASENAME@_sse2.obj', '@BASENAME@_sse4.obj',
+                          '@BASENAME@_avx.obj', '@BASENAME@_avx11.obj',
+                          '@BASENAME@_avx2.obj' ]
+        endif
       else
-	ispc_extra_args += ['--pic']
-	outputnames = [ '@BASENAME@.o']
-	if not ispc_native_only
-	   outputnames += ['@BASENAME@_sse2.o', '@BASENAME@_sse4.o', 
+        ispc_extra_args += ['--pic']
+        outputnames = [ '@BASENAME@.o']
+        if not ispc_native_only
+          outputnames += ['@BASENAME@_sse2.o', '@BASENAME@_sse4.o', 
                            '@BASENAME@_avx.o', '@BASENAME@_avx11.o',
-			   '@BASENAME@_avx2.o' ]
+                           '@BASENAME@_avx2.o' ]
         endif
       endif
       if ispc_native_only


### PR DESCRIPTION
Adding `--pic` flag (position independent code) solves linking error with object code generated from ispc. This also allows building binary with multiple architectures, that was for this error disabled with meson flag  `ispc_native_only`

Error that should be fixed:
`../winograd_ispc.o: relocation R_X86_64_32S against .rodata.cst32 can not be used when making a PIE object; recompile with -fPIC`
