### PR TITLE
Help meson find libtensorflow_cc on Darwin

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,7 @@ esac
 
 BUILDDIR=build/${BUILDTYPE}
 
+# Temporary fix for Tensorflow on Darwin until meson find_library() is fixed
 if [ `uname` == "Darwin" ] ; then
   if [ -f /usr/local/lib/tensorflow_cc/libtensorflow_cc.so ]; then
     if [ ! -f /usr/local/lib/tensorflow_cc/libtensorflow_cc.dylib ]; then

--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,15 @@ esac
 
 BUILDDIR=build/${BUILDTYPE}
 
+if [ `uname` == "Darwin" ] ; then
+  if [ -f /usr/local/lib/tensorflow_cc/libtensorflow_cc.so ]; then
+    if [ ! -f /usr/local/lib/tensorflow_cc/libtensorflow_cc.dylib ]; then
+      ln -s /usr/local/lib/tensorflow_cc/libtensorflow_cc.so /usr/local/lib/tensorflow_cc/libtensorflow_cc.dylib
+    fi
+  fi
+fi
+
+
 if [ -d ${BUILDDIR} ]
 then
   meson configure ${BUILDDIR} --buildtype ${BUILDTYPE} --prefix ${INSTALL_PREFIX:-/usr/local} "$@"


### PR DESCRIPTION
The meson find_library() routine only searches for .dylib on Darwin 
if a directory is specified. It therefore fails to find the tensorflow
.so library even though this exists in the correct location. The
Darwin linker has no problems with .so files.

This pr creates a symlink from the .so to a .dylib prior to invoking meson.