### PR TITLE
Favor winning moves that minimize DTZ to reduce shuffling by assuming repeated position by default

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -146,6 +146,10 @@ const OptionId SearchParams::kOutOfOrderEvalId{
     "in the cache or is terminal, evaluate it right away without sending the "
     "batch to the NN. When off, this may only happen with the very first node "
     "of a batch; when on, this can happen with any node."};
+const OptionId SearchParams::kSyzygyFastPlayId{
+    "syzygy-fast-play", "SyzygyFastPlay",
+    "With DTZ tablebase files, only allow the network pick from winning moves "
+    "that have shortest DTZ to play faster (but not necessarily optimally)."};
 const OptionId SearchParams::kMultiPvId{
     "multipv", "MultiPV",
     "Number of game play lines (principal variations) to show in UCI info "
@@ -188,6 +192,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kMaxCollisionEventsId, 1, 1024) = 32;
   options->Add<IntOption>(kMaxCollisionVisitsId, 1, 1000000) = 9999;
   options->Add<BoolOption>(kOutOfOrderEvalId) = true;
+  options->Add<BoolOption>(kSyzygyFastPlayId) = true;
   options->Add<IntOption>(kMultiPvId, 1, 500) = 1;
   std::vector<std::string> score_type = {"centipawn", "win_percentage", "Q"};
   options->Add<ChoiceOption>(kScoreTypeId, score_type) = "centipawn";
@@ -211,6 +216,7 @@ SearchParams::SearchParams(const OptionsDict& options)
       kMaxCollisionEvents(options.Get<int>(kMaxCollisionEventsId.GetId())),
       kMaxCollisionVisits(options.Get<int>(kMaxCollisionVisitsId.GetId())),
       kOutOfOrderEval(options.Get<bool>(kOutOfOrderEvalId.GetId())),
