### PR TITLE
Port syzygy to lc0 movegen.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -399,4 +399,9 @@ if get_option('gtest') and gtest.found()
     files, include_directories: includes, dependencies: test_deps
   ), timeout: 90)
 
+  test('SyzygyTest',
+    executable('syzygy_test', 'src/syzygy/syzygy_test.cc',
+    files, include_directories: includes, dependencies: test_deps
+  ), timeout: 90)
+
 endif

--- a/meson.build
+++ b/meson.build
@@ -86,6 +86,7 @@ files += [
   'src/selfplay/game.cc',
   'src/selfplay/loop.cc',
   'src/selfplay/tournament.cc',
+  'src/syzygy/syzygy.cc',
   'src/utils/commandline.cc',
   'src/utils/optionsdict.cc',
   'src/utils/optionsparser.cc',

--- a/src/chess/bitboard.h
+++ b/src/chess/bitboard.h
@@ -95,6 +95,13 @@ class BitBoard {
 
   std::uint64_t as_int() const { return board_; }
   void clear() { board_ = 0; }
+  int count() const {
+#ifdef _MSC_VER
+    return _mm_popcnt_u64(board_);
+#else
+    return __builtin_popcountll(board_);
+#endif
+  }
 
   // Sets the value for given square to 1 if cond is true.
   // Otherwise does nothing (doesn't reset!).

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -1327,6 +1327,10 @@ class SyzygyTablebaseImpl {
   std::vector<TbHashEntry> tbHash_;
 };
 
+SyzygyTablebase::SyzygyTablebase() : max_cardinality_(0) {}
+
+SyzygyTablebase::~SyzygyTablebase() = default;
+ 
 void SyzygyTablebase::init(const std::string& paths) {
   paths_ = paths;
   impl_.reset(new SyzygyTablebaseImpl(paths_));

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -1,0 +1,1557 @@
+/*
+ * Original from cfish tbprobe.c
+ * Copyright (c) 2013-2018 Ronald de Man
+ * This file may be redistributed and/or modified without restrictions.
+ */
+
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <random>
+#include <sstream>
+#include <string>
+
+#include "syzygy/syzygy.h"
+
+#include "utils/mutex.h"
+
+#ifndef _WIN32
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#else
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
+namespace lczero {
+
+namespace {
+
+#define TB_PIECES 7
+#define TB_HASHBITS (TB_PIECES < 7 ? 11 : 12)
+#define TB_MAX_PIECE (TB_PIECES < 7 ? 254 : 650)
+#define TB_MAX_PAWN (TB_PIECES < 7 ? 256 : 861)
+
+#ifdef _WIN32
+typedef HANDLE map_t;
+#define SEP_CHAR ';'
+#else
+typedef size_t map_t;
+#define SEP_CHAR ':'
+#endif
+
+const char* tbSuffix[] = {".rtbw", ".rtbm", ".rtbz"};
+uint32_t tbMagic[] = {0x5d23e871, 0x88ac504b, 0xa50c66d7};
+
+enum { WDL, DTM, DTZ };
+enum { PIECE_ENC, FILE_ENC, RANK_ENC };
+typedef uint64_t Key;
+enum PieceType {
+  PAWN = 1,
+  KNIGHT,
+  BISHOP,
+  ROOK,
+  QUEEN,
+  KING,
+};
+enum Piece {
+  W_PAWN = 1,
+  W_KNIGHT,
+  W_BISHOP,
+  W_ROOK,
+  W_QUEEN,
+  W_KING,
+  B_PAWN = 9,
+  B_KNIGHT,
+  B_BISHOP,
+  B_ROOK,
+  B_QUEEN,
+  B_KING,
+};
+
+struct PairsData {
+  uint8_t* indexTable;
+  uint16_t* sizeTable;
+  uint8_t* data;
+  uint16_t* offset;
+  uint8_t* symLen;
+  uint8_t* symPat;
+  uint8_t blockSize;
+  uint8_t idxBits;
+  uint8_t minLen;
+  uint8_t constValue[2];
+  uint64_t base[1];  // must be base[1] in C++
+};
+
+struct EncInfo {
+  struct PairsData* precomp;
+  size_t factor[TB_PIECES];
+  uint8_t pieces[TB_PIECES];
+  uint8_t norm[TB_PIECES];
+};
+
+struct BaseEntry {
+  Key key;
+  uint8_t* data[3];
+  map_t mapping[3];
+  std::atomic<bool> ready[3];
+  uint8_t num;
+  bool symmetric, hasPawns, hasDtm, hasDtz;
+  union {
+    bool kk_enc;
+    uint8_t pawns[2];
+  };
+  bool dtmLossOnly;
+};
+
+struct PieceEntry : BaseEntry {
+  struct EncInfo ei[5];  // 2 + 2 + 1
+  uint16_t* dtmMap;
+  uint16_t dtmMapIdx[2][2];
+  void* dtzMap;
+  uint16_t dtzMapIdx[4];
+  uint8_t dtzFlags;
+};
+
+struct PawnEntry : BaseEntry {
+  struct EncInfo ei[24];  // 4 * 2 + 6 * 2 + 4
+  uint16_t* dtmMap;
+  uint16_t dtmMapIdx[6][2][2];
+  void* dtzMap;
+  uint16_t dtzMapIdx[4][4];
+  uint8_t dtzFlags[4];
+  bool dtmSwitched;
+};
+
+struct TbHashEntry {
+  Key key;
+  struct BaseEntry* ptr;
+};
+
+int WdlToDtz[] = {-1, -101, 0, 101, 1};
+
+// DTZ tables don't store valid scores for moves that reset the rule50 counter
+// like captures and pawn moves but we can easily recover the correct dtz of the
+// previous move if we know the position's WDL score.
+int dtz_before_zeroing(WDLScore wdl) { return WdlToDtz[wdl]; }
+
+// Return the sign of a number (-1, 0, 1)
+template <typename T>
+int sign_of(T val) {
+  return (T(0) < val) - (val < T(0));
+}
+
+char PieceToChar[] = " PNBRQK  pnbrqk";
+
+int count_pieces(const ChessBoard& pos, int type, bool theirs) {
+  BitBoard all = theirs ? pos.theirs() : pos.ours();
+  switch (type) {
+    case KING:
+      return 1;
+    case QUEEN:
+      return (all * pos.queens()).count();
+    case ROOK:
+      return (all * pos.rooks()).count();
+    case BISHOP:
+      return (all * pos.bishops()).count();
+    case KNIGHT:
+      return theirs ? pos.their_knights().count() : pos.our_knights().count();
+    case PAWN:
+      return (all * pos.pawns()).count();
+  }
+  assert(false);
+  return 0;
+}
+
+BitBoard pieces(const ChessBoard& pos, int type, bool theirs) {
+  BitBoard all = theirs ? pos.theirs() : pos.ours();
+  switch (type) {
+    case KING:
+      return theirs ? pos.their_king() : pos.our_king();
+    case QUEEN:
+      return all * pos.queens();
+    case ROOK:
+      return all * pos.rooks();
+    case BISHOP:
+      return all * pos.bishops();
+    case KNIGHT:
+      return theirs ? pos.their_knights() : pos.our_knights();
+    case PAWN:
+      return all * pos.pawns();
+  }
+  assert(false);
+  return BitBoard();
+}
+
+// Given a position, produce a text string of the form KQPvKRP, where
+// "KQP" represents the white pieces if flip == false and the black pieces
+// if flip == true.
+void prt_str(const ChessBoard& pos, char* str, bool flip) {
+  bool first_theirs = flip ^ pos.flipped();
+
+  for (int pt = KING; pt >= PAWN; pt--)
+    for (int i = count_pieces(pos, pt, first_theirs); i > 0; i--)
+      *str++ = PieceToChar[pt];
+  *str++ = 'v';
+  for (int pt = KING; pt >= PAWN; pt--)
+    for (int i = count_pieces(pos, pt, !first_theirs); i > 0; i--)
+      *str++ = PieceToChar[pt];
+  *str++ = 0;
+}
+
+#define pchr(i) PieceToChar[QUEEN - (i)]
+#define Swap(a, b) \
+  {                \
+    int tmp = a;   \
+    a = b;         \
+    b = tmp;       \
+  }
+
+#define PIECE(x) (static_cast<PieceEntry*>(x))
+#define PAWN(x) (static_cast<PawnEntry*>(x))
+
+int num_tables(BaseEntry* be, const int type) {
+  return be->hasPawns ? type == DTM ? 6 : 4 : 1;
+}
+
+EncInfo* first_ei(BaseEntry* be, const int type) {
+  return be->hasPawns ? &PAWN(be)->ei[type == WDL ? 0 : type == DTM ? 8 : 20]
+                      : &PIECE(be)->ei[type == WDL ? 0 : type == DTM ? 2 : 4];
+}
+
+const int8_t OffDiag[] = {0,  -1, -1, -1, -1, -1, -1, -1, 1,  0,  -1, -1, -1,
+                          -1, -1, -1, 1,  1,  0,  -1, -1, -1, -1, -1, 1,  1,
+                          1,  0,  -1, -1, -1, -1, 1,  1,  1,  1,  0,  -1, -1,
+                          -1, 1,  1,  1,  1,  1,  0,  -1, -1, 1,  1,  1,  1,
+                          1,  1,  0,  -1, 1,  1,  1,  1,  1,  1,  1,  0};
+
+const uint8_t Triangle[] = {6, 0, 1, 2, 2, 1, 0, 6, 0, 7, 3, 4, 4, 3, 7, 0,
+                            1, 3, 8, 5, 5, 8, 3, 1, 2, 4, 5, 9, 9, 5, 4, 2,
+                            2, 4, 5, 9, 9, 5, 4, 2, 1, 3, 8, 5, 5, 8, 3, 1,
+                            0, 7, 3, 4, 4, 3, 7, 0, 6, 0, 1, 2, 2, 1, 0, 6};
+
+const uint8_t FlipDiag[] = {0,  8,  16, 24, 32, 40, 48, 56, 1,  9,  17, 25, 33,
+                            41, 49, 57, 2,  10, 18, 26, 34, 42, 50, 58, 3,  11,
+                            19, 27, 35, 43, 51, 59, 4,  12, 20, 28, 36, 44, 52,
+                            60, 5,  13, 21, 29, 37, 45, 53, 61, 6,  14, 22, 30,
+                            38, 46, 54, 62, 7,  15, 23, 31, 39, 47, 55, 63};
+
+const uint8_t Lower[] = {28, 0,  1,  2,  3,  4,  5,  6,  0,  29, 7,  8,  9,
+                         10, 11, 12, 1,  7,  30, 13, 14, 15, 16, 17, 2,  8,
+                         13, 31, 18, 19, 20, 21, 3,  9,  14, 18, 32, 22, 23,
+                         24, 4,  10, 15, 19, 22, 33, 25, 26, 5,  11, 16, 20,
+                         23, 25, 34, 27, 6,  12, 17, 21, 24, 26, 27, 35};
+
+const uint8_t Diag[] = {0, 0,  0, 0,  0, 0,  0, 8, 0,  1, 0,  0, 0,  0, 9, 0,
+                        0, 0,  2, 0,  0, 10, 0, 0, 0,  0, 0,  3, 11, 0, 0, 0,
+                        0, 0,  0, 12, 4, 0,  0, 0, 0,  0, 13, 0, 0,  5, 0, 0,
+                        0, 14, 0, 0,  0, 0,  6, 0, 15, 0, 0,  0, 0,  0, 0, 7};
+
+const uint8_t Flap[2][64] = {
+    {0, 0,  0,  0,  0,  0,  0,  0, 0, 6,  12, 18, 18, 12, 6,  0,
+     1, 7,  13, 19, 19, 13, 7,  1, 2, 8,  14, 20, 20, 14, 8,  2,
+     3, 9,  15, 21, 21, 15, 9,  3, 4, 10, 16, 22, 22, 16, 10, 4,
+     5, 11, 17, 23, 23, 17, 11, 5, 0, 0,  0,  0,  0,  0,  0,  0},
+    {0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  2,  3,  3,  2,  1,  0,
+     4,  5,  6,  7,  7,  6,  5,  4,  8,  9,  10, 11, 11, 10, 9,  8,
+     12, 13, 14, 15, 15, 14, 13, 12, 16, 17, 18, 19, 19, 18, 17, 16,
+     20, 21, 22, 23, 23, 22, 21, 20, 0,  0,  0,  0,  0,  0,  0,  0}};
+
+const uint8_t PawnTwist[2][64] = {
+    {0,  0,  0,  0, 0, 0,  0,  0,  47, 35, 23, 11, 10, 22, 34, 46,
+     45, 33, 21, 9, 8, 20, 32, 44, 43, 31, 19, 7,  6,  18, 30, 42,
+     41, 29, 17, 5, 4, 16, 28, 40, 39, 27, 15, 3,  2,  14, 26, 38,
+     37, 25, 13, 1, 0, 12, 24, 36, 0,  0,  0,  0,  0,  0,  0,  0},
+    {0,  0,  0,  0,  0,  0,  0,  0,  47, 45, 43, 41, 40, 42, 44, 46,
+     39, 37, 35, 33, 32, 34, 36, 38, 31, 29, 27, 25, 24, 26, 28, 30,
+     23, 21, 19, 17, 16, 18, 20, 22, 15, 13, 11, 9,  8,  10, 12, 14,
+     7,  5,  3,  1,  0,  2,  4,  6,  0,  0,  0,  0,  0,  0,  0,  0}};
+
+const int16_t KKIdx[10][64] = {
+    {-1, -1, -1, 0,  1,  2,  3,  4,  -1, -1, -1, 5,  6,  7,  8,  9,
+     10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+     26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
+     42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57},
+    {58,  -1,  -1,  -1,  59,  60,  61,  62,  63,  -1,  -1,  -1,  64,
+     65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,
+     78,  79,  80,  81,  82,  83,  84,  85,  86,  87,  88,  89,  90,
+     91,  92,  93,  94,  95,  96,  97,  98,  99,  100, 101, 102, 103,
+     104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115},
+    {116, 117, -1,  -1,  -1,  118, 119, 120, 121, 122, -1,  -1,  -1,
+     123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135,
+     136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148,
+     149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161,
+     162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173},
+    {174, -1,  -1,  -1,  175, 176, 177, 178, 179, -1,  -1,  -1,  180,
+     181, 182, 183, 184, -1,  -1,  -1,  185, 186, 187, 188, 189, 190,
+     191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203,
+     204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216,
+     217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228},
+    {229, 230, -1,  -1,  -1,  231, 232, 233, 234, 235, -1,  -1,  -1,
+     236, 237, 238, 239, 240, -1,  -1,  -1,  241, 242, 243, 244, 245,
+     246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258,
+     259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271,
+     272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283},
+    {284, 285, 286, 287, 288, 289, 290, 291, 292, 293, -1,  -1,  -1,
+     294, 295, 296, 297, 298, -1,  -1,  -1,  299, 300, 301, 302, 303,
+     -1,  -1,  -1,  304, 305, 306, 307, 308, 309, 310, 311, 312, 313,
+     314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 326,
+     327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338},
+    {-1,  -1,  339, 340, 341, 342, 343, 344, -1,  -1,  345, 346, 347,
+     348, 349, 350, -1,  -1,  441, 351, 352, 353, 354, 355, -1,  -1,
+     -1,  442, 356, 357, 358, 359, -1,  -1,  -1,  -1,  443, 360, 361,
+     362, -1,  -1,  -1,  -1,  -1,  444, 363, 364, -1,  -1,  -1,  -1,
+     -1,  -1,  445, 365, -1,  -1,  -1,  -1,  -1,  -1,  -1,  446},
+    {-1, -1, -1, 366, 367, 368, 369, 370, -1, -1, -1, 371, 372, 373, 374, 375,
+     -1, -1, -1, 376, 377, 378, 379, 380, -1, -1, -1, 447, 381, 382, 383, 384,
+     -1, -1, -1, -1,  448, 385, 386, 387, -1, -1, -1, -1,  -1,  449, 388, 389,
+     -1, -1, -1, -1,  -1,  -1,  450, 390, -1, -1, -1, -1,  -1,  -1,  -1,  451},
+    {452, 391, 392, 393, 394, 395, 396, 397, -1,  -1,  -1,  -1,  398,
+     399, 400, 401, -1,  -1,  -1,  -1,  402, 403, 404, 405, -1,  -1,
+     -1,  -1,  406, 407, 408, 409, -1,  -1,  -1,  -1,  453, 410, 411,
+     412, -1,  -1,  -1,  -1,  -1,  454, 413, 414, -1,  -1,  -1,  -1,
+     -1,  -1,  455, 415, -1,  -1,  -1,  -1,  -1,  -1,  -1,  456},
+    {457, 416, 417, 418, 419, 420, 421, 422, -1,  458, 423, 424, 425,
+     426, 427, 428, -1,  -1,  -1,  -1,  -1,  429, 430, 431, -1,  -1,
+     -1,  -1,  -1,  432, 433, 434, -1,  -1,  -1,  -1,  -1,  435, 436,
+     437, -1,  -1,  -1,  -1,  -1,  459, 438, 439, -1,  -1,  -1,  -1,
+     -1,  -1,  460, 440, -1,  -1,  -1,  -1,  -1,  -1,  -1,  461}};
+
+const uint8_t FileToFile[] = {0, 1, 2, 3, 3, 2, 1, 0};
+const int WdlToMap[5] = {1, 3, 0, 2, 0};
+const uint8_t PAFlags[5] = {8, 0, 0, 0, 4};
+
+size_t Binomial[7][64];
+size_t PawnIdx[2][6][24];
+size_t PawnFactorFile[6][4];
+size_t PawnFactorRank[6][6];
+Key MaterialHash[16][64];
+
+void init_indices() {
+  int i, j, k;
+
+  // Binomial[k][n] = Bin(n, k)
+  for (i = 0; i < 7; i++)
+    for (j = 0; j < 64; j++) {
+      size_t f = 1;
+      size_t l = 1;
+      for (k = 0; k < i; k++) {
+        f *= (j - k);
+        l *= (k + 1);
+      }
+      Binomial[i][j] = f / l;
+    }
+
+  for (i = 0; i < 6; i++) {
+    size_t s = 0;
+    for (j = 0; j < 24; j++) {
+      PawnIdx[0][i][j] = s;
+      s += Binomial[i][PawnTwist[0][(1 + (j % 6)) * 8 + (j / 6)]];
+      if ((j + 1) % 6 == 0) {
+        PawnFactorFile[i][j / 6] = s;
+        s = 0;
+      }
+    }
+  }
+
+  for (i = 0; i < 6; i++) {
+    size_t s = 0;
+    for (j = 0; j < 24; j++) {
+      PawnIdx[1][i][j] = s;
+      s += Binomial[i][PawnTwist[1][(1 + (j / 4)) * 8 + (j % 4)]];
+      if ((j + 1) % 4 == 0) {
+        PawnFactorRank[i][j / 4] = s;
+        s = 0;
+      }
+    }
+  }
+  // TODO: choose a good seed.
+  std::mt19937 gen(123523465);
+  std::uniform_int_distribution<Key> dist(std::numeric_limits<Key>::lowest(),
+                                          std::numeric_limits<Key>::max());
+  for (int i = 0; i < 16; i++) {
+    MaterialHash[i][0] = 0;
+    for (int j = 1; j < 64; j++) {
+      MaterialHash[i][j] = dist(gen);
+    }
+  }
+}
+
+std::once_flag indicies_flag;
+
+void initonce_indicies() { std::call_once(indicies_flag, init_indices); }
+
+// Produce a 64-bit material key corresponding to the material combination
+// defined by pcs[16], where pcs[1], ..., pcs[6] are the number of white
+// pawns, ..., kings and pcs[9], ..., pcs[14] are the number of black
+// pawns, ..., kings.
+Key calc_key_from_pcs(int* pcs, bool flip) {
+  Key key = 0;
+
+  int color = !flip ? 0 : 8;
+  for (int i = W_PAWN; i <= B_KING; i++) key += MaterialHash[i][pcs[i ^ color]];
+
+  return key;
+}
+
+// Produce a 64-bit material key corresponding to the material combination
+// piece[0], ..., piece[num - 1], where each value corresponds to a piece
+// (1-6 for white pawn-king, 9-14 for black pawn-king).
+Key calc_key_from_pieces(uint8_t* piece, int num) {
+  Key key = 0;
+
+  for (int i = 0; i < num; i++)
+    if (piece[i]) key += MaterialHash[piece[i]][1];
+
+  return key;
+}
+
+Key calc_key_from_position(const ChessBoard& pos) {
+  Key key = 0;
+  bool flipped = pos.flipped();
+  for (int i = PAWN; i <= KING; i++) {
+    // White pieces - ours if not flipped.
+    key += MaterialHash[i][count_pieces(pos, i, flipped)];
+    // Black pieces - ours if flipped.
+    key += MaterialHash[i + 8][count_pieces(pos, i, !flipped)];
+  }
+  return key;
+}
+
+int leading_pawn(int* p, BaseEntry* be, const int enc) {
+  for (int i = 1; i < be->pawns[0]; i++)
+    if (Flap[enc - 1][p[0]] > Flap[enc - 1][p[i]]) Swap(p[0], p[i]);
+
+  return enc == FILE_ENC ? FileToFile[p[0] & 7] : (p[0] - 8) >> 3;
+}
+
+size_t encode(int* p, EncInfo* ei, BaseEntry* be, const int enc) {
+  int n = be->num;
+  size_t idx;
+  int k;
+
+  if (p[0] & 0x04)
+    for (int i = 0; i < n; i++) p[i] ^= 0x07;
+
+  if (enc == PIECE_ENC) {
+    if (p[0] & 0x20)
+      for (int i = 0; i < n; i++) p[i] ^= 0x38;
+
+    for (int i = 0; i < n; i++)
+      if (OffDiag[p[i]]) {
+        if (OffDiag[p[i]] > 0 && i < (be->kk_enc ? 2 : 3))
+          for (int j = 0; j < n; j++) p[j] = FlipDiag[p[j]];
+        break;
+      }
+
+    if (be->kk_enc) {
+      idx = KKIdx[Triangle[p[0]]][p[1]];
+      k = 2;
+    } else {
+      int s1 = (p[1] > p[0]);
+      int s2 = (p[2] > p[0]) + (p[2] > p[1]);
+
+      if (OffDiag[p[0]])
+        idx = Triangle[p[0]] * 63 * 62 + (p[1] - s1) * 62 + (p[2] - s2);
+      else if (OffDiag[p[1]])
+        idx = 6 * 63 * 62 + Diag[p[0]] * 28 * 62 + Lower[p[1]] * 62 + p[2] - s2;
+      else if (OffDiag[p[2]])
+        idx = 6 * 63 * 62 + 4 * 28 * 62 + Diag[p[0]] * 7 * 28 +
+              (Diag[p[1]] - s1) * 28 + Lower[p[2]];
+      else
+        idx = 6 * 63 * 62 + 4 * 28 * 62 + 4 * 7 * 28 + Diag[p[0]] * 7 * 6 +
+              (Diag[p[1]] - s1) * 6 + (Diag[p[2]] - s2);
+      k = 3;
+    }
+    idx *= ei->factor[0];
+  } else {
+    for (int i = 1; i < be->pawns[0]; i++)
+      for (int j = i + 1; j < be->pawns[0]; j++)
+        if (PawnTwist[enc - 1][p[i]] < PawnTwist[enc - 1][p[j]])
+          Swap(p[i], p[j]);
+
+    k = be->pawns[0];
+    idx = PawnIdx[enc - 1][k - 1][Flap[enc - 1][p[0]]];
+    for (int i = 1; i < k; i++)
+      idx += Binomial[k - i][PawnTwist[enc - 1][p[i]]];
+    idx *= ei->factor[0];
+
+    // Pawns of other color
+    if (be->pawns[1]) {
+      int t = k + be->pawns[1];
+      for (int i = k; i < t; i++)
+        for (int j = i + 1; j < t; j++)
+          if (p[i] > p[j]) Swap(p[i], p[j]);
+      size_t s = 0;
+      for (int i = k; i < t; i++) {
+        int sq = p[i];
+        int skips = 0;
+        for (int j = 0; j < k; j++) skips += (sq > p[j]);
+        s += Binomial[i - k + 1][sq - skips - 8];
+      }
+      idx += s * ei->factor[k];
+      k = t;
+    }
+  }
+
+  for (; k < n;) {
+    int t = k + ei->norm[k];
+    for (int i = k; i < t; i++)
+      for (int j = i + 1; j < t; j++)
+        if (p[i] > p[j]) Swap(p[i], p[j]);
+    size_t s = 0;
+    for (int i = k; i < t; i++) {
+      int sq = p[i];
+      int skips = 0;
+      for (int j = 0; j < k; j++) skips += (sq > p[j]);
+      s += Binomial[i - k + 1][sq - skips];
+    }
+    idx += s * ei->factor[k];
+    k = t;
+  }
+
+  return idx;
+}
+
+size_t encode_piece(int* p, EncInfo* ei, BaseEntry* be) {
+  return encode(p, ei, be, PIECE_ENC);
+}
+
+size_t encode_pawn_f(int* p, EncInfo* ei, BaseEntry* be) {
+  return encode(p, ei, be, FILE_ENC);
+}
+
+size_t encode_pawn_r(int* p, EncInfo* ei, BaseEntry* be) {
+  return encode(p, ei, be, RANK_ENC);
+}
+
+// Count number of placements of k like pieces on n squares
+size_t subfactor(size_t k, size_t n) {
+  size_t f = n;
+  size_t l = 1;
+  for (size_t i = 1; i < k; i++) {
+    f *= n - i;
+    l *= i + 1;
+  }
+
+  return f / l;
+}
+
+size_t init_enc_info(EncInfo* ei, BaseEntry* be, uint8_t* tb, int shift, int t,
+                     const int enc) {
+  bool morePawns = enc != PIECE_ENC && be->pawns[1] > 0;
+
+  for (int i = 0; i < be->num; i++) {
+    ei->pieces[i] = (tb[i + 1 + morePawns] >> shift) & 0x0f;
+    ei->norm[i] = 0;
+  }
+
+  int order = (tb[0] >> shift) & 0x0f;
+  int order2 = morePawns ? (tb[1] >> shift) & 0x0f : 0x0f;
+
+  int k = ei->norm[0] = enc != PIECE_ENC ? be->pawns[0] : be->kk_enc ? 2 : 3;
+
+  if (morePawns) {
+    ei->norm[k] = be->pawns[1];
+    k += ei->norm[k];
+  }
+
+  for (int i = k; i < be->num; i += ei->norm[i])
+    for (int j = i; j < be->num && ei->pieces[j] == ei->pieces[i]; j++)
+      ei->norm[i]++;
+
+  int n = 64 - k;
+  size_t f = 1;
+
+  for (int i = 0; k < be->num || i == order || i == order2; i++) {
+    if (i == order) {
+      ei->factor[0] = f;
+      f *= enc == FILE_ENC
+               ? PawnFactorFile[ei->norm[0] - 1][t]
+               : enc == RANK_ENC ? PawnFactorRank[ei->norm[0] - 1][t]
+                                 : be->kk_enc ? 462 : 31332;
+    } else if (i == order2) {
+      ei->factor[ei->norm[0]] = f;
+      f *= subfactor(ei->norm[ei->norm[0]], 48 - ei->norm[0]);
+    } else {
+      ei->factor[k] = f;
+      f *= subfactor(ei->norm[k], n);
+      n -= ei->norm[k];
+      k += ei->norm[k];
+    }
+  }
+
+  return f;
+}
+
+void calc_symLen(PairsData* d, uint32_t s, char* tmp) {
+  uint8_t* w = d->symPat + 3 * s;
+  uint32_t s2 = (w[2] << 4) | (w[1] >> 4);
+  if (s2 == 0x0fff)
+    d->symLen[s] = 0;
+  else {
+    uint32_t s1 = ((w[1] & 0xf) << 8) | w[0];
+    if (!tmp[s1]) calc_symLen(d, s1, tmp);
+    if (!tmp[s2]) calc_symLen(d, s2, tmp);
+    d->symLen[s] = d->symLen[s1] + d->symLen[s2] + 1;
+  }
+  tmp[s] = 1;
+}
+
+int is_little_endian() {
+  union {
+    uint32_t i;
+    uint8_t byte[4];
+  } num_union = {0x01020304};
+
+  return num_union.byte[0] == 4;
+}
+
+template <typename T, int Half = sizeof(T) / 2, int End = sizeof(T) - 1>
+T swap_endian(T val) {
+  static_assert(std::is_unsigned<T>::value,
+                "Argument of swap_endian not unsigned");
+  T x = val;
+  uint8_t tmp, *c = (uint8_t*)&x;
+  for (int i = 0; i < Half; ++i)
+    tmp = c[i], c[i] = c[End - i], c[End - i] = tmp;
+  return x;
+}
+
+uint32_t from_le_u32(uint32_t v) {
+  return is_little_endian() ? v : swap_endian(v);
+}
+
+uint16_t from_le_u16(uint16_t v) {
+  return is_little_endian() ? v : swap_endian(v);
+}
+
+uint64_t from_be_u64(uint64_t v) {
+  return is_little_endian() ? swap_endian(v) : v;
+}
+
+uint32_t from_be_u32(uint32_t v) {
+  return is_little_endian() ? swap_endian(v) : v;
+}
+
+uint32_t read_le_u32(void* p) { return from_le_u32(*(uint32_t*)p); }
+
+uint16_t read_le_u16(void* p) { return from_le_u16(*(uint16_t*)p); }
+
+PairsData* setup_pairs(uint8_t** ptr, size_t tb_size, size_t* size,
+                       uint8_t* flags, int type) {
+  PairsData* d;
+  uint8_t* data = *ptr;
+
+  *flags = data[0];
+  if (data[0] & 0x80) {
+    d = static_cast<PairsData*>(malloc(sizeof(*d)));
+    d->idxBits = 0;
+    d->constValue[0] = type == WDL ? data[1] : 0;
+    d->constValue[1] = 0;
+    *ptr = data + 2;
+    size[0] = size[1] = size[2] = 0;
+    return d;
+  }
+
+  uint8_t blockSize = data[1];
+  uint8_t idxBits = data[2];
+  uint32_t realNumBlocks = read_le_u32(&data[4]);
+  uint32_t numBlocks = realNumBlocks + data[3];
+  int maxLen = data[8];
+  int minLen = data[9];
+  int h = maxLen - minLen + 1;
+  uint32_t numSyms = read_le_u16(&data[10 + 2 * h]);
+  d = static_cast<PairsData*>(
+      malloc(sizeof(*d) + h * sizeof(uint64_t) + numSyms));
+  d->blockSize = blockSize;
+  d->idxBits = idxBits;
+  d->offset = (uint16_t*)&data[10];
+  d->symLen = (uint8_t*)d + sizeof(*d) + h * sizeof(uint64_t);
+  d->symPat = &data[12 + 2 * h];
+  d->minLen = minLen;
+  *ptr = &data[12 + 2 * h + 3 * numSyms + (numSyms & 1)];
+
+  size_t num_indices = (tb_size + (1ULL << idxBits) - 1) >> idxBits;
+  size[0] = 6ULL * num_indices;
+  size[1] = 2ULL * numBlocks;
+  size[2] = (size_t)realNumBlocks << blockSize;
+
+  std::vector<char> tmp;
+  tmp.resize(numSyms);
+  memset(tmp.data(), 0, numSyms);
+  for (uint32_t s = 0; s < numSyms; s++)
+    if (!tmp[s]) calc_symLen(d, s, tmp.data());
+
+  d->base[h - 1] = 0;
+  for (int i = h - 2; i >= 0; i--)
+    d->base[i] = (d->base[i + 1] + read_le_u16((uint8_t*)(d->offset + i)) -
+                  read_le_u16((uint8_t*)(d->offset + i + 1))) /
+                 2;
+  for (int i = 0; i < h; i++) d->base[i] <<= 64 - (minLen + i);
+
+  d->offset -= d->minLen;
+
+  return d;
+}
+
+uint8_t* decompress_pairs(PairsData* d, size_t idx) {
+  if (!d->idxBits) return d->constValue;
+
+  uint32_t mainIdx = idx >> d->idxBits;
+  int litIdx =
+      (idx & (((size_t)1 << d->idxBits) - 1)) - ((size_t)1 << (d->idxBits - 1));
+  uint32_t block;
+  memcpy(&block, d->indexTable + 6 * mainIdx, sizeof(block));
+  block = from_le_u32(block);
+
+  uint16_t idxOffset = *(uint16_t*)(d->indexTable + 6 * mainIdx + 4);
+  litIdx += from_le_u16(idxOffset);
+
+  if (litIdx < 0)
+    while (litIdx < 0) litIdx += d->sizeTable[--block] + 1;
+  else
+    while (litIdx > d->sizeTable[block]) litIdx -= d->sizeTable[block++] + 1;
+
+  uint32_t* ptr = (uint32_t*)(d->data + ((size_t)block << d->blockSize));
+
+  int m = d->minLen;
+  uint16_t* offset = d->offset;
+  uint64_t* base = d->base - m;
+  uint8_t* symLen = d->symLen;
+  uint32_t sym, bitCnt;
+
+  uint64_t code = from_be_u64(*(uint64_t*)ptr);
+
+  ptr += 2;
+  bitCnt = 0;  // number of "empty bits" in code
+  for (;;) {
+    int l = m;
+    while (code < base[l]) l++;
+    sym = from_le_u16(offset[l]);
+    sym += (code - base[l]) >> (64 - l);
+    if (litIdx < (int)symLen[sym] + 1) break;
+    litIdx -= (int)symLen[sym] + 1;
+    code <<= l;
+    bitCnt += l;
+    if (bitCnt >= 32) {
+      bitCnt -= 32;
+      uint32_t tmp = from_be_u32(*ptr++);
+      code |= (uint64_t)tmp << bitCnt;
+    }
+  }
+
+  uint8_t* symPat = d->symPat;
+  while (symLen[sym] != 0) {
+    uint8_t* w = symPat + (3 * sym);
+    int s1 = ((w[1] & 0xf) << 8) | w[0];
+    if (litIdx < (int)symLen[s1] + 1)
+      sym = s1;
+    else {
+      litIdx -= (int)symLen[s1] + 1;
+      sym = (w[2] << 4) | (w[1] >> 4);
+    }
+  }
+
+  return &symPat[3 * sym];
+}
+
+// p[i] is to contain the square 0-63 (A1-H8) for a piece of type
+// pc[i] ^ flip, where 1 = white pawn, ..., 14 = black king and pc ^ flip
+// flips between white and black if flip == true.
+// Pieces of the same type are guaranteed to be consecutive.
+int fill_squares(const ChessBoard& pos, uint8_t* pc, bool flip, int mirror,
+                 int* p, int i) {
+  // if pos.flipped the board is already mirrored, so mirror it again.
+  if (pos.flipped()) mirror ^= 0x38;
+  BitBoard bb = pieces(pos, pc[i] & 7,
+                       static_cast<bool>((pc[i] >> 3)) ^ flip ^ pos.flipped());
+  for (auto pos : bb) {
+    p[i++] = pos.as_int() ^ mirror;
+  }
+  return i;
+}
+
+}  // namespace
+
+class SyzygyTablebaseImpl {
+ public:
+  SyzygyTablebaseImpl(const std::string& paths)
+      : pieceEntries_(TB_MAX_PIECE), pawnEntries_(TB_MAX_PAWN) {
+    initonce_indicies();
+
+    tbNumPiece_ = tbNumPawn_ = 0;
+    TB_MaxCardinality_ = TB_MaxCardinalityDTM_ = 0;
+    if (paths.size() == 0 || paths == "<empty>") return;
+    paths_ = paths;
+
+    tbHash_.resize(1 << TB_HASHBITS);
+
+    char str[16];
+    int i, j, k, l, m;
+
+    for (i = 0; i < 5; i++) {
+      sprintf(str, "K%cvK", pchr(i));
+      init_tb(str);
+    }
+
+    for (i = 0; i < 5; i++)
+      for (j = i; j < 5; j++) {
+        sprintf(str, "K%cvK%c", pchr(i), pchr(j));
+        init_tb(str);
+      }
+
+    for (i = 0; i < 5; i++)
+      for (j = i; j < 5; j++) {
+        sprintf(str, "K%c%cvK", pchr(i), pchr(j));
+        init_tb(str);
+      }
+
+    for (i = 0; i < 5; i++)
+      for (j = i; j < 5; j++)
+        for (k = 0; k < 5; k++) {
+          sprintf(str, "K%c%cvK%c", pchr(i), pchr(j), pchr(k));
+          init_tb(str);
+        }
+
+    for (i = 0; i < 5; i++)
+      for (j = i; j < 5; j++)
+        for (k = j; k < 5; k++) {
+          sprintf(str, "K%c%c%cvK", pchr(i), pchr(j), pchr(k));
+          init_tb(str);
+        }
+
+    // 6- and 7-piece TBs make sense only with a 64-bit address space
+    if (sizeof(size_t) < 8 || TB_PIECES < 6) goto finished;
+
+    for (i = 0; i < 5; i++)
+      for (j = i; j < 5; j++)
+        for (k = i; k < 5; k++)
+          for (l = (i == k) ? j : k; l < 5; l++) {
+            sprintf(str, "K%c%cvK%c%c", pchr(i), pchr(j), pchr(k), pchr(l));
+            init_tb(str);
+          }
+
+    for (i = 0; i < 5; i++)
+      for (j = i; j < 5; j++)
+        for (k = j; k < 5; k++)
+          for (l = 0; l < 5; l++) {
+            sprintf(str, "K%c%c%cvK%c", pchr(i), pchr(j), pchr(k), pchr(l));
+            init_tb(str);
+          }
+
+    for (i = 0; i < 5; i++)
+      for (j = i; j < 5; j++)
+        for (k = j; k < 5; k++)
+          for (l = k; l < 5; l++) {
+            sprintf(str, "K%c%c%c%cvK", pchr(i), pchr(j), pchr(k), pchr(l));
+            init_tb(str);
+          }
+
+    if (TB_PIECES < 7) goto finished;
+
+    for (i = 0; i < 5; i++)
+      for (j = i; j < 5; j++)
+        for (k = j; k < 5; k++)
+          for (l = k; l < 5; l++)
+            for (m = l; m < 5; m++) {
+              sprintf(str, "K%c%c%c%c%cvK", pchr(i), pchr(j), pchr(k), pchr(l),
+                      pchr(m));
+              init_tb(str);
+            }
+
+    for (i = 0; i < 5; i++)
+      for (j = i; j < 5; j++)
+        for (k = j; k < 5; k++)
+          for (l = k; l < 5; l++)
+            for (m = 0; m < 5; m++) {
+              sprintf(str, "K%c%c%c%cvK%c", pchr(i), pchr(j), pchr(k), pchr(l),
+                      pchr(m));
+              init_tb(str);
+            }
+
+    for (i = 0; i < 5; i++)
+      for (j = i; j < 5; j++)
+        for (k = j; k < 5; k++)
+          for (l = 0; l < 5; l++)
+            for (m = l; m < 5; m++) {
+              sprintf(str, "K%c%c%cvK%c%c", pchr(i), pchr(j), pchr(k), pchr(l),
+                      pchr(m));
+              init_tb(str);
+            }
+
+  finished:
+    std::cerr << "Found " << numWdl_ << "WDL, " << numDtm_ << " DTM and "
+              << numDtz_ << " DTZ tablebase files." << std::endl;
+  }
+
+  ~SyzygyTablebaseImpl() {
+    // if pathString was set there may be entries in need of cleaning.
+    if (!paths_.empty()) {
+      for (int i = 0; i < tbNumPiece_; i++) free_tb_entry(&pieceEntries_[i]);
+      for (int i = 0; i < tbNumPawn_; i++) free_tb_entry(&pawnEntries_[i]);
+    }
+  }
+
+  int max_cardinality() const { return TB_MaxCardinality_; }
+
+  int probe_wdl_table(const ChessBoard& pos, int* success) {
+    return probe_table(pos, 0, success, WDL);
+  }
+
+  int probe_dtm_table(const ChessBoard& pos, int won, int* success) {
+    return probe_table(pos, won, success, DTM);
+  }
+
+  int probe_dtz_table(const ChessBoard& pos, int wdl, int* success) {
+    return probe_table(pos, wdl, success, DTZ);
+  }
+
+ private:
+  std::string name_for_tb(const char* str, const char* suffix) {
+    std::stringstream path_string_stream(paths_);
+    std::string path;
+    std::ifstream stream;
+    while (std::getline(path_string_stream, path, SEP_CHAR)) {
+      std::string fname = path + "/" + str + suffix;
+      stream.open(fname);
+      if (stream.is_open()) return fname;
+    }
+    return std::string();
+  }
+
+  bool test_tb(const char* str, const char* suffix) {
+    return name_for_tb(str, suffix).size() > 0;
+  }
+
+  void* map_tb(const char* name, const char* suffix, map_t* mapping) {
+    std::string fname = name_for_tb(name, suffix);
+    void* baseAddress;
+#ifndef _WIN32
+    struct stat statbuf;
+    int fd = ::open(fname.c_str(), O_RDONLY);
+    if (fd == -1) return nullptr;
+    fstat(fd, &statbuf);
+    *mapping = statbuf.st_size;
+    baseAddress = mmap(nullptr, statbuf.st_size, PROT_READ, MAP_SHARED, fd, 0);
+    ::close(fd);
+    if (baseAddress == MAP_FAILED) {
+      std::cerr << "Could not mmap() " << fname << std::endl;
+      exit(1);
+    }
+#else
+    HANDLE fd =
+        CreateFileA(fname.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
+                    OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (fd == INVALID_HANDLE_VALUE) return nullptr;
+    DWORD size_high;
+    DWORD size_low = GetFileSize(fd, &size_high);
+    HANDLE mmap = CreateFileMapping(fd, nullptr, PAGE_READONLY, size_high,
+                                    size_low, nullptr);
+    CloseHandle(fd);
+    if (!mmap) {
+      std::cerr << "CreateFileMapping() failed" << std::endl;
+      exit(1);
+    }
+    *mapping = mmap;
+    baseAddress = MapViewOfFile(mmap, FILE_MAP_READ, 0, 0, 0);
+    if (!baseAddress) {
+      std::cerr << "MapViewOfFile() failed, name = " << fname
+                << ", error = " << GetLastError() << std::endl;
+      exit(1);
+    }
+#endif
+    return baseAddress;
+  }
+
+  void unmap_file(void* baseAddress, map_t mapping) {
+#ifndef _WIN32
+    munmap(baseAddress, mapping);
+#else
+    UnmapViewOfFile(baseAddress);
+    CloseHandle(mapping);
+#endif
+  }
+
+  void add_to_hash(BaseEntry* ptr, Key key) {
+    int idx;
+
+    idx = key >> (64 - TB_HASHBITS);
+    while (tbHash_[idx].ptr) idx = (idx + 1) & ((1 << TB_HASHBITS) - 1);
+
+    tbHash_[idx].key = key;
+    tbHash_[idx].ptr = ptr;
+  }
+
+  void init_tb(char* str) {
+    if (!test_tb(str, tbSuffix[WDL])) return;
+
+    int pcs[16];
+    for (int i = 0; i < 16; i++) pcs[i] = 0;
+    int color = 0;
+    for (char* s = str; *s; s++)
+      if (*s == 'v')
+        color = 8;
+      else
+        for (int i = PAWN; i <= KING; i++)
+          if (*s == PieceToChar[i]) {
+            pcs[i | color]++;
+            break;
+          }
+
+    Key key = calc_key_from_pcs(pcs, false);
+    Key key2 = calc_key_from_pcs(pcs, true);
+
+    bool hasPawns = pcs[W_PAWN] || pcs[B_PAWN];
+
+    BaseEntry* be =
+        hasPawns ? static_cast<BaseEntry*>(&pawnEntries_[tbNumPawn_++])
+                 : static_cast<BaseEntry*>(&pieceEntries_[tbNumPiece_++]);
+    be->hasPawns = hasPawns;
+    be->key = key;
+    be->symmetric = key == key2;
+    be->num = 0;
+    for (int i = 0; i < 16; i++) be->num += pcs[i];
+
+    numWdl_++;
+    numDtm_ += be->hasDtm = test_tb(str, tbSuffix[DTM]);
+    numDtz_ += be->hasDtz = test_tb(str, tbSuffix[DTZ]);
+
+    TB_MaxCardinality_ =
+        std::max(TB_MaxCardinality_, static_cast<int>(be->num));
+    if (be->hasDtm)
+      TB_MaxCardinalityDTM_ =
+          std::max(TB_MaxCardinalityDTM_, static_cast<int>(be->num));
+
+    for (int type = 0; type < 3; type++) be->ready[type] = 0;
+
+    if (!be->hasPawns) {
+      int j = 0;
+      for (int i = 0; i < 16; i++)
+        if (pcs[i] == 1) j++;
+      be->kk_enc = j == 2;
+    } else {
+      be->pawns[0] = pcs[W_PAWN];
+      be->pawns[1] = pcs[B_PAWN];
+      if (pcs[B_PAWN] && (!pcs[W_PAWN] || pcs[W_PAWN] > pcs[B_PAWN]))
+        Swap(be->pawns[0], be->pawns[1]);
+    }
+
+    add_to_hash(be, key);
+    if (key != key2) add_to_hash(be, key2);
+  }
+
+  void free_tb_entry(BaseEntry* be) {
+    for (int type = 0; type < 3; type++) {
+      if (atomic_load_explicit(&be->ready[type], std::memory_order_relaxed)) {
+        unmap_file(be->data[type], be->mapping[type]);
+        int num = num_tables(be, type);
+        struct EncInfo* ei = first_ei(be, type);
+        for (int t = 0; t < num; t++) {
+          free(ei[t].precomp);
+          if (type != DTZ) free(ei[num + t].precomp);
+        }
+        atomic_store_explicit(&be->ready[type], false,
+                              std::memory_order_relaxed);
+      }
+    }
+  }
+
+  bool init_table(BaseEntry* be, const char* str, int type) {
+    uint8_t* data =
+        static_cast<uint8_t*>(map_tb(str, tbSuffix[type], &be->mapping[type]));
+    if (!data) return false;
+
+    if (read_le_u32(data) != tbMagic[type]) {
+      fprintf(stderr, "Corrupted table.\n");
+      unmap_file(data, be->mapping[type]);
+      return false;
+    }
+
+    be->data[type] = data;
+
+    bool split = type != DTZ && (data[4] & 0x01);
+    if (type == DTM) be->dtmLossOnly = data[4] & 0x04;
+
+    data += 5;
+
+    size_t tb_size[6][2];
+    int num = num_tables(be, type);
+    struct EncInfo* ei = first_ei(be, type);
+    int enc = !be->hasPawns ? PIECE_ENC : type != DTM ? FILE_ENC : RANK_ENC;
+
+    for (int t = 0; t < num; t++) {
+      tb_size[t][0] = init_enc_info(&ei[t], be, data, 0, t, enc);
+      if (split)
+        tb_size[t][1] = init_enc_info(&ei[num + t], be, data, 4, t, enc);
+      data += be->num + 1 + (be->hasPawns && be->pawns[1]);
+    }
+    data += (uintptr_t)data & 1;
+
+    size_t size[6][2][3];
+    for (int t = 0; t < num; t++) {
+      uint8_t flags;
+      ei[t].precomp =
+          setup_pairs(&data, tb_size[t][0], size[t][0], &flags, type);
+      if (type == DTZ) {
+        if (!be->hasPawns)
+          PIECE(be)->dtzFlags = flags;
+        else
+          PAWN(be)->dtzFlags[t] = flags;
+      }
+      if (split)
+        ei[num + t].precomp =
+            setup_pairs(&data, tb_size[t][1], size[t][1], &flags, type);
+      else if (type != DTZ)
+        ei[num + t].precomp = NULL;
+    }
+
+    if (type == DTM && !be->dtmLossOnly) {
+      uint16_t* map = (uint16_t*)data;
+      *(be->hasPawns ? &PAWN(be)->dtmMap : &PIECE(be)->dtmMap) = map;
+      uint16_t(*mapIdx)[2][2] =
+          be->hasPawns ? &PAWN(be)->dtmMapIdx[0] : &PIECE(be)->dtmMapIdx;
+      for (int t = 0; t < num; t++) {
+        for (int i = 0; i < 2; i++) {
+          mapIdx[t][0][i] = (uint16_t*)data + 1 - map;
+          data += 2 + 2 * read_le_u16(data);
+        }
+        if (split) {
+          for (int i = 0; i < 2; i++) {
+            mapIdx[t][1][i] = (uint16_t*)data + 1 - map;
+            data += 2 + 2 * read_le_u16(data);
+          }
+        }
+      }
+    }
+
+    if (type == DTZ) {
+      void* map = data;
+      *(be->hasPawns ? &PAWN(be)->dtzMap : &PIECE(be)->dtzMap) = map;
+      uint16_t(*mapIdx)[4] =
+          be->hasPawns ? &PAWN(be)->dtzMapIdx[0] : &PIECE(be)->dtzMapIdx;
+      uint8_t* flags =
+          be->hasPawns ? &PAWN(be)->dtzFlags[0] : &PIECE(be)->dtzFlags;
+      for (int t = 0; t < num; t++) {
+        if (flags[t] & 2) {
+          if (!(flags[t] & 16)) {
+            for (int i = 0; i < 4; i++) {
+              mapIdx[t][i] = data + 1 - (uint8_t*)map;
+              data += 1 + data[0];
+            }
+          } else {
+            data += (uintptr_t)data & 0x01;
+            for (int i = 0; i < 4; i++) {
+              mapIdx[t][i] = (uint16_t*)data + 1 - (uint16_t*)map;
+              data += 2 + 2 * read_le_u16(data);
+            }
+          }
+        }
+      }
+      data += (uintptr_t)data & 0x01;
+    }
+
+    for (int t = 0; t < num; t++) {
+      ei[t].precomp->indexTable = data;
+      data += size[t][0][0];
+      if (split) {
+        ei[num + t].precomp->indexTable = data;
+        data += size[t][1][0];
+      }
+    }
+
+    for (int t = 0; t < num; t++) {
+      ei[t].precomp->sizeTable = (uint16_t*)data;
+      data += size[t][0][1];
+      if (split) {
+        ei[num + t].precomp->sizeTable = (uint16_t*)data;
+        data += size[t][1][1];
+      }
+    }
+
+    for (int t = 0; t < num; t++) {
+      data = (uint8_t*)(((uintptr_t)data + 0x3f) & ~0x3f);
+      ei[t].precomp->data = data;
+      data += size[t][0][2];
+      if (split) {
+        data = (uint8_t*)(((uintptr_t)data + 0x3f) & ~0x3f);
+        ei[num + t].precomp->data = data;
+        data += size[t][1][2];
+      }
+    }
+
+    if (type == DTM && be->hasPawns)
+      PAWN(be)->dtmSwitched =
+          calc_key_from_pieces(ei[0].pieces, be->num) != be->key;
+
+    return true;
+  }
+
+  int probe_table(const ChessBoard& pos, int s, int* success, const int type) {
+    // Obtain the position's material-signature key
+    Key key = calc_key_from_position(pos);
+
+    // Test for KvK
+    if (type == WDL && (pos.ours() + pos.theirs()).count() == 2) return 0;
+
+    int hashIdx = key >> (64 - TB_HASHBITS);
+    while (tbHash_[hashIdx].key && tbHash_[hashIdx].key != key)
+      hashIdx = (hashIdx + 1) & ((1 << TB_HASHBITS) - 1);
+    if (!tbHash_[hashIdx].ptr) {
+      *success = 0;
+      return 0;
+    }
+
+    BaseEntry* be = tbHash_[hashIdx].ptr;
+    if ((type == DTM && !be->hasDtm) || (type == DTZ && !be->hasDtz)) {
+      *success = 0;
+      return 0;
+    }
+
+    // Use double-checked locking to reduce locking overhead
+    if (!atomic_load_explicit(&be->ready[type], std::memory_order_acquire)) {
+      Mutex::Lock lock(tbMutex_);
+      if (!atomic_load_explicit(&be->ready[type], std::memory_order_relaxed)) {
+        char str[16];
+        prt_str(pos, str, be->key != key);
+        if (!init_table(be, str, type)) {
+          tbHash_[hashIdx].ptr = NULL;  // mark as deleted
+          *success = 0;
+          return 0;
+        }
+        atomic_store_explicit(&be->ready[type], true,
+                              std::memory_order_release);
+      }
+    }
+
+    bool bside, flip;
+    if (!be->symmetric) {
+      flip = key != be->key;
+      bside = (!pos.flipped()) == flip;
+      if (type == DTM && be->hasPawns && PAWN(be)->dtmSwitched) {
+        flip = !flip;
+        bside = !bside;
+      }
+    } else {
+      flip = pos.flipped();
+      bside = false;
+    }
+
+    EncInfo* ei = first_ei(be, type);
+    int p[TB_PIECES];
+    size_t idx;
+    int t = 0;
+    uint8_t flags;
+
+    if (!be->hasPawns) {
+      if (type == DTZ) {
+        flags = PIECE(be)->dtzFlags;
+        if ((flags & 1) != bside && !be->symmetric) {
+          *success = -1;
+          return 0;
+        }
+      }
+      ei = type != DTZ ? &ei[bside] : ei;
+      for (int i = 0; i < be->num;)
+        i = fill_squares(pos, ei->pieces, flip, 0, p, i);
+      idx = encode_piece(p, ei, be);
+    } else {
+      int i = fill_squares(pos, ei->pieces, flip, flip ? 0x38 : 0, p, 0);
+      t = leading_pawn(p, be, type != DTM ? FILE_ENC : RANK_ENC);
+      if (type == DTZ) {
+        flags = PAWN(be)->dtzFlags[t];
+        if ((flags & 1) != bside && !be->symmetric) {
+          *success = -1;
+          return 0;
+        }
+      }
+      ei = type == WDL ? &ei[t + 4 * bside]
+                       : type == DTM ? &ei[t + 6 * bside] : &ei[t];
+      while (i < be->num)
+        i = fill_squares(pos, ei->pieces, flip, flip ? 0x38 : 0, p, i);
+      idx = type != DTM ? encode_pawn_f(p, ei, be) : encode_pawn_r(p, ei, be);
+    }
+
+    uint8_t* w = decompress_pairs(ei->precomp, idx);
+
+    if (type == WDL) return (int)w[0] - 2;
+
+    int v = w[0] + ((w[1] & 0x0f) << 8);
+
+    if (type == DTM) {
+      if (!be->dtmLossOnly)
+        v = from_le_u16(
+            be->hasPawns
+                ? PAWN(be)->dtmMap[PAWN(be)->dtmMapIdx[t][bside][s] + v]
+                : PIECE(be)->dtmMap[PIECE(be)->dtmMapIdx[bside][s] + v]);
+    } else {
+      if (flags & 2) {
+        int m = WdlToMap[s + 2];
+        if (!(flags & 16))
+          v = be->hasPawns
+                  ? ((uint8_t*)PAWN(be)->dtzMap)[PAWN(be)->dtzMapIdx[t][m] + v]
+                  : ((uint8_t*)PIECE(be)->dtzMap)[PIECE(be)->dtzMapIdx[m] + v];
+        else
+          v = from_le_u16(
+              be->hasPawns
+                  ? ((uint16_t*)PAWN(be)->dtzMap)[PAWN(be)->dtzMapIdx[t][m] + v]
+                  : ((uint16_t*)PIECE(be)
+                         ->dtzMap)[PIECE(be)->dtzMapIdx[m] + v]);
+      }
+      if (!(flags & PAFlags[s + 2]) || (s & 1)) v *= 2;
+    }
+
+    return v;
+  }
+
+  int TB_MaxCardinality_ = 0, TB_MaxCardinalityDTM_ = 0;
+  int TB_CardinalityDTM_;
+
+  Mutex tbMutex_;
+  int numPaths_ = 0;
+  std::string paths_;
+
+  int tbNumPiece_, tbNumPawn_;
+  int numWdl_, numDtm_, numDtz_;
+
+  std::vector<PieceEntry> pieceEntries_;
+  std::vector<PawnEntry> pawnEntries_;
+  std::vector<TbHashEntry> tbHash_;
+};
+
+void SyzygyTablebase::init(const std::string& paths) {
+  paths_ = paths;
+  impl_.reset(new SyzygyTablebaseImpl(paths_));
+  max_cardinality_ = impl_->max_cardinality();
+}
+
+// For a position where the side to move has a winning capture it is not
+// necessary
+// to store a winning value so the generator treats such positions as "don't
+// cares" and tries to assign to it a value that improves the compression ratio.
+// Similarly, if the side to move has a drawing capture, then the position is at
+// least drawn. If the position is won, then the TB needs to store a win value.
+// But if the position is drawn, the TB may store a loss value if that is better
+// for compression. All of this means that during probing, the engine must look
+// at captures and probe their results and must probe the position itself. The
+// "best" result of these probes is the correct result for the position. DTZ
+// table don't store values when a following move is a zeroing winning move
+// (winning capture or winning pawn move). Also DTZ store wrong values for
+// positions where the best move is an ep-move (even if losing). So in all these
+// cases set the state to ZEROING_BEST_MOVE.
+template <bool CheckZeroingMoves>
+WDLScore SyzygyTablebase::search(const Position& pos, ProbeState* result) {
+  WDLScore value, bestValue = WDL_LOSS;
+  auto moveList = pos.GetBoard().GenerateLegalMoves();
+  size_t totalCount = moveList.size(), moveCount = 0;
+  for (const Move& move : moveList) {
+    if (!pos.GetBoard().theirs().get(move.to()) &&
+        (!CheckZeroingMoves || !pos.GetBoard().pawns().get(move.from())))
+      continue;
+    moveCount++;
+    auto newPos = Position(pos, move);
+    value = static_cast<WDLScore>(-search(newPos, result));
+    if (*result == FAIL) return WDL_DRAW;
+    if (value > bestValue) {
+      bestValue = value;
+      if (value >= WDL_WIN) {
+        *result = ZEROING_BEST_MOVE;  // Winning DTZ-zeroing move
+        return value;
+      }
+    }
+  }
+  // In case we have already searched all the legal moves we don't have to probe
+  // the TB because the stored score could be wrong. For instance TB tables
+  // do not contain information on position with ep rights, so in this case
+  // the result of probe_wdl_table is wrong. Also in case of only capture
+  // moves, for instance here 4K3/4q3/6p1/2k5/6p1/8/8/8 w - - 0 7, we have to
+  // return with ZEROING_BEST_MOVE set.
+  bool noMoreMoves = (moveCount && moveCount == totalCount);
+  if (noMoreMoves)
+    value = bestValue;
+  else {
+    int raw_result;
+    value = static_cast<WDLScore>(
+        impl_->probe_wdl_table(pos.GetBoard(), &raw_result));
+    *result = static_cast<ProbeState>(raw_result);
+    if (*result == FAIL) return WDL_DRAW;
+  }
+  // DTZ stores a "don't care" value if bestValue is a win
+  if (bestValue >= value)
+    return *result =
+               (bestValue > WDL_DRAW || noMoreMoves ? ZEROING_BEST_MOVE : OK),
+           bestValue;
+  return *result = OK, value;
+}
+
+// Probe the WDL table for a particular position.
+// If *result != FAIL, the probe was successful.
+// The return value is from the point of view of the side to move:
+// -2 : loss
+// -1 : loss, but draw under 50-move rule
+//  0 : draw
+//  1 : win, but draw under 50-move rule
+//  2 : win
+WDLScore SyzygyTablebase::probe_wdl(const Position& pos, ProbeState* result) {
+  *result = OK;
+  return search(pos, result);
+}
+// Probe the DTZ table for a particular position.
+// If *result != FAIL, the probe was successful.
+// The return value is from the point of view of the side to move:
+//         n < -100 : loss, but draw under 50-move rule
+// -100 <= n < -1   : loss in n ply (assuming 50-move counter == 0)
+//        -1        : loss, the side to move is mated
+//         0        : draw
+//     1 < n <= 100 : win in n ply (assuming 50-move counter == 0)
+//   100 < n        : win, but draw under 50-move rule
+//
+// The return value n can be off by 1: a return value -n can mean a loss
+// in n+1 ply and a return value +n can mean a win in n+1 ply. This
+// cannot happen for tables with positions exactly on the "edge" of
+// the 50-move rule.
+//
+// This implies that if dtz > 0 is returned, the position is certainly
+// a win if dtz + 50-move-counter <= 99. Care must be taken that the engine
+// picks moves that preserve dtz + 50-move-counter <= 99.
+//
+// If n = 100 immediately after a capture or pawn move, then the position
+// is also certainly a win, and during the whole phase until the next
+// capture or pawn move, the inequality to be preserved is
+// dtz + 50-movecounter <= 100.
+//
+// In short, if a move is available resulting in dtz + 50-move-counter <= 99,
+// then do not accept moves leading to dtz + 50-move-counter == 100.
+int SyzygyTablebase::probe_dtz(const Position& pos, ProbeState* result) {
+  *result = OK;
+  WDLScore wdl = search<true>(pos, result);
+  if (*result == FAIL || wdl == WDL_DRAW)  // DTZ tables don't store draws
+    return 0;
+  // DTZ stores a 'don't care' value in this case, or even a plain wrong
+  // one as in case the best move is a losing ep, so it cannot be probed.
+  if (*result == ZEROING_BEST_MOVE) return dtz_before_zeroing(wdl);
+  int raw_result = 0;
+  int dtz = impl_->probe_dtz_table(pos.GetBoard(), wdl, &raw_result);
+  *result = static_cast<ProbeState>(raw_result);
+  if (*result == FAIL) return 0;
+  if (*result != CHANGE_STM)
+    return (dtz + 100 * (wdl == WDL_BLESSED_LOSS || wdl == WDL_CURSED_WIN)) *
+           sign_of(wdl);
+  // DTZ stores results for the other side, so we need to do a 1-ply search and
+  // find the winning move that minimizes DTZ.
+  int minDTZ = 0xFFFF;
+  for (const Move& move : pos.GetBoard().GenerateLegalMoves()) {
+    Position nextPos = Position(pos, move);
+    bool zeroing = nextPos.GetNoCapturePly() == 0;
+    // For zeroing moves we want the dtz of the move _before_ doing it,
+    // otherwise we will get the dtz of the next move sequence. Search the
+    // position after the move to get the score sign (because even in a
+    // winning position we could make a losing capture or going for a draw).
+    dtz = zeroing ? -dtz_before_zeroing(search(nextPos, result))
+                  : -probe_dtz(nextPos, result);
+    // If the move mates, force minDTZ to 1
+    if (dtz == 1 && nextPos.GetBoard().IsUnderCheck() &&
+        nextPos.GetBoard().GenerateLegalMoves().empty())
+      minDTZ = 1;
+    // Convert result from 1-ply search. Zeroing moves are already accounted
+    // by dtz_before_zeroing() that returns the DTZ of the previous move.
+    if (!zeroing) dtz += sign_of(dtz);
+    // Skip the draws and if we are winning only pick positive dtz
+    if (dtz < minDTZ && sign_of(dtz) == sign_of(wdl)) minDTZ = dtz;
+    if (*result == FAIL) return 0;
+  }
+  // When there are no legal moves, the position is mate: we return -1
+  return minDTZ == 0xFFFF ? -1 : minDTZ;
+}
+// Use the DTZ tables to rank root moves.
+//
+// A return value false indicates that not all probes were successful.
+bool SyzygyTablebase::root_probe(const Position& pos,
+                                 std::vector<Move>* safe_moves) {
+  ProbeState result;
+  auto rootMoves = pos.GetBoard().GenerateLegalMoves();
+  // Obtain 50-move counter for the root position
+  int cnt50 = pos.GetNoCapturePly();
+  // Check whether a position was repeated since the last zeroing move.
+  bool rep = pos.GetRepetitions() > 0;
+  int dtz, bound = true ? 900 : 1;
+  std::vector<int> ranks;
+  ranks.reserve(rootMoves.size());
+  int best_rank = -1000;
+  // Probe and rank each move
+  for (auto& m : rootMoves) {
+    Position nextPos = Position(pos, m);
+    // Calculate dtz for the current move counting from the root position
+    if (nextPos.GetNoCapturePly() == 0) {
+      // In case of a zeroing move, dtz is one of -101/-1/0/1/101
+      WDLScore wdl = static_cast<WDLScore>(-probe_wdl(nextPos, &result));
+      dtz = dtz_before_zeroing(wdl);
+    } else {
+      // Otherwise, take dtz for the new position and correct by 1 ply
+      dtz = -probe_dtz(nextPos, &result);
+      dtz = dtz > 0 ? dtz + 1 : dtz < 0 ? dtz - 1 : dtz;
+    }
+    // Make sure that a mating move is assigned a dtz value of 1
+    if (nextPos.GetBoard().IsUnderCheck() && dtz == 2 &&
+        nextPos.GetBoard().GenerateLegalMoves().size() == 0)
+      dtz = 1;
+    if (result == FAIL) return false;
+    // Better moves are ranked higher. Certain wins are ranked equally.
+    // Losing moves are ranked equally unless a 50-move draw is in sight.
+    int r = dtz > 0
+                ? (dtz + cnt50 <= 99 && !rep ? 1000 : 1000 - (dtz + cnt50))
+                : dtz < 0 ? (-dtz * 2 + cnt50 < 100 ? -1000
+                                                    : -1000 + (-dtz + cnt50))
+                          : 0;
+    if (r > best_rank) best_rank = r;
+    ranks.push_back(r);
+  }
+  // Disable all but the equal best moves.
+  int counter = 0;
+  for (auto& m : rootMoves) {
+    if (ranks[counter] == best_rank) {
+      safe_moves->push_back(m);
+    }
+    counter++;
+  }
+  return true;
+}
+// Use the WDL tables to rank root moves.
+// This is a fallback for the case that some or all DTZ tables are missing.
+//
+// A return value false indicates that not all probes were successful.
+bool SyzygyTablebase::root_probe_wdl(const Position& pos,
+                                     std::vector<Move>* safe_moves) {
+  static const int WDL_to_rank[] = {-1000, -899, 0, 899, 1000};
+  auto rootMoves = pos.GetBoard().GenerateLegalMoves();
+  ProbeState result;
+  std::vector<int> ranks;
+  ranks.reserve(rootMoves.size());
+  int best_rank = -1000;
+  // Probe and rank each move
+  for (auto& m : rootMoves) {
+    Position nextPos = Position(pos, m);
+    WDLScore wdl = static_cast<WDLScore>(-probe_wdl(nextPos, &result));
+    if (result == FAIL) return false;
+    ranks.push_back(WDL_to_rank[wdl + 2]);
+    if (ranks.back() > best_rank) best_rank = ranks.back();
+  }
+  // Disable all but the equal best moves.
+  int counter = 0;
+  for (auto& m : rootMoves) {
+    if (ranks[counter] == best_rank) {
+      safe_moves->push_back(m);
+    }
+    counter++;
+  }
+  return true;
+}
+}  // namespace lczero

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -1010,7 +1010,7 @@ class SyzygyTablebaseImpl {
     std::string fname = name_for_tb(name, suffix);
     void* base_address;
 #ifndef _WIN32
-    stat statbuf;
+    struct stat statbuf;
     int fd = ::open(fname.c_str(), O_RDONLY);
     if (fd == -1) return nullptr;
     fstat(fd, &statbuf);

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -1547,7 +1547,8 @@ int SyzygyTablebase::probe_dtz(const Position& pos, ProbeState* result) {
   *result = static_cast<ProbeState>(raw_result);
   if (*result == FAIL) return 0;
   if (*result != CHANGE_STM) {
-    return (dtz + 1 + 100 * (wdl == WDL_BLESSED_LOSS || wdl == WDL_CURSED_WIN)) *
+    return (dtz + 1 +
+            100 * (wdl == WDL_BLESSED_LOSS || wdl == WDL_CURSED_WIN)) *
            sign_of(wdl);
   }
   // DTZ stores results for the other side, so we need to do a 1-ply search and

--- a/src/syzygy/syzygy.h
+++ b/src/syzygy/syzygy.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <atomic>
 #include <deque>
+#include <memory>
 #include <tuple>
 #include <vector>
 #include "chess/position.h"

--- a/src/syzygy/syzygy.h
+++ b/src/syzygy/syzygy.h
@@ -16,7 +16,6 @@ enum WDLScore {
   WDL_DRAW = 0,           // Draw
   WDL_CURSED_WIN = 1,     // Win, but draw under 50-move rule
   WDL_WIN = 2,            // Win
-  WDL_SCORE_NONE = -1000
 };
 
 // Possible states after a probing operation

--- a/src/syzygy/syzygy.h
+++ b/src/syzygy/syzygy.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <deque>
+#include <tuple>
+#include <vector>
+#include "chess/position.h"
+
+namespace lczero {
+
+enum WDLScore {
+  WDL_LOSS = -2,          // Loss
+  WDL_BLESSED_LOSS = -1,  // Loss, but draw under 50-move rule
+  WDL_DRAW = 0,           // Draw
+  WDL_CURSED_WIN = 1,     // Win, but draw under 50-move rule
+  WDL_WIN = 2,            // Win
+  WDL_SCORE_NONE = -1000
+};
+
+// Possible states after a probing operation
+enum ProbeState {
+  FAIL = 0,              // Probe failed (missing file table)
+  OK = 1,                // Probe succesful
+  CHANGE_STM = -1,       // DTZ should check the other side
+  ZEROING_BEST_MOVE = 2  // Best move zeroes DTZ (capture or pawn move)
+};
+
+class SyzygyTablebaseImpl;
+
+// Provides methods to load and probe syzygy tablebases.
+// Thread safe methods are thread safe subject to the non-thread sfaety
+// conditions of the init method.
+class SyzygyTablebase {
+ public:
+  // Current maximum number of pieces on board that can be probed for. Will
+  // be 0 unless initialized with tablebase paths.
+  // Thread safe.
+  int max_cardinality() { return max_cardinality_; }
+  // Allows for the tablebases being used to be changed. This method is not
+  // thread safe, there must be no concurrent usage while this method is
+  // running. All other thread safe method calls must be strictly ordered with
+  // respect to this method.
+  void init(const std::string& paths);
+  // Probes WDL tables for the given position to determine a WDLScore.
+  // Thread safe.
+  // Result is only strictly valid for positions with 0 ply 50 move counter.
+  // Probe state will return FAIL if the position is not in the tablebase.
+  WDLScore probe_wdl(const Position& pos, ProbeState* result);
+  // Probes DTZ tables for the given position to determine the number of ply
+  // before a zeroing move under optimal play.
+  // Thread safe.
+  // Probe state will return FAIL if the position is not in the tablebase.
+  int probe_dtz(const Position& pos, ProbeState* result);
+  // Probes DTZ tables to determine which moves are on the optimal play path.
+  // Assumes the position is one reached such that the side to move has been
+  // performing optimal play moves since the last 50 move counter reset.
+  // Thread safe.
+  // Returns false if the position is not in the tablebase.
+  // Safe moves are added to the safe_moves output paramater.
+  bool root_probe(const Position& pos, std::vector<Move>* safe_moves);
+  // Probes WDL tables to determine which moves might be on the optimal play
+  // path. If 50 move ply counter is non-zero some (or maybe even all) of the
+  // returned safe moves in a 'winning' position, may actually be draws.
+  // Returns false if the position is not in the tablebase.
+  // Safe moves are added to the safe_moves output paramater.
+  bool root_probe_wdl(const Position& pos, std::vector<Move>* safe_moves);
+
+ private:
+  template <bool CheckZeroingMoves = false>
+  WDLScore search(const Position& pos, ProbeState* result);
+
+  std::string paths_;
+  // Caches the max_cardinality from the impl, as max_cardinality may be a hot
+  // path.
+  int max_cardinality_;
+  std::unique_ptr<SyzygyTablebaseImpl> impl_;
+};
+
+}  // namespace lczero

--- a/src/syzygy/syzygy.h
+++ b/src/syzygy/syzygy.h
@@ -33,6 +33,8 @@ class SyzygyTablebaseImpl;
 // conditions of the init method.
 class SyzygyTablebase {
  public:
+  SyzygyTablebase();
+  virtual ~SyzygyTablebase();
   // Current maximum number of pieces on board that can be probed for. Will
   // be 0 unless initialized with tablebase paths.
   // Thread safe.

--- a/src/syzygy/syzygy_test.cc
+++ b/src/syzygy/syzygy_test.cc
@@ -120,6 +120,14 @@ TEST(Syzygy, Simple5PieceProbes) {
   // Double mirrored and color swapped.
   TestValidExpectation(&tablebase, "3k4/R7/7r/2KP4/8/8/8/8 w - - 0 1", WDL_DRAW,
                        0);
+
+  // Some suggestions.
+  TestValidExpectation(&tablebase, "kqqQK3/8/8/8/8/8/8/8 b - - 0 1", WDL_WIN,
+                       1);
+  TestValidExpectation(&tablebase, "kqqQK3/8/8/8/8/8/8/8 w - - 0 1", WDL_LOSS,
+                       -1);
+  TestValidExpectation(&tablebase, "KNNNk3/8/8/8/8/8/8/8 w - - 0 1", WDL_WIN,
+                       29);
 }
 
 }  // namespace lczero

--- a/src/syzygy/syzygy_test.cc
+++ b/src/syzygy/syzygy_test.cc
@@ -51,19 +51,19 @@ TEST(Syzygy, Simple3PieceProbes) {
   }
   // Longest 3 piece position.
   TestValidExpectation(&tablebase, "8/8/8/8/8/8/2Rk4/1K6 b - - 0 1", WDL_LOSS,
-                       -31);
+                       -32);
   // Invert color of above, no change.
   TestValidExpectation(&tablebase, "8/8/8/8/8/8/2rK4/1k6 w - - 0 1", WDL_LOSS,
-                       -31);
+                       -32);
   // Horizontal mirror.
   TestValidExpectation(&tablebase, "8/8/8/8/8/8/4kR2/6K1 b - - 0 1", WDL_LOSS,
-                       -31);
+                       -32);
   // Vertical mirror.
   TestValidExpectation(&tablebase, "6K1/4kR2/8/8/8/8/8/8 b - - 0 1", WDL_LOSS,
-                       -31);
+                       -32);
   // Horizontal mirror again.
   TestValidExpectation(&tablebase, "1K6/2Rk4/8/8/8/8/8/8 b - - 0 1", WDL_LOSS,
-                       -31);
+                       -32);
 
   // A draw by capture position, leaving KvK.
   TestValidExpectation(&tablebase, "5Qk1/8/8/8/8/8/8/4K3 b - - 0 1", WDL_DRAW,
@@ -75,11 +75,11 @@ TEST(Syzygy, Simple3PieceProbes) {
 
   // A position with a pawn that needs a king move first to win.
   TestValidExpectation(&tablebase, "8/8/8/8/8/k1p5/8/3K4 b - - 0 1", WDL_WIN,
-                       2);
+                       3);
 
   // A position with a pawn that needs a few king moves before its a loss.
   TestValidExpectation(&tablebase, "8/2p5/8/8/8/5k2/8/2K5 w - - 0 1", WDL_LOSS,
-                       -7);
+                       -8);
 }
 
 TEST(Syzygy, Simple4PieceProbes) {
@@ -93,11 +93,17 @@ TEST(Syzygy, Simple4PieceProbes) {
 
   // Longest 4 piece position.
   TestValidExpectation(&tablebase, "8/8/8/6B1/8/8/4k3/1K5N b - - 0 1", WDL_LOSS,
-                       -64);
+                       -65);
 
   // Some random checkmate position.
   TestValidExpectation(&tablebase, "8/8/8/8/8/2p5/3q2k1/4K3 w - - 0 1",
                        WDL_LOSS, -1);
+
+  // Enpassant capture victory vs loss without rights.
+  TestValidExpectation(&tablebase, "7k/8/8/8/Pp2K3/8/8/8 b - a3 0 1", WDL_WIN,
+                       1);
+  TestValidExpectation(&tablebase, "7k/8/8/8/Pp2K3/8/8/8 b - - 0 1", WDL_LOSS,
+                       -1);
 }
 
 TEST(Syzygy, Simple5PieceProbes) {
@@ -128,19 +134,25 @@ TEST(Syzygy, Simple5PieceProbes) {
   TestValidExpectation(&tablebase, "3k4/R7/7r/2KP4/8/8/8/8 w - - 0 1", WDL_DRAW,
                        0);
 
+  // En passant is a loss, without is draw by stalemate.
+  TestValidExpectation(&tablebase, "8/8/8/8/6Pp/7K/5Q2/7k b - g3 0 1", WDL_LOSS,
+                       -1);
+  TestValidExpectation(&tablebase, "8/8/8/8/6Pp/7K/5Q2/7k b - - 0 1", WDL_DRAW,
+                       0);
+
   // Some suggestions.
   TestValidExpectation(&tablebase, "kqqQK3/8/8/8/8/8/8/8 b - - 0 1", WDL_WIN,
                        1);
   TestValidExpectation(&tablebase, "kqqQK3/8/8/8/8/8/8/8 w - - 0 1", WDL_LOSS,
-                       -1);
+                       -2);
   TestValidExpectation(&tablebase, "KNNNk3/8/8/8/8/8/8/8 w - - 0 1", WDL_WIN,
-                       29);
+                       30);
   TestValidExpectation(&tablebase, "8/1k6/1p1r4/5K2/8/8/8/2R5 w - - 0 1",
                        WDL_DRAW, 0);
   TestValidExpectation(&tablebase, "8/7p/5k2/8/5PK1/7P/8/8 b - - 0 1", WDL_DRAW,
                        0);
   TestValidExpectation(&tablebase, "1k1n4/8/p7/5KP1/8/8/8/8 b - - 0 1", WDL_WIN,
-                       4);
+                       5);
   TestValidExpectation(&tablebase, "8/k7/8/2R5/8/4q3/8/4B2K w - - 0 1",
                        WDL_DRAW, 0);
 }

