### PR TITLE
Fix EncodePositionForNN test failure

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,15 +50,14 @@ install:
 - cmd: IF %GTEST%==true IF NOT EXIST KQvKQ.rtbz curl --remote-name-all https://tablebase.lichess.ovh/tables/standard/3-4-5/K{P,N,R,B,Q}vK{P,N,R,B,Q}.rtb{w,z}
 - cmd: cd C:\projects\lc0
 cache:
-  - C:\cache -> appveyor.yml
+  - C:\cache
   - 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0'
   - C:\projects\lc0\subprojects\packagecache
 before_build:
 - cmd: git submodule update --init --recursive
 - cmd: meson build --backend vs2015 --buildtype release -Dgtest=%GTEST% -Dopencl=%OPENCL% -Dblas=%BLAS% -Dcudnn=%CUDA% -Dispc_native_only=false -Dpopcnt=false -Dcudnn_include="%PKG_FOLDER%\cuda\include" -Dcudnn_libdirs="%CUDA_PATH%\lib\x64","%PKG_FOLDER%\cuda\lib\x64" -Dprotobuf_include="%PKG_FOLDER%\protobuf\include" -Dprotobuf_libdir="%PKG_FOLDER%\protobuf\lib" -Dopenblas_include="%PKG_FOLDER%\OpenBLAS.0.2.14.1\lib\native\include" -Dopenblas_libdirs="%PKG_FOLDER%\OpenBLAS.0.2.14.1\lib\native\lib\x64" -Dopencl_include="%PKG_FOLDER%\opencl-nug.0.777.12\build\native\include" -Dopencl_libdirs="%PKG_FOLDER%\opencl-nug.0.777.12\build\native\lib\x64" -Ddefault_library=static
 build_script:
-- cmd: IF %APPVEYOR_REPO_TAG%==false msbuild "C:\projects\lc0\build\lc0.sln" /m /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-- cmd: IF %APPVEYOR_REPO_TAG%==true msbuild "C:\projects\lc0\build\lc0.sln" /m /p:WholeProgramOptimization=true /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- cmd: msbuild "C:\projects\lc0\build\lc0.sln" /m /p:WholeProgramOptimization=true /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 after_build:
 - cmd: IF %APPVEYOR_REPO_TAG%==true 7z a lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%.zip %APPVEYOR_BUILD_FOLDER%\build\lc0.exe
 - cmd: IF %APPVEYOR_REPO_TAG%==true appveyor DownloadFile "https://ci.appveyor.com/api/projects/LeelaChessZero/lczero-client/artifacts/client.exe?branch=release&pr=false&job=Environment%%3A%%20NAME%%3D.exe%%2C%%20GOOS%%3Dwindows"

