### PR TITLE
fix undefined behavior in DiscoverWeightsFile()

### DIFF
--- a/src/neural/loader.cc
+++ b/src/neural/loader.cc
@@ -164,7 +164,7 @@ std::string DiscoverWeightsFile() {
     gzFile file = gzopen(candidate.second.c_str(), "rb");
 
     if (!file) continue;
-    char buf[256];
+    unsigned char buf[256];
     int sz = gzread(file, buf, 256);
     gzclose(file);
     if (sz < 0) continue;
@@ -180,8 +180,10 @@ std::string DiscoverWeightsFile() {
 
     // First byte of the protobuf stream is 0x0d for fixed32, so we ignore it as
     // our own magic should suffice.
-    auto magic = reinterpret_cast<std::uint32_t*>(buf + 1);
-    if (*magic == kWeightMagic) {
+    auto magic = buf[1] | (static_cast<uint32_t>(buf[2]) << 8) |
+                 (static_cast<uint32_t>(buf[3]) << 16) |
+                 (static_cast<uint32_t>(buf[4]) << 24);
+    if (magic == kWeightMagic) {
       CERR << "Found pb network file: " << candidate.second;
       return candidate.second;
     }


### PR DESCRIPTION
Also fixes the endianness assumption in that code. Closes #639. Checked that both gcc and clang do the right thing with this code on x86_64, at least with -O2.