### PR TITLE
Add option for doing kldgain thresholding rather than absolute visit limiting.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -164,14 +164,14 @@ const OptionId SearchParams::kHistoryFillId{
     "one. During the first moves of the game such historical positions don't "
     "exist, but they can be synthesized. This parameter defines when to "
     "synthesize them (always, never, or only at non-standard fen position)."};
-const OptionId SearchParams::kMinimumKDGainPerNode{
-    "minimum-kdgain-per-node", "MinimumKDGainPerNode",
-    "If greater than 0 search will abort unless the last KDGainAverageInterval "
+const OptionId SearchParams::kMinimumKLDGainPerNode{
+    "minimum-kldgain-per-node", "MinimumKLDGainPerNode",
+    "If greater than 0 search will abort unless the last KLDGainAverageInterval "
     "nodes have an average gain per node of at least this much."};
-const OptionId SearchParams::kKDGainAverageInterval{
-    "kdgain-average-interval", "KDGainAverageInterval",
-    "Used to decide how frequently to evaluate the average KDGainPerNode to "
-    "check the MinimumKDGainPerNode, if specified."};
+const OptionId SearchParams::kKLDGainAverageInterval{
+    "kldgain-average-interval", "KLDGainAverageInterval",
+    "Used to decide how frequently to evaluate the average KLDGainPerNode to "
+    "check the MinimumKLDGainPerNode, if specified."};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -206,8 +206,8 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kScoreTypeId, score_type) = "centipawn";
   std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
-  options->Add<IntOption>(kKDGainAverageInterval, 1, 10000000) = 100;
-  options->Add<FloatOption>(kMinimumKDGainPerNode, 0.0f, 1.0f) = 0.0f;
+  options->Add<IntOption>(kKLDGainAverageInterval, 1, 10000000) = 100;
+  options->Add<FloatOption>(kMinimumKLDGainPerNode, 0.0f, 1.0f) = 0.0f;
 }
 
 SearchParams::SearchParams(const OptionsDict& options)

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -164,6 +164,14 @@ const OptionId SearchParams::kHistoryFillId{
     "one. During the first moves of the game such historical positions don't "
     "exist, but they can be synthesized. This parameter defines when to "
     "synthesize them (always, never, or only at non-standard fen position)."};
+const OptionId SearchParams::kMinimumKDGainPerNode{
+    "minimum-kdgain-per-node", "MinimumKDGainPerNode",
+    "If greater than 0 search will abort unless the last KDGainAverageInterval "
+    "nodes have an average gain per node of at least this much."};
+const OptionId SearchParams::kKDGainAverageInterval{
+    "kdgain-average-interval", "KDGainAverageInterval",
+    "Used to decide how frequently to evaluate the average KDGainPerNode to "
+    "check the MinimumKDGainPerNode, if specified."};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -198,6 +206,8 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kScoreTypeId, score_type) = "centipawn";
   std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
+  options->Add<IntOption>(kKDGainAverageInterval, 1, 10000000) = 100;
+  options->Add<FloatOption>(kMinimumKDGainPerNode, 0.0f, 1.0f) = 0.0f;
 }
 
 SearchParams::SearchParams(const OptionsDict& options)

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -89,11 +89,11 @@ class SearchParams {
     return options_.Get<std::string>(kScoreTypeId.GetId());
   }
   FillEmptyHistory GetHistoryFill() const { return kHistoryFill; }
