### PR TITLE
Fix minor readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ section 7:_
 
 If you modify this Program, or any covered work, by linking or
 combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
-Toolkit and the the NVIDIA CUDA Deep Neural Network library (or a
+Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
 modified version of those libraries), containing parts covered by the
 terms of the respective license agreement, the licensors of this
 Program grant you additional permission to convey the resulting work.


### PR DESCRIPTION
Remove the redundant 'the' from the Nvidia license.