### PR TITLE
Efficient and informative depth computation.

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -194,23 +194,6 @@ void Node::FinalizeScoreUpdate(float v) {
   --n_in_flight_;
 }
 
-void Node::UpdateMaxDepth(int depth) {
-  if (depth > max_depth_) max_depth_ = depth;
-}
-
-bool Node::UpdateFullDepth(uint16_t* depth) {
-  // TODO(crem) If this function won't be needed, consider also killing
-  //            ChildNodes/NodeRange/Nodes_Iterator.
-  if (full_depth_ > *depth) return false;
-  for (Node* child : ChildNodes()) {
-    if (*depth > child->full_depth_) *depth = child->full_depth_;
-  }
-  if (*depth >= full_depth_) {
-    full_depth_ = ++*depth;
-    return true;
-  }
-  return false;
-}
 
 Node::NodeRange Node::ChildNodes() const { return child_.get(); }
 

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -156,8 +156,6 @@ class Node {
 
   // Returns whether the node is known to be draw/lose/win.
   bool IsTerminal() const { return is_terminal_; }
-  uint16_t GetFullDepth() const { return full_depth_; }
-  uint16_t GetMaxDepth() const { return max_depth_; }
   uint16_t GetNumEdges() const { return edges_.size(); }
 
   // Makes the node terminal and sets it's score.
@@ -225,10 +223,6 @@ class Node {
   // Sum of policy priors which have had at least one playout.
   float visited_policy_ = 0.0f;
 
-  // Maximum depth any subnodes of this node were looked at.
-  uint16_t max_depth_ = 0;
-  // Complete depth all subnodes of this node were fully searched.
-  uint16_t full_depth_ = 0;
   // Does this node end game (with a winning of either sides or draw).
   bool is_terminal_ = false;
 

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -601,7 +601,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend() {
     //            Will revisit that after rethinking locking strategy.
     if (!is_root_node) node = best_edge.GetOrSpawnNode(/* parent */ node);
     depth++;
-	// n_in_flight_ is incremented. If the method returns false, then there is
+    // n_in_flight_ is incremented. If the method returns false, then there is
     // a search collision, and this node is already being expanded.
     if (!node->TryStartScoreUpdate()) return {node, true, depth};
     // Either terminal or unexamined leaf node -- the end of this playout.
@@ -883,7 +883,7 @@ void SearchWorker::FetchMinibatchResults() {
 // 6. Propagate the new nodes' information to all their parents in the tree.
 // ~~~~~~~~~~~~~~
 void SearchWorker::DoBackupUpdate() {
-  // Update nodes, playouts and depth counters
+  // Initialize playout and depth counters.
   uint16_t max_depth_batch = 0;
   uint32_t cum_depth_batch = 0;
   uint16_t playouts_batch = 0;
@@ -921,7 +921,7 @@ void SearchWorker::DoBackupUpdate() {
     cum_depth_batch += node_to_process.depth;
     if (node_to_process.depth > max_depth_batch) {
       max_depth_batch = node_to_process.depth;
-	  }
+	}
   }
   // Update global depth and playouts from batch stats.
   // The two stage update, batch ->search, is in

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -158,9 +158,9 @@ class Search {
   int64_t total_playouts_ GUARDED_BY(nodes_mutex_) = 0;
   int remaining_playouts_ GUARDED_BY(nodes_mutex_) =
       std::numeric_limits<int>::max();
-  // Maximum search depth = length of longest path taken in picknodetoextend.
+  // Maximum search depth = length of longest path taken in PickNodetoExtend.
   uint16_t max_depth_ GUARDED_BY(nodes_mutex_) = 0;
-  // Average search depth = average of max_depth.
+  // Cummulative depth of all paths taken in PickNodetoExtend.
   uint64_t cum_depth_ GUARDED_BY(nodes_mutex_) = 0;
   BestMoveInfo::Callback best_move_callback_;
   ThinkingInfo::Callback info_callback_;

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -158,10 +158,12 @@ class Search {
   int64_t total_playouts_ GUARDED_BY(nodes_mutex_) = 0;
   int remaining_playouts_ GUARDED_BY(nodes_mutex_) =
       std::numeric_limits<int>::max();
-
+  // Maximum search depth = length of longest path taken in picknodetoextend.
+  uint16_t max_depth_ GUARDED_BY(nodes_mutex_) = 0;
+  // Average search depth = average of max_depth.
+  uint64_t cum_depth_ GUARDED_BY(nodes_mutex_) = 0;
   BestMoveInfo::Callback best_move_callback_;
   ThinkingInfo::Callback info_callback_;
-
   // External parameters.
   const int kMiniBatchSize;
   const int kMaxPrefetchBatch;
@@ -233,15 +235,16 @@ class SearchWorker {
 
  private:
   struct NodeToProcess {
-    NodeToProcess(Node* node, bool is_collision)
-        : node(node), is_collision(is_collision) {}
+    NodeToProcess(Node* node, bool is_collision, uint16_t depth)
+        : node(node), is_collision(is_collision), depth(depth) {}
     Node* node;
     bool is_collision = false;
     bool nn_queried = false;
+	uint16_t depth;
     // Value from NN's value head, or -1/0/1 for terminal nodes.
     float v;
   };
-
+  
   NodeToProcess PickNodeToExtend();
   void ExtendNode(Node* node);
   bool AddNodeToComputation(Node* node, bool add_if_cached = true);


### PR DESCRIPTION
This computes depth more efficiently and replaces full_depth with the more informative average depth:

1. both max_depth and full_depth are removed from the node structure freeing space
2. the checking of all siblings for full_depth computation is no longer needed
3. full_depth rarely got larger than 5 even on fast machines and long searches
4. average depth replaces full_depth as a more informative measure
5. max_depth reflects search depth not tree depth
6. max_depth is consistent with length of pv displayed (if pv stems from the max depth line)
7. max_depth and cum_depth (for averaging) are computed in a two step process, first per batch and only after the mutexed search->max_depth and search->cum_depth are updated. This is in preparation of a mutex reorg.
8. For discussion: average depth is true average depth and thus can also decrease (informing about leela currently exploring a wider tree). This is rare, my own testing with chessbase gui and cutechess as well as Dubslows testing showed no problems with this. It could easily be modified to be monotonically increasing.