### PR TITLE
Let lc0 switch to another NN during the game. 

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -413,7 +413,7 @@ void EngineController::Go(const GoParams& params) {
   auto board = search_->PublicHistory().Last().GetBoard();
   if((board.ours() + board.theirs()).count() < 12){
     if(!second_nn_already_loaded_){
-      std::string net_path = "ender/ender128-80.pb.gz";
+      std::string net_path = "/home/ubuntu/ender/ender128-80.pb.gz";
       std::string backend = options_.Get<std::string>(NetworkFactory::kBackendId.GetId());
       std::string backend_options = options_.Get<std::string>(NetworkFactory::kBackendOptionsId.GetId());
       LOGFILE << "Will switch to second NN on backend " << backend << " with options " << backend_options;
@@ -424,7 +424,7 @@ void EngineController::Go(const GoParams& params) {
       // TODO smarter wait
       // If some thread still has some search ongoing, then lc0 will segfault
       // First try to solve this: wait 5 seconds, works but is clumpsy
-      std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+      std::this_thread::sleep_for(std::chrono::milliseconds(10000));
       // Second try: mimic NewGame(), doesn't work.
       // SharedLock lock(busy_mutex_);
       network_ = NetworkFactory::Get()->Create(backend, weights, network_options);

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -282,7 +282,7 @@ void EngineController::UpdateFromUciOptions() {
   }
 
   // Cache size.
- cache_.SetCapacity(options_.Get<int>(kNNCacheSizeId.GetId()));
+  cache_.SetCapacity(options_.Get<int>(kNNCacheSizeId.GetId()));
 }
 
 void EngineController::EnsureReady() {

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -110,7 +110,7 @@ float ComputeMoveWeight(int ply, float peak, float left_width,
   bool second_nn_already_loaded_ = false;
   int k_pieces_left = 32;
   std::string CPuct_for_primary_NN = "";
-  std::string FPU_for_primary_NN = "";
+  std::string FPUR_for_primary_NN = "";
   std::string PolicyTemperature_for_primary_NN = "";    
 
   // Purely informational vars, writing to them do not affect behaviour, they
@@ -168,13 +168,13 @@ void EngineController::PopulateOptions(OptionsParser* options) {
 
 void EngineController::SetSearchParamsforSecondNN(OptionsParser* options) {
   options->GetMutableOptions()->Set<float>(SearchParams::kCpuctId.GetId(), options->GetOptionsDict().Get<float>(NetworkFactory::kSecondWeightsCpuctId.GetId()));
-  options->GetMutableOptions()->Set<float>(SearchParams::kFpuValueId.GetId(), options->GetOptionsDict().Get<float>(NetworkFactory::kSecondWeightsFpuValueId.GetId()));
+  options->GetMutableOptions()->Set<float>(SearchParams::kFpuReductionId.GetId(), options->GetOptionsDict().Get<float>(NetworkFactory::kSecondWeightsFpuReductionId.GetId()));
   options->GetMutableOptions()->Set<float>(SearchParams::kPolicySoftmaxTempId.GetId(), options->GetOptionsDict().Get<float>(NetworkFactory::kSecondWeightsPolicySoftmaxTempId.GetId()));    
 }
 
 void EngineController::ResetSearchParamsforPrimaryNN(OptionsParser* options) {
   options->GetMutableOptions()->Set<float>(SearchParams::kCpuctId.GetId(), stof(CPuct_for_primary_NN));
-  options->GetMutableOptions()->Set<float>(SearchParams::kFpuValueId.GetId(), stof(FPU_for_primary_NN));
+  options->GetMutableOptions()->Set<float>(SearchParams::kFpuReductionId.GetId(), stof(FPUR_for_primary_NN));
   options->GetMutableOptions()->Set<float>(SearchParams::kPolicySoftmaxTempId.GetId(), stof(PolicyTemperature_for_primary_NN));
 }
   
@@ -511,9 +511,9 @@ void EngineLoop::CmdSetOption(const std::string& name, const std::string& value,
     CPuct_for_primary_NN = value;
     LOGFILE << "Storing CPuct for original NN: " << CPuct_for_primary_NN;
   }
-  if(name == "FpuValue"){
-    FPU_for_primary_NN = value;
-    LOGFILE << "Storing FpuValue for original NN: " << FPU_for_primary_NN;
+  if(name == "FpuReduction"){
+    FPUR_for_primary_NN = value;
+    LOGFILE << "Storing FpuReduction for original NN: " << FPUR_for_primary_NN;
   }
   if(name == "PolicyTemperature"){
     PolicyTemperature_for_primary_NN = value;

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -411,7 +411,7 @@ void EngineController::Go(const GoParams& params) {
   search_->StartThreads(options_.Get<int>(kThreadsOptionId.GetId()));
 
   auto board = search_->PublicHistory().Last().GetBoard();
-  if((board.ours() + board.theirs()).count() < 13){
+  if((board.ours() + board.theirs()).count() < 17){
     if(!second_nn_already_loaded_){
       std::string net_path = "ender/ender128-80.pb.gz";
       std::string backend = options_.Get<std::string>(NetworkFactory::kBackendId.GetId());

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -427,9 +427,9 @@ void EngineController::Stop() {
 }
 
 void EngineController::SwitchNN() {
-  if(!second_nn_already_loaded_ && 
+  if(!second_nn_already_loaded_ &&
    options_.Get<std::string>(NetworkFactory::kSecondWeightsId.GetId()) != "" &&
-   k_pieces_left == options_.Get<int>(NetworkFactory::kSecondWeightsSwitchAt.GetId())){
+   k_pieces_left <= options_.Get<int>(NetworkFactory::kSecondWeightsSwitchAt.GetId())){
     std::string net_path = options_.Get<std::string>(NetworkFactory::kSecondWeightsId.GetId());
     std::string backend = options_.Get<std::string>(NetworkFactory::kBackendId.GetId());
     std::string backend_options = options_.Get<std::string>(NetworkFactory::kBackendOptionsId.GetId());

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -411,7 +411,7 @@ void EngineController::Go(const GoParams& params) {
   search_->StartThreads(options_.Get<int>(kThreadsOptionId.GetId()));
 
   auto board = search_->PublicHistory().Last().GetBoard();
-  if((board.ours() + board.theirs()).count() < 17){
+  if((board.ours() + board.theirs()).count() < 12){
     if(!second_nn_already_loaded_){
       std::string net_path = "ender/ender128-80.pb.gz";
       std::string backend = options_.Get<std::string>(NetworkFactory::kBackendId.GetId());

--- a/src/engine.h
+++ b/src/engine.h
@@ -62,6 +62,8 @@ class EngineController {
 
   void PopulateOptions(OptionsParser* options);
 
+  void SwitchNN();
+
   // Blocks.
   void EnsureReady();
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -62,7 +62,10 @@ class EngineController {
 
   void PopulateOptions(OptionsParser* options);
 
-  void SwitchNN();
+  void SwitchToSecondaryNN();
+
+  void SetSearchParamsforSecondNN(OptionsParser* options);
+  void ResetSearchParamsforPrimaryNN(OptionsParser* options);    
 
   // Blocks.
   void EnsureReady();

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -165,6 +165,8 @@ void SearchParams::Populate(OptionsParser* options) {
   // Here the "safe defaults" are listed.
   // Many of them are overridden with optimized defaults in engine.cc and
   // tournament.cc
+  // For defaults on cpuct, fpur and policy softmax temp for the endgame,
+  // see neural/factory.cc
   options->Add<IntOption>(kMiniBatchSizeId, 1, 1024) = 1;
   options->Add<IntOption>(kMaxPrefetchBatchId, 0, 1024) = 32;
   options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 1.2f;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -609,7 +609,7 @@ bool Search::IsSearchActive() const {
 }
 
 void Search::WatchdogThread() {
-  LOGFILE << "Start a watchdog thread." << " Cpuct is now " << params_.GetCpuct() ;
+  LOGFILE << "Start a watchdog thread." << " Cpuct: " << params_.GetCpuct() << " FPUR: " << params_.GetFpuReduction() << " PolicySoftMaxTemp: " << params_.GetPolicySoftmaxTemp();
   while (true) {
     MaybeTriggerStop();
     MaybeOutputInfo();

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -609,7 +609,7 @@ bool Search::IsSearchActive() const {
 }
 
 void Search::WatchdogThread() {
-  LOGFILE << "Start a watchdog thread.";
+  LOGFILE << "Start a watchdog thread." << " Cpuct is now " << params_.GetCpuct() ;
   while (true) {
     MaybeTriggerStop();
     MaybeOutputInfo();

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -94,6 +94,8 @@ class Search {
   std::int64_t GetTotalPlayouts() const;
   // Returns the search parameters.
   const SearchParams& GetParams() const { return params_; }
+   // A public version of history, needed to get piece count in engine.cc
+  const PositionHistory& PublicHistory() { return played_history_; }
 
  private:
   // Computes the best move, maybe with temperature (according to the settings).

--- a/src/neural/factory.cc
+++ b/src/neural/factory.cc
@@ -94,9 +94,9 @@ void NetworkFactory::PopulateOptions(OptionsParser* options) {
       backends.empty() ? "<none>" : backends[0];
   options->Add<StringOption>(NetworkFactory::kBackendOptionsId);
   options->Add<StringOption>(NetworkFactory::kSecondWeightsId);
-  options->Add<IntOption>(NetworkFactory::kSecondWeightsSwitchAtId, 5, 16) = 16;
+  options->Add<IntOption>(NetworkFactory::kSecondWeightsSwitchAtId, 5, 16) = 12;
   options->Add<FloatOption>(kSecondWeightsCpuctId, 0.0f, 100.0f) = 3.5f;
-  options->Add<FloatOption>(kSecondWeightsFpuReductionId, -100.0f, 100.0f) = 1.20f;
+  options->Add<FloatOption>(kSecondWeightsFpuReductionId, -100.0f, 100.0f) = 1.02f;
   options->Add<FloatOption>(kSecondWeightsPolicySoftmaxTempId, 0.1f, 10.0f) = 1.7f;
 }
 

--- a/src/neural/factory.cc
+++ b/src/neural/factory.cc
@@ -61,11 +61,13 @@ const OptionId NetworkFactory::kSecondWeightsCpuctId{
     "more exploration/wider search, lower values promote more "
     "confidence/deeper search. "
     "This value is used for the Secondary NN."};
-const OptionId NetworkFactory::kSecondWeightsFpuValueId{
-    "SWfpu-value", "SWFpuValue",
-    "\"First Play Urgency\" value. When FPU strategy is \"absolute\", value of "
-    "unvisited node is assumed to be equal to this value, and does not depend "
-    "on parent eval. "
+const OptionId NetworkFactory::kSecondWeightsFpuReductionId{
+    "SWfpu-Reduction", "SWFpuReduction",
+      "First Play Urgency reduction (used when FPU strategy is 'reduction'). Normally "
+      "when a move has no visits, it's eval is assumed to be equal to parent's eval. "
+      "With non-zero FPU reduction, eval of unvisited move is decreased by that value, "
+      "discouraging visits of unvisited moves, and saving those visits for (hopefully) "
+      "more promising moves. "
     "This value is used for the Secondary NN."};      
 const OptionId NetworkFactory::kSecondWeightsPolicySoftmaxTempId{
     "SWpolicy-softmax-temp", "SWPolicyTemperature",
@@ -94,7 +96,7 @@ void NetworkFactory::PopulateOptions(OptionsParser* options) {
   options->Add<StringOption>(NetworkFactory::kSecondWeightsId);
   options->Add<IntOption>(NetworkFactory::kSecondWeightsSwitchAtId, 5, 16) = 16;
   options->Add<FloatOption>(kSecondWeightsCpuctId, 0.0f, 100.0f) = 3.5f;
-  options->Add<FloatOption>(kSecondWeightsFpuValueId, -1.0f, 1.0f) = 1.0f;
+  options->Add<FloatOption>(kSecondWeightsFpuReductionId, -100.0f, 100.0f) = 1.20f;
   options->Add<FloatOption>(kSecondWeightsPolicySoftmaxTempId, 0.1f, 10.0f) = 1.7f;
 }
 

--- a/src/neural/factory.cc
+++ b/src/neural/factory.cc
@@ -50,11 +50,28 @@ const OptionId NetworkFactory::kSecondWeightsId{
     "secondweights", "SecondWeightsFile",
     "Path from which to load network weights for the second NN.",
     's'};
-const OptionId NetworkFactory::kSecondWeightsSwitchAt{
+const OptionId NetworkFactory::kSecondWeightsSwitchAtId{
     "switchat", "SwitchAt",
     "Switch to the second NN when this number of pieces are left on the board. "
     "Switch will take place _after_ lc0 has made a move, when it is the "
     "opponents time to think."};
+const OptionId NetworkFactory::kSecondWeightsCpuctId{
+    "SWcpuct", "SWCPuct",
+    "cpuct_init constant from \"UCT search\" algorithm. Higher values promote "
+    "more exploration/wider search, lower values promote more "
+    "confidence/deeper search. "
+    "This value is used for the Secondary NN."};
+const OptionId NetworkFactory::kSecondWeightsFpuValueId{
+    "SWfpu-value", "SWFpuValue",
+    "\"First Play Urgency\" value. When FPU strategy is \"absolute\", value of "
+    "unvisited node is assumed to be equal to this value, and does not depend "
+    "on parent eval. "
+    "This value is used for the Secondary NN."};      
+const OptionId NetworkFactory::kSecondWeightsPolicySoftmaxTempId{
+    "SWpolicy-softmax-temp", "SWPolicyTemperature",
+    "Policy softmax temperature. Higher values make priors of move candidates "
+    "closer to each other, widening the search. "
+    "This value is used for the Secondary NN."};          
   
 const char* kAutoDiscover = "<autodiscover>";
 
@@ -75,7 +92,10 @@ void NetworkFactory::PopulateOptions(OptionsParser* options) {
       backends.empty() ? "<none>" : backends[0];
   options->Add<StringOption>(NetworkFactory::kBackendOptionsId);
   options->Add<StringOption>(NetworkFactory::kSecondWeightsId);
-  options->Add<IntOption>(NetworkFactory::kSecondWeightsSwitchAt, 5, 16) = 16;
+  options->Add<IntOption>(NetworkFactory::kSecondWeightsSwitchAtId, 5, 16) = 16;
+  options->Add<FloatOption>(kSecondWeightsCpuctId, 0.0f, 100.0f) = 3.5f;
+  options->Add<FloatOption>(kSecondWeightsFpuValueId, -1.0f, 1.0f) = 1.0f;
+  options->Add<FloatOption>(kSecondWeightsPolicySoftmaxTempId, 0.1f, 10.0f) = 1.7f;
 }
 
 void NetworkFactory::RegisterNetwork(const std::string& name,

--- a/src/neural/factory.cc
+++ b/src/neural/factory.cc
@@ -46,6 +46,16 @@ const OptionId NetworkFactory::kBackendOptionsId{
     "Parameters of neural network backend. "
     "Exact parameters differ per backend.",
     'o'};
+const OptionId NetworkFactory::kSecondWeightsId{
+    "secondweights", "SecondWeightsFile",
+    "Path from which to load network weights for the second NN.",
+    's'};
+const OptionId NetworkFactory::kSecondWeightsSwitchAt{
+    "switchat", "SwitchAt",
+    "Switch to the second NN when this number of pieces are left on the board. "
+    "Switch will take place _after_ lc0 has made a move, when it is the "
+    "opponents time to think."};
+  
 const char* kAutoDiscover = "<autodiscover>";
 
 NetworkFactory* NetworkFactory::Get() {
@@ -64,6 +74,8 @@ void NetworkFactory::PopulateOptions(OptionsParser* options) {
   options->Add<ChoiceOption>(NetworkFactory::kBackendId, backends) =
       backends.empty() ? "<none>" : backends[0];
   options->Add<StringOption>(NetworkFactory::kBackendOptionsId);
+  options->Add<StringOption>(NetworkFactory::kSecondWeightsId);
+  options->Add<IntOption>(NetworkFactory::kSecondWeightsSwitchAt, 5, 16) = 16;
 }
 
 void NetworkFactory::RegisterNetwork(const std::string& name,

--- a/src/neural/factory.h
+++ b/src/neural/factory.h
@@ -73,7 +73,10 @@ class NetworkFactory {
   static const OptionId kBackendId;
   static const OptionId kBackendOptionsId;
   static const OptionId kSecondWeightsId;
-  static const OptionId kSecondWeightsSwitchAt;  
+  static const OptionId kSecondWeightsSwitchAtId;
+  static const OptionId kSecondWeightsCpuctId;
+  static const OptionId kSecondWeightsFpuValueId;
+  static const OptionId kSecondWeightsPolicySoftmaxTempId;
 
   struct BackendConfiguration {
     BackendConfiguration() = default;

--- a/src/neural/factory.h
+++ b/src/neural/factory.h
@@ -75,7 +75,7 @@ class NetworkFactory {
   static const OptionId kSecondWeightsId;
   static const OptionId kSecondWeightsSwitchAtId;
   static const OptionId kSecondWeightsCpuctId;
-  static const OptionId kSecondWeightsFpuValueId;
+  static const OptionId kSecondWeightsFpuReductionId;
   static const OptionId kSecondWeightsPolicySoftmaxTempId;
 
   struct BackendConfiguration {

--- a/src/neural/factory.h
+++ b/src/neural/factory.h
@@ -72,6 +72,8 @@ class NetworkFactory {
   static const OptionId kWeightsId;
   static const OptionId kBackendId;
   static const OptionId kBackendOptionsId;
+  static const OptionId kSecondWeightsId;
+  static const OptionId kSecondWeightsSwitchAt;  
 
   struct BackendConfiguration {
     BackendConfiguration() = default;

--- a/src/utils/optionsparser.h
+++ b/src/utils/optionsparser.h
@@ -133,6 +133,9 @@ class OptionsParser {
   OptionsDict* GetMutableDefaultsOptions() { return &defaults_; }
   // Adds a subdictionary for a given context.
   void AddContext(const std::string&);
+  // Returns an option based by its uci name.
+  Option* FindOptionByUciName(const std::string& name) const;
+
 
  private:
   // Prints help to std::cerr.
@@ -141,8 +144,6 @@ class OptionsParser {
   void ShowHidden() const;
   // Returns an option based on the long flag.
   Option* FindOptionByLongFlag(const std::string& flag) const;
-  // Returns an option based by its uci name.
-  Option* FindOptionByUciName(const std::string& name) const;
   // Returns an option based by its id.
   Option* FindOptionById(const std::string& name) const;
 


### PR DESCRIPTION
Let `lc0` switch to another NN during the game. The intended usecase is to combine a stronger general NN with and an NN which is better at endgames.

This patch exports five new UCI-options `SecondWeightsFile`, `SecondWeightsSwitchAt`, `SecondWeightsCpuct`, `SecondWeightsFpuReduction`, `SecondWeightsPolicySoftmaxTemp`

`SecondWeightsFile` defines a path to secondary weights file which substitute the primary weights file when `SecondWeightsSwitchAt`pieces remain on the board. `SecondWeightsCpuct`, `SecondWeightsFpuReduction`, `SecondWeightsPolicySoftmaxTemp` defines Cpuct, FpuReduction and PolicySoftmaxTemp to be used with the secondary NN.

As of now, this PR has been tested with lc0 T11258 vs lc0 T11258 + Ender, but the PR itself is NN neutral.