### PR TITLE
Add hidden options for controlling Dirichlet noise Alpha and Epsilon.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -87,6 +87,12 @@ const OptionId SearchParams::kTemperatureVisitOffsetId{
     "Adjusts visits by this value when picking a move with a temperature. If a "
     "negative offset reduces visits for a particular move below zero, that "
     "move is not picked. If no moves can be picked, no temperature is used."};
+const OptionId SearchParams::kNoiseId{
+    "noise", "DirichletNoise",
+    "Add Dirichlet noise to root node prior probabilities. This allows the "
+    "engine to discover new ideas during training by exploring moves which are "
+    "known to be bad. Not normally used during play.",
+    'n'};
 const OptionId SearchParams::kNoiseEpsilonId{
     "noise-epsilon", "DirichletNoiseEpsilon",
     "Amount of Dirichlet noise to combine with root priors. This allows the "
@@ -205,6 +211,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kTemperatureWinpctCutoffId, 0.0f, 100.0f) = 100.0f;
   options->Add<FloatOption>(kTemperatureVisitOffsetId, -1000.0f, 1000.0f) =
       0.0f;
+  options->Add<BoolOption>(kNoiseId) = false;
   options->Add<FloatOption>(kNoiseEpsilonId, 0.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kNoiseAlphaId, 0.0f, 10000000.0f) = 0.3f;
   options->Add<BoolOption>(kVerboseStatsId) = false;
@@ -242,7 +249,9 @@ SearchParams::SearchParams(const OptionsDict& options)
       kCpuct(options.Get<float>(kCpuctId.GetId())),
       kCpuctBase(options.Get<float>(kCpuctBaseId.GetId())),
       kCpuctFactor(options.Get<float>(kCpuctFactorId.GetId())),
-      kNoiseEpsilon(options.Get<float>(kNoiseEpsilonId.GetId())),
+      kNoiseEpsilon(options.Get<bool>(kNoiseId.GetId())
+                        ? 0.25f
+                        : options.Get<float>(kNoiseEpsilonId.GetId())),
       kNoiseAlpha(options.Get<float>(kNoiseAlphaId.GetId())),
       kSmartPruningFactor(options.Get<float>(kSmartPruningFactorId.GetId())),
       kFpuAbsolute(options.Get<std::string>(kFpuStrategyId.GetId()) ==

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -87,12 +87,15 @@ const OptionId SearchParams::kTemperatureVisitOffsetId{
     "Adjusts visits by this value when picking a move with a temperature. If a "
     "negative offset reduces visits for a particular move below zero, that "
     "move is not picked. If no moves can be picked, no temperature is used."};
-const OptionId SearchParams::kNoiseId{
-    "noise", "DirichletNoise",
-    "Add Dirichlet noise to root node prior probabilities. This allows the "
+const OptionId SearchParams::kNoiseEpsilonId{
+    "noise-epsilon", "DirichletNoiseEpsilon",
+    "Amount of Dirichlet noise to combine with root priors. This allows the "
     "engine to discover new ideas during training by exploring moves which are "
-    "known to be bad. Not normally used during play.",
-    'n'};
+    "known to be bad. Not normally used during play."};
+const OptionId SearchParams::kNoiseAlphaId{
+    "noise-alpha", "DirichletNoiseAlpha",
+    "Alpha of Dirichlet noise to control the sharpness of move probabilities. "
+    "Larger values result in flatter / more evenly distributed values."};
 const OptionId SearchParams::kVerboseStatsId{
     "verbose-move-stats", "VerboseMoveStats",
     "Display Q, V, N, U and P values of every move candidate after each move."};
@@ -202,7 +205,8 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kTemperatureWinpctCutoffId, 0.0f, 100.0f) = 100.0f;
   options->Add<FloatOption>(kTemperatureVisitOffsetId, -1000.0f, 1000.0f) =
       0.0f;
-  options->Add<BoolOption>(kNoiseId) = false;
+  options->Add<FloatOption>(kNoiseEpsilonId, 0.0f, 1.0f) = 0.0f;
+  options->Add<FloatOption>(kNoiseAlphaId, 0.0f, 10000000.0f) = 0.3f;
   options->Add<BoolOption>(kVerboseStatsId) = false;
   options->Add<BoolOption>(kLogLiveStatsId) = false;
   options->Add<FloatOption>(kSmartPruningFactorId, 0.0f, 10.0f) = 1.33f;
@@ -228,6 +232,8 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kKLDGainAverageInterval, 1, 10000000) = 100;
   options->Add<FloatOption>(kMinimumKLDGainPerNode, 0.0f, 1.0f) = 0.0f;
 
+  options->HideOption(kNoiseEpsilonId);
+  options->HideOption(kNoiseAlphaId);
   options->HideOption(kLogLiveStatsId);
 }
 
@@ -236,7 +242,8 @@ SearchParams::SearchParams(const OptionsDict& options)
       kCpuct(options.Get<float>(kCpuctId.GetId())),
       kCpuctBase(options.Get<float>(kCpuctBaseId.GetId())),
       kCpuctFactor(options.Get<float>(kCpuctFactorId.GetId())),
