### PR TITLE
Exponential moving average of q updates

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -235,7 +235,8 @@ void Node::CancelScoreUpdate() { --n_in_flight_; }
 
 void Node::FinalizeScoreUpdate(float v, float momentum) {
   // Recompute Q.
-  q_ = momentum * q_ + (1 - momentum) * v / (1 - std::pow(momentum, static_cast<float>(n_)));
+  q_buff_ = momentum * q_buff_ + (1 - momentum) * v;
+  q_ = q_buff_ / (1 - std::pow(momentum, static_cast<float>(n_)));
   // If first visit, update parent's sum of policies visited at least once.
   if (n_ == 0 && parent_ != nullptr) {
     parent_->visited_policy_ += parent_->edges_[index_].GetP();

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -233,9 +233,9 @@ bool Node::TryStartScoreUpdate() {
 
 void Node::CancelScoreUpdate() { --n_in_flight_; }
 
-void Node::FinalizeScoreUpdate(float v) {
+void Node::FinalizeScoreUpdate(float v, float momentum) {
   // Recompute Q.
-  q_ += (v - q_) / (n_ + 1);
+  q_ = momentum * q_ + (1 - momentum) * v / (1 - std::pow(momentum, static_cast<float>(n_)));
   // If first visit, update parent's sum of policies visited at least once.
   if (n_ == 0 && parent_ != nullptr) {
     parent_->visited_policy_ += parent_->edges_[index_].GetP();

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -236,7 +236,7 @@ void Node::CancelScoreUpdate() { --n_in_flight_; }
 void Node::FinalizeScoreUpdate(float v, float momentum) {
   // Recompute Q.
   q_buff_ = momentum * q_buff_ + (1 - momentum) * v;
-  q_ = q_buff_ / (1 - std::pow(momentum, static_cast<float>(n_)));
+  q_ = q_buff_ / (1 - std::pow(momentum, static_cast<float>(n_) + 1));
   // If first visit, update parent's sum of policies visited at least once.
   if (n_ == 0 && parent_ != nullptr) {
     parent_->visited_policy_ += parent_->edges_[index_].GetP();

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -214,6 +214,7 @@ class Node {
   // subtree. For terminal nodes, eval is stored. This is from the perspective
   // of the player who "just" moved to reach this position, rather than from the
   // perspective of the player-to-move for the position.
+  float q_buff_ = 0.0f;
   float q_ = 0.0f;
   // How many completed visits this node had.
   uint32_t n_ = 0;

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -172,7 +172,7 @@ class Node {
   // * Q (weighted average of all V in a subtree)
   // * N (+=1)
   // * N-in-flight (-=1)
-  void FinalizeScoreUpdate(float v);
+  void FinalizeScoreUpdate(float v, float momentum);
 
   // Updates max depth, if new depth is larger.
   void UpdateMaxDepth(int depth);

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -186,7 +186,7 @@ class Search {
   const int kAllowedNodeCollisions;
   const bool kOutOfOrderEval;
   const bool kStickyCheckmate;
-  const bool kBackPropagateMomentum;
+  const float kBackPropagateMomentum;
 
   friend class SearchWorker;
 };

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -106,6 +106,7 @@ class Search {
   static const char* kAllowedNodeCollisionsStr;
   static const char* kOutOfOrderEvalStr;
   static const char* kStickyCheckmateStr;
+  static const char* kBackPropagateMomentumStr;
 
  private:
   // Returns the best move, maybe with temperature (according to the settings).
@@ -185,6 +186,7 @@ class Search {
   const int kAllowedNodeCollisions;
   const bool kOutOfOrderEval;
   const bool kStickyCheckmate;
+  const bool kBackPropagateMomentum;
 
   friend class SearchWorker;
 };


### PR DESCRIPTION
This PR is just for experimentation for now.

As proposed by Commander8 in the Discord, this uses a different weighting scheme for q updates. Their intention is to improve scaling for high node counts (1M+). In particular, this PR implements a bias-corrected exponential moving average instead of the arithmetic mean. This closely matches how the bias-corrected EMA is written in the [Adam optimiser](https://arxiv.org/abs/1412.6980). The bias correction makes it so that it is not biased towards 0 due to the initialisation of q to 0.

This adds the param --backpropagate-momentum in the range [0, 1): The higher the value, the slower q changes with new updates from v. 0 means that q = v, 1-eps should be close to an arithmetic mean, but it probably runs into numerical precision issues.