### PR TITLE
Make engine controller track move start time in ways which more closely match how UCI hosts measure time.

### DIFF
--- a/src/engine.h
+++ b/src/engine.h
@@ -117,6 +117,7 @@ class EngineController {
 
   // How much less time was used by search than what was allocated.
   int64_t time_spared_ms_ = 0;
+  std::chrono::steady_clock::time_point move_start_time_;
 };
 
 class EngineLoop : public UciLoop {


### PR DESCRIPTION
Consider this untested - and its got a big TODO in it that I'm not sure what is the ideal behaviour.

Also this is intended to augment #404, and hopefully should be easy to merge the two together.