### PR TITLE
set CL_HPP_TARGET_OPENCL_VERSION to 110 for 32 bit windows

### DIFF
--- a/src/neural/opencl/OpenCL.h
+++ b/src/neural/opencl/OpenCL.h
@@ -21,7 +21,11 @@
 using net_t = float;
 
 #define CL_HPP_MINIMUM_OPENCL_VERSION 110
+#if defined(_WIN32) && !defined(_WIN64)
+#define CL_HPP_TARGET_OPENCL_VERSION 110
+#else
 #define CL_HPP_TARGET_OPENCL_VERSION 120
+#endif
 #define CL_HPP_ENABLE_EXCEPTIONS
 #include <cstddef>
 #include <memory>


### PR DESCRIPTION
There is an incompatibility between the OpenCL headers and 32 bit MSVC, when the OpenCL target version is 1.2 (our default). This patch sets the target version to 1.1 when building with 32 bit MSVC to avoid this