### PR TITLE
Don't apt install protobuf on Ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ in ("Deep Learning").
 
 For Ubuntu 18.04 you need the latest version of meson and clang-6.0 before performing the steps above:
 
-    sudo apt-get install clang-6.0 ninja-build pkg-config protobuf-compiler libprotobuf-dev meson
+    sudo apt-get install clang-6.0 ninja-build pkg-config meson
     CC=clang-6.0 CXX=clang++-6.0 INSTALL_PREFIX=~/.local ./build.sh
 
 Make sure that `~/.local/bin` is in your `PATH` environment variable. You can now type `lc0 --help` and start.


### PR DESCRIPTION
On Ubuntu 18.04, I had to remove apt pakages protobuf-compiler and libprotobuf-dev in oder to make `build.sh` run successfully.

### Error using apt packages

```
congvc@ai:~/w/lc0$ CC=clang-6.0 CXX=clang++-6.0 INSTALL_PREFIX=~/.local ./build.sh
~/w/lc0/build/release ~/w/lc0
[0/1] Regenerating build files.
The Meson build system
Version: 0.45.1
Source dir: /home/congvc/w/lc0
Build dir: /home/congvc/w/lc0/build/release
Build type: native build
Project name: lc0
Native C++ compiler: c++ (gcc 7.3.0 "c++ (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0")
Build machine cpu family: x86_64
Build machine cpu: x86_64
Library libprotobuf found: YES
Program protoc found: YES (/conda/bin/protoc)
Library pthread found: YES
Library dl found: YES
Library libtensorflow_cc found: NO
Found pkg-config: /usr/bin/pkg-config (0.29.1)
Dependency Accelerate found: NO
Library mkl_rt found: NO
Library openblas.dll found: NO
Library openblas found: YES
Has header "openblas_config.h": YES
Program ispc found: NO
Library OpenCL found: YES
Dependency OpenCL found: YES (cached)
Library cublas found: YES
Library cudnn found: YES
Library cudart found: YES
Program /usr/local/cuda/bin/nvcc found: YES (/usr/local/cuda/bin/nvcc)
Dependency zlib found: YES (cached)
Dependency gtest found: YES (cached)
Build targets in project: 8
Found ninja-1.8.2 at /usr/bin/ninja
[1/131] Compiling C++ object 'lc0@exe/meson-generated_proto_net.pb.cc.o'.
FAILED: lc0@exe/meson-generated_proto_net.pb.cc.o 
c++  -Ilc0@exe -I. -I../.. -I/usr/local/include/ -I../../src -I/usr/include/ -I/usr/local/cuda/include/ -I../../src/neural/cuda/ -fdiagnostics-color=always -DNDEBUG -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -std=c++14 -O3 -Wextra -pedantic -ffast-math -march=native -DUSE_OPENBLAS -isystem ../../third_party -MD -MQ 'lc0@exe/meson-generated_proto_net.pb.cc.o' -MF 'lc0@exe/meson-generated_proto_net.pb.cc.o.d' -o 'lc0@exe/meson-generated_proto_net.pb.cc.o' -c 'lc0@exe/proto/net.pb.cc'
In file included from lc0@exe/proto/net.pb.cc:4:0:
lc0@exe/proto/net.pb.h:12:2: error: #error This file was generated by a newer version of protoc which is
 #error This file was generated by a newer version of protoc which is
  ^~~~~
lc0@exe/proto/net.pb.h:13:2: error: #error incompatible with your Protocol Buffer headers. Please update
 #error incompatible with your Protocol Buffer headers.  Please update
  ^~~~~
lc0@exe/proto/net.pb.h:14:2: error: #error your headers.
 #error your headers.
  ^~~~~
In file included from lc0@exe/proto/net.pb.cc:4:0:
lc0@exe/proto/net.pb.h:25:10: fatal error: google/protobuf/generated_message_table_driven.h: そのようなファイルやディレクトリはありません
 #include <google/protobuf/generated_message_table_driven.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
[2/131] Compiling C++ object 'lc0@exe/src_neural_factory.cc.o'.
FAILED: lc0@exe/src_neural_factory.cc.o 
c++  -Ilc0@exe -I. -I../.. -I/usr/local/include/ -I../../src -I/usr/include/ -I/usr/local/cuda/include/ -I../../src/neural/cuda/ -fdiagnostics-color=always -DNDEBUG -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -std=c++14 -O3 -Wextra -pedantic -ffast-math -march=native -DUSE_OPENBLAS -isystem ../../third_party -MD -MQ 'lc0@exe/src_neural_factory.cc.o' -MF 'lc0@exe/src_neural_factory.cc.o.d' -o 'lc0@exe/src_neural_factory.cc.o' -c ../../src/neural/factory.cc
In file included from ../../src/neural/loader.h:34:0,
                 from ../../src/neural/factory.h:33,
                 from ../../src/neural/factory.cc:28:
lc0@exe/proto/net.pb.h:12:2: error: #error This file was generated by a newer version of protoc which is
 #error This file was generated by a newer version of protoc which is
  ^~~~~
lc0@exe/proto/net.pb.h:13:2: error: #error incompatible with your Protocol Buffer headers. Please update
 #error incompatible with your Protocol Buffer headers.  Please update
  ^~~~~
lc0@exe/proto/net.pb.h:14:2: error: #error your headers.
 #error your headers.
  ^~~~~
In file included from ../../src/neural/loader.h:34:0,
                 from ../../src/neural/factory.h:33,
                 from ../../src/neural/factory.cc:28:
lc0@exe/proto/net.pb.h:25:10: fatal error: google/protobuf/generated_message_table_driven.h: そのようなファイルやディレクトリはありません
 #include <google/protobuf/generated_message_table_driven.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

### After removing the apt packages

The installer `./build.sh` downloads a proper `protobuf` and runs successfully.

```
congvc@ai:~/w/lc0$ git clean -dfx; ./build.sh
Removing build/
The Meson build system
Version: 0.45.1
Source dir: /home/congvc/w/lc0
Build dir: /home/congvc/w/lc0/build/release
Build type: native build
Project name: lc0
Native C++ compiler: g++ (gcc 7.3.0 "g++ (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0")
Appending CXXFLAGS from environment: ' -DBOOST_MATH_DISABLE_FLOAT128 -fPIC'
Appending LDFLAGS from environment: ' -Wl,-rpath,/lib -L/lib'
Appending CPPFLAGS from environment: ' -I/include -I/include -I/include'
Build machine cpu family: x86_64
Build machine cpu: x86_64
Library libprotobuf found: NO
Found pkg-config: /usr/bin/pkg-config (0.29.1)
Dependency protobuf found: NO
Program protoc found: YES (/conda/bin/protoc)
Downloading protobuf from https://github.com/google/protobuf/releases/download/v3.5.1/protobuf-all-3.5.1.tar.gz
Download size: 6662844
Downloading: ..........
Downloading patch from https://github.com/borg323/protobuf/releases/download/3.5.1-2w/protobuf-3.5.1-2w-wrap.zip
Download size: 2905
Downloading: ..........

Executing subproject protobuf.

Project name: protobuf
Native C++ compiler: g++ (gcc 7.3.0 "g++ (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0")
Compiler for C++ supports arguments -DHAVE_PTHREAD -Wno-sign-compare -Wno-unused-parameter -Wno-ignored-qualifiers /wd4146 /wd4244 /wd4305 /wd4506: SOME
Dependency threads found: YES
Build targets in project: 6

Subproject protobuf finished.
```

### System info

```
congvc@ai:~/w/lc0$ uname -m && cat /etc/*release
x86_64
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=18.04
DISTRIB_CODENAME=bionic
DISTRIB_DESCRIPTION="Ubuntu 18.04.1 LTS"
NAME="Ubuntu"
VERSION="18.04.1 LTS (Bionic Beaver)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 18.04.1 LTS"
VERSION_ID="18.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=bionic
UBUNTU_CODENAME=bionic
```