### PR TITLE
no terminal multivisits

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -857,8 +857,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     // Either terminal or unexamined leaf node -- the end of this playout.
     if (!node->HasChildren()) {
       if (node->IsTerminal()) {
-        IncrementNInFlight(node, search_->root_node_, collision_limit - 1);
-        return NodeToProcess::TerminalHit(node, depth, collision_limit);
+        return NodeToProcess::TerminalHit(node, depth, 1);
       } else {
         return NodeToProcess::Extension(node, depth);
       }


### PR DESCRIPTION
This is an alternative to #629 (suggested by @mooskagh) that disables multivisits for terminal nodes.