### PR TITLE
Change U calculation to match deepmind pseudocode

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -207,8 +207,7 @@ std::vector<std::string> Search::GetVerboseStats(Node* node,
                                                  bool is_black_to_move) const {
   const float fpu = GetFpu(params_, node, node == root_node_);
   const float cpuct = ComputeCpuct(params_, node->GetN());
-  const float U_coeff =
-      cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
+  const float U_coeff = cpuct * std::sqrt(node->GetN());
 
   std::vector<EdgeAndNode> edges;
   for (const auto& edge : node->Edges()) edges.push_back(edge);
@@ -880,8 +879,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     // If we fall through, then n_in_flight_ has been incremented but this
     // playout remains incomplete; we must go deeper.
     const float cpuct = ComputeCpuct(params_, node->GetN());
-    float puct_mult =
-        cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
+    float puct_mult = cpuct * std::sqrt(node->GetN());
     float best = std::numeric_limits<float>::lowest();
     float second_best = std::numeric_limits<float>::lowest();
     int possible_moves = 0;
@@ -1099,7 +1097,7 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget) {
   typedef std::pair<float, EdgeAndNode> ScoredEdge;
   std::vector<ScoredEdge> scores;
   const float cpuct = ComputeCpuct(params_, node->GetN());
-  float puct_mult = cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
+  float puct_mult = cpuct * std::sqrt(node->GetN());
   const float fpu = GetFpu(params_, node, node == search_->root_node_);
   for (auto edge : node->Edges()) {
     if (edge.GetP() == 0.0f) continue;


### PR DESCRIPTION
While investigating why fpu mixing was having a stronger effect for leela lite than for lc0 I noticed that leela lite's formula for U was slightly different to the formula in lc0.

I'm still of the opinion that the lc0 formula is an accurate rendering of the formulas presented in papers, but I went back to the deepmind pseudocode published with the alphazero paper and found that they too had the same difference in their calculation of U.

I haven't got any positive tests in favour of this change as of yet, so it doesn't seem super relevant - but maybe it'll help someone testing fpu mixing to see if it has an amplifying effect together.