### PR TITLE
Rework Cpuct related params.

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -148,7 +148,8 @@ void EngineController::PopulateOptions(OptionsParser* options) {
 
   defaults->Set<int>(SearchParams::kMiniBatchSizeId.GetId(), 256);
   defaults->Set<float>(SearchParams::kFpuReductionId.GetId(), 1.2f);
-  defaults->Set<float>(SearchParams::kCpuctId.GetId(), 3.4f);
+  defaults->Set<float>(SearchParams::kCpuctId.GetId(), 3.0f);
+  defaults->Set<float>(SearchParams::kCpuctFactorId.GetId(), 2.0f);
   defaults->Set<float>(SearchParams::kPolicySoftmaxTempId.GetId(), 2.2f);
   defaults->Set<int>(SearchParams::kMaxCollisionVisitsId.GetId(), 9999);
   defaults->Set<int>(SearchParams::kMaxCollisionEventsId.GetId(), 32);

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -58,6 +58,8 @@ const OptionId SearchParams::kCpuctBaseId{
     "cpuct-base", "CPuctBase",
     "cpuct_base constant from \"UCT search\" algorithm. Lower value means "
     "higher growth of Cpuct as number of node visits grows."};
+const OptionId SearchParams::kCpuctFactorId{
+    "cpuct-factor", "CPuctFactor", "Multiplier for the cpuct growth formula."};
 const OptionId SearchParams::kTemperatureId{
     "temperature", "Temperature",
     "Tau value from softmax formula for the first move. If equal to 0, the "
@@ -140,8 +142,9 @@ void SearchParams::Populate(OptionsParser* options) {
   // tournament.cc
   options->Add<IntOption>(kMiniBatchSizeId, 1, 1024) = 1;
   options->Add<IntOption>(kMaxPrefetchBatchId, 0, 1024) = 32;
-  options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 1.25f;
-  options->Add<FloatOption>(kCpuctBaseId, 0.0f, 100000000000.0f) = 19652.0f;
+  options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 1.2f;
+  options->Add<FloatOption>(kCpuctBaseId, 1.0f, 1000000000.0f) = 19652.0f;
+  options->Add<FloatOption>(kCpuctFactorId, 0.0f, 1000.0f) = 0.0f;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 100) = 0;
   options->Add<FloatOption>(kTemperatureVisitOffsetId, -0.99999f, 1000.0f) =
@@ -166,6 +169,7 @@ SearchParams::SearchParams(const OptionsDict& options)
     : options_(options),
       kCpuct(options.Get<float>(kCpuctId.GetId())),
       kCpuctBase(options.Get<float>(kCpuctBaseId.GetId())),
+      kCpuctFactor(options.Get<float>(kCpuctFactorId.GetId())),
       kNoise(options.Get<bool>(kNoiseId.GetId())),
       kSmartPruningFactor(options.Get<float>(kSmartPruningFactorId.GetId())),
       kFpuReduction(options.Get<float>(kFpuReductionId.GetId())),

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -50,6 +50,7 @@ class SearchParams {
   }
   float GetCpuct() const { return kCpuct; }
   float GetCpuctBase() const { return kCpuctBase; }
+  float GetCpuctFactor() const { return kCpuctFactor; }
   float GetTemperature() const {
     return options_.Get<float>(kTemperatureId.GetId());
   }
@@ -81,6 +82,7 @@ class SearchParams {
   static const OptionId kMaxPrefetchBatchId;
   static const OptionId kCpuctId;
   static const OptionId kCpuctBaseId;
+  static const OptionId kCpuctFactorId;
   static const OptionId kTemperatureId;
   static const OptionId kTempDecayMovesId;
   static const OptionId kTemperatureVisitOffsetId;
@@ -107,6 +109,7 @@ class SearchParams {
   //            trivial search optimiations.
   const float kCpuct;
   const float kCpuctBase;
+  const float kCpuctFactor;
   const bool kNoise;
   const float kSmartPruningFactor;
   const float kFpuReduction;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -183,14 +183,23 @@ int64_t Search::GetTimeToDeadline() const {
       .count();
 }
 
+namespace {
+
+inline float ComputeCpuct(const SearchParams& params, uint32_t N) {
+  const float init = params.GetCpuct();
+  const float k = params.GetCpuctFactor();
+  const float base = params.GetCpuctBase();
+  return init + (k ? k * std::log((N + base) / base) : 0.0f);
+}
+
+}  // namespace
+
 std::vector<std::string> Search::GetVerboseStats(Node* node,
                                                  bool is_black_to_move) const {
   const float parent_q =
       -node->GetQ() -
       params_.GetFpuReduction() * std::sqrt(node->GetVisitedPolicy());
-  const float cpuct = std::log((1 + node->GetN() + params_.GetCpuctBase()) /
-                               params_.GetCpuctBase()) +
-                      params_.GetCpuct();
+  const float cpuct = ComputeCpuct(params_, node->GetN());
   const float U_coeff =
       cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
 
@@ -829,9 +838,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
 
     // If we fall through, then n_in_flight_ has been incremented but this
     // playout remains incomplete; we must go deeper.
-    const float cpuct = std::log((1 + node->GetN() + params_.GetCpuctBase()) /
-                                 params_.GetCpuctBase()) +
-                        params_.GetCpuct();
+    const float cpuct = ComputeCpuct(params_, node->GetN());
     float puct_mult =
         cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
     float best = std::numeric_limits<float>::lowest();
@@ -1032,10 +1039,7 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget) {
   // Populate all subnodes and their scores.
   typedef std::pair<float, EdgeAndNode> ScoredEdge;
   std::vector<ScoredEdge> scores;
-  const float cpuct = std::log((1 + node->GetN() + params_.GetCpuctBase()) /
-                               params_.GetCpuctBase()) +
-                      params_.GetCpuct();
-
+  const float cpuct = ComputeCpuct(params_, node->GetN());
   float puct_mult = cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
   // FPU reduction is not taken into account.
   const float parent_q = -node->GetQ();


### PR DESCRIPTION
Cpuct 3.4 -> 3.0 for play
Cpuct 1.25 -> back to 1.2 for training

Introduce CpuctFactor parameter (2 for play, 0 for training), because we have larger value space (-1..1) than alphazero (0..1)

Cut a few zeros in max CpuctBase value (went above what float could represent)
Minimal value for CpuctBase is now 1, not 0.