### PR TITLE
Informative Tournament Stats - Part 1 of PR487

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ subprojects/*
 !subprojects/*.wrap
 lc0.xcodeproj/
 *.swp
+/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ subprojects/*
 !subprojects/*.wrap
 lc0.xcodeproj/
 *.swp
-/.vs

--- a/src/selfplay/loop.cc
+++ b/src/selfplay/loop.cc
@@ -136,7 +136,7 @@ void SelfPlayLoop::SendTournament(const TournamentInfo& info) {
   if ((winp1 + losep1 + draws) > 0) {
     percentage =
         (static_cast<float>(draws) / 2 + winp1) / (winp1 + losep1 + draws);
-    }
+  }
   // Calculate elo and los if percentage strictly between 0 and 1 (avoids divide
   // by 0 or overflow).
   if ((percentage < 1) && (percentage > 0))
@@ -144,37 +144,30 @@ void SelfPlayLoop::SendTournament(const TournamentInfo& info) {
   if ((winp1 + losep1) > 0) {
     los = .5f +
           .5f * std::erf((winp1 - losep1) / std::sqrt(2.0 * (winp1 + losep1)));
-    }
-  std::string res = "tournamentstatus";
-  if (info.finished) res += " final";
-  res += " P1: +" + std::to_string(winp1) + " -" + std::to_string(losep1) +
-         " =" + std::to_string(draws);
+  }
+  std::ostringstream oss;
+  oss << "tournamentstatus";
+  if (info.finished) oss << " final";
+  oss << " P1: +" << winp1 << " -" << losep1 << " =" << draws;
 
   if (percentage > 0) {
-    std::ostringstream oss;
-    oss << std::fixed << std::setw(5) << std::setprecision(2)
+    oss << " Win: " << std::fixed << std::setw(5) << std::setprecision(2)
         << (percentage * 100.0f) << "%";
-    res += " Win: " + oss.str();
   }
   if (elo) {
-    std::ostringstream oss;
-    oss << std::fixed << std::setw(5) << std::setprecision(2) << (elo.value_or(0.0f));
-    res += " Elo: " + oss.str();
+    oss << " Elo: " << std::fixed << std::setw(5) << std::setprecision(2)
+        << (elo.value_or(0.0f));
   }
   if (los) {
-    std::ostringstream oss;
-    oss << std::fixed << std::setw(5) << std::setprecision(2) << (los.value_or(0.0f) * 100.0f)
-        << "%";
-    res += " LOS: " + oss.str();
+    oss << " LOS: " << std::fixed << std::setw(5) << std::setprecision(2)
+        << (los.value_or(0.0f) * 100.0f) << "%";
   }
-  res += " P1-W: +" + std::to_string(info.results[0][0]) + " -" +
-         std::to_string(info.results[2][0]) + " =" +
-         std::to_string(info.results[1][0]);
 
-  res += " P1-B: +" + std::to_string(info.results[0][1]) + " -" +
-         std::to_string(info.results[2][1]) + " =" +
-         std::to_string(info.results[1][1]);
-  SendResponse(res);
+  oss << " P1-W: +" << info.results[0][0] << " -" << info.results[2][0] << " ="
+      << info.results[1][0];
+  oss << " P1-B: +" << info.results[0][1] << " -" << info.results[2][1] << " ="
+      << info.results[1][1];
+  SendResponse(oss.str());
 }
 
 }  // namespace lczero

--- a/src/selfplay/loop.cc
+++ b/src/selfplay/loop.cc
@@ -123,13 +123,56 @@ void SelfPlayLoop::CmdSetOption(const std::string& name,
 }
 
 void SelfPlayLoop::SendTournament(const TournamentInfo& info) {
+  const int winp1 = info.results[0][0] + info.results[0][1];
+  const int loosep1 = info.results[2][0] + info.results[2][1];
+  const int draws = info.results[1][0] + info.results[1][1];
+
+  // Initialize variables
+  float percentage = -1;
+  float elo = 10000;
+  float los = 10000;
+
+  // Only caculate percentage if any games at all (avoid divide by 0).
+  if ((winp1 + loosep1 + draws) > 0)
+    percentage =
+        (static_cast<float>(draws) / 2 + winp1) / (winp1 + loosep1 + draws);
+
+  // Calculate elo and los if percentage strictly between 0 and 1 (avoids divide
+  // by 0 or overflow).
+  if ((percentage < 1) && (percentage > 0))
+    elo = -400 * log(1 / percentage - 1) / log(10);
+  if ((winp1 + loosep1) > 0)
+    los = .5 +
+          .5 * std::erf((winp1 - loosep1) / std::sqrt(2.0 * (winp1 + loosep1)));
+
   std::string res = "tournamentstatus";
   if (info.finished) res += " final";
-  res += " win " + std::to_string(info.results[0][0]) + " " +
-         std::to_string(info.results[0][1]);
-  res += " lose " + std::to_string(info.results[2][0]) + " " +
-         std::to_string(info.results[2][1]);
-  res += " draw " + std::to_string(info.results[1][0]) + " " +
+  res += " P1: +" + std::to_string(winp1) + " -" + std::to_string(loosep1) +
+         " =" + std::to_string(draws);
+
+  if (percentage > 0) {
+    std::ostringstream oss;
+    oss << std::fixed << std::setw(5) << std::setprecision(2)
+        << (percentage * 100) << "%";
+    res += " Win: " + oss.str();
+  }
+  if (elo < 10000) {
+    std::ostringstream oss;
+    oss << std::fixed << std::setw(5) << std::setprecision(2) << (elo);
+    res += " Elo: " + oss.str();
+  }
+  if (los < 10000) {
+    std::ostringstream oss;
+    oss << std::fixed << std::setw(5) << std::setprecision(2) << (los * 100)
+        << "%";
+    res += " LOS: " + oss.str();
+  }
+  res += " P1-W: +" + std::to_string(info.results[0][0]) + " -" +
+         std::to_string(info.results[2][0]) + " =" +
+         std::to_string(info.results[1][0]);
+  // Might be redundant to also list P1-B:
+  res += " P1-B: +" + std::to_string(info.results[0][1]) + " -" +
+         std::to_string(info.results[2][1]) + " =" +
          std::to_string(info.results[1][1]);
   SendResponse(res);
 }


### PR DESCRIPTION
Informative Tournament Stats improves display of selfplay stats::
before:
```
tournamentstatus win 3 3 lose 5 3 draw 8 10
```
after - obviously not same tournament as above ;-):
```
tournamentstatus P1: +815 -825 =1213 Win: 49.82% Elo: -1.22 LOS: 40.25% P1-W: +473 -354 =600 P1-B: +342 -471 =613
```