### PR TITLE
Fix temperature selection with positive and negative offsets

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -401,7 +401,7 @@ std::pair<Move, Move> Search::GetBestMoveInternal() const
     }
   }
 
-  auto best_node = temperature && root_node_->GetChildrenVisits() > 0
+  auto best_node = temperature
                        ? GetBestChildWithTemperature(root_node_, temperature)
                        : GetBestChildNoTemperature(root_node_);
 
@@ -451,7 +451,6 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
     PopulateRootMoveLimit(&root_limit);
   }
 
-  assert(parent->GetChildrenVisits() > 0);
   std::vector<float> cumulative_sums;
   float sum = 0.0;
   float max_n = 0.0;
@@ -467,7 +466,10 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
       max_n = edge.GetN() + offset;
     }
   }
-  assert(max_n > 0.0);
+
+  // No move had enough visits for temperature, so use default child criteria
+  if (max_n <= 0.0f) return GetBestChildNoTemperature(parent);
+
 
   for (auto edge : parent->Edges()) {
     if (parent == root_node_ && !root_limit.empty() &&


### PR DESCRIPTION
r?@Tilps Fix some corner cases introduced by #359 and simplifying code while maintaining #337.

1) Positive offset allows move selection even when children have no visits, so don't condition temperature selection on children visits.

Before `--temp-visit-offset=2` (highest prior is picked):
```
info string b2b3  (230 ) N:       0 (+ 0) (P:  1.32%) (Q:  0.03456) (U: 0.01580) (Q+U:  0.05036) (V:  -.----) 
info string g1f3  (159 ) N:       0 (+ 0) (P: 26.54%) (Q:  0.03456) (U: 0.31846) (Q+U:  0.35301) (V:  -.----) 
bestmove g1f3
```
After `--temp-visit-offset=2` (any move can be picked with no visits):
```
info string b2b3  (230 ) N:       0 (+ 0) (P:  1.32%) (Q:  0.03456) (U: 0.01580) (Q+U:  0.05036) (V:  -.----) 
info string g1f3  (159 ) N:       0 (+ 0) (P: 26.54%) (Q:  0.03456) (U: 0.31846) (Q+U:  0.35301) (V:  -.----) 
bestmove b2b3
```

2) Negative offset might cause nothing to have enough visits resulting in the "first" move being selected.
Before `--temp-visit-offset=-2` (first edge is picked):
```
info string b1a3  (34  ) N:       0 (+ 0) (P:  0.45%) (Q:  0.03456) (U: 0.00535) (Q+U:  0.03991) (V:  -.----) 
info string g1f3  (159 ) N:       0 (+ 0) (P: 26.59%) (Q:  0.03456) (U: 0.31904) (Q+U:  0.35360) (V:  -.----) 
bestmove b1a3
```
After `--temp-visit-offset=-2` (highest prior is picked):
```
info string b1a3  (34  ) N:       0 (+ 0) (P:  0.45%) (Q:  0.03456) (U: 0.00535) (Q+U:  0.03991) (V:  -.----) 
info string g1f3  (159 ) N:       0 (+ 0) (P: 26.59%) (Q:  0.03456) (U: 0.31904) (Q+U:  0.35360) (V:  -.----) 
bestmove g1f3
```

---
Ah nevermind about this simplication:

~~~3) Calculation of max_n introduced in #337 isn't necessary as the cumulative sum selection doesn't care about the denominator, e.g., a move selection from 100, 50, 50 visits:~~~

Before #337:
```
denominator = 200
T=1.0 0.5 + 0.25 + 0.25 -> 1.0 sum, 0.5 / 1.0 = 50% selection, 0.25 / 1.0 = 25% selection
T=0.5 0.25 + 0.0625 + 0.0625 -> 0.375 sum, 0.25 / 0.375 = 67% selection, 0.0625 / 0.375 = 17% selection
```
After #337:
```
denominator = 100
T=1.0 1.0 + 0.5 + 0.5 -> 2.0 sum, 1.0 / 2.0 = 50% selection, 0.5 / 2.0 = 25% selection
T=0.5 1.0 + 0.25 + 0.25 -> 1.5 sum, 1.0 / 1.5 = 67% selection, 0.25 / 1.5 = 17% selection
```
After this PR:
```
denominator = 1
T=1.0 100 + 50 + 50 -> 200 sum, 100 / 200 = 50% selection, 50 / 200 = 25% selection
T=0.5 10000 + 2500 + 2500 -> 15000 sum, 10000 / 15000 = 67% selection, 2500 / 15000 = 17% selection
```