### PR TITLE
Make out of order eval standard

### DIFF
--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -248,12 +248,11 @@ class SearchWorker {
     uint16_t depth;
     bool is_collision = false;
     bool nn_queried = false;
-    bool is_cache_hit = false;
   };
 
   NodeToProcess PickNodeToExtend();
   void ExtendNode(Node* node);
-  bool AddNodeToComputation(Node* node, bool add_if_cached);
+  bool AddNodeToComputation(Node* node);
   int PrefetchIntoCache(Node* node, int budget);
   void FetchSingleNodeResult(NodeToProcess* node_to_process,
                              int idx_in_computation);

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -104,7 +104,6 @@ class Search {
   static const char* kCacheHistoryLengthStr;
   static const char* kPolicySoftmaxTempStr;
   static const char* kAllowedNodeCollisionsStr;
-  static const char* kOutOfOrderEvalStr;
   static const char* kStickyCheckmateStr;
 
  private:
@@ -171,7 +170,7 @@ class Search {
   BestMoveInfo::Callback best_move_callback_;
   ThinkingInfo::Callback info_callback_;
   // External parameters.
-  const int kMiniBatchSize;
+  const unsigned int kMiniBatchSize;
   const int kMaxPrefetchBatch;
   const float kCpuct;
   const float kTemperature;
@@ -183,7 +182,6 @@ class Search {
   const int kCacheHistoryLength;
   const float kPolicySoftmaxTemp;
   const int kAllowedNodeCollisions;
-  const bool kOutOfOrderEval;
   const bool kStickyCheckmate;
 
   friend class SearchWorker;


### PR DESCRIPTION
I genuinely think this should go in the release (not a new feature!), but also I need a place to store testing results.

This command `./lc0 selfplay --no-share-trees --games=500 --parallelism=8 -w ../../../weights/weights_t9_9155.txt.gz --movetime=5000 --max-prefetch=0 --no-noise --reuse-tree --tempdecay-moves=15 --temperature=2 "player1:" --out-of-order-eval "player2:" --no-out-of-order-eval` produced these results (truncated early): 97-76-63, which shows a not-bad minigain for OOOeval

Meanwhile wajit used a similar command with a test10 network, t=1, tdecay=20, and got 124-126-313, with a much larger sample size showing a wash.

I've started a third run now for further testing. Testing against AB engines is probably also a good idea.