### PR TITLE
Rename to SyzygyPath

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -52,7 +52,7 @@ const char* kMoveOverheadStr = "Move time overhead in milliseconds";
 const char* kTimeCurvePeak = "Time weight curve peak ply";
 const char* kTimeCurveRightWidth = "Time weight curve width right of peak";
 const char* kTimeCurveLeftWidth = "Time weight curve width left of peak";
-const char* kSyzygyTablebaseStr = "List of Syzygy tablebase directories";
+const char* kSyzygyTablebaseStr = "SyzygyPath";
 const char* kSpendSavedTime = "Fraction of saved time to use immediately";
 
 const char* kAutoDiscover = "<autodiscover>";


### PR DESCRIPTION
For lots of GUI, the default name for List of Syzygy Directories is instead SyzygyPath. This helps to automate giving Syzygy tablebases to engines without need to manually write in the path (Chessbase and Fritz GUIs specifically). As such, the variable name should be by default standarts for ease of use.