### PR TITLE
Bring protobufs directly to backends

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -80,6 +80,7 @@ files += [
   'src/neural/factory.cc',
   'src/neural/loader.cc',
   'src/neural/network_check.cc',
+  'src/neural/network_legacy.cc',
   'src/neural/network_mux.cc',
   'src/neural/network_random.cc',
   'src/neural/network_st_batch.cc',
@@ -97,6 +98,7 @@ files += [
   'src/utils/random.cc',
   'src/utils/string.cc',
   'src/utils/transpose.cc',
+  'src/utils/weights_adapter.cc',
 ]
 includes += include_directories('src')
 
@@ -322,7 +324,8 @@ if get_option('build_backends')
   if get_option('cudnn') and cu_blas.found() and cu_dnn.found() and cu_dart.found() and nvcc.found()
     deps += [cu_blas, cu_dnn, cu_dart]
   cuda_arguments = ['-c', '@INPUT@', '-o', '@OUTPUT@',
-                    '-I', meson.current_source_dir() + '/src']
+                    '-I', meson.current_source_dir() + '/src',
+                    '-I', '@BUILD_DIR@']
   if host_machine.system() == 'windows'
     cuda_arguments += ['-Xcompiler', '-MD']
   else

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -143,8 +143,9 @@ void EngineController::PopulateOptions(OptionsParser* options) {
   defaults->Set<bool>(SearchParams::kOutOfOrderEvalId.GetId(), true);
 }
 
