### PR TITLE
Set bool options only once when using short flags

### DIFF
--- a/src/utils/optionsparser.cc
+++ b/src/utils/optionsparser.cc
@@ -442,7 +442,7 @@ bool BoolOption::ProcessLongFlag(const std::string& flag,
 
 bool BoolOption::ProcessShortFlag(char flag, OptionsDict* dict) {
   if (flag == GetShortFlag()) {
-    SetVal(dict, !GetVal(*dict));
+    if (dict->IsDefault<bool>(GetId())) SetVal(dict, !GetVal(*dict));
     return true;
   }
   return false;

--- a/src/utils/optionsparser_test.cc
+++ b/src/utils/optionsparser_test.cc
@@ -82,6 +82,28 @@ TEST(OptionsParser, ChoiceOptionCheckValueConstraints) {
   EXPECT_THROW(options.SetUciOption("choice-test-a", "choice-d"), Exception);
 }
 
+TEST(OptionsParser, BoolOptionsVerifyToggleOnlyOnce) {
+  OptionsParser options;
+  const OptionId id1{"bool-test-a", "bool-test-a", "help", 'a'};
+  options.Add<BoolOption>(id1) = false;
+  const OptionId id2{"bool-test-b", "bool-test-b", "help", 'b'};
+  options.Add<BoolOption>(id2) = true;
+
+  std::vector<std::string> args;
+  args.emplace_back("-a");
+  args.emplace_back("-b");
+
+  EXPECT_NO_THROW(options.ProcessFlags(args));
+  OptionsDict dict1 = options.GetOptionsDict();
+  EXPECT_EQ(dict1.Get<bool>(id1.GetId()), true);
+  EXPECT_EQ(dict1.Get<bool>(id2.GetId()), false);
+
+  EXPECT_NO_THROW(options.ProcessFlags(args));
+  OptionsDict dict2 = options.GetOptionsDict();
+  EXPECT_EQ(dict2.Get<bool>(id1.GetId()), true);
+  EXPECT_EQ(dict2.Get<bool>(id2.GetId()), false);
+}
+
 }  // namespace lczero
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This is to prevent bools from cancelling each other out when using the short flag.

For example:

`./lc0 -n -n` will result in noise being true instead of false.  The second `-n` is ignored.