### PR TITLE
Batch collisions and terminal node visits.

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -113,7 +113,8 @@ void EngineController::PopulateOptions(OptionsParser* options) {
   defaults->Set<float>(SearchParams::kFpuReductionStr, 1.2f);
   defaults->Set<float>(SearchParams::kCpuctStr, 3.4f);
   defaults->Set<float>(SearchParams::kPolicySoftmaxTempStr, 2.2f);
-  defaults->Set<int>(SearchParams::kAllowedNodeCollisionsStr, 32);
+  defaults->Set<int>(SearchParams::kAllowedTotalNodeCollisionsStr, 1024);
+  defaults->Set<int>(SearchParams::kAllowedNodeCollisionEventsStr, 32);
   defaults->Set<int>(SearchParams::kCacheHistoryLengthStr, 0);
   defaults->Set<bool>(SearchParams::kOutOfOrderEvalStr, true);
 }

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -231,19 +231,19 @@ bool Node::TryStartScoreUpdate() {
   return true;
 }
 
-void Node::CancelScoreUpdate() { --n_in_flight_; }
+void Node::CancelScoreUpdate(int multivisit) { n_in_flight_ -= multivisit; }
 
-void Node::FinalizeScoreUpdate(float v) {
+void Node::FinalizeScoreUpdate(float v, int multivisit) {
   // Recompute Q.
-  q_ += (v - q_) / (n_ + 1);
+  q_ += multivisit * (v - q_) / (n_ + multivisit);
   // If first visit, update parent's sum of policies visited at least once.
   if (n_ == 0 && parent_ != nullptr) {
     parent_->visited_policy_ += parent_->edges_[index_].GetP();
   }
   // Increment N.
-  ++n_;
+  n_ += multivisit;
   // Decrement virtual loss.
-  --n_in_flight_;
+  n_in_flight_ -= multivisit;
 }
 
 Node::NodeRange Node::ChildNodes() const { return child_.get(); }

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -103,7 +103,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kCacheHistoryLengthId, 0, 7) = 7;
   options->Add<FloatOption>(kPolicySoftmaxTempId, 0.1f, 10.0f) = 1.0f;
   options->Add<IntOption>(kAllowedNodeCollisionEventsId, 0, 1024) = 0;
-  options->Add<IntOption>(kAllowedTotalNodeCollisionsId, 0, 1000000) = 10000;
+  options->Add<IntOption>(kAllowedTotalNodeCollisionsId, 0, 1000000) = 0;
   options->Add<BoolOption>(kOutOfOrderEvalId) = false;
   options->Add<IntOption>(kMultiPvId, 1, 500) = 1;
 }

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -44,8 +44,10 @@ const char* SearchParams::kFpuReductionStr = "First Play Urgency Reduction";
 const char* SearchParams::kCacheHistoryLengthStr =
     "Length of history to include in cache";
 const char* SearchParams::kPolicySoftmaxTempStr = "Policy softmax temperature";
-const char* SearchParams::kAllowedNodeCollisionsStr =
-    "Allowed node collisions, per batch";
+const char* SearchParams::kAllowedNodeCollisionEventsStr =
+    "Allowed node collision events, per batch";
+const char* SearchParams::kAllowedTotalNodeCollisionsStr =
+    "Total allowed node collisions, per batch";
 const char* SearchParams::kOutOfOrderEvalStr =
     "Out-of-order cache backpropagation";
 const char* SearchParams::kMultiPvStr = "MultiPV";
@@ -72,8 +74,10 @@ void SearchParams::Populate(OptionsParser* options) {
                           "cache-history-length") = 7;
   options->Add<FloatOption>(kPolicySoftmaxTempStr, 0.1f, 10.0f,
                             "policy-softmax-temp") = 1.0f;
-  options->Add<IntOption>(kAllowedNodeCollisionsStr, 0, 1024,
-                          "allowed-node-collisions") = 0;
+  options->Add<IntOption>(kAllowedNodeCollisionEventsStr, 0, 1024,
+                          "allowed-node-collision-events") = 32;
+  options->Add<IntOption>(kAllowedTotalNodeCollisionsStr, 0, 1000000,
+                          "allowed-total-node-collisions") = 10000;
   options->Add<BoolOption>(kOutOfOrderEvalStr, "out-of-order-eval") = false;
   options->Add<IntOption>(kMultiPvStr, 1, 500, "multipv") = 1;
 }
@@ -86,7 +90,10 @@ SearchParams::SearchParams(const OptionsDict& options)
       kFpuReduction(options.Get<float>(kFpuReductionStr)),
       kCacheHistoryLength(options.Get<int>(kCacheHistoryLengthStr)),
       kPolicySoftmaxTemp(options.Get<float>(kPolicySoftmaxTempStr)),
