### PR TITLE
use fast log and pow approximations

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,7 @@ endif
 if cc.get_id() == 'clang' or cc.get_id() == 'gcc'
   add_project_arguments('-Wextra', language : 'cpp')
   add_project_arguments('-pedantic', language : 'cpp')
+  add_project_arguments('-ffast-math', language : 'cpp')
 
   if get_option('buildtype') == 'release'
     add_project_arguments('-march=native', language : 'cpp')

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -191,24 +191,22 @@ namespace {
 inline float flog2(const float a) {
   int32_t tmp;
   std::memcpy(&tmp, &a, sizeof(float));
-  int exp = (tmp >> 23) - 0x7f;
+  int expm1 = (tmp >> 23) - 0x80;
   tmp = (tmp & 0x7fffff) | (0x7f << 23);
   float out;
   std::memcpy(&out, &tmp, sizeof(float));
-  return out + exp - 1;
+  return out + expm1;
 }
 
 // The approximation used here is 2^(N+f) ~ 2^N*(1+f) where N is integer and f
 // the fractional part, f>=0.
+// Using trick from: github.com/etheory/fastapprox
 inline float fpow2(const float a) {
-  int exp = floor(a);
-  float mult = 1.0 + a - exp;
-  exp += 0x7f;
-  int32_t tmp;
-  tmp = exp < 0 ? 0 : exp << 23;
+  if (a < -126) return 0;
+  int32_t tmp = static_cast<int>((a + 127) * (1 << 23));
   float out;
   std::memcpy(&out, &tmp, sizeof(float));
-  return out * mult;
+  return out;
 }
 
 inline float flog(const float a) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -200,10 +200,10 @@ inline float flog2(const float a) {
 
 // The approximation used here is 2^(N+f) ~ 2^N*(1+f) where N is integer and f
 // the fractional part, f>=0.
-// Using trick from: github.com/etheory/fastapprox
+// Using a trick from Paul Mineiro (github.com/etheory/fastapprox).
 inline float fpow2(const float a) {
   if (a < -126) return 0;
-  int32_t tmp = static_cast<int>((a + 127) * (1 << 23));
+  int32_t tmp = static_cast<int>(a * (1 << 23)) + (127 << 23);
   float out;
   std::memcpy(&out, &tmp, sizeof(float));
   return out;

--- a/src/utils/fastmath.h
+++ b/src/utils/fastmath.h
@@ -1,0 +1,66 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#pragma once
+
+namespace lczero {
+// These stunts are performed by trained professionals, do not try this at home.
+
+// Fast approximate log2(x). Does no range checking.
+// The approximation used here is log2(2^N*(1+f)) ~ N+f*(1.342671-0.342671*f)
+// where N is the integer and f the fractional part, f>=0.
+inline float FastLog2(const float a) {
+  int32_t tmp;
+  std::memcpy(&tmp, &a, sizeof(float));
+  int expb = (tmp >> 23);
+  tmp = (tmp & 0x7fffff) | (0x7f << 23);
+  float out;
+  std::memcpy(&out, &tmp, sizeof(float));
+  return out * (2.028011f - 0.342671f * out) - 128.68534f + expb;
+}
+
+// Fast approximate 2^x. Does only limited range checking.
+// The approximation used here is 2^(N+f) ~ 2^N*(1+f*(0.656366+0.343634*f))
+// where N is the integer and f the fractional part, f>=0.
+inline float FastPow2(const float a) {
+  if (a < -126) return 0.0;
+  int exp = floor(a);
+  float out = a - exp;
+  out = 1.0f + out * (0.656366f + 0.343634f * out);
+  int32_t tmp;
+  std::memcpy(&tmp, &out, sizeof(float));
+  tmp += exp << 23;
+  std::memcpy(&out, &tmp, sizeof(float));
+  return out;
+}
+
+// Fast approximate ln(x). Does no range checking.
+inline float FastLog(const float a) {
+  return 0.6931471805599453f * FastLog2(a);
+}
+
+}  // namespace lczero

--- a/src/utils/fastmath.h
+++ b/src/utils/fastmath.h
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include <cstring>
+
 namespace lczero {
 // These stunts are performed by trained professionals, do not try this at home.
 


### PR DESCRIPTION
This uses fast approximations to calculate log and pow in search. Mainly for discussion.

The approximations used are:
log2(2^N * (1 + f)) ~ N + f 
2^(N + f) ~ 2^N * (1 + f)
N is the integer and f the fractional part, f>=0.

The absolute error of the above approximations for f in [0,1] is less than 0.08.

Better approximations (not tested) are:
log2(2^N * (1 + f)) ~ N + f * (1.34267 - 0.342671 * f)
2^(N + f) ~ 2^N*(1 + f * (0.656366 + 0.343634 * f))

Those are chosen to have zero error for f=0 and f=1 so that there are no discontinuities (also true for the simple ones).