### PR TITLE
Extend possible include dirs for cuDNN.

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -55,7 +55,7 @@ option('mkl_include',
 
 option('cudnn_include', 
        type: 'array',
-       value: ['/usr/local/cuda/include/'],
+       value: ['/opt/cuda/include/', '/usr/local/cuda/include/'],
        description: 'Paths to cudnn include directory')
 
 option('build_backends',


### PR DESCRIPTION
We support looking into /opt for cuDNN libraries, so we
should also support looking there for the include files.