### PR TITLE
Correct implementation of root_probe to consider all prior potential repeats, not just current move.

### DIFF
--- a/src/chess/position.cc
+++ b/src/chess/position.cc
@@ -118,6 +118,15 @@ int PositionHistory::ComputeLastMoveRepetitions() const {
   return 0;
 }
 
+bool PositionHistory::DidRepeatSinceLastZeroingMove() const {
+  for (auto iter = positions_.rbegin(), end = positions_.rend(); iter != end;
+       ++iter) {
+    if (iter->GetRepetitions() > 0) return true;
+    if (iter->GetNoCaptureNoPawnPly() == 0) return false;
+  }
+  return false;
+}
+
 uint64_t PositionHistory::HashLast(int positions) const {
   uint64_t hash = positions;
   for (auto iter = positions_.rbegin(), end = positions_.rend(); iter != end;

--- a/src/chess/position.h
+++ b/src/chess/position.h
@@ -123,6 +123,9 @@ class PositionHistory {
   // Builds a hash from last X positions.
   uint64_t HashLast(int positions) const;
 
+  // Checks for any repetitions since the last time 50 move rule was reset.
+  bool DidRepeatSinceLastZeroingMove() const;
+
  private:
   int ComputeLastMoveRepetitions() const;
 

--- a/src/chess/position_test.cc
+++ b/src/chess/position_test.cc
@@ -56,6 +56,78 @@ TEST(PositionHistory, ComputeLastMoveRepetitionsWithLegalEnPassant) {
   EXPECT_EQ(repeated_position.GetRepetitions(), 0);
 }
 
+TEST(PositionHistory, DidRepeatSinceLastZeroingMoveCurent) {
+  ChessBoard board;
+  PositionHistory history;
+  board.SetFromFen("3b4/rp1r1k2/8/1RP2p1p/p1KP4/P3P2P/5P2/1R2B3 b - - 2 30");
+  history.Reset(board, 2, 30);
+  history.Append(Move("f7f8", true));
+  history.Append(Move("f2f4", false));
+  history.Append(Move("d7h7", true));
+  history.Append(Move("c4d3", false));
+  history.Append(Move("h7d7", true));
+  history.Append(Move("d3c4", false));
+  EXPECT_TRUE(history.DidRepeatSinceLastZeroingMove());
+}
+
+TEST(PositionHistory, DidRepeatSinceLastZeroingMoveBefore) {
+  ChessBoard board;
+  PositionHistory history;
+  board.SetFromFen("3b4/rp1r1k2/8/1RP2p1p/p1KP4/P3P2P/5P2/1R2B3 b - - 2 30");
+  history.Reset(board, 2, 30);
+  history.Append(Move("f7f8", true));
+  history.Append(Move("f2f4", false));
+  history.Append(Move("d7h7", true));
+  history.Append(Move("c4d3", false));
+  history.Append(Move("h7d7", true));
+  history.Append(Move("d3c4", false));
+  history.Append(Move("d7e7", true));
+  EXPECT_TRUE(history.DidRepeatSinceLastZeroingMove());
+}
+
+TEST(PositionHistory, DidRepeatSinceLastZeroingMoveOlder) {
+  ChessBoard board;
+  PositionHistory history;
+  board.SetFromFen("3b4/rp1r1k2/8/1RP2p1p/p1KP4/P3P2P/5P2/1R2B3 b - - 2 30");
+  history.Reset(board, 2, 30);
+  history.Append(Move("f7f8", true));
+  history.Append(Move("f2f4", false));
+  history.Append(Move("d7h7", true));
+  history.Append(Move("c4d3", false));
+  history.Append(Move("h7d7", true));
+  history.Append(Move("d3c4", false));
+  history.Append(Move("d7e7", true));
+  history.Append(Move("c4b4", false));
+  EXPECT_TRUE(history.DidRepeatSinceLastZeroingMove());
+}
+
+TEST(PositionHistory, DidRepeatSinceLastZeroingMoveBeforeZero) {
+  ChessBoard board;
+  PositionHistory history;
+  board.SetFromFen("3b4/rp1r1k2/8/1RP2p1p/p1KP4/P3P2P/5P2/1R2B3 b - - 2 30");
+  history.Reset(board, 2, 30);
+  history.Append(Move("f7f8", true));
+  history.Append(Move("f2f4", false));
+  history.Append(Move("d7h7", true));
+  history.Append(Move("c4d3", false));
+  history.Append(Move("h7d7", true));
+  history.Append(Move("d3c4", false));
+  history.Append(Move("d7e7", true));
+  history.Append(Move("c4b4", false));
+  history.Append(Move("h5h4", true));
+  EXPECT_FALSE(history.DidRepeatSinceLastZeroingMove());
+}
+
+TEST(PositionHistory, DidRepeatSinceLastZeroingMoveNeverRepeated) {
+  ChessBoard board;
+  PositionHistory history;
+  board.SetFromFen("3b4/rp1r1k2/8/1RP2p1p/p1KP4/P3P2P/5P2/1R2B3 b - - 2 30");
+  history.Reset(board, 2, 30);
+  history.Append(Move("f7f8", true));
+  history.Append(Move("f2f4", false));
+  EXPECT_FALSE(history.DidRepeatSinceLastZeroingMove());
+}
+
 }  // namespace lczero
 
 int main(int argc, char** argv) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -402,7 +402,7 @@ bool Search::PopulateRootMoveLimit(MoveList* root_moves) const {
       (board.ours() + board.theirs()).count() > syzygy_tb_->max_cardinality()) {
     return false;
   }
-  return syzygy_tb_->root_probe(played_history_.Last(), root_moves) ||
+  return syzygy_tb_->root_probe(played_history_.Last(), played_history_.DidRepeatSinceLastZeroingMove(), root_moves) ||
          syzygy_tb_->root_probe_wdl(played_history_.Last(), root_moves);
 }
 

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -402,7 +402,9 @@ bool Search::PopulateRootMoveLimit(MoveList* root_moves) const {
       (board.ours() + board.theirs()).count() > syzygy_tb_->max_cardinality()) {
     return false;
   }
-  return syzygy_tb_->root_probe(played_history_.Last(), played_history_.DidRepeatSinceLastZeroingMove(), root_moves) ||
+  return syzygy_tb_->root_probe(played_history_.Last(),
+                                played_history_.DidRepeatSinceLastZeroingMove(),
+                                root_moves) ||
          syzygy_tb_->root_probe_wdl(played_history_.Last(), root_moves);
 }
 

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -1618,14 +1618,14 @@ int SyzygyTablebase::probe_dtz(const Position& pos, ProbeState* result) {
 // Use the DTZ tables to rank root moves.
 //
 // A return value false indicates that not all probes were successful.
-bool SyzygyTablebase::root_probe(const Position& pos,
+bool SyzygyTablebase::root_probe(const Position& pos, bool has_repeated,
                                  std::vector<Move>* safe_moves) {
   ProbeState result;
   auto root_moves = pos.GetBoard().GenerateLegalMoves();
   // Obtain 50-move counter for the root position
   int cnt50 = pos.GetNoCaptureNoPawnPly();
   // Check whether a position was repeated since the last zeroing move.
-  bool rep = pos.GetRepetitions() > 0;
+  bool rep = has_repeated;
   int dtz;
   std::vector<int> ranks;
   ranks.reserve(root_moves.size());

--- a/src/syzygy/syzygy.h
+++ b/src/syzygy/syzygy.h
@@ -84,10 +84,13 @@ class SyzygyTablebase {
   // Probes DTZ tables to determine which moves are on the optimal play path.
   // Assumes the position is one reached such that the side to move has been
   // performing optimal play moves since the last 50 move counter reset.
+  // has_repeated should be whether there are any repeats since last 50 move
+  // counter reset.
   // Thread safe.
   // Returns false if the position is not in the tablebase.
   // Safe moves are added to the safe_moves output paramater.
-  bool root_probe(const Position& pos, std::vector<Move>* safe_moves);
+  bool root_probe(const Position& pos, bool has_repeated,
+                  std::vector<Move>* safe_moves);
   // Probes WDL tables to determine which moves might be on the optimal play
   // path. If 50 move ply counter is non-zero some (or maybe even all) of the
   // returned safe moves in a 'winning' position, may actually be draws.

--- a/src/syzygy/syzygy_test.cc
+++ b/src/syzygy/syzygy_test.cc
@@ -47,7 +47,7 @@ void TestValidRootExpectation(SyzygyTablebase* tablebase,
   board.SetFromFen(fen, &rule50ply, &gameply);
   history.Reset(board, rule50ply, gameply);
   MoveList allowed_moves_dtz;
-  tablebase->root_probe(history.Last(), &allowed_moves_dtz);
+  tablebase->root_probe(history.Last(), false, &allowed_moves_dtz);
   MoveList allowed_moves_wdl;
   tablebase->root_probe_wdl(history.Last(), &allowed_moves_wdl);
   for (auto move : valid_moves) {

--- a/src/syzygy/syzygy_test.cc
+++ b/src/syzygy/syzygy_test.cc
@@ -39,7 +39,8 @@ void TestValidRootExpectation(SyzygyTablebase* tablebase,
                               const std::string& fen,
                               const MoveList& valid_moves,
                               const MoveList& invalid_moves,
-                              const MoveList& invalid_dtz_only = {}) {
+                              const MoveList& invalid_dtz_only = {},
+  bool has_repeated = false) {
   ChessBoard board;
   PositionHistory history;
   int rule50ply;
@@ -47,7 +48,7 @@ void TestValidRootExpectation(SyzygyTablebase* tablebase,
   board.SetFromFen(fen, &rule50ply, &gameply);
   history.Reset(board, rule50ply, gameply);
   MoveList allowed_moves_dtz;
-  tablebase->root_probe(history.Last(), false, &allowed_moves_dtz);
+  tablebase->root_probe(history.Last(), has_repeated, &allowed_moves_dtz);
   MoveList allowed_moves_wdl;
   tablebase->root_probe_wdl(history.Last(), &allowed_moves_wdl);
   for (auto move : valid_moves) {
@@ -228,6 +229,14 @@ TEST(Syzygy, Root5PieceProbes) {
                            {Move("a5a1", false)}, {}, {Move("a5d5", false)});
   TestValidRootExpectation(&tablebase, "8/8/8/3Q4/k7/3K4/1r6/8 w - - 81 45",
                            {Move("d5a8", false)}, {}, {Move("d3c3", false)});
+
+  // Variant of first test but with plenty of moves left.
+  TestValidRootExpectation(&tablebase, "8/8/8/Q7/8/1k1K4/1r6/8 w - - 60 44",
+                           {Move("a5a1", false), Move("a5d5", false)}, {}, {}
+                           );
+  // Same, but this time there is a repetition in history, so dtz will enforce choice of equal lowest dtz.
+  TestValidRootExpectation(&tablebase, "8/8/8/Q7/8/1k1K4/1r6/8 w - - 60 44",
+                           {Move("a5a1", false)}, {}, {Move("a5d5", false)}, true);
 }
 
 }  // namespace lczero

--- a/src/syzygy/syzygy_test.cc
+++ b/src/syzygy/syzygy_test.cc
@@ -40,7 +40,7 @@ void TestValidRootExpectation(SyzygyTablebase* tablebase,
                               const MoveList& valid_moves,
                               const MoveList& invalid_moves,
                               const MoveList& invalid_dtz_only = {},
-  bool has_repeated = false) {
+                              bool has_repeated = false) {
   ChessBoard board;
   PositionHistory history;
   int rule50ply;
@@ -232,11 +232,12 @@ TEST(Syzygy, Root5PieceProbes) {
 
   // Variant of first test but with plenty of moves left.
   TestValidRootExpectation(&tablebase, "8/8/8/Q7/8/1k1K4/1r6/8 w - - 60 44",
-                           {Move("a5a1", false), Move("a5d5", false)}, {}, {}
-                           );
-  // Same, but this time there is a repetition in history, so dtz will enforce choice of equal lowest dtz.
+                           {Move("a5a1", false), Move("a5d5", false)}, {}, {});
+  // Same, but this time there is a repetition in history, so dtz will enforce
+  // choice of equal lowest dtz.
   TestValidRootExpectation(&tablebase, "8/8/8/Q7/8/1k1K4/1r6/8 w - - 60 44",
-                           {Move("a5a1", false)}, {}, {Move("a5d5", false)}, true);
+                           {Move("a5a1", false)}, {}, {Move("a5d5", false)},
+                           true);
 }
 
 }  // namespace lczero


### PR DESCRIPTION
This was an oversight on my part when converting from cfish movegen to our movgen.