### PR TITLE
ensure bestmove is sent when aborting search

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -630,8 +630,10 @@ void Search::Stop() {
 
 void Search::Abort() {
   Mutex::Lock lock(counters_mutex_);
-  bestmove_is_sent_ = true;
-  FireStopInternal();
+  if (!stop_.load(std::memory_order_acquire)) {
+    bestmove_is_sent_ = true;
+    FireStopInternal();
+  }
   LOGFILE << "Aborting search, if it is still active.";
 }
 
@@ -644,7 +646,7 @@ void Search::Wait() {
 }
 
 Search::~Search() {
-  if (!stop_.load(std::memory_order_acquire)) Abort();
+  Abort();
   Wait();
   LOGFILE << "Search destroyed.";
 }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -630,6 +630,10 @@ void Search::Stop() {
 
 void Search::Abort() {
   Mutex::Lock lock(counters_mutex_);
+  if (ok_to_respond_bestmove_ && !bestmove_is_sent_) {
+    best_move_callback_(GetBestChildNoTemperature(root_node_)
+                            .GetMove(played_history_.IsBlackToMove()));
+  }
   bestmove_is_sent_ = true;
   FireStopInternal();
   LOGFILE << "Aborting search, if it is still active.";

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -630,10 +630,6 @@ void Search::Stop() {
 
 void Search::Abort() {
   Mutex::Lock lock(counters_mutex_);
-  if (ok_to_respond_bestmove_ && !bestmove_is_sent_) {
-    best_move_callback_(GetBestChildNoTemperature(root_node_)
-                            .GetMove(played_history_.IsBlackToMove()));
-  }
   bestmove_is_sent_ = true;
   FireStopInternal();
   LOGFILE << "Aborting search, if it is still active.";
@@ -648,7 +644,7 @@ void Search::Wait() {
 }
 
 Search::~Search() {
-  Abort();
+  if (!stop_.load(std::memory_order_acquire)) Abort();
   Wait();
   LOGFILE << "Search destroyed.";
 }


### PR DESCRIPTION
Winboard with polyglot, when stopping pondering, sends the `position` command very quickly after `stop` and then sends `go` while at the same time waiting for `bestmove` before continuing. This leads to time losses: In some cases lc0 doesn't send `bestmove` at all when stopping, so the one sent after the final `go` is taken to be the one after `stop` and both sides end up waiting until time runs out.

This ensures that a `bestmove` will always be sent when stopping the search (provided `ok_to_respond_bestmove_` is true).