### PR TITLE
Fix OpenCL tuner always loading the first saved tuning

### DIFF
--- a/src/neural/opencl/OpenCLTuner.cc
+++ b/src/neural/opencl/OpenCLTuner.cc
@@ -457,8 +457,8 @@ std::string Tuner::load_sgemm_tuners(const int m, const int n, const int k,
           // the matrix multiplication (n = WINOGRAD_P * batch_size).
           CERR << "Loaded existing SGEMM tuning for batch size "
                << n / WINOGRAD_P << ".";
+          return tuners;
         }
-        return tuners;
       }
     }
   }


### PR DESCRIPTION
Tuner always loaded the first tuning even if it had wrong parameters.