### PR TITLE
fix syzygy draw by repetition bug

### DIFF
--- a/src/chess/position.h
+++ b/src/chess/position.h
@@ -76,7 +76,7 @@ class Position {
   // How many half-moves without capture or pawn move was there.
   int no_capture_ply_ = 0;
   // How many repetitions this position had before. For new positions it's 0.
-  int repetitions_;
+  int repetitions_ = 0;
   // number of half-moves since beginning of the game.
   int ply_count_ = 0;
 };

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -1647,15 +1647,17 @@ bool SyzygyTablebase::root_probe(const Position& pos,
       dtz = 1;
     }
     if (result == FAIL) return false;
-    // Better moves are ranked higher. Certain wins are ranked equally.
-    // Losing moves are ranked equally unless a 50-move draw is in sight.
-    int r = dtz > 0
-                ? (dtz + cnt50 <= 99 ? 1000 : 1000 - (dtz + cnt50))
-                : dtz < 0 ? (-dtz * 2 + cnt50 < 100 ? -1000
-                                                    : -1000 + (-dtz + cnt50))
-                          : 0;
-    if (next_pos.GetRepetitions() > 1)
-      r = 0; //draw by repetition
+    int r = 0; //draw by repetition
+    if (next_pos.GetRepetitions() < 2)
+    {
+      // Better moves are ranked higher. Certain wins are ranked equally.
+      // Losing moves are ranked equally unless a 50-move draw is in sight.
+      int r = dtz > 0
+                  ? (dtz + cnt50 <= 99 ? 1000 : 1000 - (dtz + cnt50))
+                  : dtz < 0 ? (-dtz * 2 + cnt50 < 100 ? -1000
+                                                      : -1000 + (-dtz + cnt50))
+                            : 0;
+    }
     if (r > best_rank) best_rank = r;
     ranks.push_back(r);
   }

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -1624,8 +1624,6 @@ bool SyzygyTablebase::root_probe(const Position& pos,
   auto root_moves = pos.GetBoard().GenerateLegalMoves();
   // Obtain 50-move counter for the root position
   int cnt50 = pos.GetNoCaptureNoPawnPly();
-  // Check whether a position was repeated since the last zeroing move.
-  bool rep = pos.GetRepetitions() > 0;
   int dtz;
   std::vector<int> ranks;
   ranks.reserve(root_moves.size());
@@ -1652,10 +1650,12 @@ bool SyzygyTablebase::root_probe(const Position& pos,
     // Better moves are ranked higher. Certain wins are ranked equally.
     // Losing moves are ranked equally unless a 50-move draw is in sight.
     int r = dtz > 0
-                ? (dtz + cnt50 <= 99 && !rep ? 1000 : 1000 - (dtz + cnt50))
+                ? (dtz + cnt50 <= 99 ? 1000 : 1000 - (dtz + cnt50))
                 : dtz < 0 ? (-dtz * 2 + cnt50 < 100 ? -1000
                                                     : -1000 + (-dtz + cnt50))
                           : 0;
+    if (next_pos.GetRepetitions() > 1)
+      r = 0; //draw by repetition
     if (r > best_rank) best_rank = r;
     ranks.push_back(r);
   }

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -1652,7 +1652,7 @@ bool SyzygyTablebase::root_probe(const Position& pos,
     {
       // Better moves are ranked higher. Certain wins are ranked equally.
       // Losing moves are ranked equally unless a 50-move draw is in sight.
-      int r = dtz > 0
+      r = dtz > 0
                   ? (dtz + cnt50 <= 99 ? 1000 : 1000 - (dtz + cnt50))
                   : dtz < 0 ? (-dtz * 2 + cnt50 < 100 ? -1000
                                                       : -1000 + (-dtz + cnt50))


### PR DESCRIPTION
Set any 3-fold repetition position to have a draw score of zero, which will score less than a winning but for 50move draw but score higher than a losing but for 50 move draw. Certain wins score 1000 and certain losses score -1000, so the zero draw score should work just fine.