### PR TITLE
Fix minor bug in NN -> Edge policy storage

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -895,8 +895,9 @@ void SearchWorker::FetchMinibatchResults() {
       if (search_->kPolicySoftmaxTemp != 1.0f) {
         p = pow(p, 1 / search_->kPolicySoftmaxTemp);
       }
-      total += p;
       edge.edge()->SetP(p);
+      // Edge::SetP does some rounding, so only add to the total after rounding.
+      total += edge.edge()->GetP();
     }
     // Normalize P values to add up to 1.0.
     if (total > 0.0f) {


### PR DESCRIPTION
Edge::SetP does some rounding, meanwhile the "total unscaled policy for all moves" to be used as the scale factor was computed before this rounding.

In the rare case of there being only one legal move where the rounding didn't have anything to cancel out with on average, this could mean if the only-legal-move policy was sufficiently large and also rounded up when stored, then the "total" variable was slightly smaller than the actual edge->GetP() value, which meant that the scale = 1/total value times the GetP() value could rarely exceed 1 by a few parts per thousand. This wouldn't affect search behavior of course (especially when there's only one legal move), but it triggered the assert.

The fix is to increment the total with the rounded value, not the unrounded value.