-SearchLimits EngineController::PopulateSearchLimits(int ply, bool is_black,
-    const GoParams& params, std::chrono::steady_clock::time_point start_time) {
+SearchLimits EngineController::PopulateSearchLimits(
+    int ply, bool is_black, const GoParams& params,
+    std::chrono::steady_clock::time_point start_time) {
   SearchLimits limits;
   limits.movetime = params.movetime;
   int64_t time = (is_black ? params.btime : params.wtime);
@@ -213,8 +214,10 @@ SearchLimits EngineController::PopulateSearchLimits(int ply, bool is_black,
   this_move_time += time_to_squander;
 
   // Make sure we don't exceed current time limit with what we calculated.
-  limits.search_deadline = start_time + std::chrono::milliseconds(
-      std::min(static_cast<int64_t>(this_move_time), time - move_overhead));
+  limits.search_deadline =
+      start_time +
+      std::chrono::milliseconds(
+          std::min(static_cast<int64_t>(this_move_time), time - move_overhead));
   return limits;
 }
 
@@ -255,7 +258,7 @@ void EngineController::UpdateFromUciOptions() {
   } else {
     std::cerr << "Loading weights file from: " << net_path << std::endl;
   }
-  Weights weights = LoadWeightsFromFile(net_path);
+  WeightsFile weights = LoadWeightsFromFile(net_path);
 
   OptionsDict network_options(&options_);
   network_options.AddSubdictFromString(backend_options);
@@ -357,9 +360,8 @@ void EngineController::Go(const GoParams& params) {
     SetupPosition(ChessBoard::kStartingFen, {});
   }
 
-  auto limits = PopulateSearchLimits(tree_->GetPlyCount(),
-                                     tree_->IsBlackToMove(), params,
-                                     start_time);
+  auto limits = PopulateSearchLimits(
+      tree_->GetPlyCount(), tree_->IsBlackToMove(), params, start_time);
 
   // If there is a time limit, also store amount of time saved.
   if (limits.search_deadline) {

--- a/src/neural/blas/batchnorm.cc
+++ b/src/neural/blas/batchnorm.cc
@@ -18,13 +18,16 @@
 
 #include "neural/blas/batchnorm.h"
 
-#include <cmath>
-
 namespace lczero {
+namespace {
+constexpr int kWidth = 8;
+constexpr int kHeight = 8;
+constexpr int kSquares = kWidth * kHeight;
+}  // namespace
 
-void Batchnorm::Apply(const size_t batch_size, const size_t channels,
-                      float* data, const float* means, const float* stddivs,
-                      const float* eltwise) {
+void ApplyBatchNormalization(const size_t batch_size, const size_t channels,
+                             float* data, const float* means,
+                             const float* stddivs, const float* eltwise) {
   for (size_t i = 0; i < batch_size; i++) {
     for (size_t c = 0; c < channels; ++c) {
       auto mean = means[c];
@@ -50,40 +53,6 @@ void Batchnorm::Apply(const size_t batch_size, const size_t channels,
     data += channels * kSquares;
     if (eltwise != nullptr) eltwise += channels * kSquares;
   }
-}
-
-void Batchnorm::InvertStddev(Weights::ConvBlock* conv) {
-  std::vector<float>& stddivs = conv->bn_stddivs;
-  InvertStddev(stddivs.size(), stddivs.data());
-}
-
-void Batchnorm::OffsetMeans(Weights::ConvBlock* conv) {
-  std::vector<float>& means = conv->bn_means;
-  const std::vector<float>& biases = conv->biases;
-  OffsetMeans(means.size(), means.data(), biases.data());
-}
-
-std::vector<float> Batchnorm::InvertStddev(const Weights::ConvBlock& conv) {
-  std::vector<float> stddivs = conv.bn_stddivs;  // copy
-  InvertStddev(stddivs.size(), stddivs.data());
-  return stddivs;
-}
-
-std::vector<float> Batchnorm::OffsetMeans(const Weights::ConvBlock& conv) {
-  std::vector<float> means = conv.bn_means;  // copy
-  const std::vector<float>& biases = conv.biases;
-  OffsetMeans(means.size(), means.data(), biases.data());
-  return means;
-}
-
-void Batchnorm::InvertStddev(const size_t size, float* array) {
-  for (size_t i = 0; i < size; i++)
-    array[i] = 1.0f / std::sqrt(array[i] + kEpsilon);
-}
-
-void Batchnorm::OffsetMeans(const size_t size, float* means,
-                            const float* biases) {
-  for (size_t i = 0; i < size; i++) means[i] -= biases[i];
 }
 
 }  // namespace lczero

--- a/src/neural/blas/batchnorm.h
+++ b/src/neural/blas/batchnorm.h
@@ -25,39 +25,11 @@
 
 namespace lczero {
 
-// Batch normalization related methods
-class Batchnorm {
- public:
-  Batchnorm() = delete;
-
-  // Apply batch normalization, along with a Relu and add a possible skip
-  // connection.
-  static void Apply(const size_t batch_size, const size_t channels, float* data,
-                    const float* means, const float* stddivs,
-                    const float* eltwise = nullptr);
-
-  // Invert the bn_stddivs elements of a ConvBlock (in place).
-  static void InvertStddev(Weights::ConvBlock* conv);
-
-  // Offset bn_means by biases of a ConvBlock (in place).
-  static void OffsetMeans(Weights::ConvBlock* conv);
-
-  // Return a vector of inverted bn_stddivs of a ConvBlock.
-  static std::vector<float> InvertStddev(const Weights::ConvBlock& conv);
-
-  // Return a vector of bn_means offset by biases of a ConvBlock.
-  static std::vector<float> OffsetMeans(const Weights::ConvBlock& conv);
-
- private:
-  static constexpr float kEpsilon = 1e-5f;
-
-  static void InvertStddev(const size_t size, float* array);
-
-  static void OffsetMeans(const size_t size, float* means, const float* biases);
-
-  static constexpr auto kWidth = 8;
-  static constexpr auto kHeight = 8;
-  static constexpr auto kSquares = kWidth * kHeight;
-};
+// Apply batch normalization, along with a Relu and add a possible skip
+// connection.
+void ApplyBatchNormalization(const size_t batch_size, const size_t channels,
+                             float* data, const float* means,
+                             const float* stddivs,
+                             const float* eltwise = nullptr);
 
 }  // namespace lczero

--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -328,6 +328,13 @@ BlasNetwork::BlasNetwork(const WeightsFile& file, const OptionsDict& options)
 
 std::unique_ptr<Network> MakeBlasNetwork(const WeightsFile& weights,
                                          const OptionsDict& options) {
+  if (weights.format().network_format().network() !=
+      pblczero::NetworkFormat::NETWORK_CLASSICAL) {
+    throw Exception(
+        "Network format " +
+        std::to_string(weights.format().network_format().network()) +
+        " is not supported by BLAS backend.");
+  }
   return std::make_unique<BlasNetwork>(weights, options);
 }
 

--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -16,6 +16,10 @@
  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+
 #include "neural/blas/batchnorm.h"
 #include "neural/blas/blas.h"
 #include "neural/blas/convolution1.h"
@@ -23,17 +27,14 @@
 #include "neural/blas/winograd_convolution3.h"
 #include "neural/factory.h"
 #include "neural/network.h"
-
-#include <algorithm>
-#include <cassert>
-#include <cmath>
+#include "neural/network_legacy.h"
 
 namespace lczero {
 namespace {
 
 class BlasComputation : public NetworkComputation {
  public:
-  BlasComputation(const Weights& weights, const size_t max_batch_size);
+  BlasComputation(const LegacyWeights& weights, const size_t max_batch_size);
 
   virtual ~BlasComputation() {}
 
@@ -61,7 +62,7 @@ class BlasComputation : public NetworkComputation {
   static constexpr auto kHeight = 8;
   static constexpr auto kSquares = kWidth * kHeight;
 
-  const Weights& weights_;
+  const LegacyWeights& weights_;
   size_t max_batch_size_;
   std::vector<InputPlanes> planes_;
   std::vector<std::vector<float>> policies_;
@@ -70,7 +71,7 @@ class BlasComputation : public NetworkComputation {
 
 class BlasNetwork : public Network {
  public:
-  BlasNetwork(const Weights& weights, const OptionsDict& options);
+  BlasNetwork(const WeightsFile& weights, const OptionsDict& options);
   virtual ~BlasNetwork(){};
 
   std::unique_ptr<NetworkComputation> NewComputation() override {
@@ -81,11 +82,11 @@ class BlasNetwork : public Network {
   // A cap on the max batch size since it consumes a lot of memory
   static constexpr auto kHardMaxBatchSize = 2048;
 
-  Weights weights_;
+  LegacyWeights weights_;
   size_t max_batch_size_;
 };
 
-BlasComputation::BlasComputation(const Weights& weights,
+BlasComputation::BlasComputation(const LegacyWeights& weights,
                                  const size_t max_batch_size)
     : weights_(weights),
       max_batch_size_(max_batch_size),
@@ -155,9 +156,9 @@ void BlasComputation::ComputeBlocking() {
     convolve3.Forward(batch_size, kInputPlanes, output_channels, conv_in,
                       &weights_.input.weights[0], conv_out);
 
-    Batchnorm::Apply(batch_size, output_channels, conv_out,
-                     weights_.input.bn_means.data(),
-                     weights_.input.bn_stddivs.data());
+    ApplyBatchNormalization(batch_size, output_channels, conv_out,
+                            weights_.input.bn_means.data(),
+                            weights_.input.bn_stddivs.data());
 
     // Residual tower
 
@@ -170,8 +171,8 @@ void BlasComputation::ComputeBlocking() {
       convolve3.Forward(batch_size, output_channels, output_channels, conv_in,
                         &conv1.weights[0], conv_out);
 
-      Batchnorm::Apply(batch_size, output_channels, &conv_out[0],
-                       conv1.bn_means.data(), conv1.bn_stddivs.data());
+      ApplyBatchNormalization(batch_size, output_channels, &conv_out[0],
+                              conv1.bn_means.data(), conv1.bn_stddivs.data());
 
       std::swap(conv_in, res);
       std::swap(conv_out, conv_in);
@@ -179,8 +180,9 @@ void BlasComputation::ComputeBlocking() {
       convolve3.Forward(batch_size, output_channels, output_channels, conv_in,
                         &conv2.weights[0], conv_out);
 
-      Batchnorm::Apply(batch_size, output_channels, conv_out,
-                       conv2.bn_means.data(), conv2.bn_stddivs.data(), res);
+      ApplyBatchNormalization(batch_size, output_channels, conv_out,
+                              conv2.bn_means.data(), conv2.bn_stddivs.data(),
+                              res);
     }
 
     Convolution1::Forward(batch_size, output_channels, num_policy_input_planes,
@@ -191,13 +193,13 @@ void BlasComputation::ComputeBlocking() {
                           conv_out, weights_.value.weights.data(),
                           value_buffer.data());
 
-    Batchnorm::Apply(batch_size, num_policy_input_planes, &policy_buffer[0],
-                     weights_.policy.bn_means.data(),
-                     weights_.policy.bn_stddivs.data());
+    ApplyBatchNormalization(batch_size, num_policy_input_planes,
+                            &policy_buffer[0], weights_.policy.bn_means.data(),
+                            weights_.policy.bn_stddivs.data());
 
-    Batchnorm::Apply(batch_size, num_value_input_planes, &value_buffer[0],
-                     weights_.value.bn_means.data(),
-                     weights_.value.bn_stddivs.data());
+    ApplyBatchNormalization(batch_size, num_value_input_planes,
+                            &value_buffer[0], weights_.value.bn_means.data(),
+                            weights_.value.bn_stddivs.data());
 
     FullyConnectedLayer::Forward1D(
         batch_size, num_policy_input_planes * kSquares, num_output_policy,
@@ -241,9 +243,8 @@ void BlasComputation::EncodePlanes(const InputPlanes& sample, float* buffer) {
   }
 }
 
-BlasNetwork::BlasNetwork(const Weights& weights, const OptionsDict& options)
-    : weights_(weights) {
-  bool verbose = options.GetOrDefault<bool>("verbose", true);
+BlasNetwork::BlasNetwork(const WeightsFile& file, const OptionsDict& options)
+    : weights_(file.weights()) {
   int blas_cores = options.GetOrDefault<int>("blas_cores", 1);
   max_batch_size_ =
       static_cast<size_t>(options.GetOrDefault<int>("batch_size", 256));
@@ -251,17 +252,17 @@ BlasNetwork::BlasNetwork(const Weights& weights, const OptionsDict& options)
   if (max_batch_size_ > kHardMaxBatchSize) {
     max_batch_size_ = kHardMaxBatchSize;
   }
-  fprintf(stderr, "BLAS, maximum batch size set to %ld.\n", max_batch_size_);
+  std::cerr << "BLAS, maximum batch size set to " << max_batch_size_ << '\n';
 
   const auto inputChannels = kInputPlanes;
-  const auto channels = static_cast<int>(weights.input.biases.size());
-  const auto residual_blocks = weights.residual.size();
+  const auto channels = static_cast<int>(weights_.input.biases.size());
+  const auto residual_blocks = weights_.residual.size();
 
   weights_.input.weights = WinogradConvolution3::TransformF(
       weights_.input.weights, channels, inputChannels);
 
-  Batchnorm::OffsetMeans(&weights_.input);
-  Batchnorm::InvertStddev(&weights_.input);
+  weights_.input.OffsetMeans();
+  weights_.input.InvertStddev();
 
   // residual blocks
   for (size_t i = 0; i < residual_blocks; i++) {
@@ -274,65 +275,58 @@ BlasNetwork::BlasNetwork(const Weights& weights, const OptionsDict& options)
     conv2.weights =
         WinogradConvolution3::TransformF(conv2.weights, channels, channels);
 
-    Batchnorm::OffsetMeans(&conv1);
-    Batchnorm::OffsetMeans(&conv2);
-
-    Batchnorm::InvertStddev(&conv1);
-    Batchnorm::InvertStddev(&conv2);
+    conv1.OffsetMeans();
+    conv2.OffsetMeans();
+    conv1.InvertStddev();
+    conv2.InvertStddev();
   }
 
-  Batchnorm::OffsetMeans(&weights_.policy);
-  Batchnorm::InvertStddev(&weights_.policy);
-
-  Batchnorm::OffsetMeans(&weights_.value);
-  Batchnorm::InvertStddev(&weights_.value);
+  weights_.policy.OffsetMeans();
+  weights_.policy.InvertStddev();
+  weights_.value.OffsetMeans();
+  weights_.value.InvertStddev();
 
 #ifdef USE_OPENBLAS
   int num_procs = openblas_get_num_procs();
   blas_cores = std::min(num_procs, blas_cores);
   openblas_set_num_threads(blas_cores);
-  if (verbose) {
-    const char* core_name = openblas_get_corename();
-    const char* config = openblas_get_config();
-    fprintf(stderr, "BLAS vendor: OpenBlas.\n");
-    fprintf(stderr, "OpenBlas [%s].\n", config);
-    fprintf(stderr, "OpenBlas found %d %s core(s).\n", num_procs, core_name);
-    fprintf(stderr, "OpenBLAS using %d core(s) for this backend.\n",
-            blas_cores);
-  }
+  const char* core_name = openblas_get_corename();
+  const char* config = openblas_get_config();
+  std::cerr << "BLAS vendor: OpenBlas.\n";
+  std::cerr << "OpenBlas [" << config << "].\n";
+  std::cerr << "OpenBlas found " << num_procs << " " << core_name
+            << " core(s).\n";
+  std::cerr << "OpenBLAS using " << blas_cores
+            << " core(s) for this backend.\n";
 #endif
 
 #ifdef USE_MKL
   int max_procs = mkl_get_max_threads();
   blas_cores = std::min(max_procs, blas_cores);
   mkl_set_num_threads(blas_cores);
-  if (verbose) {
-    fprintf(stderr, "BLAS vendor: MKL.\n");
-    constexpr int len = 256;
-    char versionbuf[len];
-    mkl_get_version_string(versionbuf, len);
-    fprintf(stderr, "MKL %s.\n", versionbuf);
-    MKLVersion version;
-    mkl_get_version(&version);
-    fprintf(stderr, "MKL platform: %s, processor: %s.\n", version.Platform,
-            version.Processor);
-    fprintf(stderr, "MKL can use up to  %d thread(s).\n", max_procs);
-    fprintf(stderr, "MKL using %d thread(s) for this backend.\n", blas_cores);
-  }
+  std::cerr << "BLAS vendor: MKL.\n";
+  constexpr int len = 256;
+  char versionbuf[len];
+  mkl_get_version_string(versionbuf, len);
+  std::cerr << "MKL " << versionbuf << ".\n";
+  MKLVersion version;
+  mkl_get_version(&version);
+  std::cerr << "MKL platform: " << version.Platform
+            << ", processor: " << version.Processor << ".\n";
+  std::cerr << "MKL can use up to " << max_procs << " thread(s).\n";
+  std::cerr << "MKL using " << blas_cores << " thread(s) for this backend.\n";
 #endif
 
 #ifdef USE_ACCELERATE
-  if (verbose) {
-    fprintf(stderr, "BLAS vendor: Apple vecLib.\n");
-    fprintf(stderr, "Apple vecLib ignores blas_cores (%d) parameter.\n",
-            blas_cores);
-  }
+  std::cerr << "BLAS vendor: Apple vecLib.\n";
+  std::cerr << "Apple vecLib ignores blas_cores (" << blas_cores
+            << ") parameter.\n";
 #endif
 
-  fprintf(stderr, "BLAS max batch size is %ld.\n", max_batch_size_);
-}
+  std::cerr << "BLAS max batch size is " << max_batch_size_ << ".\n";
+}  // namespace
 
-std::unique_ptr<Network> MakeBlasNetwork(const Weights& weights,
+std::unique_ptr<Network> MakeBlasNetwork(const WeightsFile& weights,
                                          const OptionsDict& options) {
   return std::make_unique<BlasNetwork>(weights, options);
 }

--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -29,6 +29,7 @@
 #include <cmath>
 
 namespace lczero {
+namespace {
 
 class BlasComputation : public NetworkComputation {
  public:
@@ -331,6 +332,12 @@ BlasNetwork::BlasNetwork(const Weights& weights, const OptionsDict& options)
   fprintf(stderr, "BLAS max batch size is %ld.\n", max_batch_size_);
 }
 
-REGISTER_NETWORK("blas", BlasNetwork, 50)
+std::unique_ptr<Network> MakeBlasNetwork(const Weights& weights,
+                                         const OptionsDict& options) {
+  return std::make_unique<BlasNetwork>(weights, options);
+}
 
+REGISTER_NETWORK("blas", MakeBlasNetwork, 50)
+
+}  // namespace
 }  // namespace lczero

--- a/src/neural/factory.cc
+++ b/src/neural/factory.cc
@@ -55,7 +55,7 @@ std::vector<std::string> NetworkFactory::GetBackendsList() const {
 }
 
 std::unique_ptr<Network> NetworkFactory::Create(const std::string& network,
-                                                const Weights& weights,
+                                                const WeightsFile& weights,
                                                 const OptionsDict& options) {
   std::cerr << "Creating backend [" << network << "]..." << std::endl;
   for (const auto& factory : factories_) {

--- a/src/neural/factory.h
+++ b/src/neural/factory.h
@@ -82,25 +82,23 @@ class NetworkFactory {
   friend class Register;
 };
 
-#define REGISTER_NETWORK_WITH_COUNTER2(name, cls, priority, counter) \
-  namespace {                                                        \
-  static NetworkFactory::Register regH38fhs##counter(                \
-      name,                                                          \
-      [](const Weights& w, const OptionsDict& o) {                   \
-        return std::make_unique<cls>(w, o);                          \
-      },                                                             \
-      priority);                                                     \
+#define REGISTER_NETWORK_WITH_COUNTER2(name, func, priority, counter)          \
+  namespace {                                                                  \
+  static NetworkFactory::Register regH38fhs##counter(                          \
+      name, [](const Weights& w, const OptionsDict& o) { return func(w, o); }, \
+      priority);                                                               \
   }
-#define REGISTER_NETWORK_WITH_COUNTER(name, cls, priority, counter) \
-  REGISTER_NETWORK_WITH_COUNTER2(name, cls, priority, counter)
+#define REGISTER_NETWORK_WITH_COUNTER(name, func, priority, counter) \
+  REGISTER_NETWORK_WITH_COUNTER2(name, func, priority, counter)
 
 // Registers a Network.
 // Constructor of a network class must have parameters:
 // (const Weights& w, const OptionsDict& o)
 // @name -- name under which the backend will be known in configs.
-// @cls -- class name of a backend.
+// @func -- Factory function for a backend.
+//          std::unique_ptr<Network>(const WeightsFile&, const OptionsDict&)
 // @priority -- numeric priority of a backend. Higher is higher, highest number
 // is the default backend.
-#define REGISTER_NETWORK(name, cls, priority) \
-  REGISTER_NETWORK_WITH_COUNTER(name, cls, priority, __LINE__)
+#define REGISTER_NETWORK(name, func, priority) \
+  REGISTER_NETWORK_WITH_COUNTER(name, func, priority, __LINE__)
 }  // namespace lczero

--- a/src/neural/factory.h
+++ b/src/neural/factory.h
@@ -37,7 +37,7 @@ namespace lczero {
 class NetworkFactory {
  public:
   using FactoryFunc = std::function<std::unique_ptr<Network>(
-      const Weights&, const OptionsDict&)>;
+      const WeightsFile&, const OptionsDict&)>;
 
   static NetworkFactory* Get();
 
@@ -55,7 +55,8 @@ class NetworkFactory {
   std::vector<std::string> GetBackendsList() const;
 
   // Creates a backend given name and config.
-  std::unique_ptr<Network> Create(const std::string& network, const Weights&,
+  std::unique_ptr<Network> Create(const std::string& network,
+                                  const WeightsFile&,
                                   const OptionsDict& options);
 
  private:
@@ -82,11 +83,12 @@ class NetworkFactory {
   friend class Register;
 };
 
-#define REGISTER_NETWORK_WITH_COUNTER2(name, func, priority, counter)          \
-  namespace {                                                                  \
-  static NetworkFactory::Register regH38fhs##counter(                          \
-      name, [](const Weights& w, const OptionsDict& o) { return func(w, o); }, \
-      priority);                                                               \
+#define REGISTER_NETWORK_WITH_COUNTER2(name, func, priority, counter)        \
+  namespace {                                                                \
+  static NetworkFactory::Register regH38fhs##counter(                        \
+      name,                                                                  \
+      [](const WeightsFile& w, const OptionsDict& o) { return func(w, o); }, \
+      priority);                                                             \
   }
 #define REGISTER_NETWORK_WITH_COUNTER(name, func, priority, counter) \
   REGISTER_NETWORK_WITH_COUNTER2(name, func, priority, counter)

--- a/src/neural/loader.cc
+++ b/src/neural/loader.cc
@@ -93,6 +93,16 @@ WeightsFile ParseWeightsProto(const std::string& buffer) {
   if (net.format().weights_encoding() != pblczero::Format::LINEAR16)
     throw Exception("Invalid weight file: unsupported encoding.");
 
+  // Older protobufs don't have format definition.
+  // Populate format fields with legacy (or "classical") formats.
+  if (!net.format().has_network_format()) {
+    auto net_format = net.mutable_format()->mutable_network_format();
+    using nf = pblczero::NetworkFormat;
+    net_format->set_input(nf::INPUT_CLASSICAL_112_PLANE);
+    net_format->set_output(nf::OUTPUT_CLASSICAL);
+    net_format->set_network(nf::NETWORK_CLASSICAL);
+  }
+
   return net;
 }
 

--- a/src/neural/loader.cc
+++ b/src/neural/loader.cc
@@ -45,18 +45,6 @@ namespace lczero {
 namespace {
 const std::uint32_t kWeightMagic = 0x1c0;
 
-void PopulateLastIntoVector(FloatVectors* vecs, Weights::Vec* out) {
-  *out = std::move(vecs->back());
-  vecs->pop_back();
-}
-
-void PopulateConvBlockWeights(FloatVectors* vecs, Weights::ConvBlock* block) {
-  PopulateLastIntoVector(vecs, &block->bn_stddivs);
-  PopulateLastIntoVector(vecs, &block->bn_means);
-  PopulateLastIntoVector(vecs, &block->biases);
-  PopulateLastIntoVector(vecs, &block->weights);
-}
-
 std::string DecompressGzip(const std::string& filename) {
   const int kStartingSize = 8 * 1024 * 1024;  // 8M
   std::string buffer;
@@ -82,33 +70,8 @@ std::string DecompressGzip(const std::string& filename) {
   return buffer;
 }
 
-FloatVector DenormLayer(const pblczero::Weights_Layer& layer) {
-  FloatVector vec;
-  auto& buffer = layer.params();
-  auto data = reinterpret_cast<const std::uint16_t*>(buffer.data());
-  int n = buffer.length() / 2;
-  vec.resize(n);
-  for (int i = 0; i < n; i++) {
-    vec[i] = data[i] / float(0xffff);
-    vec[i] *= layer.max_val() - layer.min_val();
-    vec[i] += layer.min_val();
-  }
-  return vec;
-}
-
-void DenormConvBlock(const pblczero::Weights_ConvBlock& conv,
-                     FloatVectors* vecs) {
-  vecs->emplace_back(DenormLayer(conv.weights()));
-  vecs->emplace_back(DenormLayer(conv.biases()));
-  vecs->emplace_back(DenormLayer(conv.bn_means()));
-  vecs->emplace_back(DenormLayer(conv.bn_stddivs()));
-}
-
-}  // namespace
-
-FloatVectors LoadFloatsFromPbFile(const std::string& buffer) {
-  auto net = pblczero::Net();
-  FloatVectors vecs;
+WeightsFile ParseWeightsProto(const std::string& buffer) {
+  WeightsFile net;
   if (!net.ParseFromString(buffer))
     throw Exception("Invalid weight file: parse error.");
 
@@ -128,56 +91,14 @@ FloatVectors LoadFloatsFromPbFile(const std::string& buffer) {
                     " required.");
 
   if (net.format().weights_encoding() != pblczero::Format::LINEAR16)
-    throw Exception("Invalid weight file: wrong encoding.");
+    throw Exception("Invalid weight file: unsupported encoding.");
 
-  const auto& w = net.weights();
-
-  DenormConvBlock(w.input(), &vecs);
-
-  for (int i = 0, n = w.residual_size(); i < n; i++) {
-    DenormConvBlock(w.residual(i).conv1(), &vecs);
-    DenormConvBlock(w.residual(i).conv2(), &vecs);
-  }
-
-  DenormConvBlock(w.policy(), &vecs);
-  vecs.emplace_back(DenormLayer(w.ip_pol_w()));
-  vecs.emplace_back(DenormLayer(w.ip_pol_b()));
-  DenormConvBlock(w.value(), &vecs);
-  vecs.emplace_back(DenormLayer(w.ip1_val_w()));
-  vecs.emplace_back(DenormLayer(w.ip1_val_b()));
-  vecs.emplace_back(DenormLayer(w.ip2_val_w()));
-  vecs.emplace_back(DenormLayer(w.ip2_val_b()));
-
-  return vecs;
+  return net;
 }
 
-FloatVectors LoadFloatsFromFile(std::string* buffer) {
-  // Parse buffer.
-  FloatVectors result;
-  FloatVector line;
-  (*buffer) += "\n";
-  size_t start = 0;
-  for (size_t i = 0; i < buffer->size(); ++i) {
-    char& c = (*buffer)[i];
-    const bool is_newline = (c == '\n' || c == '\r');
-    if (!std::isspace(c)) continue;
-    if (start < i) {
-      // If previous character was not space too.
-      c = '\0';
-      line.push_back(std::atof(&(*buffer)[start]));
-    }
-    if (is_newline && !line.empty()) {
-      result.emplace_back();
-      result.back().swap(line);
-    }
-    start = i + 1;
-  }
+}  // namespace
 
-  result.erase(result.begin());
-  return result;
-}
-
-Weights LoadWeightsFromFile(const std::string& filename) {
+WeightsFile LoadWeightsFromFile(const std::string& filename) {
   FloatVectors vecs;
   auto buffer = DecompressGzip(filename);
 
@@ -186,35 +107,11 @@ Weights LoadWeightsFromFile(const std::string& filename) {
   else if (buffer[0] == '1' && buffer[1] == '\n')
     throw Exception("Invalid weight file: no longer supported.");
   else if (buffer[0] == '2' && buffer[1] == '\n')
-    vecs = LoadFloatsFromFile(&buffer);
-  else
-    vecs = LoadFloatsFromPbFile(buffer);
+    throw Exception(
+        "Text format weights files are no longer supported. Use a command line "
+        "tool to convert it to the new format.");
 
-  Weights result;
-  // Populating backwards.
-  PopulateLastIntoVector(&vecs, &result.ip2_val_b);
-  PopulateLastIntoVector(&vecs, &result.ip2_val_w);
-  PopulateLastIntoVector(&vecs, &result.ip1_val_b);
-  PopulateLastIntoVector(&vecs, &result.ip1_val_w);
-  PopulateConvBlockWeights(&vecs, &result.value);
-
-  PopulateLastIntoVector(&vecs, &result.ip_pol_b);
-  PopulateLastIntoVector(&vecs, &result.ip_pol_w);
-  PopulateConvBlockWeights(&vecs, &result.policy);
-
-  // Input + all the residual should be left.
-  if ((vecs.size() - 4) % 8 != 0)
-    throw Exception("Invalid weight file: parse error.");
-
-  const int num_residual = (vecs.size() - 4) / 8;
-  result.residual.resize(num_residual);
-  for (int i = num_residual - 1; i >= 0; --i) {
-    PopulateConvBlockWeights(&vecs, &result.residual[i].conv2);
-    PopulateConvBlockWeights(&vecs, &result.residual[i].conv1);
-  }
-
-  PopulateConvBlockWeights(&vecs, &result.input);
-  return result;
+  return ParseWeightsProto(buffer);
 }
 
 std::string DiscoverWeightsFile() {

--- a/src/neural/network.h
+++ b/src/neural/network.h
@@ -27,45 +27,13 @@
 
 #pragma once
 
-#include <memory>
-#include <vector>
+#include "proto/net.pb.h"
 
 namespace lczero {
 
 const int kInputPlanes = 112;
 
-struct Weights {
-  using Vec = std::vector<float>;
-  struct ConvBlock {
-    Vec weights;
-    Vec biases;
-    Vec bn_means;
-    Vec bn_stddivs;
-  };
-
-  struct Residual {
-    ConvBlock conv1;
-    ConvBlock conv2;
-  };
-
-  // Input convnet.
-  ConvBlock input;
-
-  // Residual tower.
-  std::vector<Residual> residual;
-
-  // Policy head
-  ConvBlock policy;
-  Vec ip_pol_w;
-  Vec ip_pol_b;
-
-  // Value head
-  ConvBlock value;
-  Vec ip1_val_w;
-  Vec ip1_val_b;
-  Vec ip2_val_w;
-  Vec ip2_val_b;
-};
+using WeightsFile = pblczero::Net;
 
 // All input planes are 64 value vectors, every element of which is either
 // 0 or some value, unique for the plane. Therefore, input is defined as

--- a/src/neural/network_check.cc
+++ b/src/neural/network_check.cc
@@ -329,8 +329,12 @@ class CheckNetwork : public Network {
   std::unique_ptr<Network> check_net_;
 };
 
+std::unique_ptr<Network> MakeCheckNetwork(const Weights& weights,
+                                          const OptionsDict& options) {
+  return std::make_unique<CheckNetwork>(weights, options);
+}
+
+REGISTER_NETWORK("check", MakeCheckNetwork, -800)
+
 }  // namespace
-
-REGISTER_NETWORK("check", CheckNetwork, -800)
-
 }  // namespace lczero

--- a/src/neural/network_check.cc
+++ b/src/neural/network_check.cc
@@ -232,7 +232,7 @@ class CheckNetwork : public Network {
   static constexpr double kDefaultAbsoluteTolerance = 1e-5;
   static constexpr double kDefaultRelativeTolerance = 1e-4;
 
-  CheckNetwork(const Weights& weights, const OptionsDict& options) {
+  CheckNetwork(const WeightsFile& weights, const OptionsDict& options) {
     params_.mode = kDefaultMode;
     params_.absolute_tolerance = kDefaultAbsoluteTolerance;
     params_.relative_tolerance = kDefaultRelativeTolerance;
@@ -329,7 +329,7 @@ class CheckNetwork : public Network {
   std::unique_ptr<Network> check_net_;
 };
 
-std::unique_ptr<Network> MakeCheckNetwork(const Weights& weights,
+std::unique_ptr<Network> MakeCheckNetwork(const WeightsFile& weights,
                                           const OptionsDict& options) {
   return std::make_unique<CheckNetwork>(weights, options);
 }

--- a/src/neural/network_cudnn.cu
+++ b/src/neural/network_cudnn.cu
@@ -1383,6 +1383,13 @@ void CudnnNetworkComputation<DataType>::ComputeBlocking() {
 template <typename DataType>
 std::unique_ptr<Network> MakeCudnnNetwork(const WeightsFile &weights,
                                           const OptionsDict &options) {
+  if (weights.format().network_format().network() !=
+      pblczero::NetworkFormat::NETWORK_CLASSICAL) {
+    throw Exception(
+        "Network format " +
+        std::to_string(weights.format().network_format().network()) +
+        " is not supported by CuDNN backend.");
+  }
   return std::make_unique<CudnnNetwork<DataType>>(weights, options);
 }
 

--- a/src/neural/network_legacy.cc
+++ b/src/neural/network_legacy.cc
@@ -1,0 +1,81 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2018 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "neural/network_legacy.h"
+
+#include <cmath>
+#include "utils/weights_adapter.h"
+
+namespace lczero {
+namespace {
+static constexpr float kEpsilon = 1e-5f;
+
+void InvertVector(std::vector<float>* vec) {
+  for (auto& x : *vec) x = 1.0f / std::sqrt(x + kEpsilon);
+}
+
+void OffsetVector(std::vector<float>* means, const std::vector<float>& biases) {
+  std::transform(means->begin(), means->end(), biases.begin(), means->begin(),
+                 std::minus<float>());
+}
+
+}  // namespace
+
+LegacyWeights::LegacyWeights(const pblczero::Weights& weights)
+    : input(weights.input()),
+      policy(weights.policy()),
+      ip_pol_w(LayerAdapter(weights.ip_pol_w()).as_vector()),
+      ip_pol_b(LayerAdapter(weights.ip_pol_b()).as_vector()),
+      value(weights.value()),
+      ip1_val_w(LayerAdapter(weights.ip1_val_w()).as_vector()),
+      ip1_val_b(LayerAdapter(weights.ip1_val_b()).as_vector()),
+      ip2_val_w(LayerAdapter(weights.ip2_val_w()).as_vector()),
+      ip2_val_b(LayerAdapter(weights.ip2_val_b()).as_vector()) {
+  for (const auto& res : weights.residual()) {
+    residual.emplace_back(res);
+  }
+}
+
+LegacyWeights::Residual::Residual(const pblczero::Weights::Residual& residual)
+    : conv1(residual.conv1()), conv2(residual.conv2()) {}
+
+LegacyWeights::ConvBlock::ConvBlock(const pblczero::Weights::ConvBlock& block)
+    : weights(LayerAdapter(block.weights()).as_vector()),
+      biases(LayerAdapter(block.biases()).as_vector()),
+      bn_means(LayerAdapter(block.bn_means()).as_vector()),
+      bn_stddivs(LayerAdapter(block.bn_stddivs()).as_vector()) {}
+
+void LegacyWeights::ConvBlock::InvertStddev() { InvertVector(&bn_stddivs); }
+
+void LegacyWeights::ConvBlock::OffsetMeans() {
+  OffsetVector(&bn_means, biases);
+}
+
+std::vector<float> LegacyWeights::ConvBlock::GetInvertedStddev() const {
+  std::vector<float> stddivs = bn_stddivs;  // Copy.
+  InvertVector(&stddivs);
+  return stddivs;
+}
+
+std::vector<float> LegacyWeights::ConvBlock::GetOffsetMeans() const {
+  std::vector<float> means = bn_means;  // Copy.
+  OffsetVector(&means, biases);
+  return means;
+}
+
+}  // namespace lczero

--- a/src/neural/network_legacy.h
+++ b/src/neural/network_legacy.h
@@ -1,0 +1,77 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2018 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <vector>
+#include "proto/net.pb.h"
+
+namespace lczero {
+
+// DEPRECATED! DEPRECATED! DEPRECATED! DEPRECATED! DEPRECATED! DEPRECATED!!!
+// Legacy structure describing network weights.
+// Please try to migrate away from this struture do not add anything new
+// to it.
+
+struct LegacyWeights {
+  explicit LegacyWeights(const pblczero::Weights& weights);
+
+  using Vec = std::vector<float>;
+  struct ConvBlock {
+    explicit ConvBlock(const pblczero::Weights::ConvBlock& block);
+    // Invert the bn_stddivs elements of a ConvBlock.
+    void InvertStddev();
+    // Offset bn_means by biases of a ConvBlock.
+    void OffsetMeans();
+    // Return a vector of inverted bn_stddivs of a ConvBlock.
+    std::vector<float> GetInvertedStddev() const;
+    // Return a vector of bn_means offset by biases of a ConvBlock.
+    std::vector<float> GetOffsetMeans() const;
+
+    Vec weights;
+    Vec biases;
+    Vec bn_means;
+    Vec bn_stddivs;
+  };
+
+  struct Residual {
+    explicit Residual(const pblczero::Weights::Residual& residual);
+    ConvBlock conv1;
+    ConvBlock conv2;
+  };
+
+  // Input convnet.
+  ConvBlock input;
+
+  // Residual tower.
+  std::vector<Residual> residual;
+
+  // Policy head
+  ConvBlock policy;
+  Vec ip_pol_w;
+  Vec ip_pol_b;
+
+  // Value head
+  ConvBlock value;
+  Vec ip1_val_w;
+  Vec ip1_val_b;
+  Vec ip2_val_w;
+  Vec ip2_val_b;
+};
+
+}  // namespace lczero

--- a/src/neural/network_mux.cc
+++ b/src/neural/network_mux.cc
@@ -80,7 +80,7 @@ class MuxingComputation : public NetworkComputation {
 
 class MuxingNetwork : public Network {
  public:
-  MuxingNetwork(const Weights& weights, const OptionsDict& options) {
+  MuxingNetwork(const WeightsFile& weights, const OptionsDict& options) {
     // int threads, int max_batch)
     //: network_(std::move(network)), max_batch_(max_batch) {
 
@@ -97,7 +97,7 @@ class MuxingNetwork : public Network {
     }
   }
 
-  void AddBackend(const std::string& name, const Weights& weights,
+  void AddBackend(const std::string& name, const WeightsFile& weights,
                   const OptionsDict& opts) {
     const int nn_threads = opts.GetOrDefault<int>("threads", 1);
     const int max_batch = opts.GetOrDefault<int>("max_batch", 256);
@@ -203,7 +203,7 @@ void MuxingComputation::ComputeBlocking() {
   dataready_cv_.wait(lock, [this]() { return dataready_; });
 }
 
-std::unique_ptr<Network> MakeMuxingNetwork(const Weights& weights,
+std::unique_ptr<Network> MakeMuxingNetwork(const WeightsFile& weights,
                                            const OptionsDict& options) {
   return std::make_unique<MuxingNetwork>(weights, options);
 }

--- a/src/neural/network_mux.cc
+++ b/src/neural/network_mux.cc
@@ -203,8 +203,12 @@ void MuxingComputation::ComputeBlocking() {
   dataready_cv_.wait(lock, [this]() { return dataready_; });
 }
 
+std::unique_ptr<Network> MakeMuxingNetwork(const Weights& weights,
+                                           const OptionsDict& options) {
+  return std::make_unique<MuxingNetwork>(weights, options);
+}
+
+REGISTER_NETWORK("multiplexing", MakeMuxingNetwork, -1000)
+
 }  // namespace
-
-REGISTER_NETWORK("multiplexing", MuxingNetwork, -1000)
-
 }  // namespace lczero

--- a/src/neural/network_random.cc
+++ b/src/neural/network_random.cc
@@ -85,7 +85,7 @@ class RandomNetwork : public Network {
 };
 }  // namespace
 
-std::unique_ptr<Network> MakeRandomNetwork(const Weights& /*weights*/,
+std::unique_ptr<Network> MakeRandomNetwork(const WeightsFile& /*weights*/,
                                            const OptionsDict& options) {
   return std::make_unique<RandomNetwork>(options);
 }

--- a/src/neural/network_random.cc
+++ b/src/neural/network_random.cc
@@ -32,6 +32,7 @@
 #include "utils/hashcat.h"
 
 namespace lczero {
+namespace {
 
 class RandomNetworkComputation : public NetworkComputation {
  public:
@@ -71,7 +72,7 @@ class RandomNetworkComputation : public NetworkComputation {
 
 class RandomNetwork : public Network {
  public:
-  RandomNetwork(const Weights& /*weights*/, const OptionsDict& options)
+  RandomNetwork(const OptionsDict& options)
       : delay_ms_(options.GetOrDefault<int>("delay", 0)),
         seed_(options.GetOrDefault<int>("seed", 0)) {}
   std::unique_ptr<NetworkComputation> NewComputation() override {
@@ -82,7 +83,13 @@ class RandomNetwork : public Network {
   int delay_ms_ = 0;
   int seed_ = 0;
 };
+}  // namespace
 
-REGISTER_NETWORK("random", RandomNetwork, -900)
+std::unique_ptr<Network> MakeRandomNetwork(const Weights& /*weights*/,
+                                           const OptionsDict& options) {
+  return std::make_unique<RandomNetwork>(options);
+}
+
+REGISTER_NETWORK("random", MakeRandomNetwork, -900)
 
 }  // namespace lczero

--- a/src/neural/network_tf.cc
+++ b/src/neural/network_tf.cc
@@ -308,9 +308,14 @@ std::unique_ptr<NetworkComputation> TFNetwork<CPU>::NewComputation() {
   return std::make_unique<TFNetworkComputation<CPU>>(this);
 }
 
+template <bool CPU>
+std::unique_ptr<Network> MakeTFNetwork(const Weights& weights,
+                                       const OptionsDict& options) {
+  return std::make_unique<TFNetwork<CPU>>(weights, options);
+}
+
+REGISTER_NETWORK("tensorflow-cpu", MakeTFNetwork<true>, 90)
+REGISTER_NETWORK("tensorflow", MakeTFNetwork<false>, 80)
+
 }  // namespace
-
-REGISTER_NETWORK("tensorflow-cpu", TFNetwork<true>, 90)
-REGISTER_NETWORK("tensorflow", TFNetwork<false>, 80)
-
 }  // namespace lczero

--- a/src/neural/opencl/network_opencl.cc
+++ b/src/neural/opencl/network_opencl.cc
@@ -289,8 +289,12 @@ class OpenCLNetwork : public Network {
   OpenCL_Network opencl_net_;
 };
 
+std::unique_ptr<Network> MakeOpenCLNetwork(const Weights& weights,
+                                           const OptionsDict& options) {
+  return std::make_unique<OpenCLNetwork>(weights, options);
+}
+
+REGISTER_NETWORK("opencl", MakeOpenCLNetwork, 100)
+
 }  // namespace
-
-REGISTER_NETWORK("opencl", OpenCLNetwork, 100)
-
 }  // namespace lczero

--- a/src/neural/opencl/network_opencl.cc
+++ b/src/neural/opencl/network_opencl.cc
@@ -292,6 +292,13 @@ class OpenCLNetwork : public Network {
 
 std::unique_ptr<Network> MakeOpenCLNetwork(const WeightsFile& weights,
                                            const OptionsDict& options) {
+  if (weights.format().network_format().network() !=
+      pblczero::NetworkFormat::NETWORK_CLASSICAL) {
+    throw Exception(
+        "Network format " +
+        std::to_string(weights.format().network_format().network()) +
+        " is not supported by OpenCL backend.");
+  }
   return std::make_unique<OpenCLNetwork>(weights, options);
 }
 

--- a/src/neural/opencl/network_opencl.cc
+++ b/src/neural/opencl/network_opencl.cc
@@ -32,8 +32,10 @@
 #include <iostream>
 #include <thread>
 
+#include "neural/network_legacy.h"
 #include "utils/bititer.h"
 #include "utils/exception.h"
+#include "utils/weights_adapter.h"
 
 namespace lczero {
 
@@ -48,11 +50,11 @@ struct OpenCLWeights {
   const size_t num_output_policies;
   const size_t num_value_channels;
 
-  OpenCLWeights(const Weights& weights)
-      : ip2_val_w(weights.ip2_val_w),
-        ip2_val_b(weights.ip2_val_b),
-        num_output_policies(weights.ip_pol_b.size()),
-        num_value_channels(weights.ip1_val_b.size()) {}
+  OpenCLWeights(const WeightsFile& file)
+      : ip2_val_w(LayerAdapter(file.weights().ip2_val_w()).as_vector()),
+        ip2_val_b(LayerAdapter(file.weights().ip2_val_b()).as_vector()),
+        num_output_policies(LayerAdapter(file.weights().ip_pol_b()).size()),
+        num_value_channels(LayerAdapter(file.weights().ip1_val_b()).size()) {}
 };
 
 class OpenCLComputation : public NetworkComputation {
@@ -154,8 +156,9 @@ class OpenCLNetwork : public Network {
  public:
   virtual ~OpenCLNetwork(){};
 
-  OpenCLNetwork(const Weights& weights, const OptionsDict& options)
-      : weights_(weights), params_(), opencl_(), opencl_net_(opencl_) {
+  OpenCLNetwork(const WeightsFile& file, const OptionsDict& options)
+      : weights_(file), params_(), opencl_(), opencl_net_(opencl_) {
+    const LegacyWeights weights(file.weights());
     params_.gpuId = options.GetOrDefault<int>("gpu", -1);
     params_.verbose = options.GetOrDefault<bool>("verbose", true);
     params_.force_tune = options.GetOrDefault<bool>("force_tune", false);
@@ -215,10 +218,9 @@ class OpenCLNetwork : public Network {
     auto Upad = WinogradConvolution3::ZeropadU(input_conv_weights, channels,
                                                inputChannels, m_ceil, k_ceil);
 
-    std::vector<float> input_batchnorm_means =
-        Batchnorm::OffsetMeans(weights.input);
+    std::vector<float> input_batchnorm_means = weights.input.GetOffsetMeans();
     std::vector<float> input_batchnorm_stddivs =
-        Batchnorm::InvertStddev(weights.input);
+        weights.input.GetInvertedStddev();
 
     // Winograd filter transformation changes filter size to 4x4.
     opencl_net_.push_input_convolution(kWinogradAlpha, inputChannels, channels,
@@ -241,12 +243,11 @@ class OpenCLNetwork : public Network {
       auto Upad2 = WinogradConvolution3::ZeropadU(conv_weights_2, channels,
                                                   channels, m_ceil, m_ceil);
 
-      std::vector<float> batchnorm_means_1 = Batchnorm::OffsetMeans(conv1);
-      std::vector<float> batchnorm_means_2 = Batchnorm::OffsetMeans(conv2);
+      std::vector<float> batchnorm_means_1 = conv1.GetOffsetMeans();
+      std::vector<float> batchnorm_means_2 = conv2.GetOffsetMeans();
 
-      std::vector<float> batchnorm_stddivs_1 = Batchnorm::InvertStddev(conv1);
-      std::vector<float> batchnorm_stddivs_2 = Batchnorm::InvertStddev(conv2);
-
+      std::vector<float> batchnorm_stddivs_1 = conv1.GetInvertedStddev();
+      std::vector<float> batchnorm_stddivs_2 = conv2.GetInvertedStddev();
       opencl_net_.push_residual(kWinogradAlpha, channels, channels, Upad1,
                                 batchnorm_means_1, batchnorm_stddivs_1, Upad2,
                                 batchnorm_means_2, batchnorm_stddivs_2);
@@ -255,8 +256,8 @@ class OpenCLNetwork : public Network {
     constexpr unsigned int width = 8;
     constexpr unsigned int height = 8;
 
-    std::vector<float> bn_pol_means = Batchnorm::OffsetMeans(weights.policy);
-    std::vector<float> bn_pol_stddivs = Batchnorm::InvertStddev(weights.policy);
+    std::vector<float> bn_pol_means = weights.policy.GetOffsetMeans();
+    std::vector<float> bn_pol_stddivs = weights.policy.GetInvertedStddev();
 
     opencl_net_.push_policy(channels, num_policy_input_planes,
                             num_policy_input_planes * width * height,
@@ -264,8 +265,8 @@ class OpenCLNetwork : public Network {
                             bn_pol_means, bn_pol_stddivs, weights.ip_pol_w,
                             weights.ip_pol_b);
 
-    std::vector<float> bn_val_means = Batchnorm::OffsetMeans(weights.value);
-    std::vector<float> bn_val_stddivs = Batchnorm::InvertStddev(weights.value);
+    std::vector<float> bn_val_means = weights.value.GetOffsetMeans();
+    std::vector<float> bn_val_stddivs = weights.value.GetInvertedStddev();
 
     opencl_net_.push_value(channels, num_value_input_planes,
                            num_value_input_planes * width * height,
@@ -289,7 +290,7 @@ class OpenCLNetwork : public Network {
   OpenCL_Network opencl_net_;
 };
 
-std::unique_ptr<Network> MakeOpenCLNetwork(const Weights& weights,
+std::unique_ptr<Network> MakeOpenCLNetwork(const WeightsFile& weights,
                                            const OptionsDict& options) {
   return std::make_unique<OpenCLNetwork>(weights, options);
 }

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -152,15 +152,15 @@ SelfPlayTournament::SelfPlayTournament(const OptionsDict& options,
     if (path == kAutoDiscover) {
       path = DiscoverWeightsFile();
     }
-    Weights weights = LoadWeightsFromFile(path);
+    WeightsFile weights = LoadWeightsFromFile(path);
     std::string backend = options.GetSubdict(kPlayerNames[idx])
                               .Get<std::string>(kNnBackendId.GetId());
     std::string backend_options =
         options.GetSubdict(kPlayerNames[idx])
             .Get<std::string>(kNnBackendOptionsId.GetId());
 
-   OptionsDict network_options(&options.GetSubdict(kPlayerNames[idx]));
-   network_options.AddSubdictFromString(backend_options);
+    OptionsDict network_options(&options.GetSubdict(kPlayerNames[idx]));
+    network_options.AddSubdictFromString(backend_options);
 
     networks_[idx] =
         NetworkFactory::Get()->Create(backend, weights, network_options);
@@ -186,7 +186,8 @@ SelfPlayTournament::SelfPlayTournament(const OptionsDict& options,
         options.GetSubdict(kPlayerNames[idx]).Get<int>(kTimeMsId.GetId());
 
     if (search_limits_[idx].playouts == -1 &&
-        search_limits_[idx].visits == -1 && search_limits_[idx].movetime == -1) {
+        search_limits_[idx].visits == -1 &&
+        search_limits_[idx].movetime == -1) {
       throw Exception(
           "Please define --visits, --playouts or --movetime, otherwise it's "
           "not clear when to stop search.");

--- a/src/utils/weights_adapter.cc
+++ b/src/utils/weights_adapter.cc
@@ -25,24 +25,28 @@
   Program grant you additional permission to convey the resulting work.
 */
 
-#pragma once
-
-#include <string>
-#include <vector>
-
-#include "neural/network.h"
+#include "src/utils/weights_adapter.h"
 
 namespace lczero {
+float LayerAdapter::Iterator::ExtractValue(const uint16_t* ptr,
+                                           const LayerAdapter* adapter) {
+  return *ptr / static_cast<float>(0xffff) * adapter->range_ + adapter->min_;
+}
 
-using FloatVector = std::vector<float>;
-using FloatVectors = std::vector<FloatVector>;
+LayerAdapter::LayerAdapter(const pblczero::Weights_Layer& layer)
+    : data_(reinterpret_cast<const uint16_t*>(layer.params().data())),
+      size_(layer.params().size() / sizeof(uint16_t)),
+      min_(layer.min_val()),
+      range_(layer.max_val() - min_) {}
 
-// Read weights file and fill the weights structure.
-WeightsFile LoadWeightsFromFile(const std::string& filename);
-
-// Tries to find a file which looks like a weights file, and located in
-// directory of binary_name or one of subdirectories. If there are several such
-// files, returns one which has the latest modification date.
-std::string DiscoverWeightsFile();
+std::vector<float> LayerAdapter::as_vector() const {
+  return std::vector<float>(begin(), end());
+}
+float LayerAdapter::Iterator::operator*() const {
+  return ExtractValue(data_, adapter_);
+}
+float LayerAdapter::Iterator::operator[](size_t idx) const {
+  return ExtractValue(data_ + idx, adapter_);
+}
 
 }  // namespace lczero

--- a/src/utils/weights_adapter.h
+++ b/src/utils/weights_adapter.h
@@ -1,0 +1,80 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#include <iterator>
+#include <vector>
+#include "proto/net.pb.h"
+
+namespace lczero {
+
+class LayerAdapter {
+ public:
+  class Iterator
+      : public std::iterator<std::random_access_iterator_tag, float> {
+   public:
+    Iterator() = default;
+    Iterator(const Iterator& other) = default;
+
+    float operator*() const;
+    float operator[](size_t idx) const;
+    Iterator& operator++() {
+      ++data_;
+      return *this;
+    }
+    Iterator& operator--() {
+      --data_;
+      return *this;
+    }
+    ptrdiff_t operator-(const Iterator& other) { return data_ - other.data_; }
+
+    // TODO(crem) implement other iterator functions when they are needed.
+
+   private:
+    friend class LayerAdapter;
+    Iterator(const LayerAdapter* adapter, const uint16_t* ptr)
+        : adapter_(adapter), data_(ptr) {}
+    static float ExtractValue(const uint16_t* ptr, const LayerAdapter* adapter);
+
+    const LayerAdapter* adapter_ = nullptr;
+    const uint16_t* data_ = nullptr;
+  };
+
+  LayerAdapter(const pblczero::Weights_Layer& layer);
+  std::vector<float> as_vector() const;
+  size_t size() const { return size_; }
+  float operator[](size_t idx) const { return begin()[idx]; }
+  Iterator begin() const { return {this, data_}; }
+  Iterator end() const { return {this, data_ + size_}; }
+
+ private:
+  const uint16_t* data_ = nullptr;
+  const size_t size_ = 0;
+  const float min_;
+  const float range_;
+};
+
+}  // namespace lczero


### PR DESCRIPTION
It's still converted to the legacy structure in backends constructor, because backends depend on that too much.
Still few things that doesn't work.
1. encode_test fails to compile as it doesn't see proto headers.
2. I wasn't able to build tensorflow backend (that same protobuf version mismatch problem as before)