### PR TITLE
Added frequent-verbose-move-stats flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Lc0 is a UCI-compliant chess engine designed to play chess via neural network, s
 
 Lc0 can be acquired either via a git clone or an archive download from GitHub. Be aware that there is a required submodule which isn't included in source archives.
 
-For essentially all purposes, including selfplay game generation and match play, we highly recommend using the `release` branch, which is equivalent to using the latest version tag.
+For essentially all purposes, including selfplay game generation and match play, we highly recommend using the latest `release/version` branch (for example `release/0.19`), which is equivalent to using the latest version tag.
 
 Versioning follows the Semantic Versioning guidelines, with major, minor and patch sections. The training server enforces game quality using the versions output by the client and engine.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,12 +31,12 @@ install:
 - cmd: IF %CUDA%==true IF NOT EXIST C:\cache\cuda 7z x cudnn-10.0-windows10-x64-v7.3.1.20.zip -oC:\cache
 - cmd: set PATH=C:\Python36;C:\Python36\scripts;%PATH%
 - cmd: pip3 install --upgrade meson
-- cmd: call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+- cmd: call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
 - cmd: set PKG_FOLDER="C:\cache"
 - cmd: IF NOT EXIST c:\cache\protobuf\ git clone -b v3.5.1 --single-branch --depth 1 https://github.com/google/protobuf.git
 - cmd: IF NOT EXIST c:\cache\protobuf\ mkdir protobuf\build_msvc
 - cmd: IF NOT EXIST c:\cache\protobuf\ cd protobuf\build_msvc
-- cmd: IF NOT EXIST c:\cache\protobuf\ cmake -G "Visual Studio 14 2015 Win64" -Dprotobuf_BUILD_SHARED_LIBS=NO -Dprotobuf_MSVC_STATIC_RUNTIME=NO -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=c:/cache/protobuf ../cmake
+- cmd: IF NOT EXIST c:\cache\protobuf\ cmake -G "Visual Studio 15 2017 Win64" -Dprotobuf_BUILD_SHARED_LIBS=NO -Dprotobuf_MSVC_STATIC_RUNTIME=NO -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=c:/cache/protobuf ../cmake
 - cmd: IF NOT EXIST c:\cache\protobuf\ msbuild INSTALL.vcxproj /p:Configuration=Release /p:Platform=x64 /m
 - cmd: set PATH=c:\cache\protobuf\bin;%PATH%
 - cmd: IF %GTEST%==true IF NOT EXIST C:\cache\syzygy mkdir C:\cache\syzygy 
@@ -51,7 +51,7 @@ cache:
   - C:\projects\lc0\subprojects\packagecache
 before_build:
 - cmd: git submodule update --init --recursive
-- cmd: meson build --backend vs2015 --buildtype release -Dgtest=%GTEST% -Dopencl=%OPENCL% -Dblas=%BLAS% -Dcudnn=%CUDA% -Dispc_native_only=false -Dpopcnt=false -Dcudnn_include="%CUDA_PATH%\include","%PKG_FOLDER%\cuda\include" -Dcudnn_libdirs="%CUDA_PATH%\lib\x64","%PKG_FOLDER%\cuda\lib\x64" -Dprotobuf_include="%PKG_FOLDER%\protobuf\include" -Dprotobuf_libdir="%PKG_FOLDER%\protobuf\lib" -Dopenblas_include="%PKG_FOLDER%\OpenBLAS.0.2.14.1\lib\native\include" -Dopenblas_libdirs="%PKG_FOLDER%\OpenBLAS.0.2.14.1\lib\native\lib\x64" -Dopencl_include="%PKG_FOLDER%\opencl-nug.0.777.12\build\native\include" -Dopencl_libdirs="%PKG_FOLDER%\opencl-nug.0.777.12\build\native\lib\x64" -Ddefault_library=static
+- cmd: meson build --backend vs2017 --buildtype release -Dgtest=%GTEST% -Dopencl=%OPENCL% -Dblas=%BLAS% -Dcudnn=%CUDA% -Dispc_native_only=false -Dpopcnt=false -Dcudnn_include="%CUDA_PATH%\include","%PKG_FOLDER%\cuda\include" -Dcudnn_libdirs="%CUDA_PATH%\lib\x64","%PKG_FOLDER%\cuda\lib\x64" -Dprotobuf_include="%PKG_FOLDER%\protobuf\include" -Dprotobuf_libdir="%PKG_FOLDER%\protobuf\lib" -Dopenblas_include="%PKG_FOLDER%\OpenBLAS.0.2.14.1\lib\native\include" -Dopenblas_libdirs="%PKG_FOLDER%\OpenBLAS.0.2.14.1\lib\native\lib\x64" -Dopencl_include="%PKG_FOLDER%\opencl-nug.0.777.12\build\native\include" -Dopencl_libdirs="%PKG_FOLDER%\opencl-nug.0.777.12\build\native\lib\x64" -Ddefault_library=static
 build_script:
 - cmd: msbuild "C:\projects\lc0\build\lc0.sln" /m /p:WholeProgramOptimization=true /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 after_build:

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@
 # along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
 
 project('lc0', 'cpp',
-        default_options : ['cpp_std=c++14', 'b_ndebug=if-release'],
+        default_options : ['cpp_std=c++14', 'b_ndebug=if-release', 'b_lto=true'],
         meson_version: '>=0.45')
 
 cc = meson.get_compiler('cpp')

--- a/meson.build
+++ b/meson.build
@@ -293,6 +293,10 @@ if get_option('build_backends')
 
   endif
 
