### PR TITLE
Add AtRoot versions of FpuStrategy and FpuValue (and convert FpuReduction to FpuValue).

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -109,24 +109,27 @@ const OptionId SearchParams::kSmartPruningFactorId{
     "pruning is deactivated."};
 const OptionId SearchParams::kFpuStrategyId{
     "fpu-strategy", "FpuStrategy",
-    "How is an eval of unvisited node determined. \"reduction\" subtracts "
-    "--fpu-reduction value from the parent eval. \"absolute\" sets eval of "
-    "unvisited nodes to the value specified in --fpu-value."};
-// TODO(crem) Make FPU in "reduction" mode use fpu-value too. For now it's kept
-// for backwards compatibility.
-const OptionId SearchParams::kFpuReductionId{
-    "fpu-reduction", "FpuReduction",
-    "\"First Play Urgency\" reduction (used when FPU strategy is "
-    "\"reduction\"). Normally when a move has no visits, "
-    "it's eval is assumed to be equal to parent's eval. With non-zero FPU "
-    "reduction, eval of unvisited move is decreased by that value, "
-    "discouraging visits of unvisited moves, and saving those visits for "
-    "(hopefully) more promising moves."};
+    "How is an eval of unvisited node determined. \"First Play Urgency\" "
+    "changes search behavior to visit unvisited nodes earlier or later by "
+    "using a placeholder eval before checking the network. The value specified "
+    "with --fpu-value results in \"reduction\" subtracting that value from the "
+    "parent eval while \"absolute\" directly uses that value."};
 const OptionId SearchParams::kFpuValueId{
     "fpu-value", "FpuValue",
-    "\"First Play Urgency\" value. When FPU strategy is \"absolute\", value of "
-    "unvisited node is assumed to be equal to this value, and does not depend "
-    "on parent eval."};
+    "\"First Play Urgency\" value used to adjust unvisited node eval based on "
+    "--fpu-strategy."};
+const OptionId SearchParams::kFpuStrategyAtRootId{
+    "fpu-strategy-at-root", "FpuStrategyAtRoot",
+    "How is an eval of unvisited root children determined. Just like "
+    "--fpu-strategy except only at the root level and adjusts unvisited root "
+    "children eval with --fpu-value-at-root. In addition to matching the "
+    "strategies from --fpu-strategy, this can be \"same\" to disable the "
+    "special root behavior."};
+const OptionId SearchParams::kFpuValueAtRootId{
+    "fpu-value-at-root", "FpuValueAtRoot",
+    "\"First Play Urgency\" value used to adjust unvisited root children eval "
+    "based on --fpu-strategy-at-root. Has no effect if --fpu-strategy-at-root "
+    "is \"same\"."};
 const OptionId SearchParams::kCacheHistoryLengthId{
     "cache-history-length", "CacheHistoryLength",
     "Length of history, in half-moves, to include into the cache key. When "
@@ -197,8 +200,10 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kSmartPruningFactorId, 0.0f, 10.0f) = 1.33f;
   std::vector<std::string> fpu_strategy = {"reduction", "absolute"};
   options->Add<ChoiceOption>(kFpuStrategyId, fpu_strategy) = "reduction";
-  options->Add<FloatOption>(kFpuReductionId, -100.0f, 100.0f) = 1.2f;
-  options->Add<FloatOption>(kFpuValueId, -1.0f, 1.0f) = -1.0f;
+  options->Add<FloatOption>(kFpuValueId, -100.0f, 100.0f) = 1.2f;
+  fpu_strategy.push_back("same");
+  options->Add<ChoiceOption>(kFpuStrategyAtRootId, fpu_strategy) = "absolute";
+  options->Add<FloatOption>(kFpuValueAtRootId, -100.0f, 100.0f) = 1.0f;
   options->Add<IntOption>(kCacheHistoryLengthId, 0, 7) = 0;
   options->Add<FloatOption>(kPolicySoftmaxTempId, 0.1f, 10.0f) = 2.2f;
   options->Add<IntOption>(kMaxCollisionEventsId, 1, 1024) = 32;
