### PR TITLE
Fix non-standard and too long UCI option

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -52,7 +52,7 @@ const char* kMoveOverheadStr = "Move time overhead in milliseconds";
 const char* kTimeCurvePeak = "Time weight curve peak ply";
 const char* kTimeCurveRightWidth = "Time weight curve width right of peak";
 const char* kTimeCurveLeftWidth = "Time weight curve width left of peak";
-const char* kSyzygyTablebaseStr = "List of Syzygy tablebase directories";
+const char* kSyzygyTablebaseStr = "SyzygyPath";
 
 const char* kAutoDiscover = "<autodiscover>";
 


### PR DESCRIPTION
As mentioned by @killerducky in #297, the standard option's name for syzygy directory should be "SyzygyPath" even if multiple directories are possible (and should be separated by a semicolon).

It's a very (very) small change but currently the string is so long that it doesn't fit in Arena.