+  if has_opencl and cc.has_header('CL/opencl.h', args: get_option('opencl_include'))
+      has_opencl = false
+  endif
+
   if get_option('opencl') and has_opencl
 
     opencl_files = [

--- a/meson.build
+++ b/meson.build
@@ -327,7 +327,8 @@ if get_option('build_backends')
   cu_blas = cc.find_library('cublas', dirs: cudnn_libdirs, required: false)
   cu_dnn = cc.find_library('cudnn', dirs: cudnn_libdirs, required: false)
   cu_dart = cc.find_library('cudart', dirs: cudnn_libdirs, required: false)
-  nvcc = find_program('/usr/local/cuda/bin/nvcc', 'nvcc', required: false)
+  nvcc = find_program('/usr/local/cuda/bin/nvcc', '/opt/cuda/bin/nvcc',
+                      'nvcc', required: false)
 
   #.cc files
   cuda_files = [

--- a/meson.build
+++ b/meson.build
@@ -293,10 +293,6 @@ if get_option('build_backends')
 
   endif
 
-  if has_opencl and cc.has_header('CL/opencl.h', args: get_option('opencl_include'))
-      has_opencl = false
-  endif
-
   if get_option('opencl') and has_opencl
 
     opencl_files = [

--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,18 @@ endif
 gen = generator(protoc, output: ['@BASENAME@.pb.cc', '@BASENAME@.pb.h'],
   arguments : ['--proto_path=@CURRENT_SOURCE_DIR@/libs/lczero-common', '--cpp_out=@BUILD_DIR@', '@INPUT@'])
 
+if run_command('checkdir.py', 'libs/lczero-common/proto').returncode() != 0
+  if run_command('git', 'status').returncode() == 0
+    message('updating git submodule libs/lczero-common')
+    run_command('git', 'submodule', 'update', '--init', '--recursive')
+  else
+    message('cloning lczero-common.git into libs/lczero-common')
+    run_command('git', 'clone', '--depth=1',
+                'https://github.com/LeelaChessZero/lczero-common.git',
+                'libs/lczero-common/')
+  endif
+endif
+
 files += gen.process('libs/lczero-common/proto/net.proto',
   preserve_path_from : meson.current_source_dir() + '/libs/lczero-common/')
 

--- a/src/chess/uciloop.h
+++ b/src/chess/uciloop.h
@@ -39,12 +39,12 @@ namespace lczero {
 struct GoParams {
   optional<std::int64_t> wtime;
   optional<std::int64_t> btime;
-  std::int64_t winc = -1;
-  std::int64_t binc = -1;
-  int movestogo = -1;
-  int depth = -1;
-  int nodes = -1;
-  std::int64_t movetime = -1;
+  optional<std::int64_t> winc;
+  optional<std::int64_t> binc;
+  optional<int> movestogo;
+  optional<int> depth;
+  optional<int> nodes;
+  optional<std::int64_t> movetime;
   bool infinite = false;
   std::vector<std::string> searchmoves;
   bool ponder = false;

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -283,7 +283,6 @@ void EngineController::UpdateFromUciOptions() {
 }
 
 void EngineController::EnsureReady() {
-  UpdateFromUciOptions();
   std::unique_lock<RpSharedMutex> lock(busy_mutex_);
   // If a UCI host is waiting for our ready response, we can consider the move
   // not started until we're done ensuring ready.

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -148,7 +148,8 @@ void EngineController::PopulateOptions(OptionsParser* options) {
 
   defaults->Set<int>(SearchParams::kMiniBatchSizeId.GetId(), 256);
   defaults->Set<float>(SearchParams::kFpuReductionId.GetId(), 1.2f);
-  defaults->Set<float>(SearchParams::kCpuctId.GetId(), 3.4f);
+  defaults->Set<float>(SearchParams::kCpuctId.GetId(), 3.0f);
+  defaults->Set<float>(SearchParams::kCpuctFactorId.GetId(), 2.0f);
   defaults->Set<float>(SearchParams::kPolicySoftmaxTempId.GetId(), 2.2f);
   defaults->Set<int>(SearchParams::kMaxCollisionVisitsId.GetId(), 9999);
   defaults->Set<int>(SearchParams::kMaxCollisionEventsId.GetId(), 32);

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -162,9 +162,9 @@ SearchLimits EngineController::PopulateSearchLimits(
     std::chrono::steady_clock::time_point start_time) {
   SearchLimits limits;
   int64_t move_overhead = options_.Get<int>(kMoveOverheadId.GetId());
-  if (params.movetime >= 0) {
-    limits.search_deadline =
-        start_time + std::chrono::milliseconds(params.movetime - move_overhead);
+  if (params.movetime) {
+    limits.search_deadline = start_time + std::chrono::milliseconds(
+                                              *params.movetime - move_overhead);
   }
 
   const optional<int64_t>& time = (is_black ? params.btime : params.wtime);
@@ -175,7 +175,7 @@ SearchLimits EngineController::PopulateSearchLimits(
     }
   }
   limits.infinite = params.infinite || params.ponder;
-  if (params.nodes >= 0) limits.visits = params.nodes;
+  if (params.nodes) limits.visits = *params.nodes;
   int ram_limit = options_.Get<int>(kRamLimitMbId.GetId());
   if (ram_limit) {
     const auto cache_size =
@@ -187,11 +187,12 @@ SearchLimits EngineController::PopulateSearchLimits(
     if (limit < 0) limit = 0;
     if (limit < limits.visits) limits.visits = limit;
   }
-  limits.depth = params.depth;
+  if (params.depth) limits.depth = *params.depth;
   if (limits.infinite || !time) return limits;
-  int increment = std::max(int64_t(0), is_black ? params.binc : params.winc);
+  const optional<int64_t>& inc = is_black ? params.binc : params.winc;
+  int increment = inc ? std::max(int64_t(0), *inc) : 0;
 
-  int movestogo = params.movestogo < 0 ? 50 : params.movestogo;
+  int movestogo = params.movestogo.value_or(50);
   // Fix non-standard uci command.
   if (movestogo == 0) movestogo = 1;
 

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -51,9 +51,13 @@ const OptionId SearchParams::kMaxPrefetchBatchId{
     "them into cache."};
 const OptionId SearchParams::kCpuctId{
     "cpuct", "CPuct",
-    "Cpuct constant from \"UCT search\" algorithm. Higher values promote more "
-    "exploration/wider search, lower values promote more confidence/deeper "
-    "search."};
+    "cpuct_init constant from \"UCT search\" algorithm. Higher values promote "
+    "more exploration/wider search, lower values promote more "
+    "confidence/deeper search."};
+const OptionId SearchParams::kCpuctBaseId{
+    "cpuct", "CPuct",
+    "cpuct_base constant from \"UCT search\" algorithm. Lower value means "
+    "higher growth of Cpuct as number of node visits grows."};
 const OptionId SearchParams::kTemperatureId{
     "temperature", "Temperature",
     "Tau value from softmax formula for the first move. If equal to 0, the "
@@ -136,7 +140,8 @@ void SearchParams::Populate(OptionsParser* options) {
   // tournament.cc
   options->Add<IntOption>(kMiniBatchSizeId, 1, 1024) = 1;
   options->Add<IntOption>(kMaxPrefetchBatchId, 0, 1024) = 32;
-  options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 1.2f;
+  options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 1.25f;
+  options->Add<FloatOption>(kCpuctBaseId, 0.0f, 100000000000.0f) = 19652.0f;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 100) = 0;
   options->Add<FloatOption>(kTemperatureVisitOffsetId, -0.99999f, 1000.0f) =
@@ -153,13 +158,14 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kMultiPvId, 1, 500) = 1;
   std::vector<std::string> score_type = {"centipawn", "win_percentage", "Q"};
   options->Add<ChoiceOption>(kScoreTypeId, score_type) = "centipawn";
-  std::vector<std::string> history_fill_opt {"no", "fen_only", "always"};
+  std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
 }
 
 SearchParams::SearchParams(const OptionsDict& options)
     : options_(options),
       kCpuct(options.Get<float>(kCpuctId.GetId())),
+      kCpuctBase(options.Get<float>(kCpuctBaseId.GetId())),
       kNoise(options.Get<bool>(kNoiseId.GetId())),
       kSmartPruningFactor(options.Get<float>(kSmartPruningFactorId.GetId())),
       kFpuReduction(options.Get<float>(kFpuReductionId.GetId())),

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -55,7 +55,7 @@ const OptionId SearchParams::kCpuctId{
     "more exploration/wider search, lower values promote more "
     "confidence/deeper search."};
 const OptionId SearchParams::kCpuctBaseId{
-    "cpuct", "CPuct",
+    "cpuct-base", "CPuctBase",
     "cpuct_base constant from \"UCT search\" algorithm. Lower value means "
     "higher growth of Cpuct as number of node visits grows."};
 const OptionId SearchParams::kTemperatureId{

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -96,6 +96,9 @@ const OptionId SearchParams::kNoiseId{
 const OptionId SearchParams::kVerboseStatsId{
     "verbose-move-stats", "VerboseMoveStats",
     "Display Q, V, N, U and P values of every move candidate after each move."};
+const OptionId SearchParams::kFrequentVerboseStatsId{
+    "frequent-verbose-move-stats", "FrequentVerboseMoveStats",
+    "Increase frequency of verbose move stats."};
 const OptionId SearchParams::kSmartPruningFactorId{
     "smart-pruning-factor", "SmartPruningFactor",
     "Do not spend time on the moves which cannot become bestmove given the "
@@ -179,6 +182,7 @@ void SearchParams::Populate(OptionsParser* options) {
       0.0f;
   options->Add<BoolOption>(kNoiseId) = false;
   options->Add<BoolOption>(kVerboseStatsId) = false;
+  options->Add<BoolOption>(kFrequentVerboseStatsId) = false;
   options->Add<FloatOption>(kSmartPruningFactorId, 0.0f, 10.0f) = 1.33f;
   std::vector<std::string> fpu_strategy = {"reduction", "absolute"};
   options->Add<ChoiceOption>(kFpuStrategyId, fpu_strategy) = "reduction";

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -58,6 +58,8 @@ const OptionId SearchParams::kCpuctBaseId{
     "cpuct-base", "CPuctBase",
     "cpuct_base constant from \"UCT search\" algorithm. Lower value means "
     "higher growth of Cpuct as number of node visits grows."};
+const OptionId SearchParams::kCpuctFactorId{
+    "cpuct-factor", "CPuctFactor", "Multiplier for the cpuct growth formula."};
 const OptionId SearchParams::kTemperatureId{
     "temperature", "Temperature",
     "Tau value from softmax formula for the first move. If equal to 0, the "
@@ -140,8 +142,9 @@ void SearchParams::Populate(OptionsParser* options) {
   // tournament.cc
   options->Add<IntOption>(kMiniBatchSizeId, 1, 1024) = 1;
   options->Add<IntOption>(kMaxPrefetchBatchId, 0, 1024) = 32;
-  options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 1.25f;
-  options->Add<FloatOption>(kCpuctBaseId, 0.0f, 100000000000.0f) = 19652.0f;
+  options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 1.2f;
+  options->Add<FloatOption>(kCpuctBaseId, 1.0f, 1000000000.0f) = 19652.0f;
+  options->Add<FloatOption>(kCpuctFactorId, 0.0f, 1000.0f) = 0.0f;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 100) = 0;
   options->Add<FloatOption>(kTemperatureVisitOffsetId, -0.99999f, 1000.0f) =
@@ -166,6 +169,7 @@ SearchParams::SearchParams(const OptionsDict& options)
     : options_(options),
       kCpuct(options.Get<float>(kCpuctId.GetId())),
       kCpuctBase(options.Get<float>(kCpuctBaseId.GetId())),
+      kCpuctFactor(options.Get<float>(kCpuctFactorId.GetId())),
       kNoise(options.Get<bool>(kNoiseId.GetId())),
       kSmartPruningFactor(options.Get<float>(kSmartPruningFactorId.GetId())),
       kFpuReduction(options.Get<float>(kFpuReductionId.GetId())),

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -74,6 +74,9 @@ class SearchParams {
   bool GetVerboseStats() const {
     return options_.Get<bool>(kVerboseStatsId.GetId());
   }
+  bool GetFrequentVerboseStats() const {
+    return options_.Get<bool>(kFrequentVerboseStatsId.GetId());
+  }
   float GetSmartPruningFactor() const { return kSmartPruningFactor; }
   bool GetFpuAbsolute() const { return kFpuAbsolute; }
   float GetFpuReduction() const { return kFpuReduction; }
@@ -103,6 +106,7 @@ class SearchParams {
   static const OptionId kTemperatureVisitOffsetId;
   static const OptionId kNoiseId;
   static const OptionId kVerboseStatsId;
+  static const OptionId kFrequentVerboseStatsId;
   static const OptionId kSmartPruningFactorId;
   static const OptionId kFpuStrategyId;
   static const OptionId kFpuReductionId;

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -50,6 +50,7 @@ class SearchParams {
   }
   float GetCpuct() const { return kCpuct; }
   float GetCpuctBase() const { return kCpuctBase; }
+  float GetCpuctFactor() const { return kCpuctFactor; }
   float GetTemperature() const {
     return options_.Get<float>(kTemperatureId.GetId());
   }
@@ -81,6 +82,7 @@ class SearchParams {
   static const OptionId kMaxPrefetchBatchId;
   static const OptionId kCpuctId;
   static const OptionId kCpuctBaseId;
+  static const OptionId kCpuctFactorId;
   static const OptionId kTemperatureId;
   static const OptionId kTempDecayMovesId;
   static const OptionId kTemperatureVisitOffsetId;
@@ -107,6 +109,7 @@ class SearchParams {
   //            trivial search optimiations.
   const float kCpuct;
   const float kCpuctBase;
+  const float kCpuctFactor;
   const bool kNoise;
   const float kSmartPruningFactor;
   const float kFpuReduction;

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -49,6 +49,7 @@ class SearchParams {
     return options_.Get<int>(kMaxPrefetchBatchId.GetId());
   }
   float GetCpuct() const { return kCpuct; }
+  float GetCpuctBase() const { return kCpuctBase; }
   float GetTemperature() const {
     return options_.Get<float>(kTemperatureId.GetId());
   }
@@ -79,6 +80,7 @@ class SearchParams {
   static const OptionId kMiniBatchSizeId;
   static const OptionId kMaxPrefetchBatchId;
   static const OptionId kCpuctId;
+  static const OptionId kCpuctBaseId;
   static const OptionId kTemperatureId;
   static const OptionId kTempDecayMovesId;
   static const OptionId kTemperatureVisitOffsetId;
@@ -104,6 +106,7 @@ class SearchParams {
   // TODO(crem) Some of those parameters can be converted to be dynamic after
   //            trivial search optimiations.
   const float kCpuct;
+  const float kCpuctBase;
   const bool kNoise;
   const float kSmartPruningFactor;
   const float kFpuReduction;

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -60,12 +60,24 @@ class SearchParams {
   int GetTempDecayMoves() const {
     return options_.Get<int>(kTempDecayMovesId.GetId());
   }
+  int GetTemperatureCutoffMove() const {
+    return options_.Get<int>(kTemperatureCutoffMoveId.GetId());
+  }
+  float GetTemperatureEndgame() const {
+    return options_.Get<float>(kTemperatureEndgameId.GetId());
+  }
+  float GetTemperatureWinpctCutoff() const {
+    return options_.Get<float>(kTemperatureWinpctCutoffId.GetId());
+  }
+
   bool GetNoise() const { return kNoise; }
   bool GetVerboseStats() const {
     return options_.Get<bool>(kVerboseStatsId.GetId());
   }
   float GetSmartPruningFactor() const { return kSmartPruningFactor; }
+  bool GetFpuAbsolute() const { return kFpuAbsolute; }
   float GetFpuReduction() const { return kFpuReduction; }
+  float GetFpuValue() const { return kFpuValue; }
   int GetCacheHistoryLength() const { return kCacheHistoryLength; }
   float GetPolicySoftmaxTemp() const { return kPolicySoftmaxTemp; }
   int GetMaxCollisionEvents() const { return kMaxCollisionEvents; }
@@ -85,11 +97,16 @@ class SearchParams {
   static const OptionId kCpuctFactorId;
   static const OptionId kTemperatureId;
   static const OptionId kTempDecayMovesId;
+  static const OptionId kTemperatureCutoffMoveId;
+  static const OptionId kTemperatureEndgameId;
+  static const OptionId kTemperatureWinpctCutoffId;
   static const OptionId kTemperatureVisitOffsetId;
   static const OptionId kNoiseId;
   static const OptionId kVerboseStatsId;
   static const OptionId kSmartPruningFactorId;
+  static const OptionId kFpuStrategyId;
   static const OptionId kFpuReductionId;
+  static const OptionId kFpuValueId;
   static const OptionId kCacheHistoryLengthId;
   static const OptionId kPolicySoftmaxTempId;
   static const OptionId kMaxCollisionEventsId;
@@ -112,7 +129,9 @@ class SearchParams {
   const float kCpuctFactor;
   const bool kNoise;
   const float kSmartPruningFactor;
+  const bool kFpuAbsolute;
   const float kFpuReduction;
+  const float kFpuValue;
   const int kCacheHistoryLength;
   const float kPolicySoftmaxTemp;
   const int kMaxCollisionEvents;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -579,8 +579,7 @@ void Search::RunBlocking(size_t threads) {
 }
 
 bool Search::IsSearchActive() const {
-  Mutex::Lock lock(counters_mutex_);
-  return !bestmove_is_sent_;
+  return !stop_.load(std::memory_order_acquire);
 }
 
 void Search::WatchdogThread() {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -184,6 +184,15 @@ int64_t Search::GetTimeToDeadline() const {
 }
 
 namespace {
+inline float GetFpu(const SearchParams& params, Node* node, bool is_root_node) {
+  return params.GetFpuAbsolute()
+             ? params.GetFpuValue()
+             : ((is_root_node && params.GetNoise()) ||
+                !params.GetFpuReduction())
+                   ? -node->GetQ()
+                   : -node->GetQ() - params.GetFpuReduction() *
+                                         std::sqrt(node->GetVisitedPolicy());
+}
 
 inline float ComputeCpuct(const SearchParams& params, uint32_t N) {
   const float init = params.GetCpuct();
@@ -191,14 +200,11 @@ inline float ComputeCpuct(const SearchParams& params, uint32_t N) {
   const float base = params.GetCpuctBase();
   return init + (k ? k * std::log((N + base) / base) : 0.0f);
 }
-
 }  // namespace
 
 std::vector<std::string> Search::GetVerboseStats(Node* node,
                                                  bool is_black_to_move) const {
-  const float parent_q =
-      -node->GetQ() -
-      params_.GetFpuReduction() * std::sqrt(node->GetVisitedPolicy());
+  const float fpu = GetFpu(params_, node, node == root_node_);
   const float cpuct = ComputeCpuct(params_, node->GetN());
   const float U_coeff =
       cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
@@ -206,13 +212,12 @@ std::vector<std::string> Search::GetVerboseStats(Node* node,
   std::vector<EdgeAndNode> edges;
   for (const auto& edge : node->Edges()) edges.push_back(edge);
 
-  std::sort(edges.begin(), edges.end(),
-            [&parent_q, &U_coeff](EdgeAndNode a, EdgeAndNode b) {
-              return std::forward_as_tuple(a.GetN(),
-                                           a.GetQ(parent_q) + a.GetU(U_coeff)) <
-                     std::forward_as_tuple(b.GetN(),
-                                           b.GetQ(parent_q) + b.GetU(U_coeff));
-            });
+  std::sort(
+      edges.begin(), edges.end(),
+      [&fpu, &U_coeff](EdgeAndNode a, EdgeAndNode b) {
+        return std::forward_as_tuple(a.GetN(), a.GetQ(fpu) + a.GetU(U_coeff)) <
+               std::forward_as_tuple(b.GetN(), b.GetQ(fpu) + b.GetU(U_coeff));
+      });
 
   std::vector<std::string> infos;
   for (const auto& edge : edges) {
@@ -230,14 +235,14 @@ std::vector<std::string> Search::GetVerboseStats(Node* node,
     oss << "(P: " << std::setw(5) << std::setprecision(2) << edge.GetP() * 100
         << "%) ";
 
-    oss << "(Q: " << std::setw(8) << std::setprecision(5) << edge.GetQ(parent_q)
+    oss << "(Q: " << std::setw(8) << std::setprecision(5) << edge.GetQ(fpu)
         << ") ";
 
     oss << "(U: " << std::setw(6) << std::setprecision(5) << edge.GetU(U_coeff)
         << ") ";
 
     oss << "(Q+U: " << std::setw(8) << std::setprecision(5)
-        << edge.GetQ(parent_q) + edge.GetU(U_coeff) << ") ";
+        << edge.GetQ(fpu) + edge.GetU(U_coeff) << ") ";
 
     oss << "(V: ";
     optional<float> v;
@@ -456,8 +461,11 @@ void Search::EnsureBestMoveKnown() REQUIRES(nodes_mutex_)
   if (!root_node_->HasChildren()) return;
 
   float temperature = params_.GetTemperature();
-  if (temperature && params_.GetTempDecayMoves()) {
-    int moves = played_history_.Last().GetGamePly() / 2;
+  const int cutoff_move = params_.GetTemperatureCutoffMove();
+  const int moves = played_history_.Last().GetGamePly() / 2;
+  if (cutoff_move && (moves + 1) >= cutoff_move) {
+    temperature = params_.GetTemperatureEndgame();
+  } else if (temperature && params_.GetTempDecayMoves()) {
     if (moves >= params_.GetTempDecayMoves()) {
       temperature = 0.0;
     } else {
@@ -525,6 +533,8 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
   float sum = 0.0;
   float max_n = 0.0;
   float offset = params_.GetTemperatureVisitOffset();
+  float max_eval = -1.0f;
+  const float fpu = GetFpu(params_, parent, parent == root_node_);
 
   for (auto edge : parent->Edges()) {
     if (parent == root_node_ && !root_limit.empty() &&
@@ -532,20 +542,23 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
             root_limit.end()) {
       continue;
     }
-    if (edge.GetN() + offset > max_n) {
-      max_n = edge.GetN() + offset;
-    }
+    if (edge.GetN() + offset > max_n) max_n = edge.GetN() + offset;
+    if (edge.GetQ(fpu) > max_eval) max_eval = edge.GetQ(fpu);
   }
 
   // No move had enough visits for temperature, so use default child criteria
   if (max_n <= 0.0f) return GetBestChildNoTemperature(parent);
 
+  // TODO(crem) Simplify this code when samplers.h is merged.
+  const float min_eval =
+      max_eval - params_.GetTemperatureWinpctCutoff() / 50.0f;
   for (auto edge : parent->Edges()) {
     if (parent == root_node_ && !root_limit.empty() &&
         std::find(root_limit.begin(), root_limit.end(), edge.GetMove()) ==
             root_limit.end()) {
       continue;
     }
+    if (edge.GetQ(fpu) < min_eval) continue;
     sum += std::pow(
         std::max(0.0f, (static_cast<float>(edge.GetN()) + offset) / max_n),
         1 / temperature);
@@ -564,6 +577,7 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
             root_limit.end()) {
       continue;
     }
+    if (edge.GetQ(fpu) < min_eval) continue;
     if (idx-- == 0) return edge;
   }
   assert(false);
@@ -844,11 +858,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     float best = std::numeric_limits<float>::lowest();
     float second_best = std::numeric_limits<float>::lowest();
     int possible_moves = 0;
-    float parent_q =
-        ((is_root_node && params_.GetNoise()) || !params_.GetFpuReduction())
-            ? -node->GetQ()
-            : -node->GetQ() - params_.GetFpuReduction() *
-                                  std::sqrt(node->GetVisitedPolicy());
+    const float fpu = GetFpu(params_, node, is_root_node);
     for (auto child : node->Edges()) {
       if (is_root_node) {
         // If there's no chance to catch up to the current best node with
@@ -868,7 +878,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         }
         ++possible_moves;
       }
-      float Q = child.GetQ(parent_q);
+      float Q = child.GetQ(fpu);
       const float score = child.GetU(puct_mult) + Q;
       if (score > best) {
         second_best = best;
@@ -882,9 +892,9 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     }
 
     if (second_best_edge) {
-      collision_limit = std::min(
-          collision_limit,
-          best_edge.GetVisitsToReachU(second_best, puct_mult, parent_q));
+      collision_limit =
+          std::min(collision_limit,
+                   best_edge.GetVisitsToReachU(second_best, puct_mult, fpu));
       assert(collision_limit >= 1);
       second_best_edge.Reset();
     }
@@ -1041,12 +1051,11 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget) {
   std::vector<ScoredEdge> scores;
   const float cpuct = ComputeCpuct(params_, node->GetN());
   float puct_mult = cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
-  // FPU reduction is not taken into account.
-  const float parent_q = -node->GetQ();
+  const float fpu = GetFpu(params_, node, node == search_->root_node_);
   for (auto edge : node->Edges()) {
     if (edge.GetP() == 0.0f) continue;
     // Flip the sign of a score to be able to easily sort.
-    scores.emplace_back(-edge.GetU(puct_mult) - edge.GetQ(parent_q), edge);
+    scores.emplace_back(-edge.GetU(puct_mult) - edge.GetQ(fpu), edge);
   }
 
   size_t first_unsorted_index = 0;
@@ -1076,7 +1085,7 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget) {
     if (i != scores.size() - 1) {
       // Sign of the score was flipped for sorting, so flip it back.
       const float next_score = -scores[i + 1].first;
-      const float q = edge.GetQ(-parent_q);
+      const float q = edge.GetQ(-fpu);
       if (next_score > q) {
         budget_to_spend =
             std::min(budget, int(edge.GetP() * puct_mult / (next_score - q) -

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -188,8 +188,11 @@ std::vector<std::string> Search::GetVerboseStats(Node* node,
   const float parent_q =
       -node->GetQ() -
       params_.GetFpuReduction() * std::sqrt(node->GetVisitedPolicy());
+  const float cpuct = std::log((1 + node->GetN() + params_.GetCpuctBase()) /
+                               params_.GetCpuctBase()) +
+                      params_.GetCpuct();
   const float U_coeff =
-      params_.GetCpuct() * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
+      cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
 
   std::vector<EdgeAndNode> edges;
   for (const auto& edge : node->Edges()) edges.push_back(edge);
@@ -826,8 +829,11 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
 
     // If we fall through, then n_in_flight_ has been incremented but this
     // playout remains incomplete; we must go deeper.
+    const float cpuct = std::log((1 + node->GetN() + params_.GetCpuctBase()) /
+                                 params_.GetCpuctBase()) +
+                        params_.GetCpuct();
     float puct_mult =
-        params_.GetCpuct() * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
+        cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
     float best = std::numeric_limits<float>::lowest();
     float second_best = std::numeric_limits<float>::lowest();
     int possible_moves = 0;
@@ -1026,8 +1032,11 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget) {
   // Populate all subnodes and their scores.
   typedef std::pair<float, EdgeAndNode> ScoredEdge;
   std::vector<ScoredEdge> scores;
-  float puct_mult =
-      params_.GetCpuct() * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
+  const float cpuct = std::log((1 + node->GetN() + params_.GetCpuctBase()) /
+                               params_.GetCpuctBase()) +
+                      params_.GetCpuct();
+
+  float puct_mult = cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
   // FPU reduction is not taken into account.
   const float parent_q = -node->GetQ();
   for (auto edge : node->Edges()) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -183,14 +183,23 @@ int64_t Search::GetTimeToDeadline() const {
       .count();
 }
 
+namespace {
+
+inline float ComputeCpuct(const SearchParams& params, uint32_t N) {
+  const float init = params.GetCpuct();
+  const float k = params.GetCpuctFactor();
+  const float base = params.GetCpuctBase();
+  return init + (k ? k * std::log((N + base) / base) : 0.0f);
+}
+
+}  // namespace
+
 std::vector<std::string> Search::GetVerboseStats(Node* node,
                                                  bool is_black_to_move) const {
   const float parent_q =
       -node->GetQ() -
       params_.GetFpuReduction() * std::sqrt(node->GetVisitedPolicy());
-  const float cpuct = std::log((1 + node->GetN() + params_.GetCpuctBase()) /
-                               params_.GetCpuctBase()) +
-                      params_.GetCpuct();
+  const float cpuct = ComputeCpuct(params_, node->GetN());
   const float U_coeff =
       cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
 
@@ -829,9 +838,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
 
     // If we fall through, then n_in_flight_ has been incremented but this
     // playout remains incomplete; we must go deeper.
-    const float cpuct = std::log((1 + node->GetN() + params_.GetCpuctBase()) /
-                                 params_.GetCpuctBase()) +
-                        params_.GetCpuct();
+    const float cpuct = ComputeCpuct(params_, node->GetN());
     float puct_mult =
         cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
     float best = std::numeric_limits<float>::lowest();
@@ -1032,10 +1039,7 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget) {
   // Populate all subnodes and their scores.
   typedef std::pair<float, EdgeAndNode> ScoredEdge;
   std::vector<ScoredEdge> scores;
-  const float cpuct = std::log((1 + node->GetN() + params_.GetCpuctBase()) /
-                               params_.GetCpuctBase()) +
-                      params_.GetCpuct();
-
+  const float cpuct = ComputeCpuct(params_, node->GetN());
   float puct_mult = cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
   // FPU reduction is not taken into account.
   const float parent_q = -node->GetQ();

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -161,6 +161,7 @@ void Search::MaybeOutputInfo() {
        last_outputted_uci_info_.time + kUciInfoMinimumFrequencyMs <
            GetTimeSinceStart())) {
     SendUciInfo();
+    if (params_.GetFrequentVerboseStats()) SendMovesStats();
     if (stop_.load(std::memory_order_acquire) && !ok_to_respond_bestmove_) {
       ThinkingInfo info;
       info.comment =

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -198,9 +198,11 @@ class SearchWorker {
   // Runs iterations while needed.
   void RunBlocking() {
     LOGFILE << "Started search thread.";
-    while (search_->IsSearchActive()) {
+    // A very early stop may arrive before this point, so the test is at the end
+    // to ensure at least one iteration runs before exiting.
+    do {
       ExecuteOneIteration();
-    }
+    } while (search_->IsSearchActive());
   }
 
   // Does one full iteration of MCTS search:

--- a/src/neural/cuda/fp16_kernels.cu
+++ b/src/neural/cuda/fp16_kernels.cu
@@ -35,7 +35,145 @@ namespace cudnn_backend {
 //          fp16-specific kernels used by certain layers                   //
 /////////////////////////////////////////////////////////////////////////////
 
-// Nothing here yet!
+
+
+// SE layer implementation using single fused kernel.
+
+// N blocks.
+// C threads per block.
+// 'HWC' input data processed by thread block.
+// Each thread processes 8x8 elements.
+// K is the no. of outputs of first fully connected layer (same as no. of inputs
+// for second fully connected layer). 
+// The kernel assumes K <= C.
+
+#define readw1(row, col) (w1[(row)*K + (col)])
+#define readw2(row, col) (w2[(row)*2 * C + (col)])
+
+template <int C, int K>
+__global__ void SE_Layer_NHWC(half* output, const half* skip, const half* input,
+                              const half* w1, const half* b1, const half* w2,
+                              const half* b2, const half *bPrev) {
+  const int elementsPerThread = 64;  // 8x8 board
+
+  int n = blockIdx.x;
+  int c = threadIdx.x;
+
+  __shared__ half sharedData[C];
+
+  half2 localData[elementsPerThread];
+
+  half S = 0;
+
+  half bias = 0;
+  if (bPrev) bias = bPrev[c];
+
+  // 1. Global avg (1 avg per thread).
+  #pragma unroll
+  for (int i = 0; i < elementsPerThread; i++) {
+    int localIndex = i * C + c;
+    int inputIndex = n * C * elementsPerThread + localIndex;
+    localData[i].x = input[inputIndex] + bias;
+    localData[i].y = skip[inputIndex];
+    S += localData[i].x;
+  }
+
+  half avg = S / (half)elementsPerThread;
+  sharedData[c] = avg;
+
+  __syncthreads();
+
+  // 2. First fully connected layer.
+  if (c < K) {
+    S = 0;
+
+    #pragma unroll
+    for (int i = 0; i < C; i++) {
+      S += sharedData[i] * readw1(i, c);
+    }
+
+    S += b1[c];
+
+    // relu
+    if (S < (half)0) S = 0;
+
+    sharedData[c] = S;
+  }
+  __syncthreads();
+
+  // 3. Second fully connected layer.
+  S = 0;
+  half B = 0;
+  #pragma unroll
+  for (int i = 0; i < K; i++) {
+    half val = sharedData[i];
+    S += val * readw2(i, c);
+    B += val * readw2(i, c + C);
+  }
+  S += b2[c];
+  B += b2[c + C];
+
+  // Sigmoid (only on the scale part).
+  S = (half)(1.0f / (1.0f + exp(-(float)(S))));
+
+  // 4. Scale, and add skip connection, perform relu, and write to output.
+  #pragma unroll
+  for (int i = 0; i < elementsPerThread; i++) {
+    int localIndex = i * C + c;
+    int inputIndex = n * C * elementsPerThread + localIndex;
+    half val = localData[i].y + localData[i].x * S + B;
+
+    // Relu activation function.
+    if (val < (half)0) val = 0;
+
+    output[inputIndex] = val;
+  }
+}
+
+void Se_Fp16_NHWC(int N, int C, int numFc1Out, half* output, const half* skip,
+                  const half* input, const half* w1, const half* b1,
+                  const half* w2, const half* b2, const half* bPrev) {
+  // TODO: Think of more elegant way to avoid this hardcoding :-/
+  if (numFc1Out == 32) {
+    if (C == 64) {
+      SE_Layer_NHWC<64, 32>
+          <<<N, C>>>(output, skip, input, w1, b1, w2, b2, bPrev);
+    } else if (C == 128) {
+      SE_Layer_NHWC<128, 32>
+          <<<N, C>>>(output, skip, input, w1, b1, w2, b2, bPrev);
+    } else if (C == 192) {
+      SE_Layer_NHWC<192, 32>
+          <<<N, C>>>(output, skip, input, w1, b1, w2, b2, bPrev);
+    } else if (C == 256) {
+      SE_Layer_NHWC<256, 32>
+          <<<N, C>>>(output, skip, input, w1, b1, w2, b2, bPrev);
+    } else {
+      // TODO: support other channel counts.
+      throw Exception("channel count unsupported by SE layer");
+    }
+  } else if (numFc1Out == 64) {
+    if (C == 64) {
+      SE_Layer_NHWC<64, 64>
+          <<<N, C>>>(output, skip, input, w1, b1, w2, b2, bPrev);
+    } else if (C == 128) {
+      SE_Layer_NHWC<128, 64>
+          <<<N, C>>>(output, skip, input, w1, b1, w2, b2, bPrev);
+    } else if (C == 192) {
+      SE_Layer_NHWC<192, 64>
+          <<<N, C>>>(output, skip, input, w1, b1, w2, b2, bPrev);
+    } else if (C == 256) {
+      SE_Layer_NHWC<256, 64>
+          <<<N, C>>>(output, skip, input, w1, b1, w2, b2, bPrev);
+    } else {
+      // TODO: support other channel counts.
+      throw Exception("channel count unsupported by SE layer");
+    }
+  } else {
+    // TODO: support other sizes.
+    throw Exception("numOutputs unsupported by SE layer");
+  }
+  ReportCUDAErrors(cudaGetLastError());
+}
 
 }   // namespace cudnn_backend
 }   // namespace lczero

--- a/src/neural/cuda/kernels.h
+++ b/src/neural/cuda/kernels.h
@@ -29,37 +29,52 @@ namespace lczero {
 namespace cudnn_backend {
 
 // Adds two vectors (possibly of different sizes), also do optional
-// activation (relu, tanh or sigmoid)
+// activation (relu, tanh or sigmoid).
 template <typename T>
 void addVectors(T* c, T* a, T* b, int size, int asize, int bsize, bool relu,
                 bool use_tanh, bool use_sigmoid);
 
-// add bias to convolution's output
+// Add bias to convolution's output.
 template <typename T>
 void addBias_NCHW(T* c, T* a, T* b, int N, int C, int H, int W);
 
-// Conversion from: fp32 -> fp16 datatype, and NCHW -> NHWC layout
-// cudnn kernels work best with NCHW layout for fp32, and with NHWC for fp16
+// Conversion from: fp32 -> fp16 datatype, and NCHW -> NHWC layout.
+// Cudnn kernels work best with NCHW layout for fp32, and with NHWC for fp16.
 void fp32NCHWtofp16NHWC(half* output_tensor, float* input_tensor, int Nin,
                         int Cin, int Nout, int Cout, int H, int W);
 
-// plain data-type conversion (no layout conversion)
+// Plain data-type conversion (no layout conversion).
 template <typename DstType, typename SrcType>
 void copyTypeConverted(DstType* op, SrcType* ip, int N);
 
-// perform batch normilization
+// Perform batch normilization.
 template <typename T>
 void batchNorm(T* output, const T* input, const T* skipInput, int N,
                int C, int H, int W, float* means, float* var_multipliers,
                bool relu);
 
-// unpack planes (input to network)
+// Unpack planes (input to network).
 void expandPlanes_Fp32_NCHW(float* output, const uint64_t* masks,
                             const float* values, int n);
 
 
 void expandPlanes_Fp16_NHWC(half* output, const uint64_t* masks,
                             const float* values, int n);
+
+// Perform global avg pool.
+template <typename T>
+void globalAvgPool(int N, int C, T* output, const T* input,
+                   const T* prevLayerBias);
+
+// Perform global scale.
+template <typename T>
+void globalScale(int N, int C, T* output, const T* input, const T* scaleBias,
+                 const T* prevLayerBias);
+
+// Perform Squeeze-and-Excitation (SE).
+void Se_Fp16_NHWC(int N, int C, int numFc1Out, half* output, const half* skip,
+                  const half* input, const half* w1, const half* b1,
+                  const half* w2, const half* b2, const half* bPrev);
 
 }  // namespace cudnn_backend
 }  // namespace lczero

--- a/src/neural/cuda/layers.cc
+++ b/src/neural/cuda/layers.cc
@@ -24,14 +24,19 @@
   terms of the respective license agreement, the licensors of this
   Program grant you additional permission to convey the resulting work.
 */
+#include <cassert>
+#include <cstring>
+#include <vector>
 #include "cuda_common.h"
 #include "kernels.h"
 #include "layers.h"
-#include <cassert>
-#include <cstring>
-
 namespace lczero {
 namespace cudnn_backend {
+
+// Use Single kernel for entire SE operation.
+// Right now supported only for fp16 and it's quite a bit faster
+// than using multiple passes. The flag can be set to false for debugging.
+static constexpr bool kUseFusedSELayer = true;
 
 template <typename DataType>
 BaseLayer<DataType>::BaseLayer(int c, int h, int w, BaseLayer* ip)
@@ -253,14 +258,199 @@ void BNLayer<float>::Eval(int N, float* output, const float* input,
                           const float* input2, void* /*scratch*/,
                           size_t /*scratch_size*/, cudnnHandle_t /*cudnn*/,
                           cublasHandle_t /*cublas*/) {
-  batchNorm(output, input, input2, N, C, H, W, means_, variances_,
-                   use_relu_);
+  batchNorm(output, input, input2, N, C, H, W, means_, variances_, use_relu_);
 }
 
 template <typename DataType>
 BNLayer<DataType>::~BNLayer() {
   ReportCUDAErrors(cudaFree(means_));
   ReportCUDAErrors(cudaFree(variances_));
+}
+
+template <typename DataType>
+SELayer<DataType>::SELayer(BaseLayer<DataType>* ip, int fc1Outputs,
+                           bool addPrevLayerBias)
+    : BaseLayer<DataType>(ip->GetC(), ip->GetH(), ip->GetW(), ip),
+      numFc1Out_(fc1Outputs),
+      addPrevLayerBias_(addPrevLayerBias) {
+  ReportCUDAErrors(cudaMalloc(&w1_, C * numFc1Out_ * sizeof(DataType)));
+  ReportCUDAErrors(cudaMalloc(&w2_, 2 * C * numFc1Out_ * sizeof(DataType)));
+
+  ReportCUDAErrors(cudaMalloc(&b1_, numFc1Out_ * sizeof(DataType)));
+  ReportCUDAErrors(cudaMalloc(&b2_, 2 * C * sizeof(DataType)));
+
+  ReportCUDAErrors(cudaMalloc(&bPrev_, C * sizeof(DataType)));
+}
+
+template <typename DataType>
+SELayer<DataType>::~SELayer() {
+  ReportCUDAErrors(cudaFree(w1_));
+  ReportCUDAErrors(cudaFree(w2_));
+  ReportCUDAErrors(cudaFree(b1_));
+  ReportCUDAErrors(cudaFree(b2_));
+  ReportCUDAErrors(cudaFree(bPrev_));
+}
+
+template <>
+void SELayer<float>::LoadWeights(float* w1, float* b1, float* w2, float* b2,
+                                 float* prevLayerBias, void* /*scratch*/) {
+  size_t num_weights1 = C * numFc1Out_;
+  size_t weight_size1 = sizeof(float) * num_weights1;
+
+  size_t num_weights2 = 2 * num_weights1;
+  size_t weight_size2 = 2 * weight_size1;
+
+  // Weight for the first FC layer.
+  ReportCUDAErrors(
+      cudaMemcpyAsync(w1_, w1, weight_size1, cudaMemcpyHostToDevice));
+
+  // Weight for the second FC layer.
+  ReportCUDAErrors(
+      cudaMemcpyAsync(w2_, w2, weight_size2, cudaMemcpyHostToDevice));
+
+  // Bias for the first FC layer.
+  ReportCUDAErrors(cudaMemcpyAsync(b1_, b1, numFc1Out_ * sizeof(float),
+                                   cudaMemcpyHostToDevice));
+
+  // Bias for the second FC layer.
+  ReportCUDAErrors(
+      cudaMemcpyAsync(b2_, b2, 2 * C * sizeof(float), cudaMemcpyHostToDevice));
+
+  // Bias for previous layer (Convolution).
+  if (prevLayerBias) {
+    ReportCUDAErrors(cudaMemcpyAsync(bPrev_, prevLayerBias, C * sizeof(float),
+                                     cudaMemcpyHostToDevice));
+  }
+}
+
+void cpuTranspose(float* op, float* ip, int rows, int cols) {
+  for (int i = 0; i < rows; i++)
+    for (int j = 0; j < cols; j++) op[j * rows + i] = ip[i * cols + j];
+}
+
+template <>
+void SELayer<half>::LoadWeights(float* w1, float* b1, float* w2, float* b2,
+                                float* prevLayerBias, void* scratch) {
+  size_t num_weights1 = C * numFc1Out_;
+  size_t weight_size1 = sizeof(float) * num_weights1;
+
+  size_t num_weights2 = 2 * num_weights1;
+  size_t weight_size2 = 2 * weight_size1;
+
+  // Transpose the weight matrices for the fused path.
+  std::vector<float> temp(weight_size2);
+
+  // Weight for the first FC layer.
+  if (kUseFusedSELayer) {
+    cpuTranspose(temp.data(), w1, numFc1Out_, C);
+    ReportCUDAErrors(cudaMemcpyAsync(scratch, temp.data(), weight_size1,
+                                     cudaMemcpyHostToDevice));
+  } else {
+    ReportCUDAErrors(
+        cudaMemcpyAsync(scratch, w1, weight_size1, cudaMemcpyHostToDevice));
+  }
+  copyTypeConverted((half*)w1_, (float*)scratch, num_weights1);
+
+  // Weight for the second FC layer.
+  if (kUseFusedSELayer) {
+    cpuTranspose(temp.data(), w2, 2 * C, numFc1Out_);
+    ReportCUDAErrors(cudaMemcpyAsync(scratch, temp.data(), weight_size2,
+                                     cudaMemcpyHostToDevice));
+  } else {
+    ReportCUDAErrors(
+        cudaMemcpyAsync(scratch, w2, weight_size2, cudaMemcpyHostToDevice));
+  }
+  copyTypeConverted((half*)w2_, (float*)scratch, num_weights2);
+
+  // Bias for the first FC layer.
+  ReportCUDAErrors(cudaMemcpyAsync(scratch, b1, numFc1Out_ * sizeof(float),
+                                   cudaMemcpyHostToDevice));
+  copyTypeConverted((half*)b1_, (float*)scratch, numFc1Out_);
+
+  // Bias for the second FC layer.
+  ReportCUDAErrors(cudaMemcpyAsync(scratch, b2, 2 * C * sizeof(float),
+                                   cudaMemcpyHostToDevice));
+  copyTypeConverted((half*)b2_, (float*)scratch, 2 * C);
+
+  // Bias for previous layer (Convolution).
+  if (prevLayerBias) {
+    ReportCUDAErrors(cudaMemcpyAsync(scratch, prevLayerBias, C * sizeof(float),
+                                     cudaMemcpyHostToDevice));
+    copyTypeConverted((half*)bPrev_, (float*)scratch, C);
+  }
+}
+
+template <>
+void SELayer<float>::Eval(int N, float* output, const float* input,
+                          const float* /*input2*/, void* scratch,
+                          size_t scratch_size, cudnnHandle_t /*cudnn*/,
+                          cublasHandle_t cublas) {
+  assert(output == input2);
+  // Ping-pong between 'op1' and 'op2' (parts of scratch memory).
+  float* op1 = (float*)scratch;
+  float* op2 = (float*)scratch + scratch_size / sizeof(float) / 2;
+
+  // 1. Global avg pooling (also adds previous layer bias before computing
+  // averages).
+  globalAvgPool(N, C, op2, input, bPrev_);
+
+  // 2. First fully connected layer.
+  float alpha = 1.0f, beta = 0.0f;
+  ReportCUBLASErrors(cublasSgemm(cublas, CUBLAS_OP_T, CUBLAS_OP_N, numFc1Out_,
+                                 N, C, &alpha, w1_, C, op2, C, &beta, op1,
+                                 numFc1Out_));
+  addVectors(op1, b1_, op1, numFc1Out_ * N, numFc1Out_, numFc1Out_ * N, true,
+             false, false);
+
+  // 3. Second fully connected layer.
+  ReportCUBLASErrors(cublasSgemm(cublas, CUBLAS_OP_T, CUBLAS_OP_N, 2 * C, N,
+                                 numFc1Out_, &alpha, w2_, numFc1Out_, op1,
+                                 numFc1Out_, &beta, op2, 2 * C));
+  addVectors(op2, b2_, op2, 2 * C * N, 2 * C, 2 * C * N, false, false, false);
+
+  // 4. (Optional prev layer bias add), Global scale, residual add, relu and
+  // bias.
+  globalScale(N, C, output, input, op2, bPrev_);
+}
+
+template <>
+void SELayer<half>::Eval(int N, half* output, const half* input,
+                         const half* input2, void* scratch, size_t scratch_size,
+                         cudnnHandle_t /*cudnn*/, cublasHandle_t cublas) {
+  if (kUseFusedSELayer) {
+    Se_Fp16_NHWC(N, C, numFc1Out_, output, input2, input, w1_, b1_, w2_, b2_,
+                 bPrev_);
+  } else {
+    assert(output == input2);
+    // Ping-pong between 'op1' and 'op2' (parts of scratch memory).
+    half* op1 = (half*)scratch;
+    half* op2 = (half*)scratch + scratch_size / sizeof(half) / 2;
+
+    // 1. Global avg pooling (also adds previous layer bias before computing
+    // averages).
+    globalAvgPool(N, C, op2, input, bPrev_);
+
+    // 2. First fully connected layer.
+    __half_raw one_h{0x3C00};
+    __half_raw zero_h{0};
+    half alpha = one_h;
+    half beta = zero_h;
+    ReportCUBLASErrors(cublasHgemm(cublas, CUBLAS_OP_T, CUBLAS_OP_N, numFc1Out_,
+                                   N, C, &alpha, w1_, C, op2, C, &beta, op1,
+                                   numFc1Out_));
+    addVectors(op1, b1_, op1, numFc1Out_ * N, numFc1Out_, numFc1Out_ * N, true,
+               false, false);
+
+    // 3. Second fully connected layer.
+    ReportCUBLASErrors(cublasHgemm(cublas, CUBLAS_OP_T, CUBLAS_OP_N, 2 * C, N,
+                                   numFc1Out_, &alpha, w2_, numFc1Out_, op1,
+                                   numFc1Out_, &beta, op2, 2 * C));
+    addVectors(op2, b2_, op2, 2 * C * N, 2 * C, 2 * C * N, false, false, false);
+
+    // 4. (Optional prev layer bias add), Global scale, residual add, relu and
+    // bias.
+    globalScale(N, C, output, input, op2, bPrev_);
+  }
 }
 
 template <typename DataType>
@@ -333,8 +523,8 @@ void FCLayer<half>::Eval(int N, half* output_tensor, const half* input_tensor,
   int num_inputs = input_->GetC() * input_->GetH() * input_->GetW();
 
   // half alpha = float2half_rn(1.0f), beta = float2half_rn(0.0f);
-  __half_raw one_h {0x3C00};
-  __half_raw zero_h {0};
+  __half_raw one_h{0x3C00};
+  __half_raw zero_h{0};
   half alpha = one_h;
   half beta = zero_h;
   ReportCUBLASErrors(cublasHgemm(cublas, CUBLAS_OP_T, CUBLAS_OP_N, num_outputs,
@@ -376,8 +566,7 @@ FCLayer<DataType>::~FCLayer() {
   ReportCUDAErrors(cudaFree(biases_));
 }
 
-
-// Template instantiation
+// Template instantiation.
 template class ConvLayer<half>;
 template class ConvLayer<float>;
 
@@ -390,7 +579,10 @@ template class BNLayer<float>;
 template class SoftMaxLayer<half>;
 template class SoftMaxLayer<float>;
 
-// misc error handling stuff
+template class SELayer<half>;
+template class SELayer<float>;
+
+// Misc error handling stuff.
 void CudnnError(cudnnStatus_t status, const char* file, const int& line) {
   if (status != CUDNN_STATUS_SUCCESS) {
     char message[128];

--- a/src/neural/cuda/layers.cc
+++ b/src/neural/cuda/layers.cc
@@ -333,12 +333,10 @@ void FCLayer<half>::Eval(int N, half* output_tensor, const half* input_tensor,
   int num_inputs = input_->GetC() * input_->GetH() * input_->GetW();
 
   // half alpha = float2half_rn(1.0f), beta = float2half_rn(0.0f);
-  std::uint16_t one_h = 0x3c00;
-  std::uint16_t zero_h = 0;
-  half alpha;
-  half beta;
-  memcpy(&alpha, &one_h, sizeof(half));
-  memcpy(&beta, &zero_h, sizeof(half));
+  __half_raw one_h {0x3C00};
+  __half_raw zero_h {0};
+  half alpha = one_h;
+  half beta = zero_h;
   ReportCUBLASErrors(cublasHgemm(cublas, CUBLAS_OP_T, CUBLAS_OP_N, num_outputs,
                                  N, num_inputs, &alpha, weights_, num_inputs,
                                  input_tensor, num_inputs, &beta, output_tensor,

--- a/src/utils/bititer.h
+++ b/src/utils/bititer.h
@@ -40,7 +40,7 @@ inline unsigned long GetLowestBit(std::uint64_t value) {
     return result;
 #elif defined(_MSC_VER)
     unsigned long result;
-    if (value_ & 0xFFFFFFFF) {
+    if (value & 0xFFFFFFFF) {
       _BitScanForward(&result, value);
     } else {
       _BitScanForward(&result, value >> 32);

--- a/src/utils/optional.h
+++ b/src/utils/optional.h
@@ -43,6 +43,7 @@ class optional {
     return *this;
   }
   void reset() { has_value_ = false; }
+  T value_or(const T& def) const { return has_value_ ? value_ : def; }
 
  private:
   T value_;


### PR DESCRIPTION
A fresh attempt at a flag to increase the frequency of verbose move stats output. If --verbose-move-stats is set then --frequent-verbose-move-stats will output N/P/Q/U values as an info string every time an info string is sent to the UCI interface. This may be useful in debugging unusual MCTS search behaviour eg in the position ``2r1r3/2pR3R/1p3kpp/p3p3/1nP1PbP1/BP3B2/5P2/5K2 b - - 3 35`` which is currently topical