+      kSyzygyFastPlay(options.Get<bool>(kSyzygyFastPlayId.GetId())),
       kHistoryFill(
           EncodeHistoryFill(options.Get<std::string>(kHistoryFillId.GetId()))),
       kMiniBatchSize(options.Get<int>(kMiniBatchSizeId.GetId())){

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -83,6 +83,7 @@ class SearchParams {
   int GetMaxCollisionEvents() const { return kMaxCollisionEvents; }
   int GetMaxCollisionVisitsId() const { return kMaxCollisionVisits; }
   bool GetOutOfOrderEval() const { return kOutOfOrderEval; }
+  bool GetSyzygyFastPlay() const { return kSyzygyFastPlay; }
   int GetMultiPv() const { return options_.Get<int>(kMultiPvId.GetId()); }
   std::string GetScoreType() const {
     return options_.Get<std::string>(kScoreTypeId.GetId());
@@ -112,6 +113,7 @@ class SearchParams {
   static const OptionId kMaxCollisionEventsId;
   static const OptionId kMaxCollisionVisitsId;
   static const OptionId kOutOfOrderEvalId;
+  static const OptionId kSyzygyFastPlayId;
   static const OptionId kMultiPvId;
   static const OptionId kScoreTypeId;
   static const OptionId kHistoryFillId;
@@ -137,6 +139,7 @@ class SearchParams {
   const int kMaxCollisionEvents;
   const int kMaxCollisionVisits;
   const bool kOutOfOrderEval;
+  const bool kSyzygyFastPlay;
   const FillEmptyHistory kHistoryFill;
   const int kMiniBatchSize;
 };

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -454,6 +454,7 @@ bool Search::PopulateRootMoveLimit(MoveList* root_moves) const {
     return false;
   }
   return syzygy_tb_->root_probe(played_history_.Last(),
+                                params_.GetSyzygyFastPlay() ||
                                 played_history_.DidRepeatSinceLastZeroingMove(),
                                 root_moves) ||
          syzygy_tb_->root_probe_wdl(played_history_.Last(), root_moves);


### PR DESCRIPTION
r?@Tilps or @jjoshua2?  This limits the winning moves to those with the smallest DTZ. This can lead to sub-optimal moves that aren’t fastest mating sequence, so it’s like the behavior of WDL where it favors pawn pushes and piece sacrifice. This just enforces forward progress instead of moving the king into a corner and shuffling other pieces around.

Here’s a move 124 position from CCC 4 lc0 32742 vs komodo (game 95) that ended up finishing on move 180. With this PR, even if the network somehow ended up favoring the suboptimal moves including sacrificing the bishop, the filtered moves would force a checkmate here in 14 moves (instead of the 56 that it took and worse than the optimal 6 moves).

https://lichess.org/analysis/standard/Q7/8/8/8/2B5/2K1k2p/8/8_w_-_-_0_124
```
position fen Q7/8/8/8/2B5/2K1k2p/8/8 w - - 0 124
go nodes 10000
```
before:
```
info string a8f3  (1603) N:       0 (+ 0) (P:  1.01%) (Q: -0.18907) (U: 3.88362) (Q+U:  3.69455) (V:  -.----) 
info string a8g2  (1601) N:       0 (+ 0) (P:  1.03%) (Q: -0.18907) (U: 3.95240) (Q+U:  3.76332) (V:  -.----) 
info string a8e4  (1605) N:       0 (+ 0) (P:  1.28%) (Q: -0.18907) (U: 4.91233) (Q+U:  4.72325) (V:  -.----) 
info string c4g8  (738 ) N:     106 (+ 0) (P:  1.03%) (Q:  0.99168) (U: 0.03679) (Q+U:  1.02846) (V:  0.9953) 
info string c4e6  (734 ) N:     106 (+ 0) (P:  1.01%) (Q:  0.99265) (U: 0.03620) (Q+U:  1.02885) (V:  0.9938) 
info string c4e2  (712 ) N:     112 (+ 0) (P:  1.01%) (Q:  0.99468) (U: 0.03414) (Q+U:  1.02881) (V:  0.9923) 
info string c4f7  (736 ) N:     116 (+ 0) (P:  1.14%) (Q:  0.99156) (U: 0.03726) (Q+U:  1.02882) (V:  0.9960) 
info string c4f1  (707 ) N:     123 (+ 0) (P:  1.14%) (Q:  0.99360) (U: 0.03527) (Q+U:  1.02887) (V:  0.9937) 
info string c4a6  (730 ) N:     137 (+ 0) (P:  1.31%) (Q:  0.99240) (U: 0.03643) (Q+U:  1.02883) (V:  0.9951) 
info string c4d3  (716 ) N:     148 (+ 0) (P:  1.46%) (Q:  0.99113) (U: 0.03770) (Q+U:  1.02883) (V:  0.9931) 
info string c4a2  (708 ) N:     154 (+ 0) (P:  1.50%) (Q:  0.99152) (U: 0.03717) (Q+U:  1.02869) (V:  0.9943) 
info string a8c6  (1610) N:     185 (+ 0) (P:  1.93%) (Q:  0.98943) (U: 0.03976) (Q+U:  1.02919) (V:  0.9939) 
info string a8a3  (1602) N:     200 (+ 0) (P:  2.06%) (Q:  0.98978) (U: 0.03924) (Q+U:  1.02902) (V:  0.9896) 
info string a8d5  (1607) N:     203 (+ 0) (P:  2.05%) (Q:  0.99061) (U: 0.03849) (Q+U:  1.02910) (V:  0.9941) 
info string c4b5  (726 ) N:     204 (+ 0) (P:  1.95%) (Q:  0.99231) (U: 0.03653) (Q+U:  1.02884) (V:  0.9944) 
info string c4d5  (728 ) N:     208 (+ 0) (P:  2.14%) (Q:  0.98974) (U: 0.03925) (Q+U:  1.02899) (V:  0.9939) 
info string a8b7  (1612) N:     208 (+ 0) (P:  2.18%) (Q:  0.98929) (U: 0.03994) (Q+U:  1.02923) (V:  0.9923) 
info string c3c2  (473 ) N:     225 (+ 0) (P:  2.18%) (Q:  0.99208) (U: 0.03698) (Q+U:  1.02906) (V:  0.9931) 
info string a8a4  (1604) N:     245 (+ 0) (P:  2.63%) (Q:  0.98799) (U: 0.04103) (Q+U:  1.02902) (V:  0.9899) 
info string a8h1  (1599) N:     252 (+ 0) (P:  2.58%) (Q:  0.98654) (U: 0.03911) (Q+U:  1.02565) (V:  0.9952) 
info string a8a5  (1606) N:     255 (+ 0) (P:  3.28%) (Q:  0.98068) (U: 0.04914) (Q+U:  1.02981) (V:  0.9916) 
info string a8g8  (1619) N:     257 (+ 0) (P:  2.52%) (Q:  0.99152) (U: 0.03743) (Q+U:  1.02896) (V:  0.9935) 
info string a8a2  (1600) N:     261 (+ 0) (P:  2.75%) (Q:  0.98873) (U: 0.04031) (Q+U:  1.02905) (V:  0.9935) 
info string a8e8  (1617) N:     268 (+ 0) (P:  2.78%) (Q:  0.98936) (U: 0.03968) (Q+U:  1.02904) (V:  0.9954) 
info string c4b3  (714 ) N:     280 (+ 0) (P:  2.83%) (Q:  0.99034) (U: 0.03859) (Q+U:  1.02892) (V:  0.9946) 
info string a8h8  (1620) N:     283 (+ 0) (P:  2.71%) (Q:  0.99216) (U: 0.03665) (Q+U:  1.02882) (V:  0.9952) 
info string a8d8  (1616) N:     312 (+ 0) (P:  2.89%) (Q:  0.99206) (U: 0.03543) (Q+U:  1.02748) (V:  0.9932) 
info string a8f8  (1618) N:     334 (+ 0) (P:  2.70%) (Q:  0.99560) (U: 0.03091) (Q+U:  1.02651) (V:  0.9938) 
info string a8a7  (1611) N:     377 (+ 0) (P:  3.94%) (Q:  0.98678) (U: 0.03995) (Q+U:  1.02673) (V:  0.9902) 
info string a8c8  (1615) N:     396 (+ 0) (P:  3.47%) (Q:  0.99309) (U: 0.03354) (Q+U:  1.02664) (V:  0.9934) 
info string a8a1  (1598) N:     434 (+ 0) (P:  4.40%) (Q:  0.98787) (U: 0.03881) (Q+U:  1.02667) (V:  0.9913) 
info string c3b2  (472 ) N:     541 (+ 0) (P:  4.91%) (Q:  0.99180) (U: 0.03477) (Q+U:  1.02657) (V:  0.9923) 
info string a8a6  (1608) N:     558 (+ 0) (P:  5.50%) (Q:  0.98890) (U: 0.03776) (Q+U:  1.02666) (V:  0.9903) 
info string a8b8  (1614) N:     753 (+ 3) (P:  6.77%) (Q:  0.99232) (U: 0.03428) (Q+U:  1.02660) (V:  0.9930) 
info string c3b3  (477 ) N:     767 (+ 0) (P:  6.89%) (Q:  0.99206) (U: 0.03442) (Q+U:  1.02648) (V:  0.9926) 
info string c3b4  (484 ) N:    1037 (+ 0) (P:  9.05%) (Q:  0.99301) (U: 0.03345) (Q+U:  1.02646) (V:  0.9932) 
bestmove c3b4 ponder e3f4
```
after:
```
…
info string c3b4  (484 ) N:       0 (+ 0) (P:  9.05%) (Q:  0.59570) (U: 34.82774) (Q+U: 35.42344) (V:  -.----) 
info string c4e6  (734 ) N:     544 (+ 0) (P:  1.01%) (Q:  0.99058) (U: 0.00713) (Q+U:  0.99770) (V:  0.9938) 
info string c4f1  (707 ) N:    1590 (+ 0) (P:  1.14%) (Q:  0.99382) (U: 0.00276) (Q+U:  0.99658) (V:  0.9937) 
info string a8h1  (1599) N:    1628 (+ 0) (P:  2.58%) (Q:  0.99066) (U: 0.00609) (Q+U:  0.99675) (V:  0.9952) 
info string a8c8  (1615) N:    2747 (+62) (P:  3.47%) (Q:  0.99149) (U: 0.00475) (Q+U:  0.99624) (V:  0.9934) 
info string a8h8  (1620) N:    3581 (+199) (P:  2.71%) (Q:  0.99284) (U: 0.00276) (Q+U:  0.99560) (V:  0.9952) 
bestmove a8h8 ponder e3f4
```

So 32742's favored c3b4 move to get the king closer to a8 is prevented.