### PR TITLE
During search, score positions repeated once as draws

### DIFF
--- a/src/chess/position.cc
+++ b/src/chess/position.cc
@@ -127,6 +127,15 @@ bool PositionHistory::DidRepeatSinceLastZeroingMove() const {
   return false;
 }
 
+bool PositionHistory::IsContainedInHistorySinceLastZeroingMove(
+    const ChessBoard& board) const {
+  for (int idx = positions_.size(); idx >= 0; idx--) {
+    if (board == positions_[idx].GetBoard()) return true;
+    if (positions_[idx].GetNoCaptureNoPawnPly() == 0) return false;
+  }
+  return false;
+}
+
 uint64_t PositionHistory::HashLast(int positions) const {
   uint64_t hash = positions;
   for (auto iter = positions_.rbegin(), end = positions_.rend(); iter != end;

--- a/src/chess/position.h
+++ b/src/chess/position.h
@@ -126,6 +126,10 @@ class PositionHistory {
   // Checks for any repetitions since the last time 50 move rule was reset.
   bool DidRepeatSinceLastZeroingMove() const;
 
+  // Verifies if the given position exists in the position history since the
+  // last time 50 move rule was reset.
+  bool IsContainedInHistorySinceLastZeroingMove(const ChessBoard& board) const;
+
  private:
   int ComputeLastMoveRepetitions() const;
 

--- a/src/chess/position_test.cc
+++ b/src/chess/position_test.cc
@@ -128,6 +128,30 @@ TEST(PositionHistory, DidRepeatSinceLastZeroingMoveNeverRepeated) {
   EXPECT_FALSE(history.DidRepeatSinceLastZeroingMove());
 }
 
+TEST(PositionHistory, IsContainedInHistorySinceLastZeroingMoveWorksAsExpected) {
+  ChessBoard board;
+  PositionHistory history;
+  board.SetFromFen("3b4/rp1r1k2/8/1RP2p1p/p1KP4/P3P2P/5P2/1R2B3 b - - 2 30");
+  history.Reset(board, 2, 30);
+  history.Append(Move("f7f8", true));
+  history.Append(Move("f2f4", false));
+  history.Append(Move("d7h7", true));
+  history.Append(Move("c4d3", false));
+  history.Append(Move("h7d7", true));
+  history.Append(Move("d3c4", false));
+  history.Append(Move("d7e7", true));
+  EXPECT_FALSE(history.IsContainedInHistorySinceLastZeroingMove(
+      ChessBoard::kStartposBoard));
+  bool expects_true = true;
+  for (int idx = history.GetLength(); idx >= 0; --idx) {
+    const bool worked = history.IsContainedInHistorySinceLastZeroingMove(
+        history.GetPositionAt(idx).GetBoard());
+    EXPECT_EQ(worked, expects_true);
+    if (history.GetPositionAt(idx).GetNoCaptureNoPawnPly() == 0)
+      expects_true = false;
+  }
+}
+
 }  // namespace lczero
 
 int main(int argc, char** argv) {

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -160,6 +160,9 @@ const OptionId SearchParams::kHistoryFillId{
     "one. During the first moves of the game such historical positions don't "
     "exist, but they can be synthesized. This parameter defines when to "
     "synthesize them (always, never, or only at non-standard fen position)."};
+const OptionId SearchParams::kRepetitionsIsDrawId{
+    "repetitions-before-draw-score", "RepetitionsBeforeDrawScore",
+    "How many repetitions before scoring nodes as draw during search."};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -193,6 +196,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kScoreTypeId, score_type) = "centipawn";
   std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
+  options->Add<IntOption>(kRepetitionsIsDrawId, 1, 2) = 2;
 }
 
 SearchParams::SearchParams(const OptionsDict& options)
@@ -213,7 +217,7 @@ SearchParams::SearchParams(const OptionsDict& options)
       kOutOfOrderEval(options.Get<bool>(kOutOfOrderEvalId.GetId())),
       kHistoryFill(
           EncodeHistoryFill(options.Get<std::string>(kHistoryFillId.GetId()))),
-      kMiniBatchSize(options.Get<int>(kMiniBatchSizeId.GetId())){
-}
+      kMiniBatchSize(options.Get<int>(kMiniBatchSizeId.GetId())),
+      kRepetitionsIsDraw(options.Get<int>(kRepetitionsIsDrawId.GetId())) {}
 
 }  // namespace lczero

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -160,9 +160,9 @@ const OptionId SearchParams::kHistoryFillId{
     "one. During the first moves of the game such historical positions don't "
     "exist, but they can be synthesized. This parameter defines when to "
     "synthesize them (always, never, or only at non-standard fen position)."};
