### PR TITLE
Honor 'go nodes X' when --futile-search-aversion is non-zero

### DIFF
--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -210,14 +210,15 @@ class Node {
   // Debug information about the node.
   std::string DebugString() const;
 
+  // TODO: shrink the padding on this somehow? It takes 16 bytes even though
+  // only 10 are real! Maybe even merge it into this class??
+  EdgeList edges_;
+
  private:
   // To minimize the number of padding bytes and to avoid having unnecessary
   // padding when new fields are added, we arrange the fields by size, largest
   // to smallest.
 
-  // TODO: shrink the padding on this somehow? It takes 16 bytes even though
-  // only 10 are real! Maybe even merge it into this class??
-  EdgeList edges_;
 
   // 8 byte fields.
   // Pointer to a parent node. nullptr for the root.

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -210,15 +210,14 @@ class Node {
   // Debug information about the node.
   std::string DebugString() const;
 
-  // TODO: shrink the padding on this somehow? It takes 16 bytes even though
-  // only 10 are real! Maybe even merge it into this class??
-  EdgeList edges_;
-
  private:
   // To minimize the number of padding bytes and to avoid having unnecessary
   // padding when new fields are added, we arrange the fields by size, largest
   // to smallest.
 
+  // TODO: shrink the padding on this somehow? It takes 16 bytes even though
+  // only 10 are real! Maybe even merge it into this class??
+  EdgeList edges_;
 
   // 8 byte fields.
   // Pointer to a parent node. nullptr for the root.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -754,9 +754,12 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         // best_move_node_ could have changed since best_node_n was retrieved.
         // To ensure we have at least one node to expand, always include
         // current best node.
+	// However, if given a certain node count to evaluate with `go nodes X`,
+	// then do not make this shortcut.
         if (child != search_->best_move_edge_ &&
             search_->remaining_playouts_ <
-                best_node_n - static_cast<int>(child.GetN())) {
+                best_node_n - static_cast<int>(child.GetN()) &&
+	    search_->limits_.visits == 0) {
           continue;
         }
         // If root move filter exists, make sure move is in the list.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -36,8 +36,6 @@
 #include <sstream>
 #include <thread>
 
-#include <cstdlib>
-
 #include "mcts/node.h"
 #include "neural/cache.h"
 #include "neural/encoder.h"
@@ -749,11 +747,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
             ? -node->GetQ()
             : -node->GetQ() - params_.GetFpuReduction() *
                                   std::sqrt(node->GetVisitedPolicy());
-
-    int r = rand() % node->Edges()->size();
-    auto child = node->Edges()[r];
-
-//    for (auto child : node->Edges()) {
+    for (auto child : node->Edges()) {
       if (is_root_node) {
         // If there's no chance to catch up to the current best node with
         // remaining playouts, don't consider it.
@@ -787,7 +781,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         second_best = score;
         second_best_edge = child;
       }
-//    }
+    }
 
     if (second_best_edge) {
       collision_limit = std::min(

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -750,8 +750,8 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
             : -node->GetQ() - params_.GetFpuReduction() *
                                   std::sqrt(node->GetVisitedPolicy());
 
-    int r = rand() % node->edges_.size();
-    auto child = node->edges_[r];
+    int r = rand() % node->Edges()->size();
+    auto child = node->Edges()[r];
 
 //    for (auto child : node->Edges()) {
       if (is_root_node) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -36,6 +36,8 @@
 #include <sstream>
 #include <thread>
 
+#include <cstdlib>
+
 #include "mcts/node.h"
 #include "neural/cache.h"
 #include "neural/encoder.h"
@@ -747,7 +749,11 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
             ? -node->GetQ()
             : -node->GetQ() - params_.GetFpuReduction() *
                                   std::sqrt(node->GetVisitedPolicy());
-    for (auto child : node->Edges()) {
+
+    int r = rand() % node->Edges()->size();
+    auto child = node->Edges()[r];
+
+//    for (auto child : node->Edges()) {
       if (is_root_node) {
         // If there's no chance to catch up to the current best node with
         // remaining playouts, don't consider it.
@@ -781,7 +787,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         second_best = score;
         second_best_edge = child;
       }
-    }
+//    }
 
     if (second_best_edge) {
       collision_limit = std::min(

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -750,8 +750,8 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
             : -node->GetQ() - params_.GetFpuReduction() *
                                   std::sqrt(node->GetVisitedPolicy());
 
-    int r = rand() % node->Edges()->size();
-    auto child = node->Edges()[r];
+    int r = rand() % node->edges_.size();
+    auto child = node->edges_[r];
 
 //    for (auto child : node->Edges()) {
       if (is_root_node) {


### PR DESCRIPTION
Honor 'go nodes X' and do actually evalute X number of nodes even if --futile-search-aversion is non-zero i.e. do not return early when the current best move cannot be surpassed by other moves.

This patch makes it possible to re-play a game, which is crucial for the analysis of NPS lc0 delivers under different circumstances.

I have written a script that _automatically replicates any previously played game_, using extracts from the log file and UCI commands, and extracts the NPS for each move, while simultaneously monitoring the GPU(s). Using that script I have been able to create data about how NPS changes with hardware and with the position, see the graphs below for examples of the kind of analysis made possible by this patch.

![image](https://user-images.githubusercontent.com/551014/47122895-0dd8fc00-d279-11e8-80d7-b67c280baefd.png)
The graph above shows an analysis of the first 14 moves of the 16th game Lc0 vs Ethereal in the TCEC cup, @scs-ben provided the log file. The game was replicated on a system with 6 x GTX 1060 under different number of GPU(s) active. Missing data points are due to diverging bestmoves.

![foo](https://user-images.githubusercontent.com/551014/47125323-0b7b9f80-d283-11e8-9b7e-6c692400f56d.png)
This is the same game, replayed on a system of K80s, and _including GPU utilisation data_ - shown with the dashed lines. I'm also planning to recreate the game using various number of V100s.

The script for automatic replay of games is available [here](http://hansekbrand.se/code/re-play-lc0.pl). If you want to include that script into the lc0 repo, you are most welcome to do so. 

The graphs suggests a number of hypotheses about lc0:s performance, as measured by NPS, in general and regards to multiGPU-scaling in particular.

- Different chess positions leads to differerent NPS.
- The earliest positions in this game are relatively fast positions.
- In this game the position at move 7, and the positions a few moves after that, are relatively slow positions (those positions came after a rather unexpected capture on b2 by Ethereal).
- NPS at a given position is non-random, when repeated, almost the same NPS will be reached.
- MultiGPU-scaling seems to vary so that fast positions scales better than slow positions.
- GPU utilisation is negatively correlated with number of GPUs.
- It looks as if GPU utilisation is also negatively correlated with NPS - at least when there are many GPUs in use. Is NPS calculated in a way that could explain that rather odd correlation?
- Even if there are similarities between on the one hand V100 (cudnn-fp16) and on the other GTX 1060 and K80 (both cudnn), further research on the V100 is needed.