### PR TITLE
no lto builds by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@
 # along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
 
 project('lc0', 'cpp',
-        default_options : ['cpp_std=c++14', 'b_ndebug=if-release', 'b_lto=true'],
+        default_options : ['cpp_std=c++14', 'b_ndebug=if-release'],
         meson_version: '>=0.45')
 
 cc = meson.get_compiler('cpp')


### PR DESCRIPTION
This reverts #581: lto builds in linux seem to be causing some trouble, so better disable it for now until we can understand what is happening.