### PR TITLE
Create executables without the popcnt instruction

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ install:
 - cmd: set PATH=c:\cache\protobuf\bin;%PATH%
 - cmd: cd C:\projects\lc0
 cache:
-  - C:\cache -> appveyor.yml
+  - C:\cache
   - 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.2'
   - C:\projects\lc0\subprojects\packagecache
 before_build:
@@ -53,8 +53,11 @@ before_build:
 build_script:
 - cmd: IF %APPVEYOR_REPO_TAG%==false msbuild "C:\projects\lc0\build\lc0.sln" /m /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 - cmd: IF %APPVEYOR_REPO_TAG%==true msbuild "C:\projects\lc0\build\lc0.sln" /m /p:WholeProgramOptimization=true /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- cmd: IF %APPVEYOR_REPO_TAG%==true meson.py configure build -Dpopcnt=false
+- cmd: IF %APPVEYOR_REPO_TAG%==true msbuild "C:\projects\lc0\build\lc0.sln" /t:REGEN /m /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- cmd: IF %APPVEYOR_REPO_TAG%==true msbuild "C:\projects\lc0\build\lc0.sln" /m /p:WholeProgramOptimization=true /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 after_build:
-- cmd: IF %APPVEYOR_REPO_TAG%==true 7z a lc0-windows-%NAME%.zip %APPVEYOR_BUILD_FOLDER%\build\lc0.exe
+- cmd: IF %APPVEYOR_REPO_TAG%==true 7z a lc0-windows-%NAME%.zip %APPVEYOR_BUILD_FOLDER%\build\lc0*.exe
 - cmd: IF %APPVEYOR_REPO_TAG%==true IF %CUDA%==false 7z a lc0-windows-%NAME%.zip C:\cache\OpenBLAS.0.2.14.1\lib\native\bin\x64\*.dll
 - cmd: IF %APPVEYOR_REPO_TAG%==true IF %CUDA%==false IF %OPENCL%==true 7z a lc0-windows-%NAME%.zip C:\cache\opencl-nug.0.777.12\build\native\bin\OpenCL.dll
 - cmd: IF %APPVEYOR_REPO_TAG%==true IF %CUDA%==true 7z a lc0-windows-%NAME%.zip "%CUDA_PATH%\bin\cudart64_92.dll" "%CUDA_PATH%\bin\cublas64_92.dll"
@@ -65,7 +68,7 @@ after_build:
 - cmd: IF %APPVEYOR_REPO_TAG%==true IF %CUDA%==true type dist\README-cuda.txt |more /P > dist\README.txt
 - cmd: IF %APPVEYOR_REPO_TAG%==true IF %CUDA%==true 7z a lc0-windows-%NAME%.zip .\dist\README.txt .\dist\COPYING .\dist\CUDA.txt .\dist\CUDNN.txt
 artifacts:
-  - path: build/lc0.exe
+  - path: build/lc0*.exe
     name: lc0-$(NAME)
   - path: lc0-windows-$(NAME).zip
     name: lc0-windows-$(NAME)-zip

--- a/meson.build
+++ b/meson.build
@@ -377,9 +377,14 @@ endif
 ## Main Executable
 #############################################################################
 
