### PR TITLE
To ensure MakeTerminal value overwrites any MCTS calculated value

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -221,9 +221,9 @@ void Node::MakeTerminal(GameResult result) {
   if (result == GameResult::DRAW) {
     q_ = 0.0f;
   } else if (result == GameResult::WHITE_WON) {
-    q_ = 1.0f;
+    q_ = 10000.0f;
   } else if (result == GameResult::BLACK_WON) {
-    q_ = -1.0f;
+    q_ = -10000.0f;
   }
 }
 

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -968,9 +968,14 @@ void SearchWorker::ExtendNode(Node* node) {
   if (legal_moves.empty()) {
     // Could be a checkmate or a stalemate
     if (board.IsUnderCheck()) {
-      node->MakeTerminal(GameResult::WHITE_WON);
-    } else {
-      node->MakeTerminal(GameResult::DRAW);
+		if (board.flipped()) {
+			node->MakeTerminal(GameResult::BLACK_WON);
+			return;
+		} else {
+			node->MakeTerminal(GameResult::WHITE_WON);
+			return;
+		}
+		node->MakeTerminal(GameResult::DRAW);
     }
     return;
   }


### PR DESCRIPTION

This is a bit of a stretch, but it does seem to fix #627 and also #572 

This is probably because overwriting the MakeTerminal with a value big enough to prevent any MCTS accumulation-visits overshooting the MCTS-Search decided MakeTerminal.

1) This would imply that for training a different MakeTerminal is to be used -to keep it at just one and minus one- but for enabling matches you want the Terminal-value to be big enough to ensure it is finalizing the search.

2) I'm not sure if the change in search.cc is actually needed, is it?

Details of go nodes after applying this as a 'hotfix' as compared to issue #627 shows the right move Bg1-f2 is found and kept after only few nodes:


````
C:\dev\lc0>lc0 --minibatch-size=128 --weights=nets\32300
       _
