### PR TITLE
Changes to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,20 +2,23 @@
 
 set -e
 
-BUILDTYPE=$1
-
-if [ -z "${BUILDTYPE}" ]
-then
-  BUILDTYPE=release
-fi
+case $1 in
+  plain|debug|debugoptimized|release|minsize)
+    BUILDTYPE=$1
+    shift
+    ;;
+  *)
+    BUILDTYPE=release
+    ;;
+esac
 
 BUILDDIR=build/${BUILDTYPE}
 
 if [ -d ${BUILDDIR} ]
 then
-  meson configure ${BUILDDIR} --buildtype ${BUILDTYPE} --prefix ${INSTALL_PREFIX:-/usr/local}
+  meson configure ${BUILDDIR} --buildtype ${BUILDTYPE} --prefix ${INSTALL_PREFIX:-/usr/local} "$@"
 else
-  meson ${BUILDDIR} --buildtype ${BUILDTYPE} --prefix ${INSTALL_PREFIX:-/usr/local}
+  meson ${BUILDDIR} --buildtype ${BUILDTYPE} --prefix ${INSTALL_PREFIX:-/usr/local} "$@"
 fi
 
 pushd ${BUILDDIR}

--- a/build.sh
+++ b/build.sh
@@ -11,8 +11,12 @@ fi
 
 BUILDDIR=build/${BUILDTYPE}
 
-rm -fr ${BUILDDIR}
-meson ${BUILDDIR} --buildtype ${BUILDTYPE} --prefix ${INSTALL_PREFIX:-/usr/local}
+if [ -d ${BUILDDIR} ]
+then
+  meson configure ${BUILDDIR} --buildtype ${BUILDTYPE} --prefix ${INSTALL_PREFIX:-/usr/local}
+else
+  meson ${BUILDDIR} --buildtype ${BUILDTYPE} --prefix ${INSTALL_PREFIX:-/usr/local}
+fi
 
 pushd ${BUILDDIR}
 


### PR DESCRIPTION
There were some complaints about build.sh removing the build directory, so here is a modifications that if it exists runs `meson configure` and reuses the existing directory. As far as I can tell/test, this does the correct thing, with ninja rebuilding everything needed.
The second part allows adding command line options after the (optional) build type, that are passed directly to meson.