### PR TITLE
Add 'Colossal Cave' Easter egg

### DIFF
--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -56,6 +56,7 @@ const std::unordered_map<std::string, std::unordered_set<std::string>>
         {{"stop"}, {}},
         {{"ponderhit"}, {}},
         {{"quit"}, {}},
+        {{"xyzzy"}, {}},
 };
 
 std::pair<std::string, std::unordered_map<std::string, std::string>>
@@ -196,6 +197,8 @@ bool UciLoop::DispatchCommand(
     CmdPonderHit();
   } else if (command == "start") {
     CmdStart();
+  } else if (command == "xyzzy") {
+    SendResponse("Nothing happens.");
   } else if (command == "quit") {
     return false;
   } else {


### PR DESCRIPTION
A PR for an Easter egg is part of the joke. This adds the [xyzzy](https://en.wikipedia.org/wiki/Colossal_Cave_Adventure#Xyzzy) command to the UCI parser. The reply is "Nothing happens."