### PR TITLE
Minor changes to `src/chess`

### DIFF
--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -406,9 +406,6 @@ bool ChessBoard::ApplyMove(Move move) {
     return reset_50_moves;
   }
 
-  // Now destination square for our piece is known.
-  our_pieces_.set(to);
-
   // Promotion
   if (move.promotion() != Move::Promotion::None) {
     switch (move.promotion()) {

--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -535,7 +535,7 @@ bool ChessBoard::IsLegalMove(Move move, bool was_under_check) const {
     return !board.IsUnderCheck();
   }
 
-  // If it's kings move, check that destination
+  // If it's king's move, check that destination
   // is not under attack.
   if (from == our_king_) {
     // Castlings were checked earlier.
@@ -544,8 +544,8 @@ bool ChessBoard::IsLegalMove(Move move, bool was_under_check) const {
     return !IsUnderAttack(to);
   }
 
-  // Not check that piece was pinned. And it was, check that after the move
-  // it is still on like of attack.
+  // Now check that piece was pinned. And if it was, check that after the move
+  // it is still on line of attack.
   int dx = from.col() - our_king_.col();
   int dy = from.row() - our_king_.row();
 

--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -591,24 +591,6 @@ MoveList ChessBoard::GenerateLegalMoves() const {
   return result;
 }
 
-std::vector<MoveExecution> ChessBoard::GenerateLegalMovesAndPositions() const {
-  MoveList move_list = GeneratePseudolegalMoves();
-  std::vector<MoveExecution> result;
-
-  for (const auto& move : move_list) {
-    result.emplace_back();
-    auto& newboard = result.back().board;
-    newboard = *this;
-    result.back().reset_50_moves = newboard.ApplyMove(move);
-    if (newboard.IsUnderCheck()) {
-      result.pop_back();
-      continue;
-    }
-    result.back().move = move;
-  }
-  return result;
-}
-
 void ChessBoard::SetFromFen(const std::string& fen, int* no_capture_ply,
                             int* moves) {
   Clear();

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -33,8 +33,6 @@
 
 namespace lczero {
 
-struct MoveExecution;
-
 // Represents a board position.
 // Unlike most chess engines, the board is mirrored for black.
 class ChessBoard {
@@ -75,8 +73,6 @@ class ChessBoard {
   MoveList GenerateLegalMoves() const;
   // Check whether pseudolegal move is legal.
   bool IsLegalMove(Move move, bool was_under_check) const;
-  // Returns a list of legal moves and board positions after the move is made.
-  std::vector<MoveExecution> GenerateLegalMovesAndPositions() const;
 
   uint64_t Hash() const {
     return HashCat({our_pieces_.as_int(), their_pieces_.as_int(),
@@ -177,13 +173,6 @@ class ChessBoard {
   BoardSquare their_king_;
   Castlings castlings_;
   bool flipped_ = false;  // aka "Black to move".
-};
-
-// Stores the move and state of the board after the move is done.
-struct MoveExecution {
-  Move move;
-  ChessBoard board;
-  bool reset_50_moves;
 };
 
 }  // namespace lczero

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -81,8 +81,10 @@ class ChessBoard {
   uint64_t Hash() const {
     return HashCat({our_pieces_.as_int(), their_pieces_.as_int(),
                     rooks_.as_int(), bishops_.as_int(), pawns_.as_int(),
-                    (static_cast<unsigned>(our_king_.as_int()) << 24) | (static_cast<unsigned>(their_king_.as_int()) << 16) |
-                    (static_cast<unsigned>(castlings_.as_int()) << 8) | flipped_});
+                    (static_cast<unsigned>(our_king_.as_int()) << 24) |
+                        (static_cast<unsigned>(their_king_.as_int()) << 16) |
+                        (static_cast<unsigned>(castlings_.as_int()) << 8) |
+                        flipped_});
   }
 
   class Castlings {

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -81,10 +81,10 @@ class ChessBoard {
   uint64_t Hash() const {
     return HashCat({our_pieces_.as_int(), their_pieces_.as_int(),
                     rooks_.as_int(), bishops_.as_int(), pawns_.as_int(),
-                    (static_cast<unsigned>(our_king_.as_int()) << 24) |
-                        (static_cast<unsigned>(their_king_.as_int()) << 16) |
-                        (static_cast<unsigned>(castlings_.as_int()) << 8) |
-                        flipped_});
+                    (static_cast<uint32_t>(our_king_.as_int()) << 24) |
+                        (static_cast<uint32_t>(their_king_.as_int()) << 16) |
+                        (static_cast<uint32_t>(castlings_.as_int()) << 8) |
+                        static_cast<uint32_t>(flipped_)});
   }
 
   class Castlings {

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -81,8 +81,8 @@ class ChessBoard {
   uint64_t Hash() const {
     return HashCat({our_pieces_.as_int(), their_pieces_.as_int(),
                     rooks_.as_int(), bishops_.as_int(), pawns_.as_int(),
-                    our_king_.as_int(), their_king_.as_int(),
-                    castlings_.as_int(), flipped_});
+                    (static_cast<unsigned>(our_king_.as_int()) << 24) | (static_cast<unsigned>(their_king_.as_int()) << 16) |
+                    (static_cast<unsigned>(castlings_.as_int()) << 8) | flipped_});
   }
 
   class Castlings {

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -68,8 +68,8 @@ class ChessBoard {
   bool IsUnderAttack(BoardSquare square) const;
   // Checks if "our" (white) king is under check.
   bool IsUnderCheck() const { return IsUnderAttack(our_king_); }
-  // Checks whether at least one of the sides has mating material.
 
+  // Checks whether at least one of the sides has mating material.
   bool HasMatingMaterial() const;
   // Generates legal moves.
   MoveList GenerateLegalMoves() const;
@@ -168,8 +168,8 @@ class ChessBoard {
   // Pawns.
   // Ranks 1 and 8 have special meaning. Pawn at rank 1 means that
   // corresponding white pawn on rank 4 can be taken en passant. Rank 8 is the
-  // same for black pawns. Those "fake" pawns are not present in white_ and
-  // black_ bitboards.
+  // same for black pawns. Those "fake" pawns are not present in our_pieces_ and
+  // their_pieces_ bitboards.
   BitBoard pawns_;
   BoardSquare our_king_;
   BoardSquare their_king_;

--- a/src/chess/position.cc
+++ b/src/chess/position.cc
@@ -128,13 +128,13 @@ bool PositionHistory::DidRepeatSinceLastZeroingMove() const {
 }
 
 uint64_t PositionHistory::HashLast(int positions) const {
-  uint64_t hash = Hash((positions << 16) | Last().GetNoCaptureNoPawnPly());
+  uint64_t hash = positions;
   for (auto iter = positions_.rbegin(), end = positions_.rend(); iter != end;
        ++iter) {
     if (!positions--) break;
     hash = HashCat(hash, iter->Hash());
   }
-  return hash;
+  return HashCat(hash, Last().GetNoCaptureNoPawnPly());
 }
 
 }  // namespace lczero

--- a/src/chess/position.cc
+++ b/src/chess/position.cc
@@ -128,13 +128,13 @@ bool PositionHistory::DidRepeatSinceLastZeroingMove() const {
 }
 
 uint64_t PositionHistory::HashLast(int positions) const {
-  uint64_t hash = positions;
+  uint64_t hash = Hash((positions << 16) | Last().GetNoCaptureNoPawnPly());
   for (auto iter = positions_.rbegin(), end = positions_.rend(); iter != end;
        ++iter) {
     if (!positions--) break;
     hash = HashCat(hash, iter->Hash());
   }
-  return HashCat(hash, Last().GetNoCaptureNoPawnPly());
+  return hash;
 }
 
 }  // namespace lczero


### PR DESCRIPTION
Some minor changes to `src/chess/board.{h,cc}`

If I am not mistaken, `ChessBoard::GenerateLegalMovesAndPositions` is not used anymore? Can this be removed or is it still present to cross-check some possible future optimizations of `IsLegalMove` used in `ChessBoard::GenerateLegalMoves`?