### PR TITLE
Do something useful with a "go depth N" value.

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -131,6 +131,7 @@ SearchLimits EngineController::PopulateSearchLimits(int ply, bool is_black,
   }
   limits.infinite = params.infinite || params.ponder;
   limits.visits = limits.infinite ? -1 : params.nodes;
+  limits.depth = params.depth;
   if (limits.infinite || time < 0) return limits;
   int increment = std::max(int64_t(0), is_black ? params.binc : params.winc);
 

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -319,6 +319,9 @@ void Search::MaybeTriggerStop() {
   if (limits_.time_ms >= 0 && GetTimeSinceStart() >= limits_.time_ms) {
     FireStopInternal();
   }
+  if (limits_.depth >= 0 && cum_depth_ / (total_playouts_ ? total_playouts_ : 1) >= (unsigned int)limits_.depth) {
+    FireStopInternal();
+  }
   // If we are the first to see that stop is needed.
   if (stop_ && !responded_bestmove_) {
     SendUciInfo();

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -319,7 +319,10 @@ void Search::MaybeTriggerStop() {
   if (limits_.time_ms >= 0 && GetTimeSinceStart() >= limits_.time_ms) {
     FireStopInternal();
   }
-  if (limits_.depth >= 0 && cum_depth_ / (total_playouts_ ? total_playouts_ : 1) >= (unsigned int)limits_.depth) {
+  // Stop if average depth reached requested depth.
+  if (limits_.depth >= 0 &&
+      cum_depth_ / (total_playouts_ ? total_playouts_ : 1) >=
+          static_cast<unsigned int>(limits_.depth) {
     FireStopInternal();
   }
   // If we are the first to see that stop is needed.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -322,7 +322,7 @@ void Search::MaybeTriggerStop() {
   // Stop if average depth reached requested depth.
   if (limits_.depth >= 0 &&
       cum_depth_ / (total_playouts_ ? total_playouts_ : 1) >=
-          static_cast<unsigned int>(limits_.depth) {
+          static_cast<unsigned int>(limits_.depth)) {
     FireStopInternal();
   }
   // If we are the first to see that stop is needed.

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -47,6 +47,7 @@ struct SearchLimits {
   std::int64_t visits = -1;
   std::int64_t playouts = -1;
   std::int64_t time_ms = -1;
+  int depth = -1;
   bool infinite = false;
   MoveList searchmoves;
 };


### PR DESCRIPTION
The value passed to a 'go depth' UCI command
is parsed but not used. The result is that
'go depth 1' is equal to a 'go infinite'.

For a GUI that doesn't support 'go nodes', like
pychess, this means that if you set the 'difficulty
slider' to any value - the engine doesn't move
until it is stop-ped. To have a better experience
it seems logical to more or less stop once the
printed uci info 'depth' value reaches the requested
depth.

Example engine output after patch:

ucinewgame
position startpos moves e2e4
go depth 3
info depth 1 seldepth 2 time 194 nodes 3 score cp -5 hashfull 0 nps 15 tbhits 0 pv c7c5 d2d4
info depth 2 seldepth 3 time 310 nodes 9 score cp -10 hashfull 0 nps 29 tbhits 0 pv c7c5 c2c3 g8f6
info depth 3 seldepth 4 time 401 nodes 20 score cp -7 hashfull 0 nps 49 tbhits 0 pv c7c5 b1c3 b8c6 g1e2
info depth 3 seldepth 4 time 401 nodes 20 score cp -7 hashfull 0 nps 49 tbhits 0 pv c7c5 b1c3 b8c6 g1e2
bestmove c7c5 ponder b1c3

Note that the last info line is duplicated (this was already the case
before this patch).

The search stops as soon as the (average) depth is reached, because it
is always possible to increment the depth, while on the other end you
can't go lower than 1.

ucinewgame
position startpos moves e2e4
go depth 1
bestmove c7c5