### PR TITLE
[Experiment] Attempt to fight with "another move is better" situation.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -129,6 +129,10 @@ const OptionId SearchParams::kHistoryFillId{
     "one. During the first moves of the game such historical positions don't "
     "exist, but they can be synthesized. This parameter defines when to "
     "synthesize them (always, never, or only at non-standard fen position)."};
+const OptionId SearchParams::kPolicyPersistenceId(
+    "policy-persistence", "PolicyPersistence",
+    "Yet another parameter. Experimental. Better desc to be written if this is "
+    "to be merged.");
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the "safe defaults" are listed.
@@ -153,8 +157,9 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kMultiPvId, 1, 500) = 1;
   std::vector<std::string> score_type = {"centipawn", "win_percentage", "Q"};
   options->Add<ChoiceOption>(kScoreTypeId, score_type) = "centipawn";
-  std::vector<std::string> history_fill_opt {"no", "fen_only", "always"};
+  std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
+  options->Add<FloatOption>(kPolicyPersistenceId, 0.0f, 1.0f) = 0.5f;
 }
 
 SearchParams::SearchParams(const OptionsDict& options)
@@ -169,7 +174,7 @@ SearchParams::SearchParams(const OptionsDict& options)
       kMaxCollisionVisits(options.Get<int>(kMaxCollisionVisitsId.GetId())),
       kOutOfOrderEval(options.Get<bool>(kOutOfOrderEvalId.GetId())),
       kHistoryFill(
-          EncodeHistoryFill(options.Get<std::string>(kHistoryFillId.GetId()))) {
-}
+          EncodeHistoryFill(options.Get<std::string>(kHistoryFillId.GetId()))),
+      kPolicyPersistence(options.Get<float>(kPolicyPersistenceId.GetId())) {}
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -74,6 +74,7 @@ class SearchParams {
     return options_.Get<std::string>(kScoreTypeId.GetId());
   }
   FillEmptyHistory GetHistoryFill() const { return kHistoryFill; }
+  float GetPolicyPersistence() const { return kPolicyPersistence; }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -94,6 +95,7 @@ class SearchParams {
   static const OptionId kMultiPvId;
   static const OptionId kScoreTypeId;
   static const OptionId kHistoryFillId;
+  static const OptionId kPolicyPersistenceId;
 
  private:
   const OptionsDict& options_;
@@ -113,6 +115,7 @@ class SearchParams {
   const int kMaxCollisionVisits;
   const bool kOutOfOrderEval;
   const FillEmptyHistory kHistoryFill;
+  const float kPolicyPersistence;
 };
 
 }  // namespace lczero

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -189,7 +189,8 @@ std::vector<std::string> Search::GetVerboseStats(Node* node,
       -node->GetQ() -
       params_.GetFpuReduction() * std::sqrt(node->GetVisitedPolicy());
   const float U_coeff =
-      params_.GetCpuct() * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
+      params_.GetCpuct() * std::pow(std::max(node->GetChildrenVisits(), 1u),
+                                    params_.GetPolicyPersistence());
 
   std::vector<EdgeAndNode> edges;
   for (const auto& edge : node->Edges()) edges.push_back(edge);
@@ -826,7 +827,8 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     // If we fall through, then n_in_flight_ has been incremented but this
     // playout remains incomplete; we must go deeper.
     float puct_mult =
-        params_.GetCpuct() * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
+        params_.GetCpuct() * std::pow(std::max(node->GetChildrenVisits(), 1u),
+                                      params_.GetPolicyPersistence());
     float best = std::numeric_limits<float>::lowest();
     float second_best = std::numeric_limits<float>::lowest();
     int possible_moves = 0;
@@ -1026,7 +1028,8 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget) {
   typedef std::pair<float, EdgeAndNode> ScoredEdge;
   std::vector<ScoredEdge> scores;
   float puct_mult =
-      params_.GetCpuct() * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
+      params_.GetCpuct() * std::pow(std::max(node->GetChildrenVisits(), 1u),
+                                    params_.GetPolicyPersistence());
   // FPU reduction is not taken into account.
   const float parent_q = -node->GetQ();
   for (auto edge : node->Edges()) {


### PR DESCRIPTION
--policy-persistence parameter

Default: 0.5
Range: 0.0 to 1.0

Higher values mean it will more likely to look into less promising moves (kind of similar to cpuct though)

I expect something slightly larger than 0.5 (e.g. 0.51) will be better for long time controls.