-  int GetKDGainAverageInterval() const {
-    return options_.Get<int>(kKDGainAverageInterval.GetId());
+  int GetKLDGainAverageInterval() const {
+    return options_.Get<int>(kKLDGainAverageInterval.GetId());
   }
-  float GetMinimumKDGainPerNode() const {
-    return options_.Get<float>(kMinimumKDGainPerNode.GetId());
+  float GetMinimumKLDGainPerNode() const {
+    return options_.Get<float>(kMinimumKLDGainPerNode.GetId());
   }
 
   // Search parameter IDs.
@@ -123,8 +123,8 @@ class SearchParams {
   static const OptionId kMultiPvId;
   static const OptionId kScoreTypeId;
   static const OptionId kHistoryFillId;
-  static const OptionId kMinimumKDGainPerNode;
-  static const OptionId kKDGainAverageInterval;
+  static const OptionId kMinimumKLDGainPerNode;
+  static const OptionId kKLDGainAverageInterval;
 
  private:
   const OptionsDict& options_;

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -89,6 +89,12 @@ class SearchParams {
     return options_.Get<std::string>(kScoreTypeId.GetId());
   }
   FillEmptyHistory GetHistoryFill() const { return kHistoryFill; }
+  int GetKDGainAverageInterval() const {
+    return options_.Get<int>(kKDGainAverageInterval.GetId());
+  }
+  float GetMinimumKDGainPerNode() const {
+    return options_.Get<float>(kMinimumKDGainPerNode.GetId());
+  }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -117,6 +123,8 @@ class SearchParams {
   static const OptionId kMultiPvId;
   static const OptionId kScoreTypeId;
   static const OptionId kHistoryFillId;
+  static const OptionId kMinimumKDGainPerNode;
+  static const OptionId kKDGainAverageInterval;
 
  private:
   const OptionsDict& options_;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -333,15 +333,15 @@ void Search::MaybeTriggerStop() {
         sum1 += prev_dist_[i];
         sum2 += new_visits[i];
       }
-      double kdgain = 0.0;
+      double kldgain = 0.0;
       for (int i = 0; i < new_visits.size(); i++) {
         double o_p = prev_dist_[i] / sum1;
         double n_p = new_visits[i] / sum2;
         if (prev_dist_[i] != 0) {
-          kdgain += o_p * log(o_p / n_p);
+          kldgain += o_p * log(o_p / n_p);
         }
       }
-      if (kdgain / (sum2 - sum1) < params_.GetMinimumKLDGainPerNode()) {
+      if (kldgain / (sum2 - sum1) < params_.GetMinimumKLDGainPerNode()) {
         kldgain_too_small = true;
       }
     }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -317,6 +317,7 @@ void Search::MaybeTriggerStop() {
   if (bestmove_is_sent_) return;
   // Don't stop when the root node is not yet expanded.
   if (total_playouts_ == 0) return;
+
   bool kdgain_too_small = false;
   if (params_.GetMinimumKDGainPerNode() > 0 &&
       total_playouts_ + initial_visits_ >
@@ -332,15 +333,15 @@ void Search::MaybeTriggerStop() {
         sum1 += prev_dist_[i];
         sum2 += new_visits[i];
       }
-      double dev1 = 0.0;
+      double kdgain = 0.0;
       for (int i = 0; i < new_visits.size(); i++) {
         double o_p = prev_dist_[i] / sum1;
         double n_p = new_visits[i] / sum2;
         if (prev_dist_[i] != 0) {
-          dev1 += o_p * log(o_p / n_p);
+          kdgain += o_p * log(o_p / n_p);
         }
       }
-      if (dev1 / (sum2 - sum1) < params_.GetMinimumKDGainPerNode()) {
+      if (kdgain / (sum2 - sum1) < params_.GetMinimumKDGainPerNode()) {
         kdgain_too_small = true;
       }
     }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -318,10 +318,10 @@ void Search::MaybeTriggerStop() {
   // Don't stop when the root node is not yet expanded.
   if (total_playouts_ == 0) return;
 
-  bool kdgain_too_small = false;
-  if (params_.GetMinimumKDGainPerNode() > 0 &&
+  bool kldgain_too_small = false;
+  if (params_.GetMinimumKLDGainPerNode() > 0 &&
       total_playouts_ + initial_visits_ >
-          prev_dist_visits_total_ + params_.GetKDGainAverageInterval()) {
+          prev_dist_visits_total_ + params_.GetKLDGainAverageInterval()) {
     std::vector<uint32_t> new_visits;
     for (auto edge : root_node_->Edges()) {
       new_visits.push_back(edge.GetN());
@@ -341,8 +341,8 @@ void Search::MaybeTriggerStop() {
           kdgain += o_p * log(o_p / n_p);
         }
       }
-      if (kdgain / (sum2 - sum1) < params_.GetMinimumKDGainPerNode()) {
-        kdgain_too_small = true;
+      if (kdgain / (sum2 - sum1) < params_.GetMinimumKLDGainPerNode()) {
+        kldgain_too_small = true;
       }
     }
     prev_dist_.swap(new_visits);
@@ -351,7 +351,7 @@ void Search::MaybeTriggerStop() {
 
   // If not yet stopped, try to stop for different reasons.
   if (!stop_.load(std::memory_order_acquire)) {
-    if (kdgain_too_small) {
+    if (kldgain_too_small) {
       FireStopInternal();
       LOGFILE << "Stopped search: KDGain per node too small.";
     }

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -174,6 +174,11 @@ class Search {
   int64_t total_playouts_ GUARDED_BY(nodes_mutex_) = 0;
   int64_t remaining_playouts_ GUARDED_BY(nodes_mutex_) =
       std::numeric_limits<int64_t>::max();
+  // If kdgain minimum checks enabled, this was the visit distribution at the
+  // last kdgain interval triggering.
+  std::vector<uint32_t> prev_dist_;
+  // Total visits at the last time prev_dist_ was cached.
+  uint32_t prev_dist_visits_total_ = 0;
   // Maximum search depth = length of longest path taken in PickNodetoExtend.
   uint16_t max_depth_ GUARDED_BY(nodes_mutex_) = 0;
   // Cummulative depth of all paths taken in PickNodetoExtend.

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -111,6 +111,7 @@ class Search {
   int64_t GetTimeSinceStart() const;
   int64_t GetTimeToDeadline() const;
   void UpdateRemainingMoves();
+  void UpdateKLDGain();
   void MaybeTriggerStop();
   void MaybeOutputInfo();
   void SendUciInfo();  // Requires nodes_mutex_ to be held.
@@ -174,11 +175,13 @@ class Search {
   int64_t total_playouts_ GUARDED_BY(nodes_mutex_) = 0;
   int64_t remaining_playouts_ GUARDED_BY(nodes_mutex_) =
       std::numeric_limits<int64_t>::max();
-  // If kdgain minimum checks enabled, this was the visit distribution at the
-  // last kdgain interval triggering.
-  std::vector<uint32_t> prev_dist_;
+  // If kldgain minimum checks enabled, this was the visit distribution at the
+  // last kldgain interval triggering.
+  std::vector<uint32_t> prev_dist_ GUARDED_BY(counters_mutex_);
   // Total visits at the last time prev_dist_ was cached.
-  uint32_t prev_dist_visits_total_ = 0;
+  uint32_t prev_dist_visits_total_ GUARDED_BY(counters_mutex_) = 0;
+  // If true, search should exit as kldgain evaluation showed too little change.
+  bool kldgain_too_small_ GUARDED_BY(counters_mutex_) = false;
   // Maximum search depth = length of longest path taken in PickNodetoExtend.
   uint16_t max_depth_ GUARDED_BY(nodes_mutex_) = 0;
   // Cummulative depth of all paths taken in PickNodetoExtend.


### PR DESCRIPTION
Primarily for Issue #684 but could be interesting to use a super small value for real games to 'give up' search and save time for other moves with more useful search in cases where there are equal options that mean the existing pruning logic can't fire.

Looking for candidate values for training I have tested averaging interval of 100 - and threshold of 5e-6.  With a current T40 net average nodes is about 900, but 1600 for a very early net (although I only gathered a very small amount of data to start).  Which probably makes sense - as nets mature more of the time they know the right search so it converges in agreement with the existing policy quickly.  But there are still outliers which get a lot more nodes.

I have not done any investigation of whether the threshold is actually 'good' but I kind of doubt it'll be hard to measure usefully without trying in RL.