### PR TITLE
`n_in_flight_` was not reverted properly in collision nodes.

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -234,7 +234,7 @@ void Node::MakeTerminal(GameResult result) {
   }
 }
 
-bool Node::TryStartScoreUpdate() { return n_in_flight_++ == 0 || n_ != 0; }
+bool Node::StartScoreUpdate() { return n_in_flight_++ == 0 || n_ != 0; }
 
 void Node::CancelScoreUpdate(int multivisit) { n_in_flight_ -= multivisit; }
 

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -216,6 +216,13 @@ std::string Node::DebugString() const {
   return oss.str();
 }
 
+void Node::DebugPrintSubtree(int depth) const {
+  CERR << std::string(depth * 2, ' ') << DebugString();
+  for (auto node : ChildNodes()) {
+    node->DebugPrintSubtree(depth + 1);
+  }
+}
+
 void Node::MakeTerminal(GameResult result) {
   is_terminal_ = true;
   if (result == GameResult::DRAW) {
@@ -227,11 +234,7 @@ void Node::MakeTerminal(GameResult result) {
   }
 }
 
-bool Node::TryStartScoreUpdate() {
-  if (n_ == 0 && n_in_flight_ > 0) return false;
-  ++n_in_flight_;
-  return true;
-}
+bool Node::TryStartScoreUpdate() { return n_in_flight_++ == 0 || n_ != 0; }
 
 void Node::CancelScoreUpdate(int multivisit) { n_in_flight_ -= multivisit; }
 

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -162,11 +162,11 @@ class Node {
   // Makes the node terminal and sets it's score.
   void MakeTerminal(GameResult result);
 
+  // Mark the node as "being updating" by incrementing n_in_flight.
   // If this node is not in the process of being expanded by another thread
-  // (which can happen only if n==0 and n-in-flight==1), mark the node as
-  // "being updated" by incrementing n-in-flight, and return true.
+  // (in which case n == 0 and n-in-flight > 1), return true.
   // Otherwise return false.
-  bool TryStartScoreUpdate();
+  bool StartScoreUpdate();
   // Decrements n-in-flight back.
   void CancelScoreUpdate(int multivisit);
   // Updates the node with newly computed value v.

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -215,6 +215,9 @@ class Node {
   // Debug information about the node.
   std::string DebugString() const;
 
+  // Prints subtree to stderr.
+  void DebugPrintSubtree(int depth = 0) const;
+
  private:
   // To minimize the number of padding bytes and to avoid having unnecessary
   // padding when new fields are added, we arrange the fields by size, largest

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1167,10 +1167,10 @@ void SearchWorker::DoBackupUpdate() {
 
 void SearchWorker::DoBackupUpdateSingleNode(
     const NodeToProcess& node_to_process) REQUIRES(search_->nodes_mutex_) {
-  Node* node = node_to_process.node;
   if (node_to_process.IsCollision()) {
     // If it was a collision, just undo counters.
-    for (; node != search_->root_node_->GetParent(); node = node->GetParent()) {
+    for (Node* node = node_to_process.node;
+         node != search_->root_node_->GetParent(); node = node->GetParent()) {
       node->CancelScoreUpdate(node_to_process.multivisit);
     }
     return;
@@ -1178,7 +1178,7 @@ void SearchWorker::DoBackupUpdateSingleNode(
 
   // Backup V value up to a root. After 1 visit, V = Q.
   float v = node_to_process.v;
-  for (Node* n = node; n != search_->root_node_->GetParent();
+  for (Node* n = node_to_process.node; n != search_->root_node_->GetParent();
        n = n->GetParent()) {
     n->FinalizeScoreUpdate(v, node_to_process.multivisit);
     // Q will be flipped for opponent.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -836,7 +836,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     depth++;
     // n_in_flight_ is incremented. If the method returns false, then there is
     // a search collision, and this node is already being expanded.
-    if (!node->TryStartScoreUpdate()) {
+    if (!node->StartScoreUpdate()) {
       IncrementNInFlight(node, search_->root_node_, collision_limit - 1);
       return NodeToProcess::Collision(node, depth, collision_limit);
     }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1170,8 +1170,7 @@ void SearchWorker::DoBackupUpdateSingleNode(
   Node* node = node_to_process.node;
   if (node_to_process.IsCollision()) {
     // If it was a collision, just undo counters.
-    for (node = node->GetParent(); node != search_->root_node_->GetParent();
-         node = node->GetParent()) {
+    for (; node != search_->root_node_->GetParent(); node = node->GetParent()) {
       node->CancelScoreUpdate(node_to_process.multivisit);
     }
     return;


### PR DESCRIPTION
When collision happened, collision code didn't have `n_in_flight_` reverted (`collision_value - 1` leaked into n_in_flight_).
Most of collisions are small in size so most likely it didn't cause large problems, but with large collisions it may happen that it leads to a blunder.

Bug was introduced in commit https://github.com/mooskagh/lc0/commit/636d326697cf88c8fc657e137ef707e1575db3d1