### PR TITLE
Add minimal root probing support.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -366,6 +366,26 @@ std::pair<Move, Move> Search::GetBestMove() const {
   return GetBestMoveInternal();
 }
 
+bool Search::PopulateRootMoveLimit(MoveList* root_moves) const {
+  // Search moves overrides tablebase.
+  if (!limits_.searchmoves.empty()) {
+    *root_moves = limits_.searchmoves;
+    return false;
+  }
+  auto board = played_history_.Last().GetBoard();
+  if (!syzygy_tb_ || !board.castlings().no_legal_castle() ||
+      (board.ours() + board.theirs()).count() > syzygy_tb_->max_cardinality()) {
+    return false;
+  }
+  if (!syzygy_tb_->root_probe(played_history_.Last(), root_moves)) {
+    if (!syzygy_tb_->root_probe_wdl(played_history_.Last(), root_moves)) {
+      // Failed both dtz and wdl hits.
+      return false;
+    }
+  }
+  return true;
+}
+
 // Returns the best move, maybe with temperature (according to the settings).
 std::pair<Move, Move> Search::GetBestMoveInternal() const
     REQUIRES_SHARED(nodes_mutex_) REQUIRES_SHARED(counters_mutex_) {
@@ -398,6 +418,10 @@ std::pair<Move, Move> Search::GetBestMoveInternal() const
 
 // Returns a child with most visits.
 EdgeAndNode Search::GetBestChildNoTemperature(Node* parent) const {
+  MoveList root_limit;
+  if (parent == root_node_) {
+    PopulateRootMoveLimit(&root_limit);
+  }
   EdgeAndNode best_edge;
   // Best child is selected using the following criteria:
   // * Largest number of playouts.
@@ -406,9 +430,9 @@ EdgeAndNode Search::GetBestChildNoTemperature(Node* parent) const {
   //   * If that number is larger than 0, the one with larger eval wins.
   std::tuple<int, float, float> best(-1, 0.0, 0.0);
   for (auto edge : parent->Edges()) {
-    if (parent == root_node_ && !limits_.searchmoves.empty() &&
-        std::find(limits_.searchmoves.begin(), limits_.searchmoves.end(),
-                  edge.GetMove()) == limits_.searchmoves.end()) {
+    if (parent == root_node_ && !root_limit.empty() &&
+        std::find(root_limit.begin(), root_limit.end(), edge.GetMove()) ==
+            root_limit.end()) {
       continue;
     }
     std::tuple<int, float, float> val(edge.GetN(), edge.GetQ(-10.0),
@@ -424,15 +448,20 @@ EdgeAndNode Search::GetBestChildNoTemperature(Node* parent) const {
 // Returns a child chosen according to weighted-by-temperature visit count.
 EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
                                                 float temperature) const {
+  MoveList root_limit;
+  if (parent == root_node_) {
+    PopulateRootMoveLimit(&root_limit);
+  }
+
   assert(parent->GetChildrenVisits() > 0);
   std::vector<float> cumulative_sums;
   float sum = 0.0;
   const float n_parent = parent->GetN();
 
   for (auto edge : parent->Edges()) {
-    if (parent == root_node_ && !limits_.searchmoves.empty() &&
-        std::find(limits_.searchmoves.begin(), limits_.searchmoves.end(),
-                  edge.GetMove()) == limits_.searchmoves.end()) {
+    if (parent == root_node_ && !root_limit.empty() &&
+        std::find(root_limit.begin(), root_limit.end(), edge.GetMove()) ==
+            root_limit.end()) {
       continue;
     }
     sum += std::pow(edge.GetN() / n_parent, 1 / temperature);
@@ -445,9 +474,9 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
       cumulative_sums.begin();
 
   for (auto edge : parent->Edges()) {
-    if (parent == root_node_ && !limits_.searchmoves.empty() &&
-        std::find(limits_.searchmoves.begin(), limits_.searchmoves.end(),
-                  edge.GetMove()) == limits_.searchmoves.end()) {
+    if (parent == root_node_ && !root_limit.empty() &&
+        std::find(root_limit.begin(), root_limit.end(), edge.GetMove()) ==
+            root_limit.end()) {
       continue;
     }
     if (idx-- == 0) return edge;
@@ -546,24 +575,8 @@ void SearchWorker::InitializeIteration(
 
   if (!root_move_filter_populated_) {
     root_move_filter_populated_ = true;
-    // Search moves overrides tablebase.
-    if (!search_->limits_.searchmoves.empty()) {
-      root_move_filter_ = search_->limits_.searchmoves;
-    } else {
-      auto board = history_.Last().GetBoard();
-      if (search_->syzygy_tb_ && board.castlings().no_legal_castle() &&
-          (board.ours() + board.theirs()).count() <=
-              search_->syzygy_tb_->max_cardinality()) {
-        if (!search_->syzygy_tb_->root_probe(history_.Last(),
-                                             &root_move_filter_)) {
-          if (search_->syzygy_tb_->root_probe_wdl(history_.Last(),
-                                                  &root_move_filter_)) {
-            search_->tb_hits_.fetch_add(1, std::memory_order_acq_rel);
-          }
-        } else {
-          search_->tb_hits_.fetch_add(1, std::memory_order_acq_rel);
-        }
-      }
+    if (search_->PopulateRootMoveLimit(&root_move_filter_)) {
+      search_->tb_hits_.fetch_add(1, std::memory_order_acq_rel);
     }
   }
 }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -556,8 +556,12 @@ void SearchWorker::InitializeIteration(
               search_->syzygy_tb_->max_cardinality()) {
         if (!search_->syzygy_tb_->root_probe(history_.Last(),
                                              &root_move_filter_)) {
-          search_->syzygy_tb_->root_probe_wdl(history_.Last(),
-                                              &root_move_filter_);
+          if (search_->syzygy_tb_->root_probe_wdl(history_.Last(),
+                                                  &root_move_filter_)) {
+            search_->tb_hits_.fetch_add(1, std::memory_order_acq_rel);
+          }
+        } else {
+          search_->tb_hits_.fetch_add(1, std::memory_order_acq_rel);
         }
       }
     }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -377,13 +377,8 @@ bool Search::PopulateRootMoveLimit(MoveList* root_moves) const {
       (board.ours() + board.theirs()).count() > syzygy_tb_->max_cardinality()) {
     return false;
   }
-  if (!syzygy_tb_->root_probe(played_history_.Last(), root_moves)) {
-    if (!syzygy_tb_->root_probe_wdl(played_history_.Last(), root_moves)) {
-      // Failed both dtz and wdl hits.
-      return false;
-    }
-  }
-  return true;
+  return syzygy_tb_->root_probe(played_history_.Last(), root_moves) ||
+         syzygy_tb_->root_probe_wdl(played_history_.Last(), root_moves);
 }
 
 // Returns the best move, maybe with temperature (according to the settings).

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -126,6 +126,10 @@ class Search {
 
   void SendMovesStats() const;
 
+  // Populates the given list with allowed root moves.
+  // Returns true if the population came from tablebase.
+  bool PopulateRootMoveLimit(MoveList* root_moves) const;
+
   // We only need first ply for debug output, but could be easily generalized.
   NNCacheLock GetCachedFirstPlyResult(EdgeAndNode) const;
 

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -268,7 +268,7 @@ class SearchWorker {
   // History is reset and extended by PickNodeToExtend().
   PositionHistory history_;
   MoveList root_move_filter_;
-  bool root_move_filter_populated_;
+  bool root_move_filter_populated_ = false;
 };
 
 }  // namespace lczero

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -267,6 +267,8 @@ class SearchWorker {
   std::unique_ptr<CachingComputation> computation_;
   // History is reset and extended by PickNodeToExtend().
   PositionHistory history_;
+  MoveList root_move_filter_;
+  bool root_move_filter_populated_;
 };
 
 }  // namespace lczero


### PR DESCRIPTION
This is untested, but should probably work to some extent I think.

Its not a 'complete' root probe support as it has two cases where it can fail.
1) If after search GetChildrenVisits is 0 the move selected may not be optimal.
2) If tree reuse brings over a lot of visits, those visits will not have been restricted to the root probe list, so the new visits to the filtered list might not have time to catch up, and an invalid move will be made.

Both of these could be fixed by adding a root probe call to GetBestChild* and applying filtering in there just like it currently does for searchmoves.