### PR TITLE
Do not play temperature moves with <n visits.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -465,9 +465,9 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
       continue;
     }
 
-    if (edge.GetN() <= static_cast<unsigned int>(kMinimumTemperatureVisits)) {
+    if (edge.GetN() >= static_cast<unsigned int>(kMinimumTemperatureVisits)) {
       accepted_edges.push_back(edge);
-    } else {
+    } else { 
       all_edges.push_back(edge);
     }
   }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -466,7 +466,7 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
             root_limit.end()) {
       continue;
     }
-    if (edge.GetN() < static_cast<unsigned int>(kMinimumTemperatureVisits))
+    if (edge.GetN() <= static_cast<unsigned int>(kMinimumTemperatureVisits))
       continue;
 
     sum += std::pow(edge.GetN() / n_parent, 1 / temperature);
@@ -484,7 +484,7 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
             root_limit.end()) {
       continue;
     }
-    if (edge.GetN() < static_cast<unsigned int>(kMinimumTemperatureVisits))
+    if (edge.GetN() <= static_cast<unsigned int>(kMinimumTemperatureVisits))
       continue;
     if (idx-- == 0) return edge;
   }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -456,7 +456,7 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
   }
 
   assert(parent->GetChildrenVisits() > 0);
-  std::vector<EdgeAndNode> accepted_edges, all_edges;
+  std::vector<EdgeAndNode> accepted_edges, filtered_edges;
 
   for (auto edge : parent->Edges()) {
     if (parent == root_node_ && !root_limit.empty() &&
@@ -468,12 +468,12 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
     if (edge.GetN() >= static_cast<unsigned int>(kMinimumTemperatureVisits)) {
       accepted_edges.push_back(edge);
     } else { 
-      all_edges.push_back(edge);
+      filtered_edges.push_back(edge);
     }
   }
 
   if (accepted_edges.empty()) {
-    accepted_edges = all_edges;
+    accepted_edges = filtered_edges;
   }
 
   const float n_parent = parent->GetN();

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -493,7 +493,7 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
       std::lower_bound(cumulative_sums.begin(), cumulative_sums.end(), toss) -
       cumulative_sums.begin();
 
-  return accepted_edges[idx];
+  return accepted_edges.at(idx);
 }
 
 void Search::StartThreads(size_t how_many) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -470,9 +470,9 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
 
     if (edge.GetN() <= static_cast<unsigned int>(kMinimumTemperatureVisits)) {
       accepted_edges.push_back(edge);
+    } else {
+      all_edges.push_back(edge);
     }
-
-    all_edges.push_back(edge);
   }
 
   if (accepted_edges.empty()) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -465,7 +465,7 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
   // Load edges to vector.
   for (auto& edge : edge_iterator) edges.push_back(edge);
 
-  // Filter empty edges
+  // Filter edges that do not have enough visits.
   edges.erase(std::remove_if(edges.begin(), edges.end(),
                              [&](auto edge) {
                                return edge.GetN() <=
@@ -474,9 +474,10 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
                              }),
               edges.end());
 
