### PR TITLE
Fix reporting that config file was loaded when it wasn't

### DIFF
--- a/src/utils/configfile.cc
+++ b/src/utils/configfile.cc
@@ -56,6 +56,11 @@ bool ConfigFile::Init(OptionsParser* options) {
   // Calculate the relative path of the config file.
   OptionsDict dict = options->GetOptionsDict();
   std::string filename = dict.Get<std::string>(kConfigFileStr);
+
+  // If filename is an empty string then return true.  This is to override 
+  // loading the default configuration file.
+  if (filename == "") return true;
+
   filename = CommandLine::BinaryDirectory() + "/" + filename;
 
   // Parses the file into the arguments_ vector.
@@ -64,7 +69,7 @@ bool ConfigFile::Init(OptionsParser* options) {
   return true;
 }
 
-bool ConfigFile::ParseFile(const std::string filename, OptionsParser* options) {
+bool ConfigFile::ParseFile(const std::string& filename, OptionsParser* options) {
   std::ifstream input(filename);
 
   // Check to see if we are using the default config file or not.

--- a/src/utils/configfile.h
+++ b/src/utils/configfile.h
@@ -49,7 +49,7 @@ class ConfigFile {
 
  private:
   // Parses the config file into the arguments_ vector.
-  static bool ParseFile(const std::string filename, OptionsParser* options);
+  static bool ParseFile(const std::string& filename, OptionsParser* options);
 
   static std::vector<std::string> arguments_;
 };


### PR DESCRIPTION
This fixes issue https://github.com/LeelaChessZero/lc0/issues/295.

If you run lc0 with the following command, it reports that the config file was found when in fact it was not.

`./lc0 --config=`

You would run the above command if you wanted to override using the default lc0.config file.  This PR will not print that the config file at ./ was found which is confusing since no config file was actually loaded.

I also changed the ParseFile function signature to use `const std::string& `instead of `const std::string`.