@@ -225,8 +230,12 @@ SearchParams::SearchParams(const OptionsDict& options)
       kSmartPruningFactor(options.Get<float>(kSmartPruningFactorId.GetId())),
       kFpuAbsolute(options.Get<std::string>(kFpuStrategyId.GetId()) ==
                    "absolute"),
-      kFpuReduction(options.Get<float>(kFpuReductionId.GetId())),
       kFpuValue(options.Get<float>(kFpuValueId.GetId())),
+      kFpuAbsoluteAtRoot(
+          options.Get<std::string>(kFpuStrategyAtRootId.GetId()) == "absolute"),
+      kFpuReductionAtRoot(options.Get<std::string>(
+                              kFpuStrategyAtRootId.GetId()) == "reduction"),
+      kFpuValueAtRoot(options.Get<float>(kFpuValueAtRootId.GetId())),
       kCacheHistoryLength(options.Get<int>(kCacheHistoryLengthId.GetId())),
       kPolicySoftmaxTemp(options.Get<float>(kPolicySoftmaxTempId.GetId())),
       kMaxCollisionEvents(options.Get<int>(kMaxCollisionEventsId.GetId())),

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -202,7 +202,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kFpuStrategyId, fpu_strategy) = "reduction";
   options->Add<FloatOption>(kFpuValueId, -100.0f, 100.0f) = 1.2f;
   fpu_strategy.push_back("same");
-  options->Add<ChoiceOption>(kFpuStrategyAtRootId, fpu_strategy) = "absolute";
+  options->Add<ChoiceOption>(kFpuStrategyAtRootId, fpu_strategy) = "same";
   options->Add<FloatOption>(kFpuValueAtRootId, -100.0f, 100.0f) = 1.0f;
   options->Add<IntOption>(kCacheHistoryLengthId, 0, 7) = 0;
   options->Add<FloatOption>(kPolicySoftmaxTempId, 0.1f, 10.0f) = 2.2f;
@@ -232,10 +232,13 @@ SearchParams::SearchParams(const OptionsDict& options)
                    "absolute"),
       kFpuValue(options.Get<float>(kFpuValueId.GetId())),
       kFpuAbsoluteAtRoot(
+          (options.Get<std::string>(kFpuStrategyAtRootId.GetId()) == "same" &&
+           kFpuAbsolute) ||
           options.Get<std::string>(kFpuStrategyAtRootId.GetId()) == "absolute"),
-      kFpuReductionAtRoot(options.Get<std::string>(
-                              kFpuStrategyAtRootId.GetId()) == "reduction"),
-      kFpuValueAtRoot(options.Get<float>(kFpuValueAtRootId.GetId())),
+      kFpuValueAtRoot(options.Get<std::string>(kFpuStrategyAtRootId.GetId()) ==
+                              "same"
+                          ? kFpuValue
+                          : options.Get<float>(kFpuValueAtRootId.GetId())),
       kCacheHistoryLength(options.Get<int>(kCacheHistoryLengthId.GetId())),
       kPolicySoftmaxTemp(options.Get<float>(kPolicySoftmaxTempId.GetId())),
       kMaxCollisionEvents(options.Get<int>(kMaxCollisionEventsId.GetId())),

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -78,11 +78,8 @@ class SearchParams {
     return options_.Get<bool>(kLogLiveStatsId.GetId());
   }
   float GetSmartPruningFactor() const { return kSmartPruningFactor; }
-  bool GetFpuAbsolute() const { return kFpuAbsolute; }
-  float GetFpuValue() const { return kFpuValue; }
-  bool GetFpuAbsoluteAtRoot() const { return kFpuAbsoluteAtRoot; }
-  bool GetFpuReductionAtRoot() const { return kFpuReductionAtRoot; }
-  float GetFpuValueAtRoot() const { return kFpuValueAtRoot; }
+  bool GetFpuAbsolute(bool at_root) const { return at_root ? kFpuAbsoluteAtRoot : kFpuAbsolute; }
+  float GetFpuValue(bool at_root) const { return at_root ? kFpuValueAtRoot : kFpuValue; }
   int GetCacheHistoryLength() const { return kCacheHistoryLength; }
   float GetPolicySoftmaxTemp() const { return kPolicySoftmaxTemp; }
   int GetMaxCollisionEvents() const { return kMaxCollisionEvents; }
