### PR TITLE
Fix incorrect index in OpenCL Winograd output transform

### DIFF
--- a/src/neural/opencl/clsource/convolve3.opencl
+++ b/src/neural/opencl/clsource/convolve3.opencl
@@ -147,7 +147,7 @@ __kernel void out_transform_fused_bn(__global const float * restrict M,
   int y = 2*block_y;
   int a_ind = y * W + x;
   if (k < K && block < P) {
-    const int kHW = batch * Kpad * BOARD_SQUARES + k * BOARD_SQUARES;
+    const int kHW = batch * K * BOARD_SQUARES + k * BOARD_SQUARES;
     float o[4];
     __out_transform_eq(M, o, Kpad, Ppad, block, batch);
     


### PR DESCRIPTION
Padded channel count was used by accident, when non-padded count was needed.

Fixes incorrect output with networks with non-power of two size channels. Shouldn't affect any of the official nets.