### PR TITLE
Do not parse flags twice (just to find config file)

### DIFF
--- a/src/utils/configfile.cc
+++ b/src/utils/configfile.cc
@@ -47,15 +47,38 @@ void ConfigFile::PopulateOptions(OptionsParser* options) {
   options->Add<StringOption>(kConfigFileId) = kDefaultConfigFile;
 }
 
+// This is needed to get the config file from the parameters without calling
+// ProcessAllFlags() that should be called only once, and needs the config file.
+std::string ConfigFile::ProcessConfigFlag(
+     const std::vector<std::string>& args) {
+  std::string filename = kDefaultConfigFile;
+  for (auto iter = args.begin(), end = args.end(); iter != end; ++iter) {
+    std::string param = *iter;
+
+    if (param.substr(0, 2) == "--") {
+      param = param.substr(2);
+      auto pos = param.find('=');
+      if (pos != std::string::npos) {
+        if (param.substr(0, pos) == kConfigFileId.long_flag) {
+          filename = param.substr(pos + 1);
+        }
+      }
+    }
+    if (param.size() == 2 && param[0] == '-') {
+      if (param[1] == kConfigFileId.short_flag && iter + 1 != end) {
+        filename = *(iter + 1);
+        ++iter;
+      }
+    }
+  }
+  return filename;
+}
+
 bool ConfigFile::Init(OptionsParser* options) {
   arguments_.clear();
 
-  // Process flags to get the config file parameter.
-  if (!options->ProcessAllFlags()) return false;
-
-  // Calculate the relative path of the config file.
-  OptionsDict dict = options->GetOptionsDict();
-  std::string filename = dict.Get<std::string>(kConfigFileId.GetId());
+  // Get the relative path from the config file parameter.
+  std::string filename = ProcessConfigFlag(CommandLine::Arguments());
 
   // If filename is an empty string then return true.  This is to override
   // loading the default configuration file.

--- a/src/utils/configfile.h
+++ b/src/utils/configfile.h
@@ -51,6 +51,8 @@ class ConfigFile {
   // Parses the config file into the arguments_ vector.
   static bool ParseFile(const std::string& filename, OptionsParser* options);
 
+  static std::string ProcessConfigFlag(const std::vector<std::string>& args);
+
   static std::vector<std::string> arguments_;
 };
 


### PR DESCRIPTION
The -n short option works as a toggle. This means that ProcessAllFlags() should not be called twice, since then the value is reset to the default. Unfortunately, this is exactly what is happening since we call it once to get the config file to open, and then once more to actually do the final option parsing. This patch introduces a ProcessConfigFlag function to just look for this specific option and get the filename.