### PR TITLE
use the ninja detected by meson

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,7 @@ fi
 
 pushd ${BUILDDIR}
 
-NINJA=$(awk '/ninja/ {print $4}' meson-logs/meson-log.txt)
+NINJA=$(awk '/ninja/ {ninja=$4} END {print ninja}' meson-logs/meson-log.txt)
 
 if [ -n "${INSTALL_PREFIX}" ]
 then

--- a/build.sh
+++ b/build.sh
@@ -23,11 +23,13 @@ fi
 
 pushd ${BUILDDIR}
 
+NINJA=$(awk '/ninja/ {print $4}' meson-logs/meson-log.txt)
+
 if [ -n "${INSTALL_PREFIX}" ]
 then
-  ninja install
+  ${NINJA} install
 else
-  ninja
+  ${NINJA}
 fi
 
 popd


### PR DESCRIPTION
`build.sh` is calling `ninja` directly, but `meson` also looks for alternatives `ninja-build` or `samu`. This parses (ha) the log file generated to see which one was actually detected. This came up in centos where the default one is `ninja-build`.