### PR TITLE
better fix for issue 651

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -660,7 +660,8 @@ void Search::Stop() {
 
 void Search::Abort() {
   Mutex::Lock lock(counters_mutex_);
-  if (!stop_.load(std::memory_order_acquire) || !bestmove_is_sent_) {
+  if (!stop_.load(std::memory_order_acquire) ||
+      (!bestmove_is_sent_ && !ok_to_respond_bestmove_)) {
     bestmove_is_sent_ = true;
     FireStopInternal();
   }


### PR DESCRIPTION
The previous fix for #651 (#658) made the problem fixed by #539 reappear. The issue is that `stop_` is set when reaching a limit so a `ponderhit` after that (with the original code) will not set `bestmove_is_sent_` that is needed for the search to exit. #658 was also checking if `bestmove_is_sent_` is not set but this allows a race when `Abort` is called too fast after `Stop` and the `bestmove` reply is not sent, thus confusing uci hosts that expect one. This patch adds a check that `ok_to_respond_bestmove_` (that is set by `Stop`) is not set, thus avoiding this race.