### PR TITLE
put mode specific options last

### DIFF
--- a/src/benchmark/benchmark.cc
+++ b/src/benchmark/benchmark.cc
@@ -48,10 +48,10 @@ const OptionId kFenId{"fen", "", "Benchmark initial position FEN."};
 void Benchmark::Run() {
   OptionsParser options;
   NetworkFactory::PopulateOptions(&options);
-  SearchParams::Populate(&options);
-
   options.Add<IntOption>(kThreadsOptionId, 1, 128) = kDefaultThreads;
   options.Add<IntOption>(kNNCacheSizeId, 0, 999999999) = 200000;
+  SearchParams::Populate(&options);
+
   options.Add<IntOption>(kNodesId, -1, 999999999) = -1;
   options.Add<IntOption>(kMovetimeId, -1, 999999999) = 10000;
   options.Add<StringOption>(kFenId) = ChessBoard::kStartposFen;

--- a/src/benchmark/benchmark.cc
+++ b/src/benchmark/benchmark.cc
@@ -50,11 +50,11 @@ void Benchmark::Run() {
   NetworkFactory::PopulateOptions(&options);
   SearchParams::Populate(&options);
 
+  options.Add<IntOption>(kThreadsOptionId, 1, 128) = kDefaultThreads;
+  options.Add<IntOption>(kNNCacheSizeId, 0, 999999999) = 200000;
   options.Add<IntOption>(kNodesId, -1, 999999999) = -1;
   options.Add<IntOption>(kMovetimeId, -1, 999999999) = 10000;
   options.Add<StringOption>(kFenId) = ChessBoard::kStartposFen;
-  options.Add<IntOption>(kNNCacheSizeId, 0, 999999999) = 200000;
-  options.Add<IntOption>(kThreadsOptionId, 1, 128) = kDefaultThreads;
 
   if (!options.ProcessAllFlags()) return;
 

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -128,6 +128,9 @@ EngineController::EngineController(BestMoveInfo::Callback best_move_callback,
 void EngineController::PopulateOptions(OptionsParser* options) {
   using namespace std::placeholders;
 
+  NetworkFactory::PopulateOptions(options);
+  SearchParams::Populate(options);
+
   options->Add<IntOption>(kThreadsOptionId, 1, 128) = kDefaultThreads;
   options->Add<IntOption>(kNNCacheSizeId, 0, 999999999) = 200000;
   options->Add<FloatOption>(kSlowMoverId, 0.0f, 100.0f) = 1.0f;
@@ -141,13 +144,11 @@ void EngineController::PopulateOptions(OptionsParser* options) {
   options->Add<FloatOption>(kSpendSavedTimeId, 0.0f, 1.0f) = 1.0f;
   options->Add<IntOption>(kRamLimitMbId, 0, 100000000) = 0;
 
+  ConfigFile::PopulateOptions(options);
+
   // Hide time curve options.
   options->HideOption(kTimeMidpointMoveId);
   options->HideOption(kTimeSteepnessId);
-
-  NetworkFactory::PopulateOptions(options);
-  SearchParams::Populate(options);
-  ConfigFile::PopulateOptions(options);
 }
 
 SearchLimits EngineController::PopulateSearchLimits(

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -129,10 +129,10 @@ void EngineController::PopulateOptions(OptionsParser* options) {
   using namespace std::placeholders;
 
   NetworkFactory::PopulateOptions(options);
-  SearchParams::Populate(options);
-
   options->Add<IntOption>(kThreadsOptionId, 1, 128) = kDefaultThreads;
   options->Add<IntOption>(kNNCacheSizeId, 0, 999999999) = 200000;
+  SearchParams::Populate(options);
+
   options->Add<FloatOption>(kSlowMoverId, 0.0f, 100.0f) = 1.0f;
   options->Add<IntOption>(kMoveOverheadId, 0, 100000000) = 200;
   options->Add<FloatOption>(kTimeMidpointMoveId, 1.0f, 100.0f) = 51.5f;

--- a/src/selfplay/loop.cc
+++ b/src/selfplay/loop.cc
@@ -44,8 +44,9 @@ SelfPlayLoop::~SelfPlayLoop() {
 }
 
 void SelfPlayLoop::RunLoop() {
-  options_.Add<BoolOption>(kInteractiveId) = false;
   SelfPlayTournament::PopulateOptions(&options_);
+
+  options_.Add<BoolOption>(kInteractiveId) = false;
 
   if (!options_.ProcessAllFlags()) return;
   if (options_.GetOptionsDict().Get<bool>(kInteractiveId.GetId())) {

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -69,11 +69,14 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   options->AddContext("player1");
   options->AddContext("player2");
 
+  NetworkFactory::PopulateOptions(options);
+  SearchParams::Populate(options);
+
+  options->Add<IntOption>(kThreadsId, 1, 8) = 1;
+  options->Add<IntOption>(kNnCacheSizeId, 0, 999999999) = 200000;
   options->Add<BoolOption>(kShareTreesId) = true;
   options->Add<IntOption>(kTotalGamesId, -1, 999999) = -1;
   options->Add<IntOption>(kParallelGamesId, 1, 256) = 8;
-  options->Add<IntOption>(kThreadsId, 1, 8) = 1;
-  options->Add<IntOption>(kNnCacheSizeId, 0, 999999999) = 200000;
   options->Add<IntOption>(kPlayoutsId, -1, 999999999) = -1;
   options->Add<IntOption>(kVisitsId, -1, 999999999) = -1;
   options->Add<IntOption>(kTimeMsId, -1, 999999999) = -1;
@@ -81,9 +84,8 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   options->Add<BoolOption>(kVerboseThinkingId) = false;
   options->Add<FloatOption>(kResignPlaythroughId, 0.0f, 100.0f) = 0.0f;
 
-  NetworkFactory::PopulateOptions(options);
-  SearchParams::Populate(options);
   SelfPlayGame::PopulateUciParams(options);
+
   auto defaults = options->GetMutableDefaultsOptions();
   defaults->Set<int>(SearchParams::kMiniBatchSizeId.GetId(), 32);
   defaults->Set<float>(SearchParams::kCpuctId.GetId(), 1.2f);

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -70,10 +70,10 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   options->AddContext("player2");
 
   NetworkFactory::PopulateOptions(options);
-  SearchParams::Populate(options);
-
   options->Add<IntOption>(kThreadsId, 1, 8) = 1;
   options->Add<IntOption>(kNnCacheSizeId, 0, 999999999) = 200000;
+  SearchParams::Populate(options);
+
   options->Add<BoolOption>(kShareTreesId) = true;
   options->Add<IntOption>(kTotalGamesId, -1, 999999) = -1;
   options->Add<IntOption>(kParallelGamesId, 1, 256) = 8;


### PR DESCRIPTION
Rearrange option initialization, so that the help text for mode specific options is printed last.