--- a/src/benchmark/benchmark.cc
+++ b/src/benchmark/benchmark.cc
@@ -49,7 +49,7 @@ void Benchmark::Run() {
   SearchParams::Populate(&options);
 
   options.Add<IntOption>(kNodesId, -1, 999999999) = 30000;
-  options.Add<StringOption>(kFenId) = ChessBoard::kStartingFen;
+  options.Add<StringOption>(kFenId) = ChessBoard::kStartposFen;
   options.Add<IntOption>(kNNCacheSizeId, 0, 999999999) = 200000;
   options.Add<IntOption>(kThreadsOptionId, 1, 128) = kDefaultThreads;
 

--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -37,10 +37,10 @@ namespace lczero {
 
 using std::string;
 
-const char* ChessBoard::kStartingFen =
+const char* ChessBoard::kStartposFen =
     "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
-const ChessBoard ChessBoard::kStartBoardPos(ChessBoard::kStartingFen);
+const ChessBoard ChessBoard::kStartposBoard(ChessBoard::kStartposFen);
 
 void ChessBoard::Clear() {
   std::memset(reinterpret_cast<void*>(this), 0, sizeof(ChessBoard));

--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -40,6 +40,8 @@ using std::string;
 const string ChessBoard::kStartingFen =
     "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
+const ChessBoard ChessBoard::kStartBoardPos(ChessBoard::kStartingFen);
+
 void ChessBoard::Clear() {
   std::memset(reinterpret_cast<void*>(this), 0, sizeof(ChessBoard));
 }

--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -37,7 +37,7 @@ namespace lczero {
 
 using std::string;
 
-const string ChessBoard::kStartingFen =
+const char* ChessBoard::kStartingFen =
     "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
 const ChessBoard ChessBoard::kStartBoardPos(ChessBoard::kStartingFen);

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -42,8 +42,8 @@ class ChessBoard {
   ChessBoard() = default;
   ChessBoard(const std::string& fen) { SetFromFen(fen); }
 
-  static const char* kStartingFen;
-  static const ChessBoard kStartBoardPos;
+  static const char* kStartposFen;
+  static const ChessBoard kStartposBoard;
 
   // Sets position from FEN string.
   // If @no_capture_ply and @moves are not nullptr, they are filled with number

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -43,6 +43,7 @@ class ChessBoard {
   ChessBoard(const std::string& fen) { SetFromFen(fen); }
 
   static const std::string kStartingFen;
+  static const ChessBoard kStartBoardPos;
 
   // Sets position from FEN string.
   // If @no_capture_ply and @moves are not nullptr, they are filled with number

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -42,7 +42,7 @@ class ChessBoard {
   ChessBoard() = default;
   ChessBoard(const std::string& fen) { SetFromFen(fen); }
 
-  static const std::string kStartingFen;
+  static const char* kStartingFen;
   static const ChessBoard kStartBoardPos;
 
   // Sets position from FEN string.

--- a/src/chess/board_test.cc
+++ b/src/chess/board_test.cc
@@ -53,7 +53,7 @@ TEST(BoardSquare, BoardSquare) {
 
 TEST(ChessBoard, PseudolegalMovesStartingPos) {
   ChessBoard board;
-  board.SetFromFen(ChessBoard::kStartingFen);
+  board.SetFromFen(ChessBoard::kStartposFen);
   board.Mirror();
   auto moves = board.GeneratePseudolegalMoves();
 
@@ -96,7 +96,7 @@ int Perft(const ChessBoard& board, int max_depth, bool dump = false,
 
 /* TEST(ChessBoard, MoveGenStartingPos) {
   ChessBoard board;
-  board.SetFromFen(ChessBoard::kStartingFen);
+  board.SetFromFen(ChessBoard::kStartposFen);
 
   EXPECT_EQ(Perft(board, 0), 1);
   EXPECT_EQ(Perft(board, 1), 20);
@@ -168,7 +168,7 @@ TEST(ChessBoard, MoveGenPosition6) {
 
 TEST(ChessBoard, HasMatingMaterialStartPosition) {
   ChessBoard board;
-  board.SetFromFen(ChessBoard::kStartingFen);
+  board.SetFromFen(ChessBoard::kStartposFen);
   EXPECT_TRUE(board.HasMatingMaterial());
 }
 

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -370,7 +370,7 @@ void EngineController::Go(const GoParams& params) {
       SetupPosition(current_position_->fen, current_position_->moves);
     }
   } else if (!tree_) {
-    SetupPosition(ChessBoard::kStartingFen, {});
+    SetupPosition(ChessBoard::kStartposFen, {});
   }
 
   auto limits = PopulateSearchLimits(
@@ -455,7 +455,7 @@ void EngineLoop::CmdUciNewGame() { engine_.NewGame(); }
 void EngineLoop::CmdPosition(const std::string& position,
                              const std::vector<std::string>& moves) {
   std::string fen = position;
-  if (fen.empty()) fen = ChessBoard::kStartingFen;
+  if (fen.empty()) fen = ChessBoard::kStartposFen;
   engine_.SetPosition(fen, moves);
 }
 

--- a/src/neural/encoder.cc
+++ b/src/neural/encoder.cc
@@ -67,7 +67,7 @@ InputPlanes EncodePositionForNN(const PositionHistory& history,
     if (history_idx < 0 && fill_empty_history == FillEmptyHistory::NO) break;
     // Board may be flipped so compare with position.GetBoard().
     if (history_idx < 0 && fill_empty_history == FillEmptyHistory::FEN_ONLY &&
-        position.GetBoard() == ChessBoard::kStartBoardPos) {
+        position.GetBoard() == ChessBoard::kStartposBoard) {
       break;
     }
 

--- a/src/neural/encoder.cc
+++ b/src/neural/encoder.cc
@@ -35,9 +35,6 @@ namespace {
 const int kMoveHistory = 8;
 const int kPlanesPerBoard = 13;
 const int kAuxPlaneBase = kPlanesPerBoard * kMoveHistory;
-
-static const ChessBoard kStartBoardPos(ChessBoard::kStartingFen);
-
 }  // namespace
 
 InputPlanes EncodePositionForNN(const PositionHistory& history,
@@ -70,7 +67,7 @@ InputPlanes EncodePositionForNN(const PositionHistory& history,
     if (history_idx < 0 && fill_empty_history == FillEmptyHistory::NO) break;
     // Board may be flipped so compare with position.GetBoard().
     if (history_idx < 0 && fill_empty_history == FillEmptyHistory::FEN_ONLY &&
-        position.GetBoard() == kStartBoardPos) {
+        position.GetBoard() == ChessBoard::kStartBoardPos) {
       break;
     }
 

--- a/src/neural/encoder_test.cc
+++ b/src/neural/encoder_test.cc
@@ -27,7 +27,7 @@ auto kAllSquaresMask = std::numeric_limits<std::uint64_t>::max();
 TEST(EncodePositionForNN, EncodeStartPosition) {
   ChessBoard board;
   PositionHistory history;
-  board.SetFromFen(ChessBoard::kStartingFen);
+  board.SetFromFen(ChessBoard::kStartposFen);
   history.Reset(board, 0, 1);
 
 
@@ -99,7 +99,7 @@ TEST(EncodePositionForNN, EncodeStartPosition) {
 TEST(EncodePositionForNN, EncodeFiftyMoveCounter) {
   ChessBoard board;
   PositionHistory history;
-  board.SetFromFen(ChessBoard::kStartingFen);
+  board.SetFromFen(ChessBoard::kStartposFen);
   history.Reset(board, 0, 1);
 
   // 1. Nf3

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -49,13 +49,13 @@ SelfPlayGame::SelfPlayGame(PlayerOptions player1, PlayerOptions player2,
                            bool shared_tree)
     : options_{player1, player2} {
   tree_[0] = std::make_shared<NodeTree>();
-  tree_[0]->ResetToPosition(ChessBoard::kStartingFen, {});
+  tree_[0]->ResetToPosition(ChessBoard::kStartposFen, {});
 
   if (shared_tree) {
     tree_[1] = tree_[0];
   } else {
     tree_[1] = std::make_shared<NodeTree>();
-    tree_[1]->ResetToPosition(ChessBoard::kStartingFen, {});
+    tree_[1]->ResetToPosition(ChessBoard::kStartposFen, {});
   }
 }
 


### PR DESCRIPTION
This is in two parts, first moves kStartBoardPos to ChessBoard and second sets Appveyor to always build with WholeProgramOptimization to avoid failing to notice tings like this before the release.