-const OptionId SearchParams::kRepetitionsIsDrawId{
-    "repetitions-before-draw-score", "RepetitionsBeforeDrawScore",
-    "How many repetitions before scoring nodes as draw during search."};
+const OptionId SearchParams::kTwoFoldRepsIsDrawId{
+    "score-two-fold-reps-as-draws", "Score two fold reps as draws",
+    "Wheter or not to score two fold reps as draws during search."};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -196,7 +196,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kScoreTypeId, score_type) = "centipawn";
   std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
-  options->Add<IntOption>(kRepetitionsIsDrawId, 1, 2) = 2;
+  options->Add<BoolOption>(kTwoFoldRepsIsDrawId) = false;
 }
 
 SearchParams::SearchParams(const OptionsDict& options)
@@ -218,6 +218,6 @@ SearchParams::SearchParams(const OptionsDict& options)
       kHistoryFill(
           EncodeHistoryFill(options.Get<std::string>(kHistoryFillId.GetId()))),
       kMiniBatchSize(options.Get<int>(kMiniBatchSizeId.GetId())),
-      kRepetitionsIsDraw(options.Get<int>(kRepetitionsIsDrawId.GetId())) {}
+      kTwoFoldRepsIsDraw(options.Get<bool>(kTwoFoldRepsIsDrawId.GetId())) {}
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -88,7 +88,7 @@ class SearchParams {
     return options_.Get<std::string>(kScoreTypeId.GetId());
   }
   FillEmptyHistory GetHistoryFill() const { return kHistoryFill; }
