### PR TITLE
v0.19.1 tp

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -152,7 +152,6 @@ void EngineController::PopulateOptions(OptionsParser* options) {
   defaults->Set<float>(SearchParams::kCpuctFactorId.GetId(), 2.0f);
   defaults->Set<float>(SearchParams::kTradePenaltyId.GetId(), 0.0f);
   defaults->Set<float>(SearchParams::kTradePenalty2Id.GetId(), 0.0f);
-  defaults->Set<float>(SearchParams::kContemptId.GetId(), 0.0f);
   defaults->Set<float>(SearchParams::kPolicySoftmaxTempId.GetId(), 2.2f);
   defaults->Set<int>(SearchParams::kMaxCollisionVisitsId.GetId(), 9999);
   defaults->Set<int>(SearchParams::kMaxCollisionEventsId.GetId(), 32);

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -150,6 +150,9 @@ void EngineController::PopulateOptions(OptionsParser* options) {
   defaults->Set<float>(SearchParams::kFpuReductionId.GetId(), 1.2f);
   defaults->Set<float>(SearchParams::kCpuctId.GetId(), 3.0f);
   defaults->Set<float>(SearchParams::kCpuctFactorId.GetId(), 2.0f);
+  defaults->Set<float>(SearchParams::kTradePenaltyId.GetId(), 0.0f);
+  defaults->Set<float>(SearchParams::kTradePenalty2Id.GetId(), 0.0f);
+  defaults->Set<float>(SearchParams::kContemptId.GetId(), 0.0f);
   defaults->Set<float>(SearchParams::kPolicySoftmaxTempId.GetId(), 2.2f);
   defaults->Set<int>(SearchParams::kMaxCollisionVisitsId.GetId(), 9999);
   defaults->Set<int>(SearchParams::kMaxCollisionEventsId.GetId(), 32);

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -68,10 +68,6 @@ const OptionId SearchParams::kTradePenalty2Id{
     "trade-penalty2", "TradePenalty2",
     "Fixed value offset, gets subtracted from current number of pieces. To use "
     "in combination with \"trade-penalty\". Values from -1000.0 to 1000.0"};
-const OptionId SearchParams::kContemptId{
-    "contempt", "Contempt",
-    "Value for contempt, multiplied with number of pieces at root not depth, "
-    "and gets added to current evaluation. Values from -1.0 to 1.0"};
 const OptionId SearchParams::kTemperatureId{
     "temperature", "Temperature",
     "Tau value from softmax formula for the first move. If equal to 0, the "
@@ -184,7 +180,6 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctFactorId, 0.0f, 1000.0f) = 0.0f;
   options->Add<FloatOption>(kTradePenaltyId, -1.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kTradePenalty2Id, -1000.0f, 1000.0f) = 0.0f;
-  options->Add<FloatOption>(kContemptId, -1.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 100) = 0;
   options->Add<IntOption>(kTemperatureCutoffMoveId, 0, 1000) = 0;
@@ -218,7 +213,6 @@ SearchParams::SearchParams(const OptionsDict& options)
       kCpuctFactor(options.Get<float>(kCpuctFactorId.GetId())),
       kTradePenalty(options.Get<float>(kTradePenaltyId.GetId())),
       kTradePenalty2(options.Get<float>(kTradePenalty2Id.GetId())),
-      kContempt(options.Get<float>(kContemptId.GetId())),
       kNoise(options.Get<bool>(kNoiseId.GetId())),
       kSmartPruningFactor(options.Get<float>(kSmartPruningFactorId.GetId())),
       kFpuAbsolute(options.Get<std::string>(kFpuStrategyId.GetId()) ==

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -60,6 +60,18 @@ const OptionId SearchParams::kCpuctBaseId{
     "higher growth of Cpuct as number of node visits grows."};
 const OptionId SearchParams::kCpuctFactorId{
     "cpuct-factor", "CPuctFactor", "Multiplier for the cpuct growth formula."};
+const OptionId SearchParams::kTradePenaltyId{
+    "trade-penalty", "TradePenalty",
+    "Value is multiplied with number of pieces on the board and added to "
+    "current evaluation. Values -1.0 to 1.0"};
+const OptionId SearchParams::kTradePenalty2Id{
+    "trade-penalty2", "TradePenalty2",
+    "Fixed value offset, gets subtracted from current number of pieces. To use "
+    "in combination with \"trade-penalty\". Values from -1000.0 to 1000.0"};
+const OptionId SearchParams::kContemptId{
+    "contempt", "Contempt",
+    "Value for contempt, multiplied with number of pieces at root not depth, "
+    "and gets added to current evaluation. Values from -1.0 to 1.0"};
 const OptionId SearchParams::kTemperatureId{
     "temperature", "Temperature",
     "Tau value from softmax formula for the first move. If equal to 0, the "
@@ -170,6 +182,9 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 1.2f;
   options->Add<FloatOption>(kCpuctBaseId, 1.0f, 1000000000.0f) = 19652.0f;
   options->Add<FloatOption>(kCpuctFactorId, 0.0f, 1000.0f) = 0.0f;
+  options->Add<FloatOption>(kTradePenaltyId, -1.0f, 1.0f) = 0.0f;
+  options->Add<FloatOption>(kTradePenalty2Id, -1000.0f, 1000.0f) = 0.0f;
+  options->Add<FloatOption>(kContemptId, -1.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 100) = 0;
   options->Add<IntOption>(kTemperatureCutoffMoveId, 0, 1000) = 0;
@@ -201,6 +216,9 @@ SearchParams::SearchParams(const OptionsDict& options)
       kCpuct(options.Get<float>(kCpuctId.GetId())),
       kCpuctBase(options.Get<float>(kCpuctBaseId.GetId())),
       kCpuctFactor(options.Get<float>(kCpuctFactorId.GetId())),
+      kTradePenalty(options.Get<float>(kTradePenaltyId.GetId())),
+      kTradePenalty2(options.Get<float>(kTradePenalty2Id.GetId())),
+      kContempt(options.Get<float>(kContemptId.GetId())),
       kNoise(options.Get<bool>(kNoiseId.GetId())),
       kSmartPruningFactor(options.Get<float>(kSmartPruningFactorId.GetId())),
       kFpuAbsolute(options.Get<std::string>(kFpuStrategyId.GetId()) ==

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -53,7 +53,6 @@ class SearchParams {
   float GetCpuctFactor() const { return kCpuctFactor; }
   float GetTradePenalty() const { return kTradePenalty; }
   float GetTradePenalty2() const { return kTradePenalty2; }
-  float GetContempt() const { return kContempt; }
   float GetTemperature() const {
     return options_.Get<float>(kTemperatureId.GetId());
   }
@@ -100,7 +99,6 @@ class SearchParams {
   static const OptionId kCpuctFactorId;
   static const OptionId kTradePenaltyId;
   static const OptionId kTradePenalty2Id;
-  static const OptionId kContemptId;
   static const OptionId kTemperatureId;
   static const OptionId kTempDecayMovesId;
   static const OptionId kTemperatureCutoffMoveId;
@@ -135,7 +133,6 @@ class SearchParams {
   const float kCpuctFactor;
   const float kTradePenalty;
   const float kTradePenalty2;
-  const float kContempt;
   const bool kNoise;
   const float kSmartPruningFactor;
   const bool kFpuAbsolute;

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -51,6 +51,9 @@ class SearchParams {
   float GetCpuct() const { return kCpuct; }
   float GetCpuctBase() const { return kCpuctBase; }
   float GetCpuctFactor() const { return kCpuctFactor; }
+  float GetTradePenalty() const { return kTradePenalty; }
+  float GetTradePenalty2() const { return kTradePenalty2; }
+  float GetContempt() const { return kContempt; }
   float GetTemperature() const {
     return options_.Get<float>(kTemperatureId.GetId());
   }
@@ -95,6 +98,9 @@ class SearchParams {
   static const OptionId kCpuctId;
   static const OptionId kCpuctBaseId;
   static const OptionId kCpuctFactorId;
+  static const OptionId kTradePenaltyId;
+  static const OptionId kTradePenalty2Id;
+  static const OptionId kContemptId;
   static const OptionId kTemperatureId;
   static const OptionId kTempDecayMovesId;
   static const OptionId kTemperatureCutoffMoveId;
@@ -127,6 +133,9 @@ class SearchParams {
   const float kCpuct;
   const float kCpuctBase;
   const float kCpuctFactor;
+  const float kTradePenalty;
+  const float kTradePenalty2;
+  const float kContempt;
   const bool kNoise;
   const float kSmartPruningFactor;
   const bool kFpuAbsolute;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1143,6 +1143,8 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
     node_to_process->v = -computation_->GetQVal(idx_in_computation) + penalty;
     // penalty shouldn't put v outside (-1, 1), and we will clip if it is:
     node_to_process->v = std::max(-0.9999f, std::min(0.9999f, node_to_process->v));
+  } else {
+    node_to_process->v = -computation_->GetQVal(idx_in_computation);
   }
   // ...and secondly, the policy data.
   float total = 0.0;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1133,16 +1133,16 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
   }
   // For NN results, we need to populate policy as well as value.
   // First the value...
-  auto penalty = params_.GetTradePenalty() * (node_to_process->piececount - params_.GetTradePenalty2());
-  // We flip penalty sign for Leela's moves (odd depths)
-  // (opponent depth is even depths and has opposite sign)
-  if(node_to_process->depth % 2 == 1)
-    penalty = -penalty;
-  node_to_process->v = -computation_->GetQVal(idx_in_computation) + penalty;
-  if(node_to_process->v < -1.0) {
-    node_to_process->v = -0.9999;
-  } else if (node_to_process->v > 1.0) {
-    node_to_process->v = 0.9999;
+  // Trade Penalty defaults to off, ie 0.0, so we only calculate penalty if it's set to != 0:
+  if (params_.GetTradePenalty() != 0.0f) {
+    auto penalty = params_.GetTradePenalty() * (node_to_process->piececount - params_.GetTradePenalty2());
+    // We flip penalty sign for Leela's moves (odd depths)
+    // (opponent depth is even depths and has opposite sign):
+    if(node_to_process->depth % 2 == 1)
+      penalty = -penalty;
+    node_to_process->v = -computation_->GetQVal(idx_in_computation) + penalty;
+    // penalty shouldn't put v outside (-1, 1), and we will clip if it is:
+    node_to_process->v = std::max(-0.9999f, std::min(0.9999f, node_to_process->v));
   }
   // ...and secondly, the policy data.
   float total = 0.0;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -25,6 +25,7 @@
   Program grant you additional permission to convey the resulting work.
 */
 
+
 #include "mcts/search.h"
 
 #include <algorithm>

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1134,11 +1134,11 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
   // For NN results, we need to populate policy as well as value.
   // First the value...
   auto penalty = params_.GetTradePenalty() * (node_to_process->piececount - params_.GetTradePenalty2());
+  // We flip penalty sign for Leela's moves (odd depths)
+  // (opponent depth is even depths and has opposite sign)
   if(node_to_process->depth % 2 == 1)
     penalty = -penalty;
-  auto board = search_->played_history_.Last().GetBoard();
-  auto contempt = params_.GetContempt() * (board.ours() + board.theirs()).count() - params_.GetContempt() * 12;
-  node_to_process->v = -computation_->GetQVal(idx_in_computation) + penalty + contempt;
+  node_to_process->v = -computation_->GetQVal(idx_in_computation) + penalty;
   // ...and secondly, the policy data.
   float total = 0.0;
   for (auto edge : node->Edges()) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -823,6 +823,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
   // True on first iteration, false as we dive deeper.
   bool is_root_node = true;
   uint16_t depth = 0;
+  uint16_t piececount;
 
   while (true) {
     // First, terminate if we find collisions or leaf nodes.
@@ -835,19 +836,20 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     if (!is_root_node) node = best_edge.GetOrSpawnNode(/* parent */ node);
     best_edge.Reset();
     depth++;
+    piececount = (history_.Last().GetBoard().ours() + history_.Last().GetBoard().theirs()).count();
     // n_in_flight_ is incremented. If the method returns false, then there is
     // a search collision, and this node is already being expanded.
     if (!node->TryStartScoreUpdate()) {
       IncrementNInFlight(node, search_->root_node_, collision_limit - 1);
-      return NodeToProcess::Collision(node, depth, collision_limit);
+      return NodeToProcess::Collision(node, depth, piececount, collision_limit);
     }
     // Either terminal or unexamined leaf node -- the end of this playout.
     if (!node->HasChildren()) {
       if (node->IsTerminal()) {
         IncrementNInFlight(node, search_->root_node_, collision_limit - 1);
-        return NodeToProcess::TerminalHit(node, depth, collision_limit);
+        return NodeToProcess::TerminalHit(node, depth, piececount, collision_limit);
       } else {
-        return NodeToProcess::Extension(node, depth);
+        return NodeToProcess::Extension(node, depth, piececount);
       }
     }
 
@@ -1131,7 +1133,12 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
   }
   // For NN results, we need to populate policy as well as value.
   // First the value...
-  node_to_process->v = -computation_->GetQVal(idx_in_computation);
+  auto penalty = params_.GetTradePenalty() * (node_to_process->piececount - params_.GetTradePenalty2());
+  if(node_to_process->depth % 2 == 1)
+    penalty = -penalty;
+  auto board = search_->played_history_.Last().GetBoard();
+  auto contempt = params_.GetContempt() * (board.ours() + board.theirs()).count() - params_.GetContempt() * 12;
+  node_to_process->v = -computation_->GetQVal(idx_in_computation) + penalty + contempt;
   // ...and secondly, the policy data.
   float total = 0.0;
   for (auto edge : node->Edges()) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1139,6 +1139,11 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
   if(node_to_process->depth % 2 == 1)
     penalty = -penalty;
   node_to_process->v = -computation_->GetQVal(idx_in_computation) + penalty;
+  if(node_to_process->v < -1.0) {
+    node_to_process->v = -0.9999;
+  } else if (node_to_process->v > 1.0) {
+    node_to_process->v = 0.9999;
+  }
   // ...and secondly, the policy data.
   float total = 0.0;
   for (auto edge : node->Edges()) {

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -251,28 +251,30 @@ class SearchWorker {
     // Value from NN's value head, or -1/0/1 for terminal nodes.
     float v;
     int multivisit = 0;
+    uint16_t piececount;
     uint16_t depth;
     bool nn_queried = false;
     bool is_cache_hit = false;
     bool is_collision = false;
 
-    static NodeToProcess Collision(Node* node, uint16_t depth,
+    static NodeToProcess Collision(Node* node, uint16_t depth, uint16_t piececount,
                                    int collision_count) {
-      return NodeToProcess(node, depth, true, collision_count);
+      return NodeToProcess(node, depth, piececount, true, collision_count);
     }
-    static NodeToProcess Extension(Node* node, uint16_t depth) {
-      return NodeToProcess(node, depth, false, 1);
+    static NodeToProcess Extension(Node* node, uint16_t depth, uint16_t piececount) {
+      return NodeToProcess(node, depth, piececount, false, 1);
     }
-    static NodeToProcess TerminalHit(Node* node, uint16_t depth,
+    static NodeToProcess TerminalHit(Node* node, uint16_t depth, uint16_t piececount,
                                      int visit_count) {
-      return NodeToProcess(node, depth, false, visit_count);
+      return NodeToProcess(node, depth, piececount, false, visit_count);
     }
 
    private:
-    NodeToProcess(Node* node, uint16_t depth, bool is_collision, int multivisit)
+    NodeToProcess(Node* node, uint16_t depth, uint16_t piececount, bool is_collision, int multivisit)
         : node(node),
           multivisit(multivisit),
           depth(depth),
+          piececount(piececount),
           is_collision(is_collision) {}
   };
 


### PR DESCRIPTION
I had to create a new PR to update instead of updating the old tp from v0.19.0 to v0.19.1 as I had all sorts of problems otherwise (although I'm very inexperienced with git).

This supports both tp and contempt, although they are both off by default.

Call tp with eg:
```
--trade-penalty=0.005 --trade-penalty2=16.0
```
Call contempt with eg:
```
--contempt=0.001
```
(there is no contempt2 as that is hardset to 12)