### PR TITLE
use invariant path for nvcc

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -312,9 +312,7 @@ if get_option('build_backends')
   cu_blas = cc.find_library('cublas', dirs: cudnn_libdirs, required: false)
   cu_dnn = cc.find_library('cudnn', dirs: cudnn_libdirs, required: false)
   cu_dart = cc.find_library('cudart', dirs: cudnn_libdirs, required: false)
-  nvcc = find_program('/usr/local/cuda-9.2/bin/nvcc',
-                      '/usr/local/cuda-9.1/bin/nvcc',
-                      'nvcc', required: false)
+  nvcc = find_program('/usr/local/bin/nvcc', 'nvcc', required: false)
   cuda_files = [
     'src/neural/network_cudnn.cu',
   ]

--- a/meson.build
+++ b/meson.build
@@ -312,7 +312,7 @@ if get_option('build_backends')
   cu_blas = cc.find_library('cublas', dirs: cudnn_libdirs, required: false)
   cu_dnn = cc.find_library('cudnn', dirs: cudnn_libdirs, required: false)
   cu_dart = cc.find_library('cudart', dirs: cudnn_libdirs, required: false)
-  nvcc = find_program('/usr/local/bin/nvcc', 'nvcc', required: false)
+  nvcc = find_program('/usr/local/cuda/bin/nvcc', 'nvcc', required: false)
   cuda_files = [
     'src/neural/network_cudnn.cu',
   ]


### PR DESCRIPTION
Instead of looking for nvcc in the cuda 9.1 and 9.2 specific paths, look in /usr/local/cuda/bin which is linked to the correct directory. This works fine as a default with the library and include path. Alternatively, nvcc should be on the path, which works on windows.
I would like some feedback from different linux and macos versions before merging this.