### PR TITLE
Define __i386__ for 32 bit Windows

### DIFF
--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -253,6 +253,11 @@ class Node {
   friend class Edge;
 };
 
+// Define __i386__ also for 32 bit Windows.
+#if defined(_WIN32) && !defined(_WIN64)
+#define __i386__ 1
+#endif
+
 // A basic sanity check. This must be adjusted when Node members are adjusted.
 #if defined(__i386__) || (defined(__arm__) && !defined(__aarch64__))
 static_assert(sizeof(Node) == 40, "Unexpected size of Node for 32bit compile");


### PR DESCRIPTION
With this fix in node.h it is possible to build the code for 32bit windows with the blas and opencl backends. The blas backend passes all tests and works (but has not been thoroughly tested).