### PR TITLE
Fix c hw switching in cudnn-fp16 mode with convolution policy head.

### DIFF
--- a/src/neural/cuda/layers.cc
+++ b/src/neural/cuda/layers.cc
@@ -587,9 +587,9 @@ void PolicyMapLayer<DataType>::LoadWeights(const short* cpuWeight,
     for (int hw = 0; hw < 64; hw++)
       for (int c = 0; c < Cin; c++) {
         if (c < C)
-          convertedWeights[c * Cin + hw] = cpuWeight[hw * 64 + c];
+          convertedWeights[hw * Cin + c] = cpuWeight[c * 64 + hw];
         else
-          convertedWeights[c * Cin + hw] = -1;
+          convertedWeights[hw * Cin + c] = -1;
       }
     ReportCUDAErrors(cudaMemcpyAsync(weights_, convertedWeights,
                                      usedSize * sizeof(short),


### PR DESCRIPTION
The index calculations all had c and hw switched.
Before start position with net 50001 was completely different policy between fp16 and non-fp16 - also Exa found that it crashed on linux.

After fix: cudnn at top fp16 below.

info string e2e4  (322 ) N:      45 (+15) (P:  4.70%) (Q:  0.00426) (D:  0.039) (U: 0.07718) (Q+U:  0.08144) (V:  0.0051)
info string f2f4  (351 ) N:      45 (+15) (P:  4.79%) (Q:  0.00444) (D:  0.037) (U: 0.07858) (Q+U:  0.08302) (V:  0.0051)
info string g2g4  (378 ) N:      46 (+14) (P:  4.86%) (Q:  0.00157) (D:  0.036) (U: 0.07971) (Q+U:  0.08128) (V:  0.0063)
info string e2e3  (317 ) N:      47 (+11) (P:  4.80%) (Q:  0.00345) (D:  0.037) (U: 0.08155) (Q+U:  0.08501) (V:  0.0063)
info string h2h4  (403 ) N:      48 (+13) (P:  5.12%) (Q: -0.00255) (D:  0.036) (U: 0.08268) (Q+U:  0.08014) (V:  0.0022)
info string c2c4  (264 ) N:      49 (+12) (P:  4.92%) (Q:  0.00051) (D:  0.037) (U: 0.07943) (Q+U:  0.07994) (V:  0.0024)
info string c2c3  (259 ) N:      49 (+12) (P:  4.94%) (Q:  0.00044) (D:  0.039) (U: 0.07983) (Q+U:  0.08026) (V:  0.0037)
info string h2h3  (400 ) N:      49 (+13) (P:  4.94%) (Q:  0.00321) (D:  0.036) (U: 0.07856) (Q+U:  0.08177) (V:  0.0010)
info string d2d3  (288 ) N:      50 (+12) (P:  4.98%) (Q:  0.00120) (D:  0.042) (U: 0.07912) (Q+U:  0.08032) (V:  0.0037)
info string a2a3  (204 ) N:      50 (+13) (P:  5.03%) (Q:  0.00218) (D:  0.037) (U: 0.07872) (Q+U:  0.08089) (V:  0.0022)
info string b2b4  (234 ) N:      50 (+12) (P:  4.83%) (Q:  0.00479) (D:  0.037) (U: 0.07679) (Q+U:  0.08158) (V:  0.0039)
info string a2a4  (207 ) N:      51 (+12) (P:  5.03%) (Q:  0.00086) (D:  0.037) (U: 0.07872) (Q+U:  0.07958) (V:  0.0039)
info string f2f3  (346 ) N:      53 (+13) (P:  5.01%) (Q:  0.00538) (D:  0.038) (U: 0.07489) (Q+U:  0.08027) (V:  0.0046)
info string g2g3  (374 ) N:      54 (+13) (P:  5.10%) (Q:  0.00591) (D:  0.037) (U: 0.07514) (Q+U:  0.08106) (V:  0.0078)
info string d2d4  (293 ) N:      54 (+10) (P:  4.89%) (Q:  0.00585) (D:  0.040) (U: 0.07534) (Q+U:  0.08120) (V:  0.0056)
info string b2b3  (230 ) N:      55 (+13) (P:  4.93%) (Q:  0.00759) (D:  0.038) (U: 0.07148) (Q+U:  0.07908) (V:  0.0088)
info string b1a3  (34  ) N:      59 (+12) (P:  5.30%) (Q:  0.00655) (D:  0.037) (U: 0.07373) (Q+U:  0.08028) (V:  0.0020)
info string b1c3  (36  ) N:      61 (+15) (P:  5.35%) (Q:  0.01168) (D:  0.036) (U: 0.06955) (Q+U:  0.08123) (V:  0.0090)
info string g1h3  (161 ) N:      64 (+14) (P:  5.30%) (Q:  0.00861) (D:  0.037) (U: 0.06719) (Q+U:  0.07580) (V:  0.0066)
info string g1f3  (159 ) N:      66 (+13) (P:  5.18%) (Q:  0.01443) (D:  0.037) (U: 0.06488) (Q+U:  0.07931) (V:  0.0137)
bestmove g1f3 ponder g8f6

info string f2f4  (351 ) N:      51 (+14) (P:  4.78%) (Q:  0.00276) (D:  0.037) (U: 0.07741) (Q+U:  0.08017) (V:  0.0050)
info string e2e3  (317 ) N:      53 (+11) (P:  4.81%) (Q: -0.00082) (D:  0.037) (U: 0.07907) (Q+U:  0.07825) (V:  0.0063)
info string e2e4  (322 ) N:      53 (+12) (P:  4.70%) (Q:  0.00231) (D:  0.038) (U: 0.07622) (Q+U:  0.07853) (V:  0.0051)
info string g2g4  (378 ) N:      53 (+11) (P:  4.87%) (Q:  0.00055) (D:  0.036) (U: 0.08010) (Q+U:  0.08065) (V:  0.0059)
info string h2h4  (403 ) N:      54 (+11) (P:  5.11%) (Q: -0.00391) (D:  0.035) (U: 0.08282) (Q+U:  0.07891) (V:  0.0018)
info string c2c4  (264 ) N:      55 (+12) (P:  4.91%) (Q:  0.00007) (D:  0.036) (U: 0.07715) (Q+U:  0.07722) (V:  0.0028)
info string c2c3  (259 ) N:      56 (+11) (P:  4.95%) (Q: -0.00168) (D:  0.039) (U: 0.07782) (Q+U:  0.07614) (V:  0.0036)
info string a2a3  (204 ) N:      56 (+12) (P:  5.03%) (Q: -0.00002) (D:  0.037) (U: 0.07792) (Q+U:  0.07790) (V:  0.0029)
info string h2h3  (400 ) N:      56 (+13) (P:  4.94%) (Q:  0.00354) (D:  0.036) (U: 0.07548) (Q+U:  0.07902) (V:  0.0012)
info string d2d3  (288 ) N:      57 (+11) (P:  4.99%) (Q:  0.00089) (D:  0.041) (U: 0.07733) (Q+U:  0.07822) (V:  0.0041)
info string a2a4  (207 ) N:      58 (+13) (P:  5.05%) (Q:  0.00178) (D:  0.036) (U: 0.07494) (Q+U:  0.07673) (V:  0.0038)
info string b2b4  (234 ) N:      59 (+10) (P:  4.83%) (Q:  0.00332) (D:  0.037) (U: 0.07385) (Q+U:  0.07716) (V:  0.0038)
info string f2f3  (346 ) N:      60 (+12) (P:  4.99%) (Q:  0.00495) (D:  0.038) (U: 0.07311) (Q+U:  0.07806) (V:  0.0048)
info string g2g3  (374 ) N:      60 (+13) (P:  5.10%) (Q:  0.00462) (D:  0.036) (U: 0.07365) (Q+U:  0.07827) (V:  0.0080)
info string d2d4  (293 ) N:      61 (+13) (P:  4.90%) (Q:  0.00645) (D:  0.039) (U: 0.06988) (Q+U:  0.07633) (V:  0.0052)
info string b2b3  (230 ) N:      61 (+13) (P:  4.92%) (Q:  0.00726) (D:  0.037) (U: 0.07014) (Q+U:  0.07740) (V:  0.0090)
info string b1a3  (34  ) N:      67 (+13) (P:  5.32%) (Q:  0.00555) (D:  0.037) (U: 0.07024) (Q+U:  0.07579) (V:  0.0020)
info string b1c3  (36  ) N:      69 (+14) (P:  5.33%) (Q:  0.00773) (D:  0.036) (U: 0.06789) (Q+U:  0.07562) (V:  0.0087)
info string g1h3  (161 ) N:      71 (+18) (P:  5.29%) (Q:  0.01212) (D:  0.036) (U: 0.06286) (Q+U:  0.07497) (V:  0.0065)
info string g1f3  (159 ) N:      72 (+19) (P:  5.18%) (Q:  0.01145) (D:  0.036) (U: 0.06027) (Q+U:  0.07172) (V:  0.0138)
bestmove g1f3 ponder g8f6
