### PR TITLE
Allow use of old flag names as alternatives to current ones, and print warning if used.

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -377,6 +377,7 @@ EngineLoop::EngineLoop()
               options_.GetOptionsDict()) {
   engine_.PopulateOptions(&options_);
   options_.Add<StringOption>(kLogFileId);
+  options_.AddDeprecatedFlag(kLogFileId.GetId(), "debuglog");
 }
 
 void EngineLoop::RunLoop() {

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -106,6 +106,11 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kAllowedTotalNodeCollisionsId, 1, 1000000) = 1;
   options->Add<BoolOption>(kOutOfOrderEvalId) = false;
   options->Add<IntOption>(kMultiPvId, 1, 500) = 1;
+
+  options->AddDeprecatedFlag(kAggressiveTimePruningId.GetId(),
+                             "futile-search-aversion");
+  options->AddDeprecatedFlag(kAllowedNodeCollisionEventsId.GetId(),
+                             "allowed-node-collisions");
 }
 
 SearchParams::SearchParams(const OptionsDict& options)

--- a/src/utils/optionsparser.h
+++ b/src/utils/optionsparser.h
@@ -131,6 +131,11 @@ class OptionsParser {
   // Adds a subdictionary for a given context.
   void AddContext(const std::string&);
 
+  // Adds an old long flag name for compatibility.
+  void AddDeprecatedFlag(const std::string& name, const std::string& flag) {
+    deprecated_flags_[flag] = name;
+  }
+
  private:
   // Prints help to std::cerr.
   void ShowHelp() const;
@@ -142,6 +147,7 @@ class OptionsParser {
   Option* FindOptionById(const std::string& name) const;
 
   std::vector<std::unique_ptr<Option>> options_;
+  std::unordered_map<std::string, std::string> deprecated_flags_;
   OptionsDict defaults_;
   OptionsDict& values_;
 };


### PR DESCRIPTION
As an example, `--futile-search-aversion`, `--debuglog` and `allowed-node-collisions` are added as alternatives to the new flags.