### PR TITLE
Movegen speedup via king attack info

### DIFF
--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -515,7 +515,7 @@ KingAttackInfo ChessBoard::GenerateKingAttackInfo() const {
   KingAttackInfo king_attack_info;
 
   // Number of attackers that give check (used for double check detection).
-  unsigned num_attackers = 0;
+  unsigned num_king_attackers = 0;
 
   const int row = our_king_.row();
   const int col = our_king_.col();
@@ -555,7 +555,7 @@ KingAttackInfo ChessBoard::GenerateKingAttackInfo() const {
               // Update attacking lines.
               king_attack_info.attacking_lines_ =
                   king_attack_info.attacking_lines_ + attack_line;
-              num_attackers++;
+              num_king_attackers++;
             }
           }
           break;
@@ -598,7 +598,7 @@ KingAttackInfo ChessBoard::GenerateKingAttackInfo() const {
               // Update attacking lines.
               king_attack_info.attacking_lines_ =
                   king_attack_info.attacking_lines_ + attack_line;
-              num_attackers++;
+              num_king_attackers++;
             }
           }
           break;
@@ -614,7 +614,7 @@ KingAttackInfo ChessBoard::GenerateKingAttackInfo() const {
 
   if (attacking_pawns.as_int()) {
     // No more than one pawn can give check.
-    num_attackers++;
+    num_king_attackers++;
   }
 
   // Check knights.
@@ -626,10 +626,11 @@ KingAttackInfo ChessBoard::GenerateKingAttackInfo() const {
 
   if (attacking_knights.as_int()) {
     // No more than one knight can give check.
-    num_attackers++;
+    num_king_attackers++;
   }
 
-  king_attack_info.double_check_ = (num_attackers > 1);
+  assert(num_king_attackers <= 2);
+  king_attack_info.double_check_ = (num_king_attackers == 2);
 
   return king_attack_info;
 }
@@ -663,7 +664,7 @@ bool ChessBoard::IsLegalMove(Move move,
       return false;
     }
 
-    // Non-pinned non-king move.
+    // The piece to move is no king and is not pinned.
     if (king_attack_info.in_double_check()) {
       // Only a king move can resolve the double check.
       return false;

--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -337,8 +337,8 @@ MoveList ChessBoard::GeneratePseudolegalMoves() const {
     }
     // Knight.
     {
-      for (const auto destination : kKnightAttacks[source.as_int()]) {
-        if (our_pieces_.get(destination)) continue;
+      for (const auto destination :
+           kKnightAttacks[source.as_int()] - our_pieces_) {
         result.emplace_back(source, destination);
       }
     }

--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -629,8 +629,6 @@ KingAttackInfo ChessBoard::GenerateKingAttackInfo() const {
     num_attackers++;
   }
 
-  // Only combinations of minor pieces, rooks and queens can give double check
-  // (no pawns).
   king_attack_info.double_check_ = (num_attackers > 1);
 
   return king_attack_info;

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -33,6 +33,23 @@
 
 namespace lczero {
 
+// Represents king attack info used during legal move detection.
+class KingAttackInfo {
+ public:
+  bool in_check() const { return attacking_squares_and_lines_.as_int(); }
+  bool in_double_check() const { return double_check_; }
+  bool is_pinned(const BoardSquare square) const {
+    return pinned_pieces_.get(square);
+  }
+  bool is_on_attack_line(const BoardSquare square) const {
+    return attacking_squares_and_lines_.get(square);
+  }
+
+  bool double_check_ = 0;
+  BitBoard pinned_pieces_ = {0};
+  BitBoard attacking_squares_and_lines_ = {0};
+};
+
 // Represents a board position.
 // Unlike most chess engines, the board is mirrored for black.
 class ChessBoard {
@@ -55,22 +72,6 @@ class ChessBoard {
   // middle of the board. (what was on rank 1 appears on rank 8, what was
   // on file b remains on file b).
   void Mirror();
-
-  class KingAttackInfo {
-   public:
-    bool in_check() const { return attacking_squares_and_lines_.as_int(); }
-    bool in_double_check() const { return double_check_; }
-    bool is_pinned_piece(const BoardSquare square) const {
-      return pinned_pieces_.get(square);
-    }
-    bool is_attacked_square(const BoardSquare square) const {
-      return attacking_squares_and_lines_.get(square);
-    }
-
-    bool double_check_ = 0;
-    BitBoard pinned_pieces_ = {0};
-    BitBoard attacking_squares_and_lines_ = {0};
-  };
 
   // Generates list of possible moves for "ours" (white), but may leave king
   // under check.

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -36,18 +36,18 @@ namespace lczero {
 // Represents king attack info used during legal move detection.
 class KingAttackInfo {
  public:
-  bool in_check() const { return attacking_squares_and_lines_.as_int(); }
+  bool in_check() const { return attacking_lines_.as_int(); }
   bool in_double_check() const { return double_check_; }
   bool is_pinned(const BoardSquare square) const {
     return pinned_pieces_.get(square);
   }
   bool is_on_attack_line(const BoardSquare square) const {
-    return attacking_squares_and_lines_.get(square);
+    return attacking_lines_.get(square);
   }
 
   bool double_check_ = 0;
   BitBoard pinned_pieces_ = {0};
-  BitBoard attacking_squares_and_lines_ = {0};
+  BitBoard attacking_lines_ = {0};
 };
 
 // Represents a board position.

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -82,7 +82,7 @@ class ChessBoard {
   // Checks if the square is under attack from "theirs" (black).
   bool IsUnderAttack(BoardSquare square) const;
   // Generates the king attack info used for legal move detection.
-  void GenerateKingAttackInfo(KingAttackInfo& king_attack_info) const;
+  KingAttackInfo GenerateKingAttackInfo() const;
   // Checks if "our" (white) king is under check.
   bool IsUnderCheck() const { return IsUnderAttack(our_king_); }
 

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -56,6 +56,22 @@ class ChessBoard {
   // on file b remains on file b).
   void Mirror();
 
+  class KingAttackInfo {
+   public:
+    bool in_check() const { return attacking_squares_and_lines_.as_int(); }
+    bool in_double_check() const { return double_check_; }
+    bool is_pinned_piece(const BoardSquare square) const {
+      return pinned_pieces_.get(square);
+    }
+    bool is_attacked_square(const BoardSquare square) const {
+      return attacking_squares_and_lines_.get(square);
+    }
+
+    bool double_check_ = 0;
+    BitBoard pinned_pieces_ = {0};
+    BitBoard attacking_squares_and_lines_ = {0};
+  };
+
   // Generates list of possible moves for "ours" (white), but may leave king
   // under check.
   MoveList GeneratePseudolegalMoves() const;
@@ -64,6 +80,8 @@ class ChessBoard {
   bool ApplyMove(Move move);
   // Checks if the square is under attack from "theirs" (black).
   bool IsUnderAttack(BoardSquare square) const;
+  // Generates the king attack info used for legal move detection.
+  void GenerateKingAttackInfo(KingAttackInfo& king_attack_info) const;
   // Checks if "our" (white) king is under check.
   bool IsUnderCheck() const { return IsUnderAttack(our_king_); }
 
@@ -72,7 +90,7 @@ class ChessBoard {
   // Generates legal moves.
   MoveList GenerateLegalMoves() const;
   // Check whether pseudolegal move is legal.
-  bool IsLegalMove(Move move, bool was_under_check) const;
+  bool IsLegalMove(Move move, const KingAttackInfo& king_attack_info) const;
 
   uint64_t Hash() const {
     return HashCat({our_pieces_.as_int(), their_pieces_.as_int(),


### PR DESCRIPTION
Various movegen optimizations centered around the introduction of precomputed *king attack info* (attacking lines, pinned pieces, double check detection) that is used to speedup several parts of legal move detection (for all moves).

Unconditional speedup for random backend up to 6% (tested with LTO builds on Linux Fedora 29 64-bit, `gcc 8.2.1`).


The following measurements all share the command line `lc0 benchmark --backend=random --smart-pruning-factor=0 --nodes=1000000 --nncache=1000000`. A 95% confidence interval for the average of the last reported nps value over 25 runs is given for the starting position, the opening position https://lichess.org/editor/rn2kb1r/pp3ppp/2p1pnb1/8/3P1N1q/4B1N1/PPPQ1PPP/R3KB1R_b_KQkq_-_5_9 and the endgame position https://lichess.org/editor/8/2R2P2/1p4K1/6R1/1r6/5rP1/1k6/2q5_w_-_-_0_55 .

The measurements are performed on an Intel Core i5-5300U CPU @ 2.30GHz with 4 cores and L1d cache: 32K, L1i cache: 32K, L2 cache: 256K, L3 cache: 3072K.

For 1 search thread:

position  |  master `6a639b6` |  this PR  | speedup
------ | ----- | ----------- | -----------
start | 208222 ± 448 | 215247 ± 726 | 3.4%
opening | 161321 ± 216 | 168776 ± 335 | 4.6%
endgame | 176833 ± 245 | 186576 ± 283 | 5.5%

For 2 search threads:

position  |  master `6a639b6` |  this PR  | speedup
------ | ----- | ----------- | -----------
start | 271137 ± 830 | 272221 ± 882 | 0.4%
opening | 224128 ± 422 | 227968 ± 551 | 1.7%
endgame | 238111 ± 511 | 243892 ± 758 | 2.4%