-      kNoise(options.Get<bool>(kNoiseId.GetId())),
+      kNoiseEpsilon(options.Get<float>(kNoiseEpsilonId.GetId())),
+      kNoiseAlpha(options.Get<float>(kNoiseAlphaId.GetId())),
       kSmartPruningFactor(options.Get<float>(kSmartPruningFactorId.GetId())),
       kFpuAbsolute(options.Get<std::string>(kFpuStrategyId.GetId()) ==
                    "absolute"),

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -70,7 +70,8 @@ class SearchParams {
     return options_.Get<float>(kTemperatureWinpctCutoffId.GetId());
   }
 
-  bool GetNoise() const { return kNoise; }
+  float GetNoiseEpsilon() const { return kNoiseEpsilon; }
+  float GetNoiseAlpha() const { return kNoiseAlpha; }
   bool GetVerboseStats() const {
     return options_.Get<bool>(kVerboseStatsId.GetId());
   }
@@ -111,7 +112,8 @@ class SearchParams {
   static const OptionId kTemperatureEndgameId;
   static const OptionId kTemperatureWinpctCutoffId;
   static const OptionId kTemperatureVisitOffsetId;
-  static const OptionId kNoiseId;
+  static const OptionId kNoiseEpsilonId;
+  static const OptionId kNoiseAlphaId;
   static const OptionId kVerboseStatsId;
   static const OptionId kLogLiveStatsId;
   static const OptionId kSmartPruningFactorId;
@@ -143,7 +145,8 @@ class SearchParams {
   const float kCpuct;
   const float kCpuctBase;
   const float kCpuctFactor;
-  const bool kNoise;
+  const float kNoiseEpsilon;
+  const float kNoiseAlpha;
   const float kSmartPruningFactor;
   const bool kFpuAbsolute;
   const float kFpuValue;

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -112,6 +112,7 @@ class SearchParams {
   static const OptionId kTemperatureEndgameId;
   static const OptionId kTemperatureWinpctCutoffId;
   static const OptionId kTemperatureVisitOffsetId;
+  static const OptionId kNoiseId;
   static const OptionId kNoiseEpsilonId;
   static const OptionId kNoiseAlphaId;
   static const OptionId kVerboseStatsId;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1262,8 +1262,9 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
     for (auto edge : node->Edges()) edge.edge()->SetP(edge.GetP() * scale);
   }
   // Add Dirichlet noise if enabled and at root.
-  if (params_.GetNoise() && node == search_->root_node_) {
-    ApplyDirichletNoise(node, 0.25, 0.3);
+  if (params_.GetNoiseEpsilon() && node == search_->root_node_) {
+    ApplyDirichletNoise(node, params_.GetNoiseEpsilon(),
+                        params_.GetNoiseAlpha());
   }
 }
 

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -97,7 +97,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   defaults->Set<bool>(SearchParams::kOutOfOrderEvalId.GetId(), false);
   defaults->Set<float>(SearchParams::kSmartPruningFactorId.GetId(), 0.0f);
   defaults->Set<float>(SearchParams::kTemperatureId.GetId(), 1.0f);
-  defaults->Set<bool>(SearchParams::kNoiseId.GetId(), true);
+  defaults->Set<float>(SearchParams::kNoiseEpsilonId.GetId(), 0.25f);
   defaults->Set<float>(SearchParams::kFpuValueId.GetId(), 0.0f);
   defaults->Set<std::string>(SearchParams::kHistoryFillId.GetId(), "no");
   defaults->Set<std::string>(NetworkFactory::kBackendId.GetId(),


### PR DESCRIPTION
In preparation for experiments adjusting some magic numbers from A0-chess (α = 0.3, ε = 0.25), we can add options for the server to control these values. ~NB: with `--noise` replaced by `--noise-epsilon`, existing commands that use the old option will fail: `Unknown command line flag: --noise.`~

```
./lc0 --show-hidden --help
  -n,  --[no-]noise
               Add Dirichlet noise to root node prior probabilities. This allows the engine to
               discover new ideas during training by exploring moves which are known to be bad.
               Not normally used during play.
               [UCI: DirichletNoise  DEFAULT: false]

       --noise-epsilon=0.00..1.00
               Amount of Dirichlet noise to combine with root priors. This allows the engine to
               discover new ideas during training by exploring moves which are known to be bad.
               Not normally used during play.
               [UCI: DirichletNoiseEpsilon  DEFAULT: 0.00  MIN: 0.00  MAX: 1.00]

       --noise-alpha=0.00..10000000.00
               Alpha of Dirichlet noise to control the sharpness of move probabilities. Larger
               values result in flatter / more evenly distributed values.
               [UCI: DirichletNoiseAlpha  DEFAULT: 0.30  MIN: 0.00  MAX: 10000000.00]
```

The 1e7 for alpha is to allow for flat noise, e.g.,
```
./lc0 --verbose-move-stats --noise-epsilon=1 --noise-alpha=10000000
go nodes 1
info string a2a3  (204 ) N:       0 (+ 0) (P:  5.00%) (Q:  0.03735) (U: 0.17010) (Q+U:  0.20745) (V:  -.----) (T: 0) 
info string h2h4  (403 ) N:       0 (+ 0) (P:  5.00%) (Q:  0.03735) (U: 0.17010) (Q+U:  0.20745) (V:  -.----) (T: 0) 
info string a2a4  (207 ) N:       0 (+ 0) (P:  5.00%) (Q:  0.03735) (U: 0.17014) (Q+U:  0.20748) (V:  -.----) (T: 0) 
```