### PR TITLE
Check Syzygy tablebase file sizes for corruption

### DIFF
--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -44,6 +44,7 @@
 
 #include "syzygy/syzygy.h"
 
+#include "utils/exception.h"
 #include "utils/logging.h"
 #include "utils/mutex.h"
 
@@ -1042,8 +1043,7 @@ class SyzygyTablebaseImpl {
     if (fd == -1) return nullptr;
     fstat(fd, &statbuf);
     if (statbuf.st_size % 64 != 16) {
-      CERR << "Corrupt tablebase file " << fname;
-      throw std::runtime_error("Corrupt tablebase file.");
+      throw Exception("Corrupt tablebase file " + fname);
     }
     *mapping = statbuf.st_size;
     base_address = mmap(nullptr, statbuf.st_size, PROT_READ, MAP_SHARED, fd, 0);
@@ -1060,8 +1060,7 @@ class SyzygyTablebaseImpl {
     DWORD size_high;
     DWORD size_low = GetFileSize(fd, &size_high);
     if (size_low % 64 != 16) {
-      CERR << "Corrupt tablebase file " << fname;
-      throw std::runtime_error("Corrupt tablebase file.");
+      throw Exception("Corrupt tablebase file " + fname);
     }
     HANDLE mmap = CreateFileMapping(fd, nullptr, PAGE_READONLY, size_high,
                                     size_low, nullptr);

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -1041,6 +1041,10 @@ class SyzygyTablebaseImpl {
     int fd = ::open(fname.c_str(), O_RDONLY);
     if (fd == -1) return nullptr;
     fstat(fd, &statbuf);
+    if (statbuf.st_size % 64 != 16) {
+      CERR << "Corrupt tablebase file " << fname;
+      exit(1);
+    }
     *mapping = statbuf.st_size;
     base_address = mmap(nullptr, statbuf.st_size, PROT_READ, MAP_SHARED, fd, 0);
     ::close(fd);
@@ -1055,6 +1059,10 @@ class SyzygyTablebaseImpl {
     if (fd == INVALID_HANDLE_VALUE) return nullptr;
     DWORD size_high;
     DWORD size_low = GetFileSize(fd, &size_high);
+    if (size_low % 64 != 16) {
+      CERR << "Corrupt tablebase file " << fname;
+      exit(1);
+    }
     HANDLE mmap = CreateFileMapping(fd, nullptr, PAGE_READONLY, size_high,
                                     size_low, nullptr);
     CloseHandle(fd);

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -1043,7 +1043,7 @@ class SyzygyTablebaseImpl {
     fstat(fd, &statbuf);
     if (statbuf.st_size % 64 != 16) {
       CERR << "Corrupt tablebase file " << fname;
-      exit(1);
+      throw std::runtime_error("Corrupt tablebase file.");
     }
     *mapping = statbuf.st_size;
     base_address = mmap(nullptr, statbuf.st_size, PROT_READ, MAP_SHARED, fd, 0);
@@ -1061,7 +1061,7 @@ class SyzygyTablebaseImpl {
     DWORD size_low = GetFileSize(fd, &size_high);
     if (size_low % 64 != 16) {
       CERR << "Corrupt tablebase file " << fname;
-      exit(1);
+      throw std::runtime_error("Corrupt tablebase file.");
     }
     HANDLE mmap = CreateFileMapping(fd, nullptr, PAGE_READONLY, size_high,
                                     size_low, nullptr);


### PR DESCRIPTION
Check that Syzygy tablebase file sizes modulo 64 are 16 as a simple check for corruption.
Inspired by a [Stockfish PR](https://github.com/official-stockfish/Stockfish/commit/bb843a00c1ef381162dc9c2491b5436b6cf5563f) by vondele.