### PR TITLE
Fix data race in MuxingComputation::NotifyReady with heavy threading

### DIFF
--- a/src/neural/network_mux.cc
+++ b/src/neural/network_mux.cc
@@ -62,10 +62,8 @@ class MuxingComputation : public NetworkComputation {
   }
 
   void NotifyReady() {
-    {
-      std::unique_lock<std::mutex> lock(mutex_);
-      dataready_ = true;
-    }
+    std::unique_lock<std::mutex> lock(mutex_);
+    dataready_ = true;
     dataready_cv_.notify_one();
   }
 


### PR DESCRIPTION
notify_one in MutexComputing::NotifyReady in some cases ends up running after/while its object is being destroyed after SearchWorker::ExecuteOneIteration inside SearchWorker::InitializeIteration  by a different thread corrupting memory.

*Force dataready_cv_.notify_one(); to finish before the lock is released to a different thread
*Fixes Crash in multiplexed setup with blas, opencl and heavy threading #98