|   _ | |
|_ |_ |_| v0.21.0-dev built Jan 13 2019
position startpos moves e2e4 c7c5 g1f3 d7d6 d2d4 c5d4 f3d4 g8f6 b1c3 a7a6 c1e3 e7e5 d4b3 f8e7 f2f3 c8e6 d1d2 h7h5 c3d5 f6d5 e4d5 e6f5 b3a5 b7b6 a5c4 b8d7 a2a4 e8g8 f1e2 a8c8 e1g1 h5h4 h2h3 f5g6 b2b4 d8c7 f1c1 c7b7 c2c3 f8e8 e2f1 c8b8 e3f2 f7f5 d2e1 b7c7 f2h4 e7h4 e1h4 f5f4 a4a5 b6b5 c4d2 d7f6 c3c4 b5c4 d2c4 b8b4 c4b6 c7e7 f1a6 e5e4 h4f4 f6h5 f4e3 e7e5 f3f4 h5f4 a6f1 f4d3 c1d1 e5b2 b6d7 b4b3 a5a6 d3e5 e3g5 b3h3 g5d2 b2b3 d7e5 b3g3 e5g4 g3g4 d2e1 h3h8 a6a7 e4e3 a7a8Q g4f4 g2g3 f4h6
go nodes 25000
Loading weights file from: nets\32300
Creating backend [cudnn]...
info depth 1 seldepth 2 time 119 nodes 5 score cp 270 hashfull 0 nps 42 tbhits 0 pv a8e8 g6e8
info depth 2 seldepth 3 time 187 nodes 7 score cp 406 hashfull 0 nps 37 tbhits 0 pv a8e8 g8h7 g3g4
info depth 2 seldepth 3 time 241 nodes 11 score cp 95 hashfull 0 nps 45 tbhits 0 pv f1g2 g8f7 g3g4
info depth 3 seldepth 4 time 295 nodes 21 score cp 446 hashfull 0 nps 71 tbhits 0 pv a8e8 g8h7 e8h8 h7h8
info depth 3 seldepth 5 time 445 nodes 24 score cp 382 hashfull 0 nps 53 tbhits 0 pv a8e8 g8h7 e8h8 h7h8
info depth 3 seldepth 6 time 496 nodes 25 score cp 311 hashfull 0 nps 50 tbhits 0 pv a8e8 g8h7 e8h8 h7h8
info depth 3 seldepth 7 time 559 nodes 26 score cp 238 hashfull 0 nps 46 tbhits 0 pv a8e8 g8h7 e8h8 h7h8
info depth 3 seldepth 8 time 653 nodes 30 score cp 145 hashfull 0 nps 45 tbhits 0 pv a8e8 g8h7 e8h8 h7h8
info depth 4 seldepth 9 time 719 nodes 41 score cp 109 hashfull 1 nps 57 tbhits 0 pv a8e8 g8h7 e8h8 h7h8
info depth 4 seldepth 9 time 817 nodes 77 score cp 121 hashfull 1 nps 94 tbhits 0 pv f1h3 g8f7 e1f1 f7e7
info depth 4 seldepth 9 time 870 nodes 94 score cp 143 hashfull 1 nps 108 tbhits 0 pv f1g2 g8h7 g3g4 e8a8 a1a8
info depth 4 seldepth 9 time 923 nodes 126 score cp 115 hashfull 1 nps 136 tbhits 0 pv f1h3 g8f7 e1f1 f7e7
info depth 4 seldepth 10 time 1188 nodes 157 score cp 104 hashfull 2 nps 132 tbhits 0 pv f1g2 g8h7 g3g4 e8a8 a1a8 h8a8 e1g3
info depth 4 seldepth 11 time 1596 nodes 300 score cp 556 hashfull 3 nps 187 tbhits 0 pv f1g2 g8h7 a1a2 h6h5 a2a4 e3e2
info depth 4 seldepth 12 time 1703 nodes 321 score cp 556 hashfull 3 nps 188 tbhits 0 pv f1g2 g8h7 a1a2 h6h5 a2a4 e3e2
info depth 5 seldepth 13 time 1808 nodes 340 score cp 556 hashfull 3 nps 188 tbhits 0 pv f1g2 g8h7 a1a2 h6h5 a2a4 e3e2
info depth 5 seldepth 14 time 1869 nodes 341 score cp 556 hashfull 3 nps 182 tbhits 0 pv f1g2 g8h7 a1a2 h6h5 a2a4 e3e2
info depth 5 seldepth 15 time 2294 nodes 397 score cp 2103 hashfull 4 nps 173 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 g3g4 h8f8 f1e2 h2g2 e1f2 g2f2
info depth 6 seldepth 15 time 2561 nodes 425 score cp -26 hashfull 5 nps 165 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 g3g4 h8f8 f1e2 h2g2 e1f2 g2f2
info depth 6 seldepth 16 time 3264 nodes 513 score cp -166 hashfull 6 nps 157 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 e2d1q e1d1 f8f4
info depth 7 seldepth 16 time 3316 nodes 518 score cp 215 hashfull 7 nps 156 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 e2d1q e1d1 f8f4
info depth 7 seldepth 17 time 3369 nodes 520 score cp -317 hashfull 7 nps 154 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 e2d1q e1d1 f8f4
info depth 8 seldepth 18 time 3624 nodes 615 score cp 836 hashfull 7 nps 169 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 e1e2 e8e2 a4h4 h2h4 g3h4 e2b2 g2f3 b2b1 d1b1
info depth 9 seldepth 18 time 3820 nodes 705 score cp -74 hashfull 8 nps 184 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 e1e2 e8e2 a4h4 h2h4 g3h4 e2a2 d1e1 g6f5 e1e8 a2a4
info depth 9 seldepth 19 time 3943 nodes 771 score cp 488 hashfull 8 nps 195 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 e1e2 e8e2 a4h4 h2h4 g3h4 e2a2 g2f3 a2a4 f1f2 a4h4
info depth 10 seldepth 20 time 4102 nodes 867 score cp 157 hashfull 8 nps 211 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 e1e2 e8e2 a4h4 h2h4 g3h4 e2a2 d1d4 h7h6 g2f3 g6f5 d4b4
info depth 11 seldepth 20 time 4504 nodes 971 score cp -327 hashfull 9 nps 215 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 e1e2 e8e2 a4h4 h2h4 g3h4 e2a2 d1d4 g6f5 g2e4 h7g6 e4f5 g6f5
info depth 12 seldepth 21 time 4829 nodes 1230 score cp -116 hashfull 10 nps 254 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 e1e2 e8e2 a4h4 h2h4 g3h4 e2a2 d1d4 g6f5 g2e4 h7g6 e4f5 g6f5 d4b4
info depth 12 seldepth 22 time 5317 nodes 1493 score cp 5162 hashfull 11 nps 280 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 e1e2 e8e2 a4h4 h2h4 g3h4 e2a2 d1d4 g6f5 g2e4 h7g6 e4f5 g6f5 d4b4
info depth 13 seldepth 22 time 5406 nodes 1547 score cp -811 hashfull 12 nps 286 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 e1e2 e8e2 a4h4 h2h4 g3h4 e2a2 d1d4 g6f5 g2e4 h7g6 e4f5 g6f5 d4b4
info depth 14 seldepth 23 time 6030 nodes 1934 score cp 7 hashfull 13 nps 320 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1q e1d1 h2f4 g2f3 g6f5 d1h1 h7g8 h1h5 g7g6
info depth 14 seldepth 24 time 6214 nodes 2044 score cp -459 hashfull 13 nps 328 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1q e1d1 h2f4 g2f3 g6f5 d1h1 h7g8 h1h5 g7g6
info depth 15 seldepth 25 time 6922 nodes 2483 score cp 426 hashfull 15 nps 358 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1q e1d1 h2f4 g2f3 g6f5 d1h1 h7g8 h1h5 g7g6
info depth 16 seldepth 26 time 7518 nodes 2871 score cp -175 hashfull 17 nps 381 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 e3e5 h2g1 h7h6 d1d2 h6h5 g2f3
info depth 17 seldepth 27 time 8254 nodes 3424 score cp -197 hashfull 20 nps 414 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 e3e5 h2g1 g6f5 d1h5 h7g8 h5g5 g8f7 g1f2
info depth 17 seldepth 28 time 8986 nodes 4007 score cp -54936 hashfull 22 nps 445 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 e3e5 h2g1 g6f5 d1h5 h7g8 h5h4 g8f7 h4h5
info depth 18 seldepth 28 time 9173 nodes 4150 score cp 2213 hashfull 23 nps 452 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 e3e5 h2g1 g6f5 d1h5 h7g8 h5g5 g8f7 g1f2 g7g6
info depth 19 seldepth 28 time 11227 nodes 5464 score cp 14 hashfull 29 nps 486 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 e3e5 h2g1 g6f5 d1h5 h7g8 h5g5 g8f7 g1f2 g7g6
info depth 19 seldepth 29 time 12692 nodes 6165 score cp 618 hashfull 33 nps 485 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 e3e5 h2g1 g6f5 d1h5 h7g8 h5g5 g8f7 g1f2 e5d4 f2g3
info depth 18 seldepth 29 time 13098 nodes 6248 score cp -136 hashfull 34 nps 477 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 e3e5 h2g1 g6f5 d1h5 h7g8 h5g5 g8f7 g1f2 e5d4 f2g3
info depth 19 seldepth 29 time 13237 nodes 6301 score cp 297 hashfull 34 nps 476 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 e3e5 h2g1 g6f5 d1h5 h7g8 h5g5 g8f7 g1f2 e5d4 f2g3
info depth 19 seldepth 30 time 13340 nodes 6429 score cp -276 hashfull 35 nps 481 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 e3e5 h2g1 g6f5 d1h5 h7g8 h5g5 g8f7 g1f2 e5d4 f2g3
info depth 19 seldepth 31 time 13897 nodes 6881 score cp 755 hashfull 36 nps 495 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 e3e5 h2g1 g6f5 d1h5 h7g8 h5g5 g8f7 g1f2 g7g6 g2f3 e5h2
info depth 20 seldepth 31 time 15632 nodes 8019 score cp 2 hashfull 41 nps 512 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 h7h6 d1g4 e3e5 h2g1 g6h5 g4c8 h6g5 c8d8 e5f6 d8b6
info depth 19 seldepth 31 time 15901 nodes 8067 score cp 121 hashfull 42 nps 507 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 h7h6 d1g4 e3e5 h2g1 g6h5 g4c8 h6g5 c8d8 e5f6 d8b6
info depth 20 seldepth 31 time 15952 nodes 8117 score cp -705 hashfull 42 nps 508 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 h7h6 d1g4 e3e5 h2g1 g6h5 g4c8 h6g5 c8d8 e5f6 d8b6
info depth 20 seldepth 32 time 17449 nodes 9244 score cp -63 hashfull 46 nps 529 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 e3e5 h2g1 g6f5 d1h5 h7g8 h5g5 g8f7 g1f2 g7g6 g2f3 e5h2
info depth 19 seldepth 32 time 19991 nodes 10664 score cp 190 hashfull 53 nps 533 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 e3e5 h2g1 g6f5 d1h5 h7g8 h5g5 g8f7 g5d8 f7g6 d8h4
info depth 20 seldepth 32 time 21733 nodes 11659 score cp 51 hashfull 58 nps 536 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 e3e5 h2g1 g6f5 d1h5 h7g8 h5g5 g8f7 g5d8 f7g6 d8h4
info depth 20 seldepth 33 time 21833 nodes 11787 score cp 313 hashfull 59 nps 539 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 e3e5 h2g1 g6f5 d1h5 h7g8 h5g5 g8f7 g5d8 f7g6 d8h4
info depth 20 seldepth 33 time 23472 nodes 12886 score cp 67 hashfull 63 nps 548 tbhits 0 pv f1g2 h6h2 g1f1 g8h7 a8e8 h8e8 a1a4 e3e2 f1f2 e8f8 a4f4 f8f4 g3f4 e2d1n e1d1 h2f4 f2g1 f4e3 g1h2 e3e5 h2g1 g6f5 d1h5 h7g8 h5h4 g8f7 h4h5 f5g6 h5e5 d6e5 g1f2
bestmove f1g2 ponder h6h2
````
