### PR TITLE
[WIP] Change nps estimation formula to use exponential smoothing and more

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -218,16 +218,10 @@ SearchLimits EngineController::PopulateSearchLimits(
   // Evenly split total time between all moves.
   float this_move_time = total_moves_time / movestogo;
 
-  // Only extend thinking time with slowmover if smart pruning can potentially
-  // reduce it.
-  constexpr int kSmartPruningToleranceMs = 200;
-  if (slowmover < 1.0 ||
-      this_move_time * slowmover > kSmartPruningToleranceMs) {
-    this_move_time *= slowmover;
-    // If time is planned to be overused because of slowmover, remove excess
-    // of that time from spared time.
-    time_spared_ms_ -= this_move_time * (slowmover - 1);
-  }
+  this_move_time *= slowmover;
+  // If time is planned to be overused because of slowmover, remove excess
+  // of that time from spared time.
+  time_spared_ms_ -= this_move_time * (slowmover - 1);
 
   LOGFILE << "Budgeted time for the move: " << this_move_time << "ms(+"
           << time_to_squander << "ms to squander -"

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -418,10 +418,12 @@ void Search::UpdateRemainingMoves() {
       if (initial_nps_trend_present_ && previous_npms_average) {
         const float npms_trend = (*npms_average_ - *previous_npms_average) /
                                  time_since_last_nps_update;
+        const bool skip = !!npms_average_trend_;  // dirty fix to ensure trend has been calculated at least twice.
         npms_average_trend_ = ExponentialSmoothingUpdate(
             npms_average_trend_, npms_trend,
             1 - std::exp(-time_since_last_nps_update / 100.0f));
-        if (*npms_average_trend_ <= 0) {
+        
+        if (*npms_average_trend_ <= 0 && !skip) {
           initial_nps_trend_present_ = false;
           if (!average_move_npms_) {
             npms_average_ = *npms_average_ * 2;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -405,6 +405,7 @@ void Search::UpdateRemainingMoves() {
           npms_average_ = alpha * *npms_average_ + (1 - alpha) * instant_npms;
           LOGFILE << "Updating average: " << *npms_average_
                   << ", alpha: " << alpha;
+
           if (!npms_trend_average_) {
             npms_trend_average_ =
                 (*npms_average_ - prev_npms_average) / time_delta;
@@ -436,11 +437,11 @@ void Search::UpdateRemainingMoves() {
             }
           }
         }
+        npms_prev_time_ = npms_start_time;
+        npms_prev_playouts_ = total_playouts_;
       }
-      npms_prev_time_ = npms_start_time;
-      npms_prev_playouts_ = total_playouts_;
-      prev_remaining_playouts_ = remaining_playouts_;
     }
+    prev_remaining_playouts_ = remaining_playouts_;
   }
 
   // Check how many visits are left.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -360,88 +360,95 @@ void Search::MaybeTriggerStop() {
          final_pondermove_.GetMove(!played_history_.IsBlackToMove())});
     bestmove_is_sent_ = true;
     current_best_edge_ = EdgeAndNode();
-    const float move_npms = 1.0f * total_playouts_ / GetTimeSinceStart();
-    if (!average_move_npms_) {
-      average_move_npms_ = move_npms;
-    } else {
-      const float alpha = 2.0f / 3.0f;
-      average_move_npms_ =
-          *average_move_npms_ * (1 - alpha) + move_npms * alpha;
-    }
+    average_move_npms_ = ExponentialSmoothingUpdate(
+        average_move_npms_, 1.0f * total_playouts_ / GetTimeSinceStart(),
+        2.0f / 3.0f);
   }
