### PR TITLE
Quick fix for smart pruning tolerance to avoid instamoves.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -61,8 +61,8 @@ const char* Search::kAllowedNodeCollisionsStr =
 const char* Search::kOutOfOrderEvalStr = "Out-of-order cache backpropagation";
 
 namespace {
-const int kSmartPruningToleranceNodes = 500;
-const int kSmartPruningToleranceMs = 400;
+const int kSmartPruningToleranceNodes = 300;
+const int kSmartPruningToleranceMs = 200;
 // Maximum delay between outputting "uci info" when nothing interesting happens.
 const int kUciInfoMinimumFrequencyMs = 5000;
 }  // namespace
@@ -315,7 +315,7 @@ void Search::UpdateRemainingMoves() {
   // Check for how many playouts there is time remaining.
   if (limits_.time_ms >= 0) {
     auto time_since_start = GetTimeSinceStart();
-    if (time_since_start > kSmartPruningToleranceMs) {
+    if (time_since_start > kSmartPruningToleranceMs * 2) {
       auto nps = 1000LL * (total_playouts_ + kSmartPruningToleranceNodes) /
                      (time_since_start - kSmartPruningToleranceMs) +
                  1;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -61,8 +61,8 @@ const char* Search::kAllowedNodeCollisionsStr =
 const char* Search::kOutOfOrderEvalStr = "Out-of-order cache backpropagation";
 
 namespace {
-const int kSmartPruningToleranceNodes = 100;
-const int kSmartPruningToleranceMs = 200;
+const int kSmartPruningToleranceNodes = 500;
+const int kSmartPruningToleranceMs = 400;
 // Maximum delay between outputting "uci info" when nothing interesting happens.
 const int kUciInfoMinimumFrequencyMs = 5000;
 }  // namespace
@@ -316,7 +316,7 @@ void Search::UpdateRemainingMoves() {
   if (limits_.time_ms >= 0) {
     auto time_since_start = GetTimeSinceStart();
     if (time_since_start > kSmartPruningToleranceMs) {
-      auto nps = (1000LL * total_playouts_ + kSmartPruningToleranceNodes) /
+      auto nps = 1000LL * (total_playouts_ + kSmartPruningToleranceNodes) /
                      (time_since_start - kSmartPruningToleranceMs) +
                  1;
       int64_t remaining_time = limits_.time_ms - time_since_start;
@@ -463,7 +463,7 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
             root_limit.end()) {
       continue;
     }
-    if(edge.GetN() + offset > max_n) {
+    if (edge.GetN() + offset > max_n) {
       max_n = edge.GetN() + offset;
     }
   }


### PR DESCRIPTION
1. Bug with kSmartPruningToleranceNodes meaning millinodes is fixed
2. kSmartPruningToleranceNodes set to 500
3. kSmartPruningToleranceMs set to 400 (was 200).
On very slow configurations (e.g. CPU) this will cause smart pruning to almost never trigger, but for now it's better than instamoving.