### PR TITLE
Separate exploration from training feedback

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -360,6 +360,22 @@ std::string EdgeAndNode::DebugString() const {
 // NodeTree
 /////////////////////////////////////////////////////////////////////////
 
+void NodeTree::CloneCurrentHeadBranch(NodeTree& cloned) {
+  std::vector<Move> moves;
+  bool flip = !IsBlackToMove();
+  for (Node* node = GetCurrentHead(); node != GetGameBeginNode();
+       node = node->GetParent()) {
+    moves.push_back(node->GetParent()->GetEdgeToNode(node)->GetMove(flip));
+    flip = !flip;
+  }
+  std::reverse(moves.begin(), moves.end());
+
+  cloned.ResetToPosition(ChessBoard::kStartposFen, {});
+  for (auto m : moves) {
+    cloned.MakeMove(m);
+  }
+}
+
 void NodeTree::MakeMove(Move move) {
   if (HeadPosition().IsBlackToMove()) move.Mirror();
 

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -509,6 +509,7 @@ class Node::NodeRange {
 class NodeTree {
  public:
   ~NodeTree() { DeallocateTree(); }
+  void CloneCurrentHeadBranch(NodeTree & cloned);
   // Adds a move to current_head_.
   void MakeMove(Move move);
   // Resets the current head to ensure it doesn't carry over details from a

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -437,6 +437,12 @@ std::pair<Move, Move> Search::GetBestMove() {
           final_pondermove_.GetMove(!played_history_.IsBlackToMove())};
 }
 
+Move Search::GetBestMoveNoTemp() {
+  SharedMutex::Lock lock(nodes_mutex_);
+  auto best_move = GetBestChildNoTemperature(root_node_);
+  return best_move.GetMove(played_history_.IsBlackToMove());
+}
+
 std::int64_t Search::GetTotalPlayouts() const {
   SharedMutex::SharedLock lock(nodes_mutex_);
   return total_playouts_;

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -87,7 +87,8 @@ class Search {
   // May or may not use temperature, according to the settings.
   std::pair<Move, Move> GetBestMove();
   // Returns best move, from the point of view of white player. Without temp.
-  Move GetBestMoveNoTemp();
+  Move GetBestMoveNoTemp() const;
+  bool CurrentlyUsingEndgameTemperature() const;
   // Returns the evaluation of the best move, WITHOUT temperature. This differs
   // from the above function; with temperature enabled, these two functions may
   // return results from different possible moves.

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -86,6 +86,8 @@ class Search {
   // Returns best move, from the point of view of white player. And also ponder.
   // May or may not use temperature, according to the settings.
   std::pair<Move, Move> GetBestMove();
+  // Returns best move, from the point of view of white player. Without temp.
+  Move GetBestMoveNoTemp();
   // Returns the evaluation of the best move, WITHOUT temperature. This differs
   // from the above function; with temperature enabled, these two functions may
   // return results from different possible moves.

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -128,11 +128,10 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
       // Play the temperature-chosen move and store the resulting game state so
       // a new match can be started from that position.
       ResumableGame resumable_game;
-      resumable_game.tree[0] = std::make_shared<NodeTree>(tree_[0]);
-      resumable_game.tree[1] = std::make_shared<NodeTree>(tree_[1]);
-      resumable_game.tree[0]->MakeMove(move);
-      if (resumable_game.tree[0] != resumable_game.tree[1]) {
-        resumable_game.tree[1]->MakeMove(move);
+      for (auto idx : {0, 1}) {
+        resumable_game.tree[idx] = std::make_shared<NodeTree>();
+        tree_[idx]->CloneCurrentHeadBranch(*resumable_game.tree[idx]);
+        resumable_game.tree[idx]->MakeMove(move);
       }
       resumable_game.blacks_move = !blacks_move;
     }

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -109,6 +109,12 @@ std::queue<ResumableGame> SelfPlayGame::Play(int white_threads,
     if (abort_) break;
 
     if (training) {
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        std::ofstream outfile;
+        outfile.open("trainingdata_ply.txt", std::ios_base::app);
+        outfile << tree_[idx]->GetPlyCount() << "\n";
+      }
       // Append training data. The GameResult is later overwritten.
       training_data_.push_back(tree_[idx]->GetCurrentHead()->GetV3TrainingData(
           GameResult::UNDECIDED, tree_[idx]->GetPositionHistory(),

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -98,7 +98,7 @@ class SelfPlayGame {
   // Node tree for player1 and player2. If the tree is shared between players,
   // tree_[0] == tree_[1].
   std::shared_ptr<NodeTree> tree_[2];
-  bool blacks_move_;
+  const bool black_moved_first_;
 
   // Search that is currently in progress. Stored in members so that Abort()
   // can stop it.

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include <queue>
+
 #include "chess/position.h"
 #include "chess/uciloop.h"
 #include "mcts/search.h"
@@ -69,13 +71,14 @@ class SelfPlayGame {
   // (useful for training games). Otherwise the tree is separate for black
   // and white (useful i.e. when they use different networks).
   SelfPlayGame(PlayerOptions player1, PlayerOptions player2, bool shared_tree);
+  SelfPlayGame(PlayerOptions player1, PlayerOptions player2, ResumableGame game_to_resume);
 
   // Populate command line options that it uses.
   static void PopulateUciParams(OptionsParser* options);
 
   // Starts the game and blocks until the game is finished.
-  void Play(int white_threads, int black_threads, bool training,
-            bool enable_resign = true);
+  std::queue<ResumableGame> Play(int white_threads, int black_threads,
+                                 bool training, bool enable_resign = true);
   // Aborts the game currently played, doesn't matter if it's synchronous or
   // not.
   void Abort();
@@ -95,6 +98,7 @@ class SelfPlayGame {
   // Node tree for player1 and player2. If the tree is shared between players,
   // tree_[0] == tree_[1].
   std::shared_ptr<NodeTree> tree_[2];
+  bool blacks_move_;
 
   // Search that is currently in progress. Stored in members so that Abort()
   // can stop it.

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -56,6 +56,11 @@ struct PlayerOptions {
   SelfPlayLimits search_limits;
 };
 
+struct ResumableGame {
+  std::shared_ptr<NodeTree> tree[2];
+  bool blacks_move;
+};
+
 // Plays a single game vs itself.
 class SelfPlayGame {
  public:

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -228,10 +228,14 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
   std::list<std::unique_ptr<SelfPlayGame>>::iterator game_iter;
   {
     Mutex::Lock lock(mutex_);
+    std::ofstream outfile;
+    outfile.open("starting_plies.txt", std::ios_base::app);
     if (resumable_games_.empty()) {
+      outfile << "0\n";
       games_.emplace_front(
           std::make_unique<SelfPlayGame>(options[0], options[1], kShareTree));
     } else {
+      outfile << resumable_games_.front().tree[0]->GetPlyCount() << "\n";
       games_.emplace_front(std::make_unique<SelfPlayGame>(
           options[0], options[1], resumable_games_.front()));
       resumable_games_.pop();

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -76,6 +76,7 @@ class SelfPlayTournament {
   // Abort(). Stored as list and not vector so that threads can keep iterators
   // to them and not worry that it becomes invalid.
   std::list<std::unique_ptr<SelfPlayGame>> games_ GUARDED_BY(mutex_);
+  std::queue<ResumableGame> resumable_games_ GUARDED_BY(mutex_);
   // Place to store tournament stats.
   TournamentInfo tournament_info_ GUARDED_BY(mutex_);
 

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -77,6 +77,8 @@ class SelfPlayTournament {
   // to them and not worry that it becomes invalid.
   std::list<std::unique_ptr<SelfPlayGame>> games_ GUARDED_BY(mutex_);
   std::queue<ResumableGame> resumable_games_ GUARDED_BY(mutex_);
+  size_t full_games_started_ = 0;
+  size_t sub_games_started_ = 0;
   // Place to store tournament stats.
   TournamentInfo tournament_info_ GUARDED_BY(mutex_);
 
@@ -100,6 +102,7 @@ class SelfPlayTournament {
   const size_t kParallelism;
   const bool kTraining;
   const float kResignPlaythrough;
+  const float kSubgamesPercentage;
 };
 
 }  // namespace lczero


### PR DESCRIPTION
This PR is intended to solve both https://github.com/LeelaChessZero/lc0/issues/237 and https://github.com/LeelaChessZero/lc0/issues/342.

The idea is to branch a new "sub-game" every time temperetarue causes the selection of a move that hasn't the highest number of visits. The original game is then played with the zero-temp move. Once that game finishes the branched sub-game is resumed from just after the temperature-move.

Using this method the game result value (Z) that is used to score any position is the result of playing with the equivalent of zero-temperature, but still getting the exploration temperature would normally cause.

Example of the output with added debuging prints:
```
gameready trainingfile ./data-pgltswkheuie/game_000000.gz gameid 0 player1 black result draw moves e2e4 c7c6 g1f3 d7d5 b1c3 c8g4 h2h3 g4f3 d1f3 g8f6 g2g3 e7e6 f1g2 f8b4 a2a3 b4e7 d2d3 e8g8 e1g1 a7a5 a3a4 d8b6 f3e2 f8d8 e4d5 c6d5 c3b5 b8c6 c2c3 d5d4 c1f4 a8c8 a1c1 h7h6 f1d1 e7c5 h3h4 f6d5 f4d2 d8d7 d2e1 c8d8 c1b1 e6e5 b2b4 a5b4 c3b4 c5f8 d1c1 d8a8 e2d1 b6d8 d1b3 g7g6 b5a3 c6b4 e1b4 d5b4 a3c4 d8f6 c1e1 d7c7 c4e5 g8g7 e5c4 a8d8 a4a5 h6h5 b3d1 f6f5 g2e4 f5f6 d1d2 b4d5 b1b3 c7e7 e4d5 d8d5 e1e7 f6e7 d2b2 g6g5 b3b5 d5b5 b2b5 g5h4 g3h4 g7h6 b5b6 h6h7 b6d4 e7e6 g1g2 f8b4 d4f4 e6d5 f4f3 d5f3 g2f3 h7g6 f3e4 b4e7 c4e5 g6g7 e5c4 e7h4 c4d6 h4f2 d6b7 h5h4 e4f3 f2g1 a5a6 g7f6 f3g2 g1e3 b7d6 f6e6 d6b5 e6d5 g2f3 e3g1 a6a7 g1a7 b5a7 h4h3 a7b5 d5c5 b5c3 c5d4 c3e4 d4d3 e4f2 d3d4 f2h1 d4d5 f3f4 f7f5 h1f2 d5d4 f2h1 d4d5 h1g3 d5e6 g3h1 e6f6 h1f2 f6g7 f2h3 g7f8 h3f2 f8g7 f2h3 g7g6 f4e5 g6h6 e5d6 h6h5 d6e5 h5h4 h3f4 h4g4 f4g2 g4h5 e5d4 h5g6 d4e3 g6g5 g2f4 g5g4 f4e6 g4g3 e6f8 f5f4 e3e2 g3g2 f8g6 f4f3 e2e3 f3f2 g6f4 g2g1 f4h3 g1g2 h3f2

Adding game to resumable games, ply: 1, side to move: black.
Adding game to resumable games, ply: 5, side to move: black.
```
This means that 2 subgames were added, one will be continued from an alternative to `1. e2e4` and the other from an alternative to `3. b1c3`.

After that the first game is resumed:
```
Resuming game at ply 1, side to move: black.
gameready trainingfile ./data-pgltswkheuie/game_000001.gz gameid 1 player1 white result blackwon moves g2g3 c7c5 f1g2 b8c6 g1f3 g7g6 c2c4 f8g7 b1c3 e7e6 e2e3 g8e7 e1g1 e8g8 d2d4 c5d4 f3d4 d7d5 c4d5 e7d5 c3d5 e6d5 d4e2 c8f5 e2f4 d5d4 e3e4 f5d7 f4d5 a8c8 h2h4 h7h6 c1f4 d7e6 d1d2 g8h7 a1c1 d8d7 c1c5 b7b6 c5c1 c6e7 d5c7 e6a2 d2b4 a2e6 b4d6 f8d8 c7e6 d7d6 f4d6 d8d6 c1c8 e7c8 e6g7 h7g7 f1d1 d4d3 g2f1 d3d2 f2f3 f7f5 g1f2 f5e4 f3e4 g7f6 f2e3 f6e5 f1d3 d6d4 d1d2 c8d6 d2c2 d6e4 c2c6 e4f6 d3g6 d4g4 h4h5 g4g3 e3d2 g3g5 g6f7 g5g7 f7g6 g7d7 d2c2 f6d5 c2b3 d5e7 c6c1 e7g6 h5g6 e5f6 c1c6 f6g5 b3c4 d7g7 c4d3 g7g6 c6c7 a7a5 d3e4 h6h5 e4f3 g6f6 f3g3 h5h4 g3h2 f6f2 h2h3 f2b2 c7c5 g5f4 c5b5 b2b5 h3h2 b5d5 h2g1 f4g3 g1h1 d5d1
```

And then the second game:
```
Resuming game at ply 5, side to move: black.
gameready trainingfile ./data-pgltswkheuie/game_000002.gz gameid 2 player1 black result whitewon moves e2e4 c7c6 g1f3 d7d5 f3e5 d5e4 b1c3 d8d4 e5c4 g8f6 d2d3 e4d3 f1d3 d4g4 e1g1 g4d1 f1d1 g7g6 c3e4 f6e4 d3e4 f8g7 c1e3 b8d7 a2a4 d7e5 e3d4 e5c4 d4g7 h8g8 g7c3 c8f5 e4f5 g6f5 a4a5 c4d6 c3b4 e8c8 b4c5 a7a6 f2f3 d6c4 c5e7 d8e8 d1e1 c4b2 h2h4 g8g6 h4h5 g6e6 e1e6 f7e6 e7f6 b2c4 g2g4 f5g4 f3g4 e6e5 g4g5 c8d7 f6g7 d7e6 a1f1 c4e3 f1f6 e6d5 h5h6 e3g4 f6f7 e8e6 g7f8 e6g6 f7g7 e5e4 g7g6 h7g6 h6h7 g4e5 h7h8q e5f3 g1g2 f3e5 g2g3 e5d3 c2d3 e4e3 g3f4 d5e6 f4e4 c6c5 e4e3 b7b6 a5b6 a6a5 e3f4 e6d7 f4e4 a5a4 d3d4 c5c4 d4d5 a4a3 e4d4 a3a2 h8h1 d7c8 h1a1 c8b8 a1a2 b8b7 a2b1 b7a6 b6b7 a6a5 b1c1 a5a4 c1d1 a4b5 d1e1 b5b6 e1e2 c4c3 e2d1 b6a6 d1e1 a6a7 e1f1 a7b8 f1e1 b8a7 e1c1 a7b6 c1a3 c3c2 a3a4 c2c1r d4e5 c1c8 a4a5 b6b7 d5d6 c8c5 a5c5 b7b8 c5d5 b8c8 e5e6 c8d8 d5a8
```

I'm still not sure that the logic is completly polished, there might be still a few bugs, so would like more eyes on it.
Thoughts?