### PR TITLE
Add Win32-compatible version of "popcount" and "bitscan"

### DIFF
--- a/src/chess/bitboard.h
+++ b/src/chess/bitboard.h
@@ -97,7 +97,11 @@ class BitBoard {
   void clear() { board_ = 0; }
   int count() const {
 #ifdef _MSC_VER
+#ifdef _WIN64
     return _mm_popcnt_u64(board_);
+#else
+    return __popcnt(board_) + __popcnt(board_ >> 32);
+#endif
 #else
     return __builtin_popcountll(board_);
 #endif

--- a/src/chess/bitboard.h
+++ b/src/chess/bitboard.h
@@ -96,12 +96,10 @@ class BitBoard {
   std::uint64_t as_int() const { return board_; }
   void clear() { board_ = 0; }
   int count() const {
-#ifdef _MSC_VER
-#ifdef _WIN64
+#if defined(_MSC_VER) && defined(_WIN64)
     return _mm_popcnt_u64(board_);
-#else
+#elif defined(_MSC_VER)
     return __popcnt(board_) + __popcnt(board_ >> 32);
-#endif
 #else
     return __builtin_popcountll(board_);
 #endif

--- a/src/utils/bititer.h
+++ b/src/utils/bititer.h
@@ -50,7 +50,7 @@ class BitIterator {
     return result;
 #else
     unsigned long result;
-    if (result & 0xFFFFFFFF) {
+    if (value_ & 0xFFFFFFFF) {
       _BitScanForward(&result, value_);
     } else {
       _BitScanForward(&result, value_ >> 32);

--- a/src/utils/bititer.h
+++ b/src/utils/bititer.h
@@ -43,12 +43,11 @@ class BitIterator {
 
   void operator++() { value_ &= (value_ - 1); }
   T operator*() const {
-#ifdef _MSC_VER
-#ifdef _WIN64
+#if defined(_MSC_VER) && defined(_WIN64)
     unsigned long result;
     _BitScanForward64(&result, value_);
     return result;
-#else
+#elif defined(_MSC_VER)
     unsigned long result;
     if (value_ & 0xFFFFFFFF) {
       _BitScanForward(&result, value_);
@@ -57,7 +56,6 @@ class BitIterator {
       result += 32;
     }
     return result;
-#endif
 #else
     return __builtin_ctzll(value_);
 #endif

--- a/src/utils/bititer.h
+++ b/src/utils/bititer.h
@@ -44,9 +44,20 @@ class BitIterator {
   void operator++() { value_ &= (value_ - 1); }
   T operator*() const {
 #ifdef _MSC_VER
+#ifdef _WIN64
     unsigned long result;
     _BitScanForward64(&result, value_);
     return result;
+#else
+    unsigned long result;
+    if (result & 0xFFFFFFFF) {
+      _BitScanForward(&result, value_);
+    } else {
+      _BitScanForward(&result, value_ >> 32);
+      result += 32;
+    }
+    return result;
+#endif
 #else
     return __builtin_ctzll(value_);
 #endif


### PR DESCRIPTION
Add win32-compatible versions of those functions so it doesn't fail to compile when using 32 bits Visual Studio.