### PR TITLE
History plane initialization corrects misevals

### DIFF
--- a/src/chess/position.cc
+++ b/src/chess/position.cc
@@ -91,7 +91,17 @@ GameResult PositionHistory::ComputeGameResult() const {
 
 void PositionHistory::Reset(const ChessBoard& board, int no_capture_ply,
                             int game_ply) {
+  // No move history is available to initialize history planes.
+  // However presence of empty history planes yields nonsensical evaluations.
+  // As a workaround all history planes are filled with the current position.
   positions_.clear();
+  Position currentPos = Position(board, no_capture_ply, game_ply);
+  Move nullMove = Move(0);
+  const int kMoveHistory = 8;
+  for (int idx = 0; idx < kMoveHistory - 1; idx++) {
+    positions_.emplace_back(Position(currentPos, nullMove).GetBoard(),
+                            no_capture_ply, game_ply);
+  }
   positions_.emplace_back(board, no_capture_ply, game_ply);
 }
 


### PR DESCRIPTION
In recent weeks/months, it has been noted that the recent testnet versions (10xxx) perform poorly compared to the mainnet when judged on the basis of test suites (such as STS) or when playing match games at shorter time controls. This finding has seemed puzzling, given the dominance of these nets by seemingly all other measures.  To give just one example, the mainnet 532 scores about 10,800 points in STS compared to only 8,670 points for testnet 10664 (both at 1000 visits per position).

It turns out this is related to the fact that tests positions are provided to Leela without history (as noted by ObiWanBenoni and possibly others on Discord several weeks ago) This causes nonsensical evaluations by Leela (increasingly so with later versions of the network which are more sensitized to history planes). 

Consider for example running LC0 as follows:
```
lc0.exe --verbose-move-stats --backend=cudnn-fp16 --minibatch-size=1 --max-prefetch=0 --weights=D:\weights\testserver.lczero.org\weights_10664.txt.gz 
```
and providing this fairly balanced position for analysis at low visit counts:
```
position fen r1bq1rk1/pp2bppp/2np1n2/3Np3/4P3/3B1N2/PPP2PPP/R1BQ1RK1 b - - 7 9
go nodes 0
```
This yield Q=-0.95166 (i.e. almost certainly a lost position). If instead we provided some made-up shuffling history:
```  
position fen r1bq1rk1/pp2bppp/2np1n2/3Np3/4P3/3B1N2/PPP2PPP/R1BQ1RK1 b - - 7 9 moves d8d7 d1d2 d7d8 d2d1
go nodes 0
```
then a more reasonable Q=-0.05435 is returned. Furthermore, the policy vector completely changes to something more reasonable.

The implications of the above include:
- test suite benchmark results are seriously flawed
- matchplay results at low to medium visits may yield dramatically inferior play by Leela, depending on the method by which the driving program sends the positions to the engine (if a single explicit FEN of the current position is provided rather than a sequence of moves starting from the startpos)
- use of Leela interactively for study of ad hoc positions is compromised

A simple workaround seems possible, and is provided in this PR for review and discussion. When a single FEN is provided to PositionHistory::Reset, we first fill history planes with positions which are obtained by applying a null move to the current position. (Interestingly, simply adding the current position multiple times fails to yield similar improvement).

The improvement is dramatic at low to medium visit counts. For example, the STS suite score improves: 
  - from 8,670 to 12,267 at  1,000 visits 
  - from 9,550 to 12,965 at 10,000 visits 

Hopefully many other Leela benchmark tests could benefit from rerun if this PR is incorporated.