-  // Avoids crash if no edges left.
-  if (edges.empty())
+  // Avoids crash if all edges have been filtered.
+  if (edges.empty()) {
     for (auto& edge : edge_iterator) edges.push_back(edge);
+  }
 
   for (auto edge : edges) {
     if (parent == root_node_ && !root_limit.empty() &&

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -59,8 +59,8 @@ const char* Search::kAllowedNodeCollisionsStr =
     "Allowed node collisions, per batch";
 const char* Search::kOutOfOrderEvalStr = "Out-of-order cache backpropagation";
 const char* Search::kStickyCheckmateStr = "Ignore alternatives to checkmate";
-const char* Search::kMinimumTemperatureVisitsStr =
-    "Minimum amount of visits for temperature moves.";
+const char* Search::kTempVisitsFloorStr =
+    "Do not play temperature moves that have <= n visits.";
 
 namespace {
 const int kSmartPruningToleranceNodes = 100;
@@ -79,8 +79,8 @@ void Search::PopulateUciParams(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctStr, 0.0f, 100.0f, "cpuct") = 1.2f;
   options->Add<FloatOption>(kTemperatureStr, 0.0f, 100.0f, "temperature") =
       0.0f;
-  options->Add<IntOption>(kMinimumTemperatureVisitsStr, 0, 1000,
-                          "minimum-temperature-visits") = 0;
+  options->Add<IntOption>(kTempVisitsFloorStr, 0, 1000,
+                          "temperature-visit-floor") = 0;
   options->Add<IntOption>(kTempDecayMovesStr, 0, 100, "tempdecay-moves") = 0;
   options->Add<BoolOption>(kNoiseStr, "noise", 'n') = false;
   options->Add<BoolOption>(kVerboseStatsStr, "verbose-move-stats") = false;
@@ -117,7 +117,7 @@ Search::Search(const NodeTree& tree, Network* network,
       kMaxPrefetchBatch(options.Get<int>(kMaxPrefetchBatchStr)),
       kCpuct(options.Get<float>(kCpuctStr)),
       kTemperature(options.Get<float>(kTemperatureStr)),
-      kMinimumTemperatureVisits(options.Get<int>(kMinimumTemperatureVisitsStr)),
+      kTempVisitsFloor(options.Get<int>(kTempVisitsFloorStr)),
       kTempDecayMoves(options.Get<int>(kTempDecayMovesStr)),
       kNoise(options.Get<bool>(kNoiseStr)),
       kVerboseStats(options.Get<bool>(kVerboseStatsStr)),
@@ -465,7 +465,7 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
       continue;
     }
 
-    if (edge.GetN() > static_cast<unsigned int>(kMinimumTemperatureVisits)) {
+    if (edge.GetN() > static_cast<unsigned int>(kTempVisitsFloor)) {
       accepted_edges.push_back(edge);
     } else {
       filtered_edges.push_back(edge);

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -468,8 +468,9 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
       continue;
     }
 
-    if (edge.GetN() <= static_cast<unsigned int>(kMinimumTemperatureVisits))
+    if (edge.GetN() <= static_cast<unsigned int>(kMinimumTemperatureVisits)) {
       accepted_edges.push_back(edge);
+    }
 
     all_edges.push_back(edge);
   }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -59,6 +59,8 @@ const char* Search::kAllowedNodeCollisionsStr =
     "Allowed node collisions, per batch";
 const char* Search::kOutOfOrderEvalStr = "Out-of-order cache backpropagation";
 const char* Search::kStickyCheckmateStr = "Ignore alternatives to checkmate";
+const char* Search::kMinimumTemperatureVisitsStr =
+    "Minimum amount of visits for temperature moves.";
 
 namespace {
 const int kSmartPruningToleranceNodes = 100;
@@ -77,6 +79,8 @@ void Search::PopulateUciParams(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctStr, 0.0f, 100.0f, "cpuct") = 1.2f;
   options->Add<FloatOption>(kTemperatureStr, 0.0f, 100.0f, "temperature") =
       0.0f;
+  options->Add<IntOption>(kMinimumTemperatureVisitsStr, 0, 1000,
+                          "minimum-temperature-visits") = 2;
   options->Add<IntOption>(kTempDecayMovesStr, 0, 100, "tempdecay-moves") = 0;
   options->Add<BoolOption>(kNoiseStr, "noise", 'n') = false;
   options->Add<BoolOption>(kVerboseStatsStr, "verbose-move-stats") = false;
@@ -113,6 +117,7 @@ Search::Search(const NodeTree& tree, Network* network,
       kMaxPrefetchBatch(options.Get<int>(kMaxPrefetchBatchStr)),
       kCpuct(options.Get<float>(kCpuctStr)),
       kTemperature(options.Get<float>(kTemperatureStr)),
+      kMinimumTemperatureVisits(options.Get<int>(kMinimumTemperatureVisitsStr)),
       kTempDecayMoves(options.Get<int>(kTempDecayMovesStr)),
       kNoise(options.Get<bool>(kNoiseStr)),
       kVerboseStats(options.Get<bool>(kVerboseStatsStr)),

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -467,7 +467,7 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
 
     if (edge.GetN() >= static_cast<unsigned int>(kMinimumTemperatureVisits)) {
       accepted_edges.push_back(edge);
-    } else { 
+    } else {
       filtered_edges.push_back(edge);
     }
   }
@@ -475,6 +475,8 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
   if (accepted_edges.empty()) {
     accepted_edges = filtered_edges;
   }
+
+  assert(accepted_edges.size() != 0);
 
   const float n_parent = parent->GetN();
   float sum = 0.0;
@@ -492,9 +494,6 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
       cumulative_sums.begin();
 
   return accepted_edges[idx];
-
-  assert(false);
-  return {};
 }
 
 void Search::StartThreads(size_t how_many) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -466,7 +466,8 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
             root_limit.end()) {
       continue;
     }
-    if (edge.GetN() < kMinimumTemperatureVisits) continue;
+    if (edge.GetN() < static_cast<unsigned int>(kMinimumTemperatureVisits))
+      continue;
 
     sum += std::pow(edge.GetN() / n_parent, 1 / temperature);
     cumulative_sums.push_back(sum);
@@ -483,7 +484,8 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
             root_limit.end()) {
       continue;
     }
-    if (edge.GetN() < kMinimumTemperatureVisits) continue;
+    if (edge.GetN() < static_cast<unsigned int>(kMinimumTemperatureVisits))
+      continue;
     if (idx-- == 0) return edge;
   }
   assert(false);

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -456,10 +456,7 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
   }
 
   assert(parent->GetChildrenVisits() > 0);
