### PR TITLE
Reserve container space

### DIFF
--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -188,6 +188,7 @@ BitBoard ChessBoard::en_passant() const { return pawns_ - pawns(); }
 
 MoveList ChessBoard::GeneratePseudolegalMoves() const {
   MoveList result;
+  result.reserve(60);
   for (auto source : our_pieces_) {
     // King
     if (source == our_king_) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -83,6 +83,7 @@ namespace {
 void ApplyDirichletNoise(Node* node, float eps, double alpha) {
   float total = 0;
   std::vector<float> noise;
+  noise.reserve(node->GetNumEdges());
 
   for (int i = 0; i < node->GetNumEdges(); ++i) {
     float eta = Random::Get().GetGamma(alpha, 1.0);
@@ -989,7 +990,8 @@ bool SearchWorker::AddNodeToComputation(Node* node, bool add_if_cached) {
 
   if (node && node->HasChildren()) {
     // Legal moves are known, use them.
-    for (auto edge : node->Edges()) {
+    moves.reserve(node->GetNumEdges());
+    for (const auto& edge : node->Edges()) {
       moves.emplace_back(edge.GetMove().as_nn_index());
     }
   } else {

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -193,7 +193,9 @@ class Search {
 class SearchWorker {
  public:
   SearchWorker(Search* search, const SearchParams& params)
-      : search_(search), history_(search_->played_history_), params_(params) {}
+      : search_(search), history_(search_->played_history_), params_(params) {
+    minibatch_.reserve(32);
+  }
 
   // Runs iterations while needed.
   void RunBlocking() {


### PR DESCRIPTION
Add reserve for containers that are used often.
1. GeneratePseudolegalMoves populated result with the number of valid moves.  A comment on discord indicated that for the average game this number is "30". It was recommended to double it. 
2. ApplyDirichletNoise always populates "noise" with the number of edges so it makes sense to reserve it.
3.  SearchWorker populates minibatch_. I make a guess as to a reasonable number.

Note: I don't like that two of these are magic numbers. Recommendations on what to call consts to represent them and where to put the constants is appreciated.