### PR TITLE
Propagate parent terminal

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1174,7 +1174,17 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
   if (!node_to_process->nn_queried) {
     // Terminal nodes don't involve the neural NetworkComputation, nor do
     // they require any further processing after value retrieval.
+	  
     node_to_process->v = node->GetQ();
+	Node* parent = node->GetParent();
+	if (parent != nullptr) {
+		if (node_to_process->v == 1.0f) { // assume opposite won
+			parent->MakeTerminal(GameResult::BLACK_WON);
+		}
+		else {  // Cursed wins and blessed losses count as draws.
+			parent->MakeTerminal(GameResult::DRAW);
+		}
+	}
     return;
   }
   // For NN results, we need to populate policy as well as value.


### PR DESCRIPTION
For certain positions this properly identifies moves that lead to mates.

Example fen: 
6k1/pb3ppp/1pq5/2p5/2P5/1PQ5/P4PPP/2B3K1 w - - 0 1

https://lichess.org/analysis/standard/6k1/pb3ppp/1pq5/2p5/2P5/1PQ5/P4PPP/2B3K1_w_-_-

In case white makes a blunder move, black queen can mate on G2. With this change, the fact that a mate is in sight is visible via the (T) indicators in the evaluation:

```
position fen 6k1/pb3ppp/1pq5/2p5/2P5/1PQ5/P4PPP/2B3K1 w - - 0 1
go nodes 25000
info depth 5 seldepth 8 time 102 nodes 1075 score cp 18 hashfull 153 nps 245 tbhits 0 pv c3g3 h7h6 f2f3 b7c8 c1b2 f7f6 g3b8 c6d7
info depth 6 seldepth 11 time 360 nodes 1331 score cp 18 hashfull 154 nps 780 tbhits 0 pv c3g3 h7h6 f2f3 c6f6 g3b8 g8h7 b8b7 f6d4 g1f1
info depth 6 seldepth 12 time 912 nodes 1739 score cp 19 hashfull 156 nps 755 tbhits 0 pv c3g3 h7h6 f2f3 c6f6 g3b8 g8h7 b8b7 f6d4 g1f1
info depth 6 seldepth 13 time 2725 nodes 3179 score cp 20 hashfull 162 nps 781 tbhits 0 pv c3g3 f7f6 c1h6 c6d7 h2h3 b7e4 h6f4 e4b1 a2a3 b1a2 g3f3
info depth 6 seldepth 14 time 3466 nodes 3777 score cp 19 hashfull 164 nps 786 tbhits 0 pv c3g3 h7h6 f2f3 b7c8 c1b2 f7f6 g3b8 c6d7 h2h3 g8f7
info depth 7 seldepth 14 time 6736 nodes 6585 score cp 18 hashfull 176 nps 821 tbhits 0 pv c3g3 f7f6 h2h4 g8f7 c1f4 c6e4 g1h2 h7h6 f4b8 a7a6
info depth 7 seldepth 15 time 9654 nodes 9168 score cp 17 hashfull 186 nps 840 tbhits 0 pv c3g3 h7h6 h2h3 g8h7 c1b2 f7f6 b2c3 c6e4 g1h2 b7c6 f2f3
info depth 7 seldepth 16 time 11855 nodes 11170 score cp 17 hashfull 194 nps 853 tbhits 0 pv c3g3 f7f6 f2f3 c6d7 g3b8 b7c8 c1e3 g8f7 h2h3 d7b7 b8d6 b7d7
info depth 7 seldepth 16 time 16857 nodes 15776 score cp 16 hashfull 210 nps 873 tbhits 0 pv c3g3 h7h6 h2h3 g8h7 c1b2 f7f6 b2c3 c6e4 g1h2 b7c6 f2f3 e4e7 g3f4
info depth 7 seldepth 17 time 17700 nodes 16732 score cp 16 hashfull 214 nps 885 tbhits 0 pv c3g3 f7f6 f2f3 c6d7 g3b8 b7c8 c1e3 g8f7 h2h3 d7b7 b8d6 b7d7
info depth 7 seldepth 17 time 21415 nodes 20429 score cp 16 hashfull 227 nps 904 tbhits 0 pv c3g3 h7h6 h2h3 g8h7 c1b2 f7f6 b2c3 c6e4 g1h2 b7c6 f2f3 e4e7 g3f4
info string c1h6  (69  ) N:       3 (+ 0) (P:  0.78%) (Q: -1.00000) (U: 1.23015) (Q+U:  0.23015) (V: -1.0000) (T)
info string c3f6  (494 ) N:       4 (+ 0) (P:  0.85%) (Q: -1.00000) (U: 1.07551) (Q+U:  0.07551) (V: -1.0000) (T)
info string c3b4  (484 ) N:       4 (+ 0) (P:  0.86%) (Q: -1.00000) (U: 1.08323) (Q+U:  0.08323) (V: -1.0000) (T)
info string c1e3  (63  ) N:       4 (+ 0) (P:  0.87%) (Q: -1.00000) (U: 1.10204) (Q+U:  0.10204) (V: -1.0000) (T)
info string c1g5  (67  ) N:       4 (+ 0) (P:  0.89%) (Q: -1.00000) (U: 1.12181) (Q+U:  0.12181) (V: -1.0000) (T)
info string g2g4  (378 ) N:       4 (+ 0) (P:  0.91%) (Q: -1.00000) (U: 1.14641) (Q+U:  0.14641) (V: -1.0000) (T)
info string c3a1  (466 ) N:       4 (+ 0) (P:  0.92%) (Q: -1.00000) (U: 1.15895) (Q+U:  0.15895) (V: -1.0000) (T)
info string c1a3  (59  ) N:       4 (+ 0) (P:  0.92%) (Q: -1.00000) (U: 1.16908) (Q+U:  0.16908) (V: -1.0000) (T)
info string g2g3  (374 ) N:       4 (+ 0) (P:  0.93%) (Q: -1.00000) (U: 1.17004) (Q+U:  0.17004) (V: -1.0000) (T)
info string g1h1  (153 ) N:       4 (+ 0) (P:  0.93%) (Q: -1.00000) (U: 1.17245) (Q+U:  0.17245) (V: -1.0000) (T)
info string c3a5  (488 ) N:       4 (+ 0) (P:  0.93%) (Q: -1.00000) (U: 1.17583) (Q+U:  0.17583) (V: -1.0000) (T)
info string b3b4  (453 ) N:       4 (+ 0) (P:  0.94%) (Q: -1.00000) (U: 1.19416) (Q+U:  0.19416) (V: -1.0000) (T)
info string c3d4  (486 ) N:       4 (+ 0) (P:  0.98%) (Q: -1.00000) (U: 1.23322) (Q+U:  0.23322) (V: -1.0000) (T)
info string c1d2  (57  ) N:       4 (+ 0) (P:  0.98%) (Q: -1.00000) (U: 1.24190) (Q+U:  0.24190) (V: -1.0000) (T)
info string c1f4  (65  ) N:       5 (+ 0) (P:  1.02%) (Q: -1.00000) (U: 1.07149) (Q+U:  0.07149) (V: -1.0000) (T)
info string a2a4  (207 ) N:       5 (+ 0) (P:  1.08%) (Q: -1.00000) (U: 1.14103) (Q+U:  0.14103) (V: -1.0000) (T)
info string c3e1  (470 ) N:       5 (+ 0) (P:  1.09%) (Q: -1.00000) (U: 1.14585) (Q+U:  0.14585) (V: -1.0000) (T)
info string c1b2  (55  ) N:       5 (+ 0) (P:  1.14%) (Q: -1.00000) (U: 1.19810) (Q+U:  0.19810) (V: -1.0000) (T)
info string a2a3  (204 ) N:       5 (+ 0) (P:  1.15%) (Q: -1.00000) (U: 1.20895) (Q+U:  0.20895) (V: -1.0000) (T)
info string h2h4  (403 ) N:       5 (+ 0) (P:  1.16%) (Q: -1.00000) (U: 1.22302) (Q+U:  0.22302) (V: -1.0000) (T)
info string c3b2  (472 ) N:       5 (+ 0) (P:  1.19%) (Q: -1.00000) (U: 1.25155) (Q+U:  0.25155) (V: -1.0000) (T)
info string c3c2  (473 ) N:       5 (+ 0) (P:  1.20%) (Q: -1.00000) (U: 1.26039) (Q+U:  0.26039) (V: -1.0000) (T)
info string c3g7  (496 ) N:       6 (+ 0) (P:  1.09%) (Q: -0.87725) (U: 0.98560) (Q+U:  0.10835) (V: -0.3615)
info string c3e5  (492 ) N:       6 (+ 0) (P:  1.31%) (Q: -1.00000) (U: 1.18334) (Q+U:  0.18334) (V: -1.0000) (T)
info string h2h3  (400 ) N:       6 (+ 0) (P:  1.39%) (Q: -1.00000) (U: 1.25327) (Q+U:  0.25327) (V: -1.0000) (T)
info string c3d3  (478 ) N:       7 (+ 0) (P:  1.58%) (Q: -1.00000) (U: 1.24793) (Q+U:  0.24793) (V: -1.0000) (T)
info string c3d2  (474 ) N:       8 (+ 0) (P:  1.63%) (Q: -1.00000) (U: 1.14839) (Q+U:  0.14839) (V: -1.0000) (T)
info string f2f4  (351 ) N:       8 (+ 0) (P:  1.70%) (Q: -1.00000) (U: 1.19234) (Q+U:  0.19234) (V: -1.0000) (T)
info string c3e3  (479 ) N:       9 (+ 0) (P:  1.87%) (Q: -1.00000) (U: 1.17921) (Q+U:  0.17921) (V: -1.0000) (T)
info string g1f1  (152 ) N:       9 (+ 0) (P:  1.72%) (Q: -0.85292) (U: 1.08757) (Q+U:  0.23465) (V: -0.5288)
info string c3h3  (482 ) N:      56 (+ 0) (P:  4.37%) (Q: -0.35644) (U: 0.48449) (Q+U:  0.12805) (V: -0.0795)
info string c3f3  (480 ) N:     120 (+ 0) (P:  2.41%) (Q: -0.05536) (U: 0.12591) (Q+U:  0.07056) (V: -0.0554) (T)
info string f2f3  (346 ) N:    7414 (+ 0) (P: 31.90%) (Q:  0.02412) (U: 0.02719) (Q+U:  0.05132) (V:  0.0152)
info string c3g3  (481 ) N:   12684 (+286) (P: 27.34%) (Q:  0.03694) (U: 0.01333) (Q+U:  0.05026) (V:  0.0226)
bestmove c3g3 ponder h7h6
```