-executable('lc0', 'src/main.cc',
-  files, include_directories: includes, dependencies: deps, install: true)
-
+if get_option('popcnt')
+  executable('lc0', 'src/main.cc',
+    files, include_directories: includes, dependencies: deps, install: true)
+else
+  add_project_arguments('-DNO_POPCNT', language : 'cpp')
+  executable('lc0_nopopcnt', 'src/main.cc',
+    files, include_directories: includes, dependencies: deps, install: true)
+endif
 
 ### Tests
 gtest = dependency('gtest', fallback: ['gtest', 'gtest_dep'], required: false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -108,6 +108,11 @@ option('accelerate',
        value: true,
        description: 'Enable Accelerate BLAS support')
 
+option('popcnt',
+       type: 'boolean',
+       value: true,
+       description: 'Use the popcnt instruction')
+
 option('gtest',
        type: 'boolean',
        value: true,

--- a/src/chess/bitboard.h
+++ b/src/chess/bitboard.h
@@ -96,10 +96,18 @@ class BitBoard {
   std::uint64_t as_int() const { return board_; }
   void clear() { board_ = 0; }
   int count() const {
+#ifdef NO_POPCNT
+    std::uint64_t x = board_;
+    x -= (x >> 1) & 0x5555555555555555;
+    x = (x & 0x3333333333333333) + ((x >> 2) & 0x3333333333333333);
+    x = (x + (x >> 4)) & 0x0F0F0F0F0F0F0F0F;
+    return (x * 0x0101010101010101) >> 56;
+#else
 #ifdef _MSC_VER
     return _mm_popcnt_u64(board_);
 #else
     return __builtin_popcountll(board_);
+#endif
 #endif
   }
 

--- a/src/chess/bitboard.h
+++ b/src/chess/bitboard.h
@@ -96,18 +96,16 @@ class BitBoard {
   std::uint64_t as_int() const { return board_; }
   void clear() { board_ = 0; }
   int count() const {
-#ifdef NO_POPCNT
+#if defined(NO_POPCNT)
     std::uint64_t x = board_;
     x -= (x >> 1) & 0x5555555555555555;
     x = (x & 0x3333333333333333) + ((x >> 2) & 0x3333333333333333);
     x = (x + (x >> 4)) & 0x0F0F0F0F0F0F0F0F;
     return (x * 0x0101010101010101) >> 56;
-#else
-#ifdef _MSC_VER
+#elif defined(_MSC_VER)
     return _mm_popcnt_u64(board_);
 #else
     return __builtin_popcountll(board_);
-#endif
 #endif
   }
 

--- a/src/chess/bitboard.h
+++ b/src/chess/bitboard.h
@@ -108,6 +108,18 @@ class BitBoard {
     return __builtin_popcountll(board_);
 #endif
   }
+  int count_few() const {
+#if defined(NO_POPCNT)
+    std::uint64_t x = board_;
+    int count;
+    for (count = 0; x != 0; ++count) {
+      x &= x - 1;
+    }
+    return count;
+#else
+    return count();
+#endif
+  }
 
   // Sets the value for given square to 1 if cond is true.
   // Otherwise does nothing (doesn't reset!).

--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -705,14 +705,7 @@ bool ChessBoard::HasMatingMaterial() const {
     return true;
   }
 
-  // Count the total pieces on the board.
-  uint64_t x = our_pieces_.as_int() | their_pieces_.as_int();
-  // x &= x - 1 clears the rigthmost set bit (if any).
-  x &= x - 1;
-  x &= x - 1;
-  x &= x - 1;
-  // If x is zero we started with 3 or less bits set.
-  if (x == 0) {
+  if ((our_pieces_ + their_pieces_).count() < 4) {
     // K v K, K+B v K, K+N v K.
     return false;
   }

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -187,15 +187,15 @@ int count_pieces(const ChessBoard& pos, int type, bool theirs) {
     case KING:
       return 1;
     case QUEEN:
-      return (all * pos.queens()).count();
+      return (all * pos.queens()).count_few();
     case ROOK:
-      return (all * pos.rooks()).count();
+      return (all * pos.rooks()).count_few();
     case BISHOP:
-      return (all * pos.bishops()).count();
+      return (all * pos.bishops()).count_few();
     case KNIGHT:
-      return theirs ? pos.their_knights().count() : pos.our_knights().count();
+      return (theirs ? pos.their_knights() : pos.our_knights()).count_few();
     case PAWN:
-      return (all * pos.pawns()).count();
+      return (all * pos.pawns()).count_few();
     default:
       assert(false);
   }


### PR DESCRIPTION
This adds an alternative implementation of the bitboard count() method that isn't using the popcnt instruction and meson support for it, specifically a popcnt binary option, default true to use the popcnt instruction as usual, or build the lc0_nopopcnt executable if false. Appveyor uses this to package both lc0.exe and lc0_nopopcnt.exe in the release zip files.