### PR TITLE
remove movetime from limits

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -396,9 +396,7 @@ void EngineController::Go(const GoParams& params) {
 
   if (limits.search_deadline) {
     LOGFILE << "Timer started at "
-            << FormatTime(SteadyClockToSystemClock(move_start_time_))
-            << ", deadline at "
-            << FormatTime(SteadyClockToSystemClock(*limits.search_deadline));
+            << FormatTime(SteadyClockToSystemClock(move_start_time_));
   }
   search_->StartThreads(options_.Get<int>(kThreadsOptionId.GetId()));
 }

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -146,7 +146,12 @@ void EngineController::PopulateOptions(OptionsParser* options) {
 SearchLimits EngineController::PopulateSearchLimits(int ply, bool is_black,
     const GoParams& params, std::chrono::steady_clock::time_point start_time) {
   SearchLimits limits;
-  limits.movetime = params.movetime;
+  int64_t move_overhead = options_.Get<int>(kMoveOverheadId.GetId());
+  if (params.movetime >= 0) {
+    limits.search_deadline =
+        start_time + std::chrono::milliseconds(params.movetime - move_overhead);
+  }
+
   int64_t time = (is_black ? params.btime : params.wtime);
   if (!params.searchmoves.empty()) {
     limits.searchmoves.reserve(params.searchmoves.size());
@@ -166,7 +171,6 @@ SearchLimits EngineController::PopulateSearchLimits(int ply, bool is_black,
 
   // How to scale moves time.
   float slowmover = options_.Get<float>(kSlowMoverId.GetId());
-  int64_t move_overhead = options_.Get<int>(kMoveOverheadId.GetId());
   float time_curve_peak = options_.Get<float>(kTimeCurvePeakId.GetId());
   float time_curve_left_width =
       options_.Get<float>(kTimeCurveLeftWidthId.GetId());

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -53,8 +53,12 @@ const auto kNNComputationWarningTime = std::chrono::milliseconds(500);
 
 std::string SearchLimits::DebugString() const {
   std::ostringstream ss;
-  ss << "visits:" << visits << " playouts:" << playouts
-     << " depth:" << depth << " infinite:" << infinite;
+  ss << "visits:" << visits << " playouts:" << playouts << " depth:" << depth
+     << " infinite:" << infinite;
+  if (search_deadline) {
+    ss << " search_deadline:"
+       << FormatTime(SteadyClockToSystemClock(*search_deadline));
+  }
   return ss.str();
 }
 

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -65,15 +65,7 @@ Search::Search(const NodeTree& tree, Network* network,
       initial_visits_(root_node_->GetN()),
       best_move_callback_(best_move_callback),
       info_callback_(info_callback),
-      params_(options) {
-  if (limits_.movetime >= 0) {
-    search_deadline_ =
-        std::chrono::steady_clock::now() +
-        std::chrono::milliseconds(limits_.movetime);
-  } else {
-    search_deadline_ = limits_.search_deadline;
-  }
-}
+      params_(options) {}
 
 namespace {
 void ApplyDirichletNoise(Node* node, float eps, double alpha) {
@@ -160,9 +152,9 @@ int64_t Search::GetTimeSinceStart() const {
 }
 
 int64_t Search::GetTimeToDeadline() const {
-  if (!search_deadline_) return 0;
+  if (!limits_.search_deadline) return 0;
   return std::chrono::duration_cast<std::chrono::milliseconds>(
-             *search_deadline_ - std::chrono::steady_clock::now())
+             *limits_.search_deadline - std::chrono::steady_clock::now())
       .count();
 }
 
@@ -270,7 +262,7 @@ void Search::MaybeTriggerStop() {
     FireStopInternal();
   }
   // Stop if reached time limit.
-  if (search_deadline_ && GetTimeToDeadline() <= 0) {
+  if (limits_.search_deadline && GetTimeToDeadline() <= 0) {
     FireStopInternal();
   }
   // Stop if average depth reached requested depth.
@@ -295,9 +287,9 @@ void Search::UpdateRemainingMoves() {
   SharedMutex::Lock lock(nodes_mutex_);
   remaining_playouts_ = std::numeric_limits<int>::max();
   // Check for how many playouts there is time remaining.
-  if (search_deadline_ && !nps_start_time_) {
+  if (limits_.search_deadline && !nps_start_time_) {
     nps_start_time_ = std::chrono::steady_clock::now();
-  } else if (search_deadline_) {
+  } else if (limits_.search_deadline) {
     auto time_since_start =
         std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - *nps_start_time_)
@@ -531,7 +523,7 @@ void Search::WatchdogThread() {
       constexpr auto kMaxWaitTime = 100ms;
       constexpr auto kMinWaitTime = 1ms;
       Mutex::Lock lock(counters_mutex_);
-      auto remaining_time = search_deadline_
+      auto remaining_time = limits_.search_deadline
                                 ? std::chrono::milliseconds(GetTimeToDeadline())
                                 : kMaxWaitTime;
       if (remaining_time > kMaxWaitTime) remaining_time = kMaxWaitTime;

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -46,7 +46,6 @@ namespace lczero {
 struct SearchLimits {
   std::int64_t visits = -1;
   std::int64_t playouts = -1;
-  std::int64_t movetime = -1;
   int depth = -1;
   optional<std::chrono::steady_clock::time_point> search_deadline;
   bool infinite = false;
@@ -147,7 +146,6 @@ class Search {
 
   Network* const network_;
   const SearchLimits limits_;
-  optional<std::chrono::steady_clock::time_point> search_deadline_;
   const std::chrono::steady_clock::time_point start_time_;
   const int64_t initial_visits_;
   optional<std::chrono::steady_clock::time_point> nps_start_time_;

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -75,10 +75,10 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
     if (!options_[idx].uci_options->Get<bool>(kReuseTreeId.GetId())) {
       tree_[idx]->TrimTreeAtHead();
     }
-    if (options_[idx].movetime > -1) {
+    if (options_[idx].search_limits.movetime > -1) {
       options_[idx].search_limits.search_deadline =
           std::chrono::steady_clock::now() +
-          std::chrono::milliseconds(options_[idx].movetime);
+          std::chrono::milliseconds(options_[idx].search_limits.movetime);
     }
     {
       std::lock_guard<std::mutex> lock(mutex_);

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -75,6 +75,11 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
     if (!options_[idx].uci_options->Get<bool>(kReuseTreeId.GetId())) {
       tree_[idx]->TrimTreeAtHead();
     }
+    if (options_[idx].movetime > -1) {
+      options_[idx].search_limits.search_deadline =
+          std::chrono::steady_clock::now() +
+          std::chrono::milliseconds(options_[idx].movetime);
+    }
     {
       std::lock_guard<std::mutex> lock(mutex_);
       if (abort_) break;

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -36,6 +36,11 @@
 
 namespace lczero {
 
+struct SelfPlayLimits : SearchLimits {
+  // Movetime
+  std::int64_t movetime;
+};
+
 struct PlayerOptions {
   // Network to use by the player.
   Network* network;
@@ -48,9 +53,7 @@ struct PlayerOptions {
   // User options dictionary.
   const OptionsDict* uci_options;
   // Limits to use for every move.
-  SearchLimits search_limits;
-  // Movetime
-  int movetime;
+  SelfPlayLimits search_limits;
 };
 
 // Plays a single game vs itself.

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -49,6 +49,8 @@ struct PlayerOptions {
   const OptionsDict* uci_options;
   // Limits to use for every move.
   SearchLimits search_limits;
+  // Movetime
+  int movetime;
 };
 
 // Plays a single game vs itself.

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -182,11 +182,11 @@ SelfPlayTournament::SelfPlayTournament(const OptionsDict& options,
         options.GetSubdict(kPlayerNames[idx]).Get<int>(kPlayoutsId.GetId());
     search_limits_[idx].visits =
         options.GetSubdict(kPlayerNames[idx]).Get<int>(kVisitsId.GetId());
-    movetime_[idx] =
+    search_limits_[idx].movetime =
         options.GetSubdict(kPlayerNames[idx]).Get<int>(kTimeMsId.GetId());
 
     if (search_limits_[idx].playouts == -1 &&
-        search_limits_[idx].visits == -1 && movetime_[idx] == -1) {
+        search_limits_[idx].visits == -1 && search_limits_[idx].movetime == -1) {
       throw Exception(
           "Please define --visits, --playouts or --movetime, otherwise it's "
           "not clear when to stop search.");
@@ -215,7 +215,6 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
     opt.cache = cache_[pl_idx].get();
     opt.uci_options = &player_options_[pl_idx];
     opt.search_limits = search_limits_[pl_idx];
-    opt.movetime = movetime_[pl_idx];
 
     // "bestmove" callback.
     opt.best_move_callback = [this, game_number, pl_idx, player1_black,

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -182,11 +182,11 @@ SelfPlayTournament::SelfPlayTournament(const OptionsDict& options,
         options.GetSubdict(kPlayerNames[idx]).Get<int>(kPlayoutsId.GetId());
     search_limits_[idx].visits =
         options.GetSubdict(kPlayerNames[idx]).Get<int>(kVisitsId.GetId());
-    search_limits_[idx].movetime =
+    movetime_[idx] =
         options.GetSubdict(kPlayerNames[idx]).Get<int>(kTimeMsId.GetId());
 
     if (search_limits_[idx].playouts == -1 &&
-        search_limits_[idx].visits == -1 && search_limits_[idx].movetime == -1) {
+        search_limits_[idx].visits == -1 && movetime_[idx] == -1) {
       throw Exception(
           "Please define --visits, --playouts or --movetime, otherwise it's "
           "not clear when to stop search.");
@@ -215,6 +215,7 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
     opt.cache = cache_[pl_idx].get();
     opt.uci_options = &player_options_[pl_idx];
     opt.search_limits = search_limits_[pl_idx];
+    opt.movetime = movetime_[pl_idx];
 
     // "bestmove" callback.
     opt.best_move_callback = [this, game_number, pl_idx, player1_black,

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -87,8 +87,7 @@ class SelfPlayTournament {
   std::shared_ptr<Network> networks_[2];
   std::shared_ptr<NNCache> cache_[2];
   const OptionsDict player_options_[2];
-  SearchLimits search_limits_[2];
-  int movetime_[2];
+  SelfPlayLimits search_limits_[2];
 
   BestMoveInfo::Callback best_move_callback_;
   ThinkingInfo::Callback info_callback_;

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -88,6 +88,7 @@ class SelfPlayTournament {
   std::shared_ptr<NNCache> cache_[2];
   const OptionsDict player_options_[2];
   SearchLimits search_limits_[2];
+  int movetime_[2];
 
   BestMoveInfo::Callback best_move_callback_;
   ThinkingInfo::Callback info_callback_;


### PR DESCRIPTION
I'm not entirely happy with the selfplay changes. Any suggestions for improvement are welcome.
Also it isn't very easy to test this interactively, since time is running while you type. The best way is to write some uci commands in a text editor and paste them as a bloc, something like:
```
position startpos
go movetime 1000
```