### PR TITLE
Exception during lc0 startup - using backend opts

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -225,8 +225,8 @@ void EngineController::UpdateTBAndNetwork() {
   }
   Weights weights = LoadWeightsFromFile(net_path);
 
-  OptionsDict network_options =
-      OptionsDict::FromString(backend_options, &options_);
+  OptionsDict network_options(&options_);
+  network_options.AddSubdictFromString(backend_options);
 
   network_ = NetworkFactory::Get()->Create(backend, weights, network_options);
 }

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -146,8 +146,8 @@ SelfPlayTournament::SelfPlayTournament(const OptionsDict& options,
     std::string backend_options = options.GetSubdict(kPlayerNames[idx])
                                       .Get<std::string>(kNnBackendOptionsStr);
 
-    OptionsDict network_options = OptionsDict::FromString(
-        backend_options, &options.GetSubdict(kPlayerNames[idx]));
+   OptionsDict network_options(&options.GetSubdict(kPlayerNames[idx]));
+   network_options.AddSubdictFromString(backend_options);
 
     networks_[idx] =
         NetworkFactory::Get()->Create(backend, weights, network_options);

--- a/src/utils/optionsdict.cc
+++ b/src/utils/optionsdict.cc
@@ -317,12 +317,18 @@ class Parser {
 
 }  // namespace
 
+<<<<<<< HEAD
 OptionsDict OptionsDict::FromString(const std::string& str,
                                     const OptionsDict* parent) {
   OptionsDict *dict = new OptionsDict(parent);
   Parser parser(str);
   parser.ParseMain(dict);
   return *dict;
+=======
+void OptionsDict::AddSubdictFromString(const std::string& str) {
+  Parser parser(str);
+  parser.ParseMain(this);
+>>>>>>> master
 }
 
 }  // namespace lczero

--- a/src/utils/optionsdict.cc
+++ b/src/utils/optionsdict.cc
@@ -317,18 +317,9 @@ class Parser {
 
 }  // namespace
 
-<<<<<<< HEAD
-OptionsDict OptionsDict::FromString(const std::string& str,
-                                    const OptionsDict* parent) {
-  OptionsDict *dict = new OptionsDict(parent);
-  Parser parser(str);
-  parser.ParseMain(dict);
-  return *dict;
-=======
 void OptionsDict::AddSubdictFromString(const std::string& str) {
   Parser parser(str);
   parser.ParseMain(this);
->>>>>>> master
 }
 
 }  // namespace lczero

--- a/src/utils/optionsdict.cc
+++ b/src/utils/optionsdict.cc
@@ -319,10 +319,10 @@ class Parser {
 
 OptionsDict OptionsDict::FromString(const std::string& str,
                                     const OptionsDict* parent) {
-  OptionsDict dict(parent);
+  OptionsDict *dict = new OptionsDict(parent);
   Parser parser(str);
-  parser.ParseMain(&dict);
-  return dict;
+  parser.ParseMain(dict);
+  return *dict;
 }
 
 }  // namespace lczero

--- a/src/utils/optionsdict.h
+++ b/src/utils/optionsdict.h
@@ -46,10 +46,6 @@ class OptionsDict : TypeDict<bool>,
                     TypeDict<std::string>,
                     TypeDict<float> {
  public:
-  // Creates options dict from string. Example of a string:
-  // option1=1, option_two = "string val", subdict(option3=3.14)
-  static OptionsDict FromString(const std::string& str,
-                                const OptionsDict* parent = nullptr);
 
   OptionsDict(const OptionsDict* parent = nullptr) : parent_(parent) {}
 
@@ -90,6 +86,14 @@ class OptionsDict : TypeDict<bool>,
 
   // Returns list of subdictionaries.
   std::vector<std::string> ListSubdicts() const;
+
+  // Creates options dict from string. Example of a string:
+  // option1=1, option_two = "string val", subdict(option3=3.14)
+  //
+  // the sub dictionary is containing a parent pointer refering 
+  // back to this object. You need to ensure, that this object
+  // is still in scope, when the parent pointer is used
+  void AddSubdictFromString(const std::string& str);
 
   bool HasSubdict(const std::string& name) const;
 


### PR DESCRIPTION
When backend options are used like: 
lc0.exe selfplay --backend-opts="cudnn(threads=1, minibatch-size=512)"
the variable dict used before will get invalid, when the methode FromString will end, which lead to an exception in the debug mode and might lead to bigger issues later in the runtime mode, when the options are overwritten by random.

I'm sorry if something is wrong with my pull request. It's my first try. 