-  int GetRepetitionsIsDraw() const { return kRepetitionsIsDraw; }
+  int GetTwoFoldRepsIsDraw() const { return kTwoFoldRepsIsDraw; }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -116,7 +116,7 @@ class SearchParams {
   static const OptionId kMultiPvId;
   static const OptionId kScoreTypeId;
   static const OptionId kHistoryFillId;
-  static const OptionId kRepetitionsIsDrawId;
+  static const OptionId kTwoFoldRepsIsDrawId;
 
  private:
   const OptionsDict& options_;
@@ -141,7 +141,7 @@ class SearchParams {
   const bool kOutOfOrderEval;
   const FillEmptyHistory kHistoryFill;
   const int kMiniBatchSize;
-  const int kRepetitionsIsDraw;
+  const bool kTwoFoldRepsIsDraw;
 };
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -88,6 +88,7 @@ class SearchParams {
     return options_.Get<std::string>(kScoreTypeId.GetId());
   }
   FillEmptyHistory GetHistoryFill() const { return kHistoryFill; }
+  int GetRepetitionsIsDraw() const { return kRepetitionsIsDraw; }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -115,6 +116,7 @@ class SearchParams {
   static const OptionId kMultiPvId;
   static const OptionId kScoreTypeId;
   static const OptionId kHistoryFillId;
+  static const OptionId kRepetitionsIsDrawId;
 
  private:
   const OptionsDict& options_;
@@ -139,6 +141,7 @@ class SearchParams {
   const bool kOutOfOrderEval;
   const FillEmptyHistory kHistoryFill;
   const int kMiniBatchSize;
+  const int kRepetitionsIsDraw;
 };
 
 }  // namespace lczero

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -988,9 +988,29 @@ void SearchWorker::ExtendNode(Node* node) {
       return;
     }
 
-    if (history_.Last().GetRepetitions() >= 2) {
-      node->MakeTerminal(GameResult::DRAW);
-      return;
+    if (params_.GetRepetitionsIsDraw() == 2) {
+      // Old behaviour
+      if (history_.Last().GetRepetitions() >= 2) {
+        node->MakeTerminal(GameResult::DRAW);
+        return;
+      }
+    } else {
+      // New draw scoring
+      if (history_.Last().GetRepetitions() >= 1) {
+        int repeats_required = 1;
+        const auto& played_history = search_->played_history_;
+        for (int idx = played_history.GetLength() - 1; idx >= 0; --idx) {
+          if (history_.Last().GetBoard() ==
+              played_history.GetPositionAt(idx).GetBoard()) {
+            repeats_required = 2;
+            break;
+          }
+        }
+        if (history_.Last().GetRepetitions() >= repeats_required) {
+          node->MakeTerminal(GameResult::DRAW);
+          return;
+        }
+      }
     }
 
     // Neither by-position or by-rule termination, but maybe it's a TB position.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -991,15 +991,13 @@ void SearchWorker::ExtendNode(Node* node) {
     if (params_.GetTwoFoldRepsIsDraw()) {
       // Two fold reps are scored as draws during search
       if (history_.Last().GetRepetitions() > 0) {
-        int repeats_required = 1;
-        const auto& played_history = search_->played_history_;
-        for (int idx = played_history.GetLength() - 1; idx >= 0; --idx) {
-          if (history_.Last().GetBoard() ==
-              played_history.GetPositionAt(idx).GetBoard()) {
-            repeats_required = 2;
-            break;
-          }
-        }
+        // If the previous position was repeated in the played history, then at
+        // least two repetitions are required for Draw scoring.
+        int repeats_required =
+            search_->played_history_.IsContainedInHistorySinceLastZeroingMove(
+                history_.Last().GetBoard())
+                ? 2
+                : 1;
         if (history_.Last().GetRepetitions() >= repeats_required) {
           node->MakeTerminal(GameResult::DRAW);
           return;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -988,15 +988,9 @@ void SearchWorker::ExtendNode(Node* node) {
       return;
     }
 
-    if (params_.GetRepetitionsIsDraw() == 2) {
-      // Old behaviour
-      if (history_.Last().GetRepetitions() >= 2) {
-        node->MakeTerminal(GameResult::DRAW);
-        return;
-      }
-    } else {
-      // New draw scoring
-      if (history_.Last().GetRepetitions() >= 1) {
+    if (params_.GetTwoFoldRepsIsDraw()) {
+      // Two fold reps are scored as draws during search
+      if (history_.Last().GetRepetitions() > 0) {
         int repeats_required = 1;
         const auto& played_history = search_->played_history_;
         for (int idx = played_history.GetLength() - 1; idx >= 0; --idx) {
@@ -1010,6 +1004,12 @@ void SearchWorker::ExtendNode(Node* node) {
           node->MakeTerminal(GameResult::DRAW);
           return;
         }
+      }
+    } else {
+      // Old behaviour
+      if (history_.Last().GetRepetitions() >= 2) {
+        node->MakeTerminal(GameResult::DRAW);
+        return;
       }
     }
 


### PR DESCRIPTION
This is a draft to check if there is interest on this. The idea is to score positions that have happened at least once before in search as terminal node draws. If the position was repeated before it needs two reps to score as draw. This way the search becomes a directed acyclic graph.
More info: https://www.chessprogramming.org/Repetitions

The intention of this is to help with perpetuals and make Leela play a little less troll in general, but could also help with strength a bit.

Test results using a ID 35920:
```
command: lc0.exe selfplay --no-share-trees --games=1500 --visits=1000 --temperature=1 --tempdecay-moves=10 --player1.repetitions-before-draw-score=1
Result: tournamentstatus final win 196 93 lose 80 190 draw 474 467
```
```
command: lc0.exe selfplay --no-share-trees --games=1500 --visits=1200 --temperature=1 --tempdecay-moves=10 --player1.repetitions-before-draw-score=1
Result: tournamentstatus final win 196 73 lose 49 174 draw 505 503
```

If there is interest on having this, then the search history could be improved to have a hash for fast lookup of repeated positions to address this TODO: https://github.com/LeelaChessZero/lc0/blob/f66f69e1bd82509c2582afa3cefc71ea1352dec9/src/chess/position.cc#L108