### PR TITLE
Install pkg-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ in ("Deep Learning").
 
 For Ubuntu 18.04 you need the latest version of meson and clang-6.0 before performing the steps above:
 
-    sudo apt-get install clang-6.0 ninja-build protobuf-compiler libprotobuf-dev meson
+    sudo apt-get install clang-6.0 ninja-build pkg-config protobuf-compiler libprotobuf-dev meson
     CC=clang-6.0 CXX=clang++-6.0 INSTALL_PREFIX=~/.local ./build.sh
 
 Make sure that `~/.local/bin` is in your `PATH` environment variable. You can now type `lc0 --help` and start.


### PR DESCRIPTION
Fixes the following error when pkg-config is not already installed.

Found Pkg-config: NO
meson.build:368:2: ERROR: Pkg-config not found.