### PR TITLE
Fix minor data race condition on application exit

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -95,7 +95,7 @@ class NodeGarbageCollector {
   std::vector<std::unique_ptr<Node>> subtrees_to_gc_ GUARDED_BY(gc_mutex_);
 
   // When true, Worker() should stop and exit.
-  volatile bool stop_ = false;
+  std::atomic<bool> stop_ = {false};
   std::thread gc_thread_;
 };  // namespace
 


### PR DESCRIPTION
Fix a minor data race on exiting application.

```
==================
WARNING: ThreadSanitizer: data race (pid=31556)
  Write of size 1 at 0x0000013ac798 by main thread:
    #0 ~NodeGarbageCollector /home/chris/src/leela/build/release/../../src/mcts/node.cc:67 (lc0+0x56ff26)
    #1 cxa_at_exit_wrapper(void*) tsan_interceptors.cc.o:? (lc0+0x439583)

  Previous read of size 1 at 0x0000013ac798 by thread T1:
    #0 lczero::(anonymous namespace)::NodeGarbageCollector::Worker() /home/chris/src/leela/build/release/../../src/mcts/node.cc:88 (lc0+0x5743a7)
    #1 operator() /home/chris/src/leela/build/release/../../src/mcts/node.cc:55 (lc0+0x574308)
    #2 void std::_Bind_simple<lczero::(anonymous namespace)::NodeGarbageCollector::NodeGarbageCollector()::{lambda()#1} ()>::_M_invoke<>(std::_Index_tuple<>) /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/functional:1530 (lc0+0x574268)
    #3 std::_Bind_simple<lczero::(anonymous namespace)::NodeGarbageCollector::NodeGarbageCollector()::{lambda()#1} ()>::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/functional:1520 (lc0+0x574208)
    #4 std::thread::_Impl<std::_Bind_simple<lczero::(anonymous namespace)::NodeGarbageCollector::NodeGarbageCollector()::{lambda()#1} ()> >::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/thread:115 (lc0+0x573fec)
    #5 std::this_thread::__sleep_for(std::chrono::duration<long, std::ratio<1l, 1l> >, std::chrono::duration<long, std::ratio<1l, 1000000000l> >) ??:? (libstdc++.so.6+0xb8c7f)

  Location is global '<null>' at 0x000000000000 (lc0+0x0000013ac798)

  Thread T1 (tid=31558, running) created by main thread at:
    #0 pthread_create ??:? (lc0+0x43e3bb)
    #1 std::thread::_M_start_thread(std::shared_ptr<std::thread::_Impl_base>, void (*)()) ??:? (libstdc++.so.6+0xb8dc2)
    #2 NodeGarbageCollector /home/chris/src/leela/build/release/../../src/mcts/node.cc:55 (lc0+0x56feb0)
    #3 __cxx_global_var_init.1 /home/chris/src/leela/build/release/../../src/mcts/node.cc:102 (lc0+0x430caa)
    #4 _GLOBAL__sub_I_node.cc node.cc:? (lc0+0x430d1f)
    #5 __libc_csu_init ??:? (lc0+0x6451fc)

SUMMARY: ThreadSanitizer: data race /home/chris/src/leela/build/release/../../src/mcts/node.cc:67 in ~NodeGarbageCollector
==================
ThreadSanitizer: reported 1 warnings
```