+}
+
+float Search::ExponentialSmoothingUpdate(optional<float> smoothed_value,
+                                         float next_value,
+                                         float smoothing_factor) {
+  if (!smoothed_value) return next_value;
+  return smoothing_factor * next_value +
+         (1 - smoothing_factor) * smoothed_value;
 }
 
 void Search::UpdateRemainingMoves() {
   if (params_.GetSmartPruningFactor() <= 0.0f) return;
   SharedMutex::Lock lock(nodes_mutex_);
   remaining_playouts_ = std::numeric_limits<int64_t>::max();
-  // Check for how many playouts there is time remaining.
+  // Estimate how many more nodes we will visit in the remaining search time.
   if (limits_.search_deadline) {
-    const auto npms_start_time = std::chrono::steady_clock::now();
-    if (!npms_prev_time_) {
-      npms_prev_time_ = npms_start_time;
-      npms_prev_playouts_ = total_playouts_;
-    } else {
-      const auto time_delta =
-          std::chrono::duration_cast<std::chrono::milliseconds>(
-              npms_start_time - *npms_prev_time_)
-              .count();
-      const auto nodes_delta = total_playouts_ - npms_prev_playouts_;
-      LOGFILE << "time_delta: " << time_delta
-              << ", nodes_delta: " << nodes_delta;
-      if (time_delta <= 0 || nodes_delta <= 0) {
-        remaining_playouts_ = prev_remaining_playouts_;
-        LOGFILE << "same playouts, using prev playouts: "
-                << remaining_playouts_;
-      } else {
-        const float instant_npms = 1.0f * nodes_delta / time_delta;
-        LOGFILE << "instant_npms: " << instant_npms;
-        if (!npms_average_) {
-          npms_average_ = instant_npms;
-          LOGFILE << "setting up average: " << *npms_average_;
-        } else {
-          const float alpha = std::exp(-time_delta / 2000.0f);
-          const auto prev_npms_average = *npms_average_;
-          npms_average_ = alpha * *npms_average_ + (1 - alpha) * instant_npms;
-          LOGFILE << "Updating average: " << *npms_average_
-                  << ", alpha: " << alpha;
+    const auto nps_update_time = std::chrono::steady_clock::now();
+    if (!last_nps_update_time_) {
+      last_nps_update_time_ = nps_update_time;
+      last_nps_update_playouts_ = total_playouts_;
+    }
 
-          if (!npms_trend_average_) {
-            npms_trend_average_ =
-                (*npms_average_ - prev_npms_average) / time_delta;
-            LOGFILE << "Setting up trend" << *npms_trend_average_;
-          } else {
-            if (npms_beginning_trend_) {
-              const auto instant_npms_trend =
-                  (*npms_average_ - prev_npms_average) / time_delta;
-              const float beta = std::exp(-time_delta / 100.0f);
-              npms_trend_average_ =
-                  *npms_trend_average_ * beta + instant_npms_trend * (1 - beta);
-              LOGFILE << "Updating trend: " << *npms_trend_average_
-                      << ", beta: " << beta;
-              if (*npms_trend_average_ <= 0) {
-                LOGFILE << "End of trend";
-                npms_beginning_trend_ = false;
-                remaining_playouts_ = std::numeric_limits<int>::max();
-                if (!average_move_npms_) {
-                  npms_average_ = *npms_average_ * 2;
-                  LOGFILE << "Doubling average npms for first move";
-                }
-              }
-            }
-            if (!npms_beginning_trend_) {
-              remaining_playouts_ =
-                  *npms_average_ * GetTimeToDeadline() /
-                  params_.GetSmartPruningFactor();  // Can this overflow?
-              LOGFILE << "Setting remaining playouts " << remaining_playouts_;
-            }
+    const auto time_since_last_nps_update =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            nps_update_time - *last_nps_update_time_)
+            .count();
+    const auto nodes_since_last_nps_update =
+        total_playouts_ - last_nps_update_playouts_;
+
+    if (time_since_last_nps_update <= 0 || nodes_since_last_nps_update <= 0) {
+      // Skip the update.
+      remaining_playouts_ = prev_remaining_playouts_;
+    } else {
+      const float npms_since_last_update =
+          static_cast<float>(nodes_since_last_nps_update) /
+          time_since_last_nps_update;
+
+      optional<float> previous_npms_average;
+      if (npms_average_) {
+        previous_npms_average = *npms_average_;
+      }
+
+      npms_average_ = ExponentialSmoothingUpdate(
+          npms_average_, npms_since_last_update,
+          1 - std::exp(-time_since_last_nps_update / 2000.0f));
+
+      // Only update the npms trend estimate if we detect a trend in the
+      // beginning of the move.
+      if (!initial_nps_trend_present_ && previous_npms_average) {
+        const float npms_trend = (*npms_average_ - *previous_npms_average) /
+                                 time_since_last_nps_update;
+        npms_average_trend_ = ExponentialSmoothingUpdate(
+            npms_average_trend_, npms_trend,
+            1 - std::exp(-time_since_last_nps_update / 100.0f));
+        if (*npms_average_trend_ <= 0) {
+          initial_nps_trend_present_ = false;
+          if (!average_move_npms_) {
+            npms_average_ = *npms_average_ * 2;
+            LOGFILE << "[NPS] Doubling average npms for first move after trend";
           }
         }
-        npms_prev_time_ = npms_start_time;
-        npms_prev_playouts_ = total_playouts_;
+        LOGFILE << "[NPS] npms_trend: " << npms_trend
+                << ", npms_average_trend: " << *npms_average_trend_
+                << ", initial_trend_present: " << initial_nps_trend_present_;
       }
+
+      if (initial_nps_trend_present_) {
+        remaining_playouts_ = prev_remaining_playouts_;
+      } else {
+        remaining_playouts_ =
+            *npms_average_ * GetTimeToDeadline() /
+            params_.GetSmartPruningFactor();  // Maybe check for overflow here.
+      }
+
+      LOGFILE << "[NPS] update_time: " << nps_update_time
+              << ", time_since_last_update: " << time_since_last_nps_update
+              << ", nodes_since_last_update: " << nodes_since_last_nps_update
+              << ", npms_since_last_update: " << npms_since_last_update
+              << ", npms_average: " << *npms_average_
+              << ", remaining_playouts: " << remaining_playouts_;
+
+      last_nps_update_time_ = nps_update_time;
+      last_nps_update_playouts_ = total_playouts_;
+      prev_remaining_playouts_ = remaining_playouts_;
     }
-    prev_remaining_playouts_ = remaining_playouts_;
   }
 
   // Check how many visits are left.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -418,7 +418,7 @@ void Search::UpdateRemainingMoves() {
       if (initial_nps_trend_present_ && previous_npms_average) {
         const float npms_trend = (*npms_average_ - *previous_npms_average) /
                                  time_since_last_nps_update;
-        const bool skip = !!npms_average_trend_;  // dirty fix to ensure trend has been calculated at least twice.
+        const bool skip = !npms_average_trend_;  // dirty fix to ensure trend has been calculated at least twice.
         npms_average_trend_ = ExponentialSmoothingUpdate(
             npms_average_trend_, npms_trend,
             1 - std::exp(-time_since_last_nps_update / 100.0f));

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -404,6 +404,9 @@ void Search::UpdateRemainingMoves() {
       optional<float> previous_npms_average;
       if (npms_average_) {
         previous_npms_average = *npms_average_;
+      } else if (average_move_npms_) {
+        npms_average_ = *average_move_npms_;
+        previous_npms_average = *previous_npms_average;
       }
 
       npms_average_ = ExponentialSmoothingUpdate(

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -438,7 +438,7 @@ void Search::UpdateRemainingMoves() {
             params_.GetSmartPruningFactor();  // Maybe check for overflow here.
       }
 
-      LOGFILE << "[NPS] update_time: " << nps_update_time
+      LOGFILE << "[NPS] update_time: " << GetTimeSinceStart()
               << ", time_since_last_update: " << time_since_last_nps_update
               << ", nodes_since_last_update: " << nodes_since_last_nps_update
               << ", npms_since_last_update: " << npms_since_last_update

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -378,7 +378,10 @@ void Search::UpdateRemainingMoves() {
   // Check for how many playouts there is time remaining.
   if (limits_.search_deadline) {
     const auto npms_start_time = std::chrono::steady_clock::now();
-    if (npms_prev_time_) {
+    if (!npms_prev_time_) {
+      npms_prev_time_ = npms_start_time;
+      npms_prev_playouts_ = total_playouts_;
+    } else {
       const auto time_delta =
           std::chrono::duration_cast<std::chrono::milliseconds>(
               npms_start_time - *npms_prev_time_)

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -412,7 +412,7 @@ void Search::UpdateRemainingMoves() {
 
       // Only update the npms trend estimate if we detect a trend in the
       // beginning of the move.
-      if (!initial_nps_trend_present_ && previous_npms_average) {
+      if (initial_nps_trend_present_ && previous_npms_average) {
         const float npms_trend = (*npms_average_ - *previous_npms_average) /
                                  time_since_last_nps_update;
         npms_average_trend_ = ExponentialSmoothingUpdate(

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -381,7 +381,7 @@ void Search::UpdateRemainingMoves() {
     if (npms_prev_time_) {
       const auto time_delta =
           std::chrono::duration_cast<std::chrono::milliseconds>(
-              nps_start_time - *npms_prev_time_)
+              npms_start_time - *npms_prev_time_)
               .count();
       const auto nodes_delta = total_playouts_ - npms_prev_playouts_;
       LOGFILE << "time_delta: " << time_delta

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -371,7 +371,7 @@ float Search::ExponentialSmoothingUpdate(optional<float> smoothed_value,
                                          float smoothing_factor) {
   if (!smoothed_value) return next_value;
   return smoothing_factor * next_value +
-         (1 - smoothing_factor) * smoothed_value;
+         (1 - smoothing_factor) * *smoothed_value;
 }
 
 void Search::UpdateRemainingMoves() {

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -44,7 +44,7 @@
 namespace lczero {
 
 namespace {
-  optional<float> average_move_npms_;
+optional<float> average_move_npms_;
 }
 
 struct SearchLimits {
@@ -115,6 +115,8 @@ class Search {
   int64_t GetTimeSinceStart() const;
   int64_t GetTimeToDeadline() const;
   void UpdateRemainingMoves();
+  float ExponentialSmoothingUpdate(optional<float> smoothed_value,
+                                   float next_value, float smoothing_factor);
   void MaybeTriggerStop();
   void MaybeOutputInfo();
   void SendUciInfo();  // Requires nodes_mutex_ to be held.
@@ -178,11 +180,12 @@ class Search {
   int64_t remaining_playouts_ GUARDED_BY(nodes_mutex_) =
       std::numeric_limits<int64_t>::max();
 
-  optional<std::chrono::steady_clock::time_point> npms_prev_time_ GUARDED_BY(nodes_mutex_);
+  optional<std::chrono::steady_clock::time_point> last_nps_update_time_
+      GUARDED_BY(nodes_mutex_);
   optional<float> npms_average_ GUARDED_BY(nodes_mutex_) = average_move_npms_;
-  optional<float> npms_trend_average_ GUARDED_BY(nodes_mutex_);
-  int64_t npms_prev_playouts_ GUARDED_BY(nodes_mutex_) = total_playouts_;
-  bool npms_beginning_trend_ GUARDED_BY(nodes_mutex_) = true;
+  optional<float> npms_average_trend_ GUARDED_BY(nodes_mutex_);
+  int64_t last_nps_update_playouts_ GUARDED_BY(nodes_mutex_) = total_playouts_;
+  bool initial_nps_trend_present_ GUARDED_BY(nodes_mutex_) = true;
   int64_t prev_remaining_playouts_ GUARDED_BY(nodes_mutex_) =
       std::numeric_limits<int64_t>::max();
 

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -43,6 +43,10 @@
 
 namespace lczero {
 
+namespace {
+  optional<float> average_move_npms_;
+}
+
 struct SearchLimits {
   // Type for N in nodes is currently uint32_t, so set limit in order not to
   // overflow it.
@@ -165,7 +169,6 @@ class Search {
   const SearchLimits limits_;
   const std::chrono::steady_clock::time_point start_time_;
   const int64_t initial_visits_;
-  optional<std::chrono::steady_clock::time_point> nps_start_time_;
 
   mutable SharedMutex nodes_mutex_;
   EdgeAndNode current_best_edge_ GUARDED_BY(nodes_mutex_);
@@ -174,6 +177,15 @@ class Search {
   int64_t total_playouts_ GUARDED_BY(nodes_mutex_) = 0;
   int64_t remaining_playouts_ GUARDED_BY(nodes_mutex_) =
       std::numeric_limits<int64_t>::max();
+
+  optional<std::chrono::steady_clock::time_point> npms_prev_time_ GUARDED_BY(nodes_mutex_);
+  optional<float> npms_average_ GUARDED_BY(nodes_mutex_) = average_move_npms_;
+  optional<float> npms_trend_average_ GUARDED_BY(nodes_mutex_);
+  int64_t npms_prev_playouts_ GUARDED_BY(nodes_mutex_) = total_playouts_;
+  bool npms_beginning_trend_ GUARDED_BY(nodes_mutex_) = true;
+  int64_t prev_remaining_playouts_ GUARDED_BY(nodes_mutex_) =
+      std::numeric_limits<int64_t>::max();
+
   // Maximum search depth = length of longest path taken in PickNodetoExtend.
   uint16_t max_depth_ GUARDED_BY(nodes_mutex_) = 0;
   // Cummulative depth of all paths taken in PickNodetoExtend.

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -182,7 +182,7 @@ class Search {
 
   optional<std::chrono::steady_clock::time_point> last_nps_update_time_
       GUARDED_BY(nodes_mutex_);
-  optional<float> npms_average_ GUARDED_BY(nodes_mutex_) = average_move_npms_;
+  optional<float> npms_average_ GUARDED_BY(nodes_mutex_);
   optional<float> npms_average_trend_ GUARDED_BY(nodes_mutex_);
   int64_t last_nps_update_playouts_ GUARDED_BY(nodes_mutex_) = total_playouts_;
   bool initial_nps_trend_present_ GUARDED_BY(nodes_mutex_) = true;


### PR DESCRIPTION
This changes the nps calculation for smart pruning by:
- Using exponential smoothing (formula [here](https://pdfs.semanticscholar.org/882e/93570eae184ae737bf0344cb50a2925e353d.pdf) which deals with irregular time steps) instead of playouts / time. _This makes smart pruning more responsive to changes in nps._
- Turning off smart pruning if there is a trend upwards in nps at the beginning of the move. _Because we don't know how high it will go and don't want to underestimate._
- Using the previous move's average nps to seed the exponential smoothing of the next move. _Helps make next nps estimation more accurate, as long as the npss' are similar, and helps account for any initial trend in the nps._
- Doubles the initial nps estimate for the first move of the game (after the initial trend is finished). _My analysis shows that the first move typically underestimates, so this seems to counteract it well_.

Instead of smart pruning nodes tolerance and smart pruning time tolerance there is now:
- `nps_smoothing_factor = 2000`
- `nps_trend_smoothing_factor = 200`
- `average_move_nps_smoothing_factor = 2/3`

My analysis showed that these are decent values at least for Google Colab. Needs to be tested for other setups.

Code is still convoluted and needs commenting but it seems to work and can be tested for bugs and performance now (I haven't yet tested if it is stronger than master). `SmartPruningFactor` may need to be retuned.

The pictures that follow are an analysis of the first 5 moves of a 15+10 game I tested with.
- The ideal curve uses future information so is unobtainable.
- The y-axis is remaining playouts, x-axis is time (ms).
- Curves show behaviour with `SmartPruningFactor = 1`
- A good result is to match the ideal curve and not go too much under it (or you will underestimate and maybe instamove in a bad situation). It's better to be over than under.
- Parameters can be changed to make the graph smoother like master, but there is a trade off in responsiveness.
- Rest of the moves are [in this album](https://imgur.com/a/AviYe9p).

![0](https://user-images.githubusercontent.com/313295/51099294-d817c500-181f-11e9-9cad-c8c199e0bbff.png)
![1](https://user-images.githubusercontent.com/313295/51099295-d8b05b80-181f-11e9-9651-b17ed4e0f26f.png)
![2](https://user-images.githubusercontent.com/313295/51099296-d8b05b80-181f-11e9-8579-fc5c406d0877.png)
![3](https://user-images.githubusercontent.com/313295/51099297-d948f200-181f-11e9-8608-fa4214b0a2b7.png)
![4](https://user-images.githubusercontent.com/313295/51099298-d948f200-181f-11e9-9cbd-0e7f54d15480.png)