### PR TITLE
Have a separate thread which watches time and `stop` command.

### DIFF
--- a/src/utils/mutex.h
+++ b/src/utils/mutex.h
@@ -70,6 +70,7 @@ class CAPABILITY("mutex") Mutex {
    public:
     Lock(Mutex& m) ACQUIRE(m) : lock_(m.get_raw()) {}
     ~Lock() RELEASE() {}
+    std::unique_lock<std::mutex>& get_raw() { return lock_; }
 
    private:
     std::unique_lock<std::mutex> lock_;


### PR DESCRIPTION
Have a separate thread which watches time and `stop` command to reduce delay of reporting the move.

Should fix timeout problems that we have.

Time between sending `stop` and getting the `bestmove`:

Before:
```
Cudnn:   30.27± 5.03ms
Blas:    36.30± 5.46ms
OpenCl: 136.30±52.34ms
```
After:
```
Cudnn:   0.14± 0.03ms
Blas:    0.49± 1.75ms
OpenCl:  0.47±1.65ms
```
