### PR TITLE
Fix OpenCL tuner matrix size

### DIFF
--- a/src/neural/opencl/OpenCL.cc
+++ b/src/neural/opencl/OpenCL.cc
@@ -773,7 +773,7 @@ void OpenCL::initialize(const int channels, const OpenCLParams& params) {
 
   auto t = Tuner(*this, params, m_context, m_device);
   auto sgemm_tuners = t.load_sgemm_tuners(
-      channels, WINOGRAD_P, channels, params.tune_batch_size * WINOGRAD_TILE);
+      channels, params.tune_batch_size * WINOGRAD_P, channels, WINOGRAD_TILE);
 
   // Build program for these specific devices.
   try {

--- a/src/neural/opencl/OpenCLTuner.cc
+++ b/src/neural/opencl/OpenCLTuner.cc
@@ -455,10 +455,10 @@ std::string Tuner::load_sgemm_tuners(const int m, const int n, const int k,
         auto tuners = sgemm_tuners_from_line(line, m, n, k, batch_size);
         if (tuners.size() != 0) {
           if (m_params.verbose) {
-            /* batch_size argument is the number of batched sgemm calls, which
-             * equals the number of elements in one tile.
-             * Convolution batch size affects the "n" dimension of
-             * the matrix multiplication (n = WINOGRAD_P * batch_size) */
+            // batch_size argument is the number of batched sgemm calls, which
+            // equals the number of elements in one tile.
+            // Convolution batch size affects the "n" dimension of
+            // the matrix multiplication (n = WINOGRAD_P * batch_size).
             std::cerr << "Loaded existing SGEMM tuning for batch size "
                       << n / WINOGRAD_P << "." << std::endl;
           }

--- a/src/neural/opencl/OpenCLTuner.cc
+++ b/src/neural/opencl/OpenCLTuner.cc
@@ -223,7 +223,7 @@ std::string Tuner::tune_sgemm(const int m, const int n, const int k,
   auto cBuffer = cl::Buffer(m_context, CL_MEM_READ_WRITE,
                             sizeof(float) * c_size, nullptr, nullptr);
 
-  std::cerr << "Started OpenCL SGEMM tuner with batch size " << batch_size
+  std::cerr << "Started OpenCL SGEMM tuner with batch size " << n / WINOGRAD_P
             << "." << std::endl;
 
   auto valid_params = std::vector<int>{};
@@ -455,8 +455,12 @@ std::string Tuner::load_sgemm_tuners(const int m, const int n, const int k,
         auto tuners = sgemm_tuners_from_line(line, m, n, k, batch_size);
         if (tuners.size() != 0) {
           if (m_params.verbose) {
-            std::cerr << "Loaded existing SGEMM tuning for batch_size "
-                      << batch_size << "." << std::endl;
+            /* batch_size argument is the number of batched sgemm calls, which
+             * equals the number of elements in one tile.
+             * Convolution batch size affects the "n" dimension of
+             * the matrix multiplication (n = WINOGRAD_P * batch_size) */
+            std::cerr << "Loaded existing SGEMM tuning for batch size "
+                      << n / WINOGRAD_P << "." << std::endl;
           }
           return tuners;
         }


### PR DESCRIPTION
OpenCL backend tuned the sgemm for wrong matrix size. With the correct dimension nps increases from 630 to 930 using batch size of 16.