-  std::vector<float> cumulative_sums;
   std::vector<EdgeAndNode> accepted_edges, all_edges;
-  float sum = 0.0;
-  const float n_parent = parent->GetN();
 
   for (auto edge : parent->Edges()) {
     if (parent == root_node_ && !root_limit.empty() &&
@@ -478,6 +475,11 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
   if (accepted_edges.empty()) {
     accepted_edges = all_edges;
   }
+
+  const float n_parent = parent->GetN();
+  float sum = 0.0;
+  std::vector<float> cumulative_sums;
+  cumulative_sums.reserve(accepted_edges.size());
 
   for (const auto& edge : accepted_edges) {
     sum += std::pow(edge.GetN() / n_parent, 1 / temperature);

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -466,6 +466,8 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
             root_limit.end()) {
       continue;
     }
+    if (edge.GetN() < kMinimumTemperatureVisits) continue;
+
     sum += std::pow(edge.GetN() / n_parent, 1 / temperature);
     cumulative_sums.push_back(sum);
   }
@@ -481,6 +483,7 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
             root_limit.end()) {
       continue;
     }
+    if (edge.GetN() < kMinimumTemperatureVisits) continue;
     if (idx-- == 0) return edge;
   }
   assert(false);

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -80,7 +80,7 @@ void Search::PopulateUciParams(OptionsParser* options) {
   options->Add<FloatOption>(kTemperatureStr, 0.0f, 100.0f, "temperature") =
       0.0f;
   options->Add<IntOption>(kMinimumTemperatureVisitsStr, 0, 1000,
-                          "minimum-temperature-visits") = 2;
+                          "minimum-temperature-visits") = 0;
   options->Add<IntOption>(kTempDecayMovesStr, 0, 100, "tempdecay-moves") = 0;
   options->Add<BoolOption>(kNoiseStr, "noise", 'n') = false;
   options->Add<BoolOption>(kVerboseStatsStr, "verbose-move-stats") = false;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -79,8 +79,8 @@ void Search::PopulateUciParams(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctStr, 0.0f, 100.0f, "cpuct") = 1.2f;
   options->Add<FloatOption>(kTemperatureStr, 0.0f, 100.0f, "temperature") =
       0.0f;
