### PR TITLE
Fix Cpuct formula to match AlphaZero paper

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -58,8 +58,6 @@ const OptionId SearchParams::kCpuctBaseId{
     "cpuct-base", "CPuctBase",
     "cpuct_base constant from \"UCT search\" algorithm. Lower value means "
     "higher growth of Cpuct as number of node visits grows."};
-const OptionId SearchParams::kCpuctFactorId{
-    "cpuct-factor", "CPuctFactor", "Multiplier for the cpuct growth formula."};
 const OptionId SearchParams::kTemperatureId{
     "temperature", "Temperature",
     "Tau value from softmax formula for the first move. If equal to 0, the "
@@ -166,9 +164,8 @@ void SearchParams::Populate(OptionsParser* options) {
   // Many of them are overridden with training specific values in tournament.cc.
   options->Add<IntOption>(kMiniBatchSizeId, 1, 1024) = 256;
   options->Add<IntOption>(kMaxPrefetchBatchId, 0, 1024) = 32;
-  options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 3.0f;
+  options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 1.5f;
   options->Add<FloatOption>(kCpuctBaseId, 1.0f, 1000000000.0f) = 19652.0f;
-  options->Add<FloatOption>(kCpuctFactorId, 0.0f, 1000.0f) = 2.0f;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 100) = 0;
   options->Add<IntOption>(kTemperatureCutoffMoveId, 0, 1000) = 0;
@@ -199,7 +196,6 @@ SearchParams::SearchParams(const OptionsDict& options)
     : options_(options),
       kCpuct(options.Get<float>(kCpuctId.GetId())),
       kCpuctBase(options.Get<float>(kCpuctBaseId.GetId())),
-      kCpuctFactor(options.Get<float>(kCpuctFactorId.GetId())),
       kNoise(options.Get<bool>(kNoiseId.GetId())),
       kSmartPruningFactor(options.Get<float>(kSmartPruningFactorId.GetId())),
       kFpuAbsolute(options.Get<std::string>(kFpuStrategyId.GetId()) ==
@@ -213,7 +209,6 @@ SearchParams::SearchParams(const OptionsDict& options)
       kOutOfOrderEval(options.Get<bool>(kOutOfOrderEvalId.GetId())),
       kHistoryFill(
           EncodeHistoryFill(options.Get<std::string>(kHistoryFillId.GetId()))),
-      kMiniBatchSize(options.Get<int>(kMiniBatchSizeId.GetId())){
-}
+      kMiniBatchSize(options.Get<int>(kMiniBatchSizeId.GetId())) {}
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -42,15 +42,12 @@ class SearchParams {
   static void Populate(OptionsParser* options);
 
   // Parameter getters.
-  int GetMiniBatchSize() const {
-    return kMiniBatchSize;
-  }
+  int GetMiniBatchSize() const { return kMiniBatchSize; }
   int GetMaxPrefetchBatch() const {
     return options_.Get<int>(kMaxPrefetchBatchId.GetId());
   }
   float GetCpuct() const { return kCpuct; }
   float GetCpuctBase() const { return kCpuctBase; }
-  float GetCpuctFactor() const { return kCpuctFactor; }
   float GetTemperature() const {
     return options_.Get<float>(kTemperatureId.GetId());
   }
@@ -94,7 +91,6 @@ class SearchParams {
   static const OptionId kMaxPrefetchBatchId;
   static const OptionId kCpuctId;
   static const OptionId kCpuctBaseId;
-  static const OptionId kCpuctFactorId;
   static const OptionId kTemperatureId;
   static const OptionId kTempDecayMovesId;
   static const OptionId kTemperatureCutoffMoveId;
@@ -126,7 +122,6 @@ class SearchParams {
   //            trivial search optimiations.
   const float kCpuct;
   const float kCpuctBase;
-  const float kCpuctFactor;
   const bool kNoise;
   const float kSmartPruningFactor;
   const bool kFpuAbsolute;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -197,9 +197,9 @@ inline float GetFpu(const SearchParams& params, Node* node, bool is_root_node) {
 
 inline float ComputeCpuct(const SearchParams& params, uint32_t N) {
   const float init = params.GetCpuct();
-  const float k = params.GetCpuctFactor();
   const float base = params.GetCpuctBase();
-  return init + (k ? k * FastLog((N + base) / base) : 0.0f);
+  // Double Cpuct because our Q is [-1,1] vs A0 [0,1].
+  return 2 * (init + FastLog((1 + N + base) / base));
 }
 }  // namespace
 
@@ -850,7 +850,8 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     // a search collision, and this node is already being expanded.
     if (!node->TryStartScoreUpdate()) {
       if (!is_root_node) {
-        IncrementNInFlight(node->GetParent(), search_->root_node_, collision_limit - 1);
+        IncrementNInFlight(node->GetParent(), search_->root_node_,
+                           collision_limit - 1);
       }
       return NodeToProcess::Collision(node, depth, collision_limit);
     }

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -86,8 +86,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   SelfPlayGame::PopulateUciParams(options);
   auto defaults = options->GetMutableDefaultsOptions();
   defaults->Set<int>(SearchParams::kMiniBatchSizeId.GetId(), 32);
-  defaults->Set<float>(SearchParams::kCpuctId.GetId(), 1.2f);
-  defaults->Set<float>(SearchParams::kCpuctFactorId.GetId(), 0.0f);
+  defaults->Set<float>(SearchParams::kCpuctId.GetId(), 0.6f);
   defaults->Set<float>(SearchParams::kPolicySoftmaxTempId.GetId(), 1.0f);
   defaults->Set<int>(SearchParams::kMaxCollisionVisitsId.GetId(), 1);
   defaults->Set<int>(SearchParams::kMaxCollisionEventsId.GetId(), 1);


### PR DESCRIPTION
I believe the Cpuct factor is defaulted to 2 because our Q is from -1 to 1 and AlphaZero's is 0 to 1. That means that our entire formula for calculating `U(s,a)` needs to be scaled by 2, not just the Cpuct growth part of the formula.

This also means that our Cpuct values are off by a factor of 2. ~~So really we are training the network with Cpuct = 0.6 not Cpuct=1.2.~~ I've adjusted the default self-play Cpuct value to match master's behaviour, ~~but to match AlphaZero it will need to be adjusted back.~~

You'll also notice that the default match Cpuct value is now closer to AlphaZero's chosen Cpuct value (maybe a coincidence).

I've also removed the Cpuct factor parameter. The AlphaZero paper says _C(s) is essentially constant during the fast training games_. They would've said something like _"C(s) is set to be constant during the fast training games"_ if they meant that C(s) is actually set to a constant value. With their CpuctBase value set to 16592, C(s) is essentially constant which matches what they say in the paper and also their pseudocode.