### PR TITLE
Easily run latest releases of lc0 and client using NVIDIA docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Make sure that `~/.local/bin` is in your `PATH` environment variable. You can no
 
 #### Docker
 
-Follow https://github.com/vochicong/lc0-nvidia-docker
-to run lc0 and the client under NVIDIA docker.
+Use https://github.com/vochicong/lc0-nvidia-docker
+to run latest releases of lc0 and the client under NVIDIA docker.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ For Ubuntu 16.04 you need the latest version of meson and clang-6.0 before perfo
 
 Make sure that `~/.local/bin` is in your `PATH` environment variable. You can now type `lc0 --help` and start.
 
+#### Docker
+
+Follow https://github.com/vochicong/lc0-nvidia-docker
+to run lc0 and the client under NVIDIA docker.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Make sure that `~/.local/bin` is in your `PATH` environment variable. You can no
 
 #### Docker
 
-Use https://github.com/vochicong/lc0-nvidia-docker
-to run latest releases of lc0 and the client under NVIDIA docker.
+Use https://github.com/vochicong/lc0-docker
+to run latest releases of lc0 and the client inside a Docker container.
 
 ### Windows
 


### PR DESCRIPTION
I've make a repo
https://github.com/vochicong/lc0-docker
that help you easily run the latest versions of lc0 and the client under docker.
Both CPU and GPU versions are available.