### PR TITLE
support 'meson configure' with older versions of meson

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ BUILDDIR=build/${BUILDTYPE}
 
 if [ -f ${BUILDDIR}/build.ninja ]
 then
-  meson configure ${BUILDDIR} --buildtype ${BUILDTYPE} --prefix ${INSTALL_PREFIX:-/usr/local} "$@"
+  meson configure ${BUILDDIR} -Dbuildtype=${BUILDTYPE} -Dprefix=${INSTALL_PREFIX:-/usr/local} "$@"
 else
   meson ${BUILDDIR} --buildtype ${BUILDTYPE} --prefix ${INSTALL_PREFIX:-/usr/local} "$@"
 fi


### PR DESCRIPTION
Older versions of meson (before 0.46) do not support `--buildtype` and `--prefix` with `meson configure`, e.g. see https://github.com/mesonbuild/meson/issues/969. Similarly seems the initial `meson` did not support the `-Dbuildtype=` and `-Dprefix=` form so we should use different syntax in `build.sh` for the two cases.