### PR TITLE
Insert dummy a1a1 history for fen positions

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -364,8 +364,11 @@ void EngineLoop::CmdPosition(const std::string& position,
                              const std::vector<std::string>& moves) {
   EnsureOptionsSent();
   std::string fen = position;
+  std::vector<std::string> history = moves;
   if (fen.empty()) fen = ChessBoard::kStartingFen;
-  engine_.SetPosition(fen, moves);
+  // Make sure the history has at least 2 moves when not from startpos
+  else if (history.size() < 2) history.insert(history.begin(), 2, "a1a1");
+  engine_.SetPosition(fen, history);
 }
 
 void EngineLoop::CmdGo(const GoParams& params) {


### PR DESCRIPTION
Perhaps as an alternative to #253, specifically for handling "position fen …" by adding in a couple "a1a1" moves to get more expected behavior.

![screen shot 2018-08-24 at 12 19 53 pm](https://user-images.githubusercontent.com/438537/44603666-3c19ee00-a798-11e8-90d8-98af1ed59617.png)

Before:
```
position fen rnb1kbnr/pppppppp/8/8/8/3q4/PPPPPPPP/RNBQKBNR b KQkq - 0 1
info string e7e5  (322 ) N:       0 (+ 0) (P:  9.59%) (Q:  0.02389) (U: 0.32601) (Q+U:  0.34990) (V:  -.----) 
info string d7d5  (293 ) N:       0 (+ 0) (P: 11.91%) (Q:  0.02389) (U: 0.40487) (Q+U:  0.42876) (V:  -.----) 
info string g8f6  (159 ) N:       0 (+ 0) (P: 15.69%) (Q:  0.02389) (U: 0.53353) (Q+U:  0.55742) (V:  -.----) 

position fen rnb1kbnr/pppppppp/8/8/8/3q4/PPPPPPPP/RNBQKBNR b KQkq - 0 1 moves a1a1 a1a1
info string d3f5  (1237) N:       0 (+ 0) (P:  8.26%) (Q:  0.06871) (U: 0.28067) (Q+U:  0.34938) (V:  -.----) 
info string d3d5  (1235) N:       0 (+ 0) (P:  9.46%) (Q:  0.06871) (U: 0.32176) (Q+U:  0.39047) (V:  -.----) 
info string d3g6  (1232) N:       0 (+ 0) (P: 11.24%) (Q:  0.06871) (U: 0.38215) (Q+U:  0.45085) (V:  -.----) 

position fen rnb1kbnr/pppppppp/8/8/8/3q4/PPPPPPPP/RNBQKBNR b KQkq - 0 1 moves a1a1 a1a1 a1a1 a1a1 a1a1 a1a1 a1a1 a1a1
info string d3f5  (1237) N:       0 (+ 0) (P:  8.26%) (Q:  0.06871) (U: 0.28067) (Q+U:  0.34938) (V:  -.----) 
info string d3d5  (1235) N:       0 (+ 0) (P:  9.46%) (Q:  0.06871) (U: 0.32176) (Q+U:  0.39047) (V:  -.----) 
info string d3g6  (1232) N:       0 (+ 0) (P: 11.24%) (Q:  0.06871) (U: 0.38215) (Q+U:  0.45085) (V:  -.----) 
```
After:
```
position fen rnb1kbnr/pppppppp/8/8/8/3q4/PPPPPPPP/RNBQKBNR b KQkq - 0 1
info string d3f5  (1237) N:       0 (+ 0) (P:  8.26%) (Q:  0.06871) (U: 0.28067) (Q+U:  0.34938) (V:  -.----) 
info string d3d5  (1235) N:       0 (+ 0) (P:  9.46%) (Q:  0.06871) (U: 0.32176) (Q+U:  0.39047) (V:  -.----) 
info string d3g6  (1232) N:       0 (+ 0) (P: 11.24%) (Q:  0.06871) (U: 0.38215) (Q+U:  0.45085) (V:  -.----) 
```