@@ -149,7 +146,6 @@ class SearchParams {
   const bool kFpuAbsolute;
   const float kFpuValue;
   const bool kFpuAbsoluteAtRoot;
-  const bool kFpuReductionAtRoot;
   const float kFpuValueAtRoot;
   const int kCacheHistoryLength;
   const float kPolicySoftmaxTemp;

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -79,8 +79,10 @@ class SearchParams {
   }
   float GetSmartPruningFactor() const { return kSmartPruningFactor; }
   bool GetFpuAbsolute() const { return kFpuAbsolute; }
-  float GetFpuReduction() const { return kFpuReduction; }
   float GetFpuValue() const { return kFpuValue; }
+  bool GetFpuAbsoluteAtRoot() const { return kFpuAbsoluteAtRoot; }
+  bool GetFpuReductionAtRoot() const { return kFpuReductionAtRoot; }
+  float GetFpuValueAtRoot() const { return kFpuValueAtRoot; }
   int GetCacheHistoryLength() const { return kCacheHistoryLength; }
   float GetPolicySoftmaxTemp() const { return kPolicySoftmaxTemp; }
   int GetMaxCollisionEvents() const { return kMaxCollisionEvents; }
@@ -116,8 +118,9 @@ class SearchParams {
   static const OptionId kLogLiveStatsId;
   static const OptionId kSmartPruningFactorId;
   static const OptionId kFpuStrategyId;
-  static const OptionId kFpuReductionId;
   static const OptionId kFpuValueId;
+  static const OptionId kFpuStrategyAtRootId;
+  static const OptionId kFpuValueAtRootId;
   static const OptionId kCacheHistoryLengthId;
   static const OptionId kPolicySoftmaxTempId;
   static const OptionId kMaxCollisionEventsId;
@@ -144,8 +147,10 @@ class SearchParams {
   const bool kNoise;
   const float kSmartPruningFactor;
   const bool kFpuAbsolute;
-  const float kFpuReduction;
   const float kFpuValue;
+  const bool kFpuAbsoluteAtRoot;
+  const bool kFpuReductionAtRoot;
+  const float kFpuValueAtRoot;
   const int kCacheHistoryLength;
   const float kPolicySoftmaxTemp;
   const int kMaxCollisionEvents;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -189,13 +189,17 @@ int64_t Search::GetTimeToDeadline() const {
 
 namespace {
 inline float GetFpu(const SearchParams& params, Node* node, bool is_root_node) {
+  // Use root FPU behavior unless it's "same"
+  if (is_root_node) {
+    if (params.GetFpuAbsoluteAtRoot()) return params.GetFpuValueAtRoot();
+    if (params.GetFpuReductionAtRoot())
+      return -node->GetQ() -
+             params.GetFpuValueAtRoot() * std::sqrt(node->GetVisitedPolicy());
+  }
   return params.GetFpuAbsolute()
              ? params.GetFpuValue()
-             : ((is_root_node && params.GetNoise()) ||
-                !params.GetFpuReduction())
-                   ? -node->GetQ()
-                   : -node->GetQ() - params.GetFpuReduction() *
-                                         std::sqrt(node->GetVisitedPolicy());
+             : -node->GetQ() -
+                   params.GetFpuValue() * std::sqrt(node->GetVisitedPolicy());
 }
 
 inline float ComputeCpuct(const SearchParams& params, uint32_t N) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -189,17 +189,10 @@ int64_t Search::GetTimeToDeadline() const {
 
 namespace {
 inline float GetFpu(const SearchParams& params, Node* node, bool is_root_node) {
-  // Use root FPU behavior unless it's "same"
-  if (is_root_node) {
-    if (params.GetFpuAbsoluteAtRoot()) return params.GetFpuValueAtRoot();
-    if (params.GetFpuReductionAtRoot())
-      return -node->GetQ() -
-             params.GetFpuValueAtRoot() * std::sqrt(node->GetVisitedPolicy());
-  }
-  return params.GetFpuAbsolute()
-             ? params.GetFpuValue()
-             : -node->GetQ() -
-                   params.GetFpuValue() * std::sqrt(node->GetVisitedPolicy());
+  const auto value = params.GetFpuValue(is_root_node);
+  return params.GetFpuAbsolute(is_root_node)
+             ? value
+             : -node->GetQ() - value * std::sqrt(node->GetVisitedPolicy());
 }
 
 inline float ComputeCpuct(const SearchParams& params, uint32_t N) {

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -99,8 +99,6 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   defaults->Set<float>(SearchParams::kTemperatureId.GetId(), 1.0f);
   defaults->Set<bool>(SearchParams::kNoiseId.GetId(), true);
   defaults->Set<float>(SearchParams::kFpuValueId.GetId(), 0.0f);
-  defaults->Set<std::string>(SearchParams::kFpuStrategyAtRootId.GetId(),
-                             "same");
   defaults->Set<std::string>(SearchParams::kHistoryFillId.GetId(), "no");
   defaults->Set<std::string>(NetworkFactory::kBackendId.GetId(),
                              "multiplexing");

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -98,7 +98,9 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   defaults->Set<float>(SearchParams::kSmartPruningFactorId.GetId(), 0.0f);
   defaults->Set<float>(SearchParams::kTemperatureId.GetId(), 1.0f);
   defaults->Set<bool>(SearchParams::kNoiseId.GetId(), true);
-  defaults->Set<float>(SearchParams::kFpuReductionId.GetId(), 0.0f);
+  defaults->Set<float>(SearchParams::kFpuValueId.GetId(), 0.0f);
+  defaults->Set<std::string>(SearchParams::kFpuStrategyAtRootId.GetId(),
+                             "same");
   defaults->Set<std::string>(SearchParams::kHistoryFillId.GetId(), "no");
   defaults->Set<std::string>(NetworkFactory::kBackendId.GetId(),
                              "multiplexing");


### PR DESCRIPTION
r?@mooskagh ~Wasn't sure if this should be conditional on self-play / noise. Or if it needs another param -- without, the logic simplifies a little bit.~ ~Edit: Added `fpu-strategy=root-absolute` to do absolute at root and reduction otherwise. Self-play maintains current previous default `fpu-strategy=reduction` and still sets `fpu-reduction=0`, so that's unaffected by the code simplification of not checking noise (but would prevent wanting to use reduction with noise except at root -- do we want to keep that?). To turn on new behavior for training, server would set `fpu-strategy=root-absolute` (with `fpu-value=1 fpu-reduction=0` still set on the client). Added `--early-root-widening` flag which changes FPU behavior at root only for search (leaving verbose, temperature, other `GetFPU` callers unaffected).~

Edit: Added the suggested FpuStrategyAtRoot and FpuValueAtRoot; and at the same time converted FpuReduction to FpuValue. I made "same" ignore FpuValueAtRoot and documented help as such to avoid complexities of thinking "same" might mean.. "if strategy is reduction, reduce eval by --fpu-value for most nodes except reduce root children by --fpu-value-at-root instead."

Analyzing the position from page 81 (fix #748) again with 32930 with `minibatch-size=1 smart-pruning-factor=0` (expecting to explore more than top 4):
![page81](https://user-images.githubusercontent.com/438537/53203446-0edeb900-35de-11e9-9ecc-232e06e1d8b0.png)
```
position startpos moves g1f3 g8f6 c2c4 e7e6 b1c3 f8b4 d1c2 e8g8 a2a3 b4c3 c2c3 a7a5 b2b4 d7d6 e2e3 f6e4 c3c2 e4g5 b4b5 g5f3 g2f3 d8f6 d2d4 f6f3 h1g1 b8d7 f1e2 f3f6 c1b2 f6h4 g1g4 h4h2 g4g3 f7f5 e1c1 f8f7 e2f3 h2h4 d1h1 h4f6 c1b1 g7g6 g3g1 a5a4 b1a1 f7g7 e3e4 f5f4 c4c5 f6e7 g1c1 d7f6 e4e5 d6e5 h1e1 e5e4 f3e4 e7f8
go nodes 68

before:
…
c2c4  (264 ) N:   0 (+ 0) (P:  3.59%) (Q: -0.66368) (U: 0.88393) (Q+U:  0.22025) (V:  -.----) 
e4d3  (783 ) N:   9 (+ 0) (P: 16.80%) (Q:  0.01363) (U: 0.41335) (Q+U:  0.42698) (V:  0.1071) 
d4d5  (761 ) N:  10 (+ 0) (P: 12.22%) (Q:  0.09005) (U: 0.27343) (Q+U:  0.36348) (V:  0.6982) 
e4f3  (785 ) N:  22 (+ 0) (P: 11.60%) (Q:  0.29520) (U: 0.12411) (Q+U:  0.41931) (V:  0.2686) 
c5c6  (973 ) N:  26 (+ 0) (P: 13.87%) (Q:  0.28326) (U: 0.12639) (Q+U:  0.40965) (V:  0.3732) 

after:
c2b3  (258 ) N:   1 (+ 0) (P:  0.59%) (Q: -0.97691) (U: 0.07363) (Q+U: -0.90328) (V: -0.9769) 
e4d5  (795 ) N:   1 (+ 0) (P:  0.83%) (Q: -0.98659) (U: 0.10328) (Q+U: -0.88331) (V: -0.9866) 
e4f5  (797 ) N:   1 (+ 0) (P:  0.86%) (Q: -0.96944) (U: 0.10715) (Q+U: -0.86229) (V: -0.9694) 
e1e3  (111 ) N:   1 (+ 0) (P:  0.84%) (Q: -0.92453) (U: 0.10422) (Q+U: -0.82031) (V: -0.9245) 
c2a4  (262 ) N:   1 (+ 0) (P:  0.55%) (Q: -0.85741) (U: 0.06828) (Q+U: -0.78913) (V: -0.8574) 
e4c6  (799 ) N:   1 (+ 0) (P:  0.71%) (Q: -0.71045) (U: 0.08829) (Q+U: -0.62217) (V: -0.7105) 
e4g6  (803 ) N:   1 (+ 0) (P:  0.72%) (Q: -0.47933) (U: 0.08895) (Q+U: -0.39038) (V: -0.4793) 
a1b1  (0   ) N:   1 (+ 0) (P:  1.11%) (Q: -0.00074) (U: 0.13756) (Q+U:  0.13682) (V: -0.0007) 
b2c3  (231 ) N:   1 (+ 0) (P:  1.29%) (Q: -0.02199) (U: 0.15988) (Q+U:  0.13789) (V: -0.0220) 
a1a2  (7   ) N:   1 (+ 0) (P:  1.12%) (Q:  0.03331) (U: 0.13893) (Q+U:  0.17224) (V:  0.0333) 
c1b1  (48  ) N:   1 (+ 0) (P:  1.23%) (Q:  0.07281) (U: 0.15246) (Q+U:  0.22526) (V:  0.0728) 
e1f1  (101 ) N:   1 (+ 0) (P:  1.27%) (Q:  0.11431) (U: 0.15737) (Q+U:  0.27169) (V:  0.1143) 
b5b6  (941 ) N:   1 (+ 0) (P:  1.64%) (Q:  0.10347) (U: 0.20353) (Q+U:  0.30699) (V:  0.1035) 
e1d1  (100 ) N:   1 (+ 0) (P:  1.41%) (Q:  0.17411) (U: 0.17497) (Q+U:  0.34907) (V:  0.1741) 
c2c3  (259 ) N:   1 (+ 0) (P:  1.44%) (Q:  0.19155) (U: 0.17794) (Q+U:  0.36950) (V:  0.1916) 
c2d2  (252 ) N:   1 (+ 0) (P:  1.80%) (Q:  0.16386) (U: 0.22263) (Q+U:  0.38649) (V:  0.1639) 
c2b1  (246 ) N:   1 (+ 0) (P:  1.63%) (Q:  0.19083) (U: 0.20183) (Q+U:  0.39265) (V:  0.1908) 
c2d1  (248 ) N:   1 (+ 0) (P:  1.62%) (Q:  0.22839) (U: 0.20069) (Q+U:  0.42908) (V:  0.2284) 
e1e2  (106 ) N:   1 (+ 0) (P:  1.55%) (Q:  0.25640) (U: 0.19218) (Q+U:  0.44858) (V:  0.2564) 
c2d3  (260 ) N:   1 (+ 0) (P:  1.75%) (Q:  0.24711) (U: 0.21667) (Q+U:  0.46379) (V:  0.2471) 
e4b7  (804 ) N:   1 (+ 0) (P:  0.71%) (Q:  0.38252) (U: 0.08786) (Q+U:  0.47038) (V:  0.3825) 
c1d1  (49  ) N:   1 (+ 0) (P:  1.54%) (Q:  0.28285) (U: 0.19137) (Q+U:  0.47423) (V:  0.2829) 
e1h1  (103 ) N:   1 (+ 0) (P:  1.97%) (Q:  0.24280) (U: 0.24410) (Q+U:  0.48690) (V:  0.2428) 
e1g1  (102 ) N:   1 (+ 0) (P:  2.36%) (Q:  0.21439) (U: 0.29309) (Q+U:  0.50748) (V:  0.2144) 
f2f3  (346 ) N:   1 (+ 0) (P:  2.47%) (Q:  0.22276) (U: 0.30605) (Q+U:  0.52881) (V:  0.2228) 
e4g2  (781 ) N:   1 (+ 0) (P:  2.99%) (Q:  0.16545) (U: 0.37093) (Q+U:  0.53638) (V:  0.1654) 
c2e2  (253 ) N:   2 (+ 0) (P:  2.34%) (Q:  0.19584) (U: 0.19319) (Q+U:  0.38903) (V:  0.2921) 
e4h1  (776 ) N:   2 (+ 0) (P:  3.57%) (Q:  0.11043) (U: 0.29533) (Q+U:  0.40576) (V:  0.1988) 
c2c4  (264 ) N:   2 (+ 0) (P:  3.59%) (Q:  0.18332) (U: 0.29684) (Q+U:  0.48016) (V:  0.2804) 
e4f3  (785 ) N:   5 (+ 0) (P: 11.60%) (Q:  0.05569) (U: 0.47931) (Q+U:  0.53500) (V:  0.2686) 
d4d5  (761 ) N:   6 (+ 0) (P: 12.22%) (Q:  0.07366) (U: 0.43289) (Q+U:  0.50655) (V:  0.6982) 
e4d3  (783 ) N:   8 (+ 0) (P: 16.80%) (Q:  0.03414) (U: 0.46271) (Q+U:  0.49684) (V:  0.1071) 
c5c6  (973 ) N:  17 (+ 0) (P: 13.87%) (Q:  0.35679) (U: 0.19100) (Q+U:  0.54779) (V:  0.3732)
```

This patch also happens to avoid @sergiovieri’s stalemate capture to queen promotion with t40 (41000 used here with `policy-softmax-temp=1`; expecting to find non-stalemate move):
![stalemate](https://user-images.githubusercontent.com/438537/53203440-08e8d800-35de-11e9-9b2c-be090eb30ca3.png)
```
position fen 5n2/4P2k/8/8/8/2K3Q1/8/8 w - - 0 1
go nodes 800

before:
…
e7f8r (1832) N:   0 (+ 0) (P:  0.05%) (Q: -1.19817) (U: 0.04482) (Q+U: -1.15335) (V:  -.----) 
e7f8q (1831) N: 799 (+ 0) (P: 99.90%) (Q:  0.00000) (U: 0.10854) (Q+U:  0.10854) (V:  0.0000) (T) 

after:
…
e7f8q (1831) N:  86 (+ 0) (P: 99.90%) (Q:  0.00000) (U: 0.99810) (Q+U:  0.99810) (V:  0.0000) (T) 
g3g1  (600 ) N: 115 (+ 1) (P:  0.00%) (Q:  0.99785) (U: 0.00000) (Q+U:  0.99785) (V:  0.9981) 
e7f8r (1832) N: 134 (+ 0) (P:  0.05%) (Q:  0.99622) (U: 0.00033) (Q+U:  0.99656) (V:  0.9994) 
e7e8q (1828) N: 244 (+ 0) (P:  0.00%) (Q:  0.99420) (U: 0.00000) (Q+U:  0.99420) (V:  0.9985) 
```

Bonus 32930 trying to find this “houdini tactic” from tactics list (fix #8; expecting Qxe7 sacrifice):
![tactic](https://user-images.githubusercontent.com/438537/53203432-04242400-35de-11e9-9ac1-86f2804bc2e8.png)
```
position startpos moves d2d4 e7e6 c2c4 f8b4 c1d2 b4e7 e2e4 d7d5 e4e5 c7c5 d1g4 e7f8 d4c5 h7h5 g4g3 h5h4 g3a3 b8d7 g1f3 f8c5 b2b4 c5b6 d2g5 g8e7 a3b2 h8h5 c4d5 e6d5 f1b5 e8f8 e1g1 d7e5 b2e5 f7f6 e5f4 b6c7 f4e3 f6g5 b1c3 d8d6 b5d3 c7b6 e3e2 h4h3 f1e1 g5g4 f3e5 h5g5 e5g6 g5g6 d3g6 c8d7 g6h5 a8c8 a1c1 c8c4
go nodes 800

before:
…
e2e7  (330 ) N:   0 (+ 0) (P:  0.81%) (Q: -1.44808) (U: 0.70426) (Q+U: -0.74382) (V:  -.----) 
…
c3a4  (483 ) N:  21 (+ 0) (P:  8.25%) (Q: -0.58938) (U: 0.32603) (Q+U: -0.26336) (V: -0.4660) 
e1d1  (100 ) N:  22 (+ 0) (P:  2.83%) (Q: -0.38214) (U: 0.10682) (Q+U: -0.27532) (V: -0.5075) 
g2h3  (375 ) N:  98 (+ 0) (P: 13.42%) (Q: -0.38267) (U: 0.11784) (Q+U: -0.26484) (V: -0.1010) 
e2d2  (311 ) N: 540 (+ 0) (P:  3.21%) (Q: -0.26595) (U: 0.00516) (Q+U: -0.26079) (V: -0.5581) 

after:
…
c3a4  (483 ) N:  16 (+ 0) (P:  8.25%) (Q: -0.46731) (U: 0.42192) (Q+U: -0.04539) (V: -0.4660) 
e1d1  (100 ) N:  21 (+ 0) (P:  2.83%) (Q: -0.24851) (U: 0.11168) (Q+U: -0.13683) (V: -0.5075) 
g2h3  (375 ) N:  38 (+ 0) (P: 13.42%) (Q: -0.37856) (U: 0.29913) (Q+U: -0.07944) (V: -0.1010) 
e2d2  (311 ) N: 200 (+ 0) (P:  3.21%) (Q: -0.18384) (U: 0.01390) (Q+U: -0.16994) (V: -0.5581) 
e2e7  (330 ) N: 437 (+ 1) (P:  0.81%) (Q:  0.76966) (U: 0.00160) (Q+U:  0.77127) (V: -0.2049) 
```