### PR TITLE
Simplify movestogo approximator to use median residual time.

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -97,15 +97,22 @@ const size_t kAvgCacheItemSize =
     NNCache::GetItemStructSize() + sizeof(CachedNNRequest) +
     sizeof(CachedNNRequest::IdxAndProb) * kAvgMovesPerPosition;
 
-float ComputeSurvivalAtPly(int ply, float midpoint, float steepness) {
-  // This function is the survival function of the log-logistic distribution, it
-  // was chosen as it fit empirical analysis finding P(game ended at ply). We
-  // determine how many moves to plan time management for by summing over this
-  // function from ply to infinity (or some other reasonably large value).
-  // midpoint: The ply where the function is half its maximum value.
+float ComputeMedianMovesToGo(int ply, float midpoint, float steepness) {
+  // An analysis of chess games shows that the distribution of game lengths
+  // looks like a log-logistic distribution. The mean residual time function
+  // calculates how many more moves are expected in the game given that we are
+  // at the current ply. Given that this function can be expensive to compute,
+  // we calculate the median residual time function instead. This is derived and
+  // shown to be similar to the mean residual time in "Some Useful Properties of
+  // Log-Logistic Random Variables for Health Care Simulations" (Clark &
+  // El-Taha, 2015).
+  // midpoint: The median length of games.
   // steepness: How quickly the function drops off from its maximum value,
   // around the midpoint.
-  return 1 / (1 + std::pow(ply / midpoint, steepness));
+  return (midpoint * std::pow(1 + 2 * std::pow(ply / midpoint, steepness),
+                              1 / steepness) -
+          ply) /
+         2; // Divide plies by 2 to get moves.
 }
 
 }  // namespace
@@ -125,8 +132,8 @@ void EngineController::PopulateOptions(OptionsParser* options) {
   options->Add<IntOption>(kNNCacheSizeId, 0, 999999999) = 200000;
   options->Add<FloatOption>(kSlowMoverId, 0.0f, 100.0f) = 1.0f;
   options->Add<IntOption>(kMoveOverheadId, 0, 100000000) = 200;
-  options->Add<FloatOption>(kTimeMidpointPlyId, 1.0f, 200.0f) = 100.0f;
-  options->Add<FloatOption>(kTimeSteepnessId, 1.0f, 100.0f) = 9.0f;
+  options->Add<FloatOption>(kTimeMidpointPlyId, 1.0f, 200.0f) = 103.0f;
+  options->Add<FloatOption>(kTimeSteepnessId, 1.0f, 100.0f) = 7.0f;
   options->Add<StringOption>(kSyzygyTablebaseId);
   // Add "Ponder" option to signal to GUIs that we support pondering.
   // This option is currently not used by lc0 in any way.
@@ -183,21 +190,8 @@ SearchLimits EngineController::PopulateSearchLimits(
   float time_curve_midpoint = options_.Get<float>(kTimeMidpointPlyId.GetId());
   float time_curve_steepness = options_.Get<float>(kTimeSteepnessId.GetId());
 
-  // Sum over the survival function to guess how many moves ahead are worth
-  // planning time for. All values must be scaled relative to the first value,
-  // so compute the first ply separately.
-  float this_move_survival =
-      ComputeSurvivalAtPly(ply, time_curve_midpoint, time_curve_steepness);
-
-  // Sum over a large range of plies to approximate summing to infinity.
-  float movestogo = 0.0f;
-  for (int i = ply + 2; i < ply + 300; i += 2) {
-    movestogo +=
-        ComputeSurvivalAtPly(i, time_curve_midpoint, time_curve_steepness);
-  }
-
-  // Normalize to account for the game being at the current ply.
-  movestogo = movestogo / this_move_survival + 1;
+  float movestogo =
+      ComputeMedianMovesToGo(ply, time_curve_midpoint, time_curve_steepness);
 
   // If the number of moves remaining until the time control are less than
   // the estimated number of moves left in the game, then use the number of


### PR DESCRIPTION
cc: @jjoshua2 
Replaces calculating the mean residual time (summing to approximate an integral) with the median residual time (a much simpler function) as per @borg323's suggestion in #271. So it now uses 2 std::pow calls instead of 300.

I've also adjusted the default parameters to match the current tuned curve better. See purple and red lines in graph below. Red = current master curve, purple = this PR curve.

<img width="586" alt="screen shot 2018-12-30 at 8 34 22 pm" src="https://user-images.githubusercontent.com/313295/50546180-5b0f1c00-0c73-11e9-85a9-cd0a48ff8b01.png">

I haven't tested this at all apart from the spreadsheet and won't be able to get to it for a while, so would appreciate some help with that.