### PR TITLE
search for nvcc on the path first

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -344,8 +344,8 @@ if get_option('build_backends')
   cu_blas = cc.find_library('cublas', dirs: cudnn_libdirs, required: false)
   cu_dnn = cc.find_library('cudnn', dirs: cudnn_libdirs, required: false)
   cu_dart = cc.find_library('cudart', dirs: cudnn_libdirs, required: false)
-  nvcc = find_program('/usr/local/cuda/bin/nvcc', '/opt/cuda/bin/nvcc',
-                      'nvcc', required: false)
+  nvcc = find_program('nvcc', '/usr/local/cuda/bin/nvcc', '/opt/cuda/bin/nvcc',
+                      required: false)
 
   #.cc files
   cuda_files = [


### PR DESCRIPTION
This allows to override the nvcc used by default, if you have multiple cuda versions installed. 