--- a/src/syzygy/syzygy_test.cc
+++ b/src/syzygy/syzygy_test.cc
@@ -23,6 +23,9 @@
 
 namespace lczero {
 
+// TODO: Tests for root_probe and root_probe_wdl. The former needs to check
+// scenarios with non-zero rule 50 count.
+
 void TestValidExpectation(SyzygyTablebase* tablebase, const std::string& fen,
                           WDLScore expected, int expected_dtz) {
   ChessBoard board;
@@ -114,6 +117,10 @@ TEST(Syzygy, Simple5PieceProbes) {
   TestValidExpectation(&tablebase, "8/6B1/8/8/B7/8/K1pk4/8 b - - 0 1",
                        WDL_BLESSED_LOSS, -101);
 
+  // A mate to be played on the board that is a capture.
+  TestValidExpectation(&tablebase, "k7/p7/8/8/3Q4/8/5B2/7K w - - 0 1", WDL_WIN,
+                       1);
+
   // Philidor draw position.
   TestValidExpectation(&tablebase, "8/8/8/8/4pk2/R7/7r/4K3 b - - 0 1", WDL_DRAW,
                        0);
@@ -128,6 +135,14 @@ TEST(Syzygy, Simple5PieceProbes) {
                        -1);
   TestValidExpectation(&tablebase, "KNNNk3/8/8/8/8/8/8/8 w - - 0 1", WDL_WIN,
                        29);
+  TestValidExpectation(&tablebase, "8/1k6/1p1r4/5K2/8/8/8/2R5 w - - 0 1",
+                       WDL_DRAW, 0);
+  TestValidExpectation(&tablebase, "8/7p/5k2/8/5PK1/7P/8/8 b - - 0 1", WDL_DRAW,
+                       0);
+  TestValidExpectation(&tablebase, "1k1n4/8/p7/5KP1/8/8/8/8 b - - 0 1", WDL_WIN,
+                       4);
+  TestValidExpectation(&tablebase, "8/k7/8/2R5/8/4q3/8/4B2K w - - 0 1",
+                       WDL_DRAW, 0);
 }
 
 }  // namespace lczero

--- a/src/syzygy/syzygy_test.cc
+++ b/src/syzygy/syzygy_test.cc
@@ -1,0 +1,130 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include "src/syzygy/syzygy.h"
+
+namespace lczero {
+
+void TestValidExpectation(SyzygyTablebase* tablebase, const std::string& fen,
+                          WDLScore expected, int expected_dtz) {
+  ChessBoard board;
+  PositionHistory history;
+  board.SetFromFen(fen);
+  history.Reset(board, 0, 1);
+  ProbeState result;
+  WDLScore score = tablebase->probe_wdl(history.Last(), &result);
+  EXPECT_NE(result, FAIL);
+  EXPECT_EQ(score, expected);
+  int moves = tablebase->probe_dtz(history.Last(), &result);
+  EXPECT_NE(result, FAIL);
+  EXPECT_EQ(moves, expected_dtz);
+}
+
+TEST(Syzygy, Simple3PieceProbes) {
+  SyzygyTablebase tablebase;
+  // Try to find syzygy relative to current working directory.
+  tablebase.init("syzygy");
+  if (tablebase.max_cardinality() < 3) {
+    // These probes require 3 piece tablebase.
+    return;
+  }
+  // Longest 3 piece position.
+  TestValidExpectation(&tablebase, "8/8/8/8/8/8/2Rk4/1K6 b - - 0 1", WDL_LOSS,
+                       -31);
+  // Invert color of above, no change.
+  TestValidExpectation(&tablebase, "8/8/8/8/8/8/2rK4/1k6 w - - 0 1", WDL_LOSS,
+                       -31);
+  // Horizontal mirror.
+  TestValidExpectation(&tablebase, "8/8/8/8/8/8/4kR2/6K1 b - - 0 1", WDL_LOSS,
+                       -31);
+  // Vertical mirror.
+  TestValidExpectation(&tablebase, "6K1/4kR2/8/8/8/8/8/8 b - - 0 1", WDL_LOSS,
+                       -31);
+  // Horizontal mirror again.
+  TestValidExpectation(&tablebase, "1K6/2Rk4/8/8/8/8/8/8 b - - 0 1", WDL_LOSS,
+                       -31);
+
+  // A draw by capture position, leaving KvK.
+  TestValidExpectation(&tablebase, "5Qk1/8/8/8/8/8/8/4K3 b - - 0 1", WDL_DRAW,
+                       0);
+
+  // A position with a pawn which is to move and win from there.
+  TestValidExpectation(&tablebase, "6k1/8/8/8/8/5p2/8/2K5 b - - 0 1", WDL_WIN,
+                       1);
+
+  // A position with a pawn that needs a king move first to win.
+  TestValidExpectation(&tablebase, "8/8/8/8/8/k1p5/8/3K4 b - - 0 1", WDL_WIN,
+                       2);
+
+  // A position with a pawn that needs a few king moves before its a loss.
+  TestValidExpectation(&tablebase, "8/2p5/8/8/8/5k2/8/2K5 w - - 0 1", WDL_LOSS,
+                       -7);
+}
+
+TEST(Syzygy, Simple4PieceProbes) {
+  SyzygyTablebase tablebase;
+  // Try to find syzygy relative to current working directory.
+  tablebase.init("syzygy");
+  if (tablebase.max_cardinality() < 4) {
+    // These probes require 4 piece tablebase.
+    return;
+  }
+
+  // Longest 4 piece position.
+  TestValidExpectation(&tablebase, "8/8/8/6B1/8/8/4k3/1K5N b - - 0 1", WDL_LOSS,
+                       -64);
+
+  // Some random checkmate position.
+  TestValidExpectation(&tablebase, "8/8/8/8/8/2p5/3q2k1/4K3 w - - 0 1",
+                       WDL_LOSS, -1);
+}
+
+TEST(Syzygy, Simple5PieceProbes) {
+  SyzygyTablebase tablebase;
+  // Try to find syzygy relative to current working directory.
+  tablebase.init("syzygy");
+  if (tablebase.max_cardinality() < 5) {
+    // These probes require 5 piece tablebase.
+    return;
+  }
+
+  // Longest 5 piece position.
+  TestValidExpectation(&tablebase, "8/8/8/8/1p2P3/4P3/1k6/3K4 w - - 0 1",
+                       WDL_CURSED_WIN, 101);
+
+  // A blessed loss position.
+  TestValidExpectation(&tablebase, "8/6B1/8/8/B7/8/K1pk4/8 b - - 0 1",
+                       WDL_BLESSED_LOSS, -101);
+
+  // Philidor draw position.
+  TestValidExpectation(&tablebase, "8/8/8/8/4pk2/R7/7r/4K3 b - - 0 1", WDL_DRAW,
+                       0);
+  // Double mirrored and color swapped.
+  TestValidExpectation(&tablebase, "3k4/R7/7r/2KP4/8/8/8/8 w - - 0 1", WDL_DRAW,
+                       0);
+}
+
+}  // namespace lczero
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This time starting from the cfish version - combined with code I wrote for the previous version with intent to have a final product which is compatible with GPL with exception.

There are a couple of places I'm sure this has performance issues - and in all its very ugly - but it compiles.  I even tested that it could successfully load the 6-piece tablebases for both wdl and wdl+dtz without crashing.

No probing has been tested at all yet.

Has an identical surface API to the previous attempt, so attempts at integrating it into search should be able to be reused.