### PR TITLE
SendMovesStats on every info update.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -96,6 +96,9 @@ const OptionId SearchParams::kNoiseId{
 const OptionId SearchParams::kVerboseStatsId{
     "verbose-move-stats", "VerboseMoveStats",
     "Display Q, V, N, U and P values of every move candidate after each move."};
+const OptionId SearchParams::kLogLiveStatsId{
+    "log-live-stats", "LogLiveStats",
+    "Do VerboseMoveStats on every info update."};
 const OptionId SearchParams::kSmartPruningFactorId{
     "smart-pruning-factor", "SmartPruningFactor",
     "Do not spend time on the moves which cannot become bestmove given the "
@@ -190,6 +193,7 @@ void SearchParams::Populate(OptionsParser* options) {
       0.0f;
   options->Add<BoolOption>(kNoiseId) = false;
   options->Add<BoolOption>(kVerboseStatsId) = false;
+  options->Add<BoolOption>(kLogLiveStatsId) = false;
   options->Add<FloatOption>(kSmartPruningFactorId, 0.0f, 10.0f) = 1.33f;
   std::vector<std::string> fpu_strategy = {"reduction", "absolute"};
   options->Add<ChoiceOption>(kFpuStrategyId, fpu_strategy) = "reduction";
@@ -208,6 +212,8 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
   options->Add<IntOption>(kKLDGainAverageInterval, 1, 10000000) = 100;
   options->Add<FloatOption>(kMinimumKLDGainPerNode, 0.0f, 1.0f) = 0.0f;
+
+  options->HideOption(kLogLiveStatsId);
 }
 
 SearchParams::SearchParams(const OptionsDict& options)

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -74,6 +74,9 @@ class SearchParams {
   bool GetVerboseStats() const {
     return options_.Get<bool>(kVerboseStatsId.GetId());
   }
+  bool GetLogLiveStats() const {
+    return options_.Get<bool>(kLogLiveStatsId.GetId());
+  }
   float GetSmartPruningFactor() const { return kSmartPruningFactor; }
   bool GetFpuAbsolute() const { return kFpuAbsolute; }
   float GetFpuReduction() const { return kFpuReduction; }
@@ -110,6 +113,7 @@ class SearchParams {
   static const OptionId kTemperatureVisitOffsetId;
   static const OptionId kNoiseId;
   static const OptionId kVerboseStatsId;
+  static const OptionId kLogLiveStatsId;
   static const OptionId kSmartPruningFactorId;
   static const OptionId kFpuStrategyId;
   static const OptionId kFpuReductionId;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -162,6 +162,9 @@ void Search::MaybeOutputInfo() {
        last_outputted_uci_info_.time + kUciInfoMinimumFrequencyMs <
            GetTimeSinceStart())) {
     SendUciInfo();
+    if (params_.GetLogLiveStats()) {
+      SendMovesStats();
+    }
     if (stop_.load(std::memory_order_acquire) && !ok_to_respond_bestmove_) {
       ThinkingInfo info;
       info.comment =


### PR DESCRIPTION
Use this magic combination of UCI parameters to print out our raw values periodically in addition to the UCI standard ones. I'd like to use this mode for my lc0_analyzer.py script, I think others could find it useful too.

This seems intuitive enough to avoid yet another UCI param, because if they have VerboseStats on and a large MultiPv value they probably want to see as much information as possible.