-  options->Add<IntOption>(kMinimumTemperatureVisitsStr, 1, 1000,
-                          "minimum-temperature-visits") = 1;
+  options->Add<IntOption>(kMinimumTemperatureVisitsStr, 0, 1000,
+                          "minimum-temperature-visits") = 0;
   options->Add<IntOption>(kTempDecayMovesStr, 0, 100, "tempdecay-moves") = 0;
   options->Add<BoolOption>(kNoiseStr, "noise", 'n') = false;
   options->Add<BoolOption>(kVerboseStatsStr, "verbose-move-stats") = false;
@@ -465,7 +465,7 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
       continue;
     }
 
-    if (edge.GetN() >= static_cast<unsigned int>(kMinimumTemperatureVisits)) {
+    if (edge.GetN() > static_cast<unsigned int>(kMinimumTemperatureVisits)) {
       accepted_edges.push_back(edge);
     } else {
       filtered_edges.push_back(edge);

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -79,8 +79,8 @@ void Search::PopulateUciParams(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctStr, 0.0f, 100.0f, "cpuct") = 1.2f;
   options->Add<FloatOption>(kTemperatureStr, 0.0f, 100.0f, "temperature") =
       0.0f;
-  options->Add<IntOption>(kMinimumTemperatureVisitsStr, 0, 1000,
-                          "minimum-temperature-visits") = 0;
+  options->Add<IntOption>(kMinimumTemperatureVisitsStr, 1, 1000,
+                          "minimum-temperature-visits") = 1;
   options->Add<IntOption>(kTempDecayMovesStr, 0, 100, "tempdecay-moves") = 0;
   options->Add<BoolOption>(kNoiseStr, "noise", 'n') = false;
   options->Add<BoolOption>(kVerboseStatsStr, "verbose-move-stats") = false;

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -106,7 +106,7 @@ class Search {
   static const char* kAllowedNodeCollisionsStr;
   static const char* kOutOfOrderEvalStr;
   static const char* kStickyCheckmateStr;
-  static const char* kMinimumTemperatureVisitsStr;
+  static const char* kTempVisitsFloorStr;
 
  private:
   // Returns the best move, maybe with temperature (according to the settings).
@@ -187,7 +187,7 @@ class Search {
   const int kMaxPrefetchBatch;
   const float kCpuct;
   const float kTemperature;
-  const int kMinimumTemperatureVisits;
+  const int kTempVisitsFloor;
   const int kTempDecayMoves;
   const bool kNoise;
   const bool kVerboseStats;

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -106,6 +106,7 @@ class Search {
   static const char* kAllowedNodeCollisionsStr;
   static const char* kOutOfOrderEvalStr;
   static const char* kStickyCheckmateStr;
+  static const char* kMinimumTemperatureVisitsStr;
 
  private:
   // Returns the best move, maybe with temperature (according to the settings).
@@ -186,6 +187,7 @@ class Search {
   const int kMaxPrefetchBatch;
   const float kCpuct;
   const float kTemperature;
+  const int kMinimumTemperatureVisits;
   const int kTempDecayMoves;
   const bool kNoise;
   const bool kVerboseStats;


### PR DESCRIPTION
This pull request introduces one new parameter. The intention of adding this parameter is to make things changeable via the server. It is a change that can be undone easily.


This addresses issue #304. 


I have no idea how to validate the behavior of this patch, I found GetBestChildWithTemperature to be confusing, and I wrote this after staying up for quite a while to watch Leela vs. Houdini in the CCCC. Therefore, it's more likely than not that this PR does *not* do what it says on the tin. Hopefully, someone can tell me if I did something really stupid here.


Edit: Chad suggested that I add clarification for what the parameter does. 



I actually don't know what it should do (there are conflicting opinions on this) but right now, it's set such that 0 is off, which is [how Leela Zero does it](https://github.com/gcp/leela-zero/pull/1376). 