-      kAllowedNodeCollisions(options.Get<int>(kAllowedNodeCollisionsStr)),
+      kAllowedNodeCollisionEvents(
+          options.Get<int>(kAllowedNodeCollisionEventsStr)),
+      kAllowedTotalNodeCollisions(
+          options.Get<int>(kAllowedTotalNodeCollisionsStr)),
       kOutOfOrderEval(options.Get<bool>(kOutOfOrderEvalStr)) {}
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -58,7 +58,12 @@ class SearchParams {
   float GetFpuReduction() const { return kFpuReduction; }
   int GetCacheHistoryLength() const { return kCacheHistoryLength; }
   float GetPolicySoftmaxTemp() const { return kPolicySoftmaxTemp; }
-  int GetAllowedNodeCollisions() const { return kAllowedNodeCollisions; }
+  int GetAllowedNodeCollisionEvents() const {
+    return kAllowedNodeCollisionEvents;
+  }
+  int GetAllowedTotalNodeCollisions() const {
+    return kAllowedTotalNodeCollisions;
+  }
   bool GetOutOfOrderEval() const { return kOutOfOrderEval; }
   int GetMultiPv() const { return options_.Get<int>(kMultiPvStr); }
 
@@ -77,7 +82,8 @@ class SearchParams {
   static const char* kFpuReductionStr;
   static const char* kCacheHistoryLengthStr;
   static const char* kPolicySoftmaxTempStr;
-  static const char* kAllowedNodeCollisionsStr;
+  static const char* kAllowedNodeCollisionEventsStr;
+  static const char* kAllowedTotalNodeCollisionsStr;
   static const char* kOutOfOrderEvalStr;
   static const char* kMultiPvStr;
 
@@ -95,7 +101,8 @@ class SearchParams {
   const float kFpuReduction;
   const int kCacheHistoryLength;
   const float kPolicySoftmaxTemp;
-  const int kAllowedNodeCollisions;
+  const int kAllowedNodeCollisionEvents;
+  const int kAllowedTotalNodeCollisions;
   const bool kOutOfOrderEval;
 };
 

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -389,7 +389,7 @@ std::vector<EdgeAndNode> Search::GetBestChildrenNoTemperature(Node* parent,
   // * If two nodes have equal number:
   //   * If that number is 0, the one with larger prior wins.
   //   * If that number is larger than 0, the one with larger eval wins.
-  using El = std::tuple<int, float, float, EdgeAndNode>;
+  using El = std::tuple<uint64_t, float, float, EdgeAndNode>;
   std::vector<El> edges;
   for (auto edge : parent->Edges()) {
     if (parent == root_node_ && !root_limit.empty() &&

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1072,7 +1072,7 @@ void SearchWorker::DoBackupUpdateSingleNode(
           search_->GetBestChildNoTemperature(search_->root_node_);
     }
   }
-  ++search_->total_playouts_;
+  search_->total_playouts_ += node_to_process.multivisit;
   search_->cum_depth_ += node_to_process.depth;
   search_->max_depth_ = std::max(search_->max_depth_, node_to_process.depth);
 }  // namespace lczero

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -216,16 +216,36 @@ class SearchWorker {
 
  private:
   struct NodeToProcess {
-    NodeToProcess(Node* node, bool is_collision, uint16_t depth)
-        : node(node), depth(depth), is_collision(is_collision) {}
+    bool IsExtendable() const {
+      return collision_count == 0 && !node->IsTerminal();
+    }
+    bool IsCollision() const { return collision_count > 0; }
+    bool CanEvalOutOfOrder() const {
+      return is_cache_hit || node->IsTerminal();
+    }
+
+    // The node to extend.
     Node* node;
     // Value from NN's value head, or -1/0/1 for terminal nodes.
     float v;
+    int collision_count = 0;
     uint16_t depth;
-    bool is_collision = false;
     bool nn_queried = false;
     bool is_cache_hit = false;
+
+    static NodeToProcess Collision(Node* node, uint16_t depth,
+                                   int collision_count) {
+      return NodeToProcess(node, depth, collision_count);
+    }
+    static NodeToProcess Extension(Node* node, uint16_t depth) {
+      return NodeToProcess(node, depth, 0);
+    }
+
+   private:
+    NodeToProcess(Node* node, uint16_t depth, int collision_count)
+        : node(node), collision_count(collision_count), depth(depth) {}
   };
+  //  return NodeToProcess::Collision(node, depth, node_at_root);
 
   NodeToProcess PickNodeToExtend();
   void ExtendNode(Node* node);


### PR DESCRIPTION
If there is a collision, estimate how much more visits will be collisions and apply them at once.
The same for terminal node visits.

