### PR TITLE
Add FPU visits parameter

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -238,9 +238,9 @@ void Node::CancelScoreUpdate(int multivisit) {
   best_child_cached_ = nullptr;
 }
 
-void Node::FinalizeScoreUpdate(float v, int multivisit) {
+void Node::FinalizeScoreUpdate(float v, int multivisit, float fpu_visits) {
   // Recompute Q.
-  q_ += multivisit * (v - q_) / (n_ + multivisit);
+  q_ += multivisit * (v - q_) / (fpu_visits + n_ + multivisit);
   // If first visit, update parent's sum of policies visited at least once.
   if (n_ == 0 && parent_ != nullptr) {
     parent_->visited_policy_ += parent_->edges_[index_].GetP();

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -174,7 +174,7 @@ class Node {
   // * Q (weighted average of all V in a subtree)
   // * N (+=1)
   // * N-in-flight (-=1)
-  void FinalizeScoreUpdate(float v, int multivisit);
+  void FinalizeScoreUpdate(float v, int multivisit, float fpu_visits);
   // When search decides to treat one visit as several (in case of collisions
   // or visiting terminal nodes several times), it amplifies the visit by
   // incrementing n_in_flight.
@@ -264,7 +264,8 @@ class Node {
   // subtree. For terminal nodes, eval is stored. This is from the perspective
   // of the player who "just" moved to reach this position, rather than from the
   // perspective of the player-to-move for the position.
-  float q_ = 0.0f;
+  // Initialized to loss (-1).
+  float q_ = -1.0f;
   // Sum of policy priors which have had at least one playout.
   float visited_policy_ = 0.0f;
   // How many completed visits this node had.

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -160,6 +160,10 @@ const OptionId SearchParams::kHistoryFillId{
     "one. During the first moves of the game such historical positions don't "
     "exist, but they can be synthesized. This parameter defines when to "
     "synthesize them (always, never, or only at non-standard fen position)."};
+const OptionId SearchParams::kFpuVisitsId{
+    "fpu-visits", "FpuVisits",
+    "Number of visits for first play urgency in calculation of the value. "
+    "Higher than zero value decreases the value of low visit nodes."};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -193,6 +197,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kScoreTypeId, score_type) = "centipawn";
   std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
+  options->Add<FloatOption>(kFpuVisitsId, 0.0f, 2.0f) = 0.6f;
 }
 
 SearchParams::SearchParams(const OptionsDict& options)
@@ -213,7 +218,8 @@ SearchParams::SearchParams(const OptionsDict& options)
       kOutOfOrderEval(options.Get<bool>(kOutOfOrderEvalId.GetId())),
       kHistoryFill(
           EncodeHistoryFill(options.Get<std::string>(kHistoryFillId.GetId()))),
-      kMiniBatchSize(options.Get<int>(kMiniBatchSizeId.GetId())){
+      kMiniBatchSize(options.Get<int>(kMiniBatchSizeId.GetId())),
+      kFpuVisits(options.Get<float>(kFpuVisitsId.GetId())) {
 }
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -88,6 +88,7 @@ class SearchParams {
     return options_.Get<std::string>(kScoreTypeId.GetId());
   }
   FillEmptyHistory GetHistoryFill() const { return kHistoryFill; }
+  float GetFpuVisits() const { return kFpuVisits; }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -115,6 +116,7 @@ class SearchParams {
   static const OptionId kMultiPvId;
   static const OptionId kScoreTypeId;
   static const OptionId kHistoryFillId;
+  static const OptionId kFpuVisitsId;
 
  private:
   const OptionsDict& options_;
@@ -139,6 +141,7 @@ class SearchParams {
   const bool kOutOfOrderEval;
   const FillEmptyHistory kHistoryFill;
   const int kMiniBatchSize;
+  const float kFpuVisits;
 };
 
 }  // namespace lczero

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1231,9 +1231,10 @@ void SearchWorker::DoBackupUpdateSingleNode(
 
   // Backup V value up to a root. After 1 visit, V = Q.
   float v = node_to_process.v;
+  float fpu_visits = params_.GetFpuVisits();
   for (Node* n = node; n != search_->root_node_->GetParent();
        n = n->GetParent()) {
-    n->FinalizeScoreUpdate(v, node_to_process.multivisit);
+    n->FinalizeScoreUpdate(v, node_to_process.multivisit, fpu_visits);
     // Q will be flipped for opponent.
     v = -v;
 

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -100,6 +100,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   defaults->Set<std::string>(SearchParams::kHistoryFillId.GetId(), "no");
   defaults->Set<std::string>(NetworkFactory::kBackendId.GetId(),
                              "multiplexing");
+  defaults->Set<float>(SearchParams::kFpuVisitsId.GetId(), 0.0f);
 }
 
 SelfPlayTournament::SelfPlayTournament(const OptionsDict& options,


### PR DESCRIPTION
This parameter controls the number of visits that initial Q should have in later Q updates. I clopped the best value at very quick time controls to be around 0.6.

At longer time controls and other values being default it seems to be improvement:

```
Score of lc0_fpu_visits_35258 vs lc0_master_35258: 45 - 25 - 330  [0.525] 400
Elo difference: 17.39 +/- 14.16, LOS: 99.16 %, DrawRatio: 82.5 %

Network 35258, TC: 10s+0.5s, GPU GTX 1080 Ti, 5 man TBs and all other parameters defaults.
```