### PR TITLE
updated include dirs for cuda 10

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -20,7 +20,7 @@ option('opencl_include',
 
 option('cuda_include',
        type: 'array',
-       value: ['/usr/local/cuda/include/'],
+       value: ['/opt/cuda/include/'],
        description: 'Paths to CUDA include directories')
 
 option('tensorflow_libdir',
@@ -60,7 +60,7 @@ option('mkl_include',
 
 option('cudnn_include', 
        type: 'array',
-       value: ['/usr/local/cuda/include/'],
+       value: ['/opt/cuda/include/'],
        description: 'Paths to cudnn include directory')
 
 option('build_backends',


### PR DESCRIPTION
Updated include dirs for the latest cuda. Needed to be approved that location changed not only for Arch Linux. In other case this change must to be more complicated than changing 2 lines of the text file :-)