### PR TITLE
First move boost

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -251,9 +251,8 @@ SearchLimits EngineController::PopulateSearchLimits(
   // tree to reuse.
   if (first_move_of_game_) {
     float adj = options_.Get<float>(kFirstMoveTimeAdjId.GetId());
-    LOGFILE << "Giving extra time: New move time is " << this_move_time * adj
-            << " ms";
     this_move_time *= adj;
+    LOGFILE << "Giving extra time: New move time " << this_move_time << " ms";
   }
 
   // Make sure we don't exceed current time limit with what we calculated.

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -251,8 +251,10 @@ SearchLimits EngineController::PopulateSearchLimits(
   // Steal some extra time for the first move of the game since it never has a
   // tree to reuse.
   if (first_move_of_game_) {
-    LOGFILE << "GIVING EXTRA TIME";
-    this_move_time *= options_.Get<float>(kFirstMoveTimeAdjId.GetId());
+    float adj = options_.Get<float>(kFirstMoveTimeAdjId.GetId());
+    LOGFILE << "Giving extra time: New move time is " << this_move_time * adj
+            << " ms";
+    this_move_time *= adj;
   }
 
   // Make sure we don't exceed current time limit with what we calculated.

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -244,7 +244,7 @@ SearchLimits EngineController::PopulateSearchLimits(
   // tree to reuse.
   if (first_move_of_game_) {
     LOGFILE << "GIVING EXTRA TIME";
-    this_move_time *= 1.7;
+    this_move_time *= 3.0;
   }
 
   // Make sure we don't exceed current time limit with what we calculated.

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -80,6 +80,12 @@ const OptionId kSpendSavedTimeId{
     "the next move rather than to the entire game. When 1, all saved time is "
     "added to the next move's budget; when 0, saved time is distributed among "
     "all future moves."};
+const OptionId kFirstMoveTimeAdjId{
+    "first-move-time-adj", "FirstMoveTimeAdj",
+    "Fraction of move time allocated to give extra for the first move to "
+    "offset smart pruning savings. When 1, no extra time is given and the "
+    "first move is likely to be shorter. When 2 the first move time doubles, "
+    "when 3 triples etc."};
 const OptionId kPonderId{"ponder", "Ponder",
                          "This option is ignored. Here to please chess GUIs."};
 // Warning! When changed, also change number 30 in the help below!
@@ -139,11 +145,13 @@ void EngineController::PopulateOptions(OptionsParser* options) {
   // This option is currently not used by lc0 in any way.
   options->Add<BoolOption>(kPonderId) = true;
   options->Add<FloatOption>(kSpendSavedTimeId, 0.0f, 1.0f) = 1.0f;
+  options->Add<FloatOption>(kFirstMoveTimeAdjId, 1.0f, 10.0f) = 3.0f;
   options->Add<IntOption>(kRamLimitMbId, 0, 100000000) = 0;
 
   // Hide time curve options.
   options->HideOption(kTimeMidpointMoveId);
   options->HideOption(kTimeSteepnessId);
+  options->HideOption(kFirstMoveTimeAdjId);
 
   NetworkFactory::PopulateOptions(options);
   SearchParams::Populate(options);
@@ -244,7 +252,7 @@ SearchLimits EngineController::PopulateSearchLimits(
   // tree to reuse.
   if (first_move_of_game_) {
     LOGFILE << "GIVING EXTRA TIME";
-    this_move_time *= 3.0;
+    this_move_time *= options_.Get<float>(kFirstMoveTimeAdjId.GetId());
   }
 
   // Make sure we don't exceed current time limit with what we calculated.

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -145,7 +145,7 @@ void EngineController::PopulateOptions(OptionsParser* options) {
   // This option is currently not used by lc0 in any way.
   options->Add<BoolOption>(kPonderId) = true;
   options->Add<FloatOption>(kSpendSavedTimeId, 0.0f, 1.0f) = 1.0f;
-  options->Add<FloatOption>(kFirstMoveTimeAdjId, 1.0f, 10.0f) = 3.0f;
+  options->Add<FloatOption>(kFirstMoveTimeAdjId, 1.0f, 10.0f) = 1.6f;
   options->Add<IntOption>(kRamLimitMbId, 0, 100000000) = 0;
 
   // Hide time curve options.

--- a/src/engine.h
+++ b/src/engine.h
@@ -117,6 +117,7 @@ class EngineController {
   // How much less time was used by search than what was allocated.
   int64_t time_spared_ms_ = 0;
   std::chrono::steady_clock::time_point move_start_time_;
+  bool first_move_of_game_ = true;
 };
 
 class EngineLoop : public UciLoop {


### PR DESCRIPTION
I'm guessing someone will want this to be a configurable parameter.  But I doubt there is a lot of elo in tuning this, so I didn't bother...

I instead 'derived' this value by experiment - looking at the distribution of ratio of initial_nodes to total_playouts at the end of each turn across a bunch of games played under time control.
With default, there is a clear growth of that ratio over the first 3-4 moves out of book.  With the current multiplier of 3, that growth is not clear.
I didn't really expect to need a multiplier greater than 2, but 2 clearly still had a growth pattern happening.

Publishing in case someone wants to try and see if there is any elo improvement.  I don't think I have the patience :P