### PR TITLE
Add auto kld thresholding for use in time control situations.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -228,8 +228,8 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kMinimumKLDGainPerNode, 0.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kAutoKLDGainMoveFraction, 0.0f, 10.0f) = 0.0f;
   options->Add<FloatOption>(kAutoKLDGainIntervalRatio, 0.0f, 1.0f) = 0.125f;
-  options->Add<FloatOption>(kAutoKLDGainMultiplier, 0.0f, 1.0f) = 0.023f;
-  options->Add<FloatOption>(kAutoKLDGainExponent, -10.0f, 0.0f) = -1.21f;
+  options->Add<FloatOption>(kAutoKLDGainMultiplier, 0.0f, 1.0f) = 0.016f;
+  options->Add<FloatOption>(kAutoKLDGainExponent, -10.0f, 0.0f) = -1.16f;
 }
 
 SearchParams::SearchParams(const OptionsDict& options)

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -172,6 +172,24 @@ const OptionId SearchParams::kKLDGainAverageInterval{
     "kldgain-average-interval", "KLDGainAverageInterval",
     "Used to decide how frequently to evaluate the average KLDGainPerNode to "
     "check the MinimumKLDGainPerNode, if specified."};
+const OptionId SearchParams::kAutoKLDGainMoveFraction{
+    "auto-kldgain-move-fraction", "AutoKLDGainMoveFraction",
+    "If non-zero this fraction of the estimated total allowed playouts for the "
+    "move is used as input to the kld target estimation logic"};
+const OptionId SearchParams::kAutoKLDGainIntervalRatio{
+    "auto-kldgain-interval-ratio", "AutoKLDGainIntervalRatio",
+    "If AutoKLDGainMoveFraction is non-zero, this is a further multiplier to "
+    "calculate the interval of averaging."};
+const OptionId SearchParams::kAutoKLDGainMultiplier{
+    "auto-kldgain-multiplier", "AutoKLDGainMultiplier",
+    "If AutoKLDGainMoveFraction is non-zero, this is a constant multiplier to "
+    "calculate the target kldgain threshold."};
+const OptionId SearchParams::kAutoKLDGainExponent{
+    "auto-kldgain-exponent", "AutoKLDGainExponent",
+    "If AutoKLDGainMoveFraction is non-zero, this is the power to apply to the "
+    "fraction of the estimated total playouts in calculating the target "
+    "kldgain threshold."};
+
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -208,6 +226,10 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
   options->Add<IntOption>(kKLDGainAverageInterval, 1, 10000000) = 100;
   options->Add<FloatOption>(kMinimumKLDGainPerNode, 0.0f, 1.0f) = 0.0f;
+  options->Add<FloatOption>(kAutoKLDGainMoveFraction, 0.0f, 10.0f) = 0.0f;
+  options->Add<FloatOption>(kAutoKLDGainIntervalRatio, 0.0f, 1.0f) = 0.125f;
+  options->Add<FloatOption>(kAutoKLDGainMultiplier, 0.0f, 1.0f) = 0.023f;
+  options->Add<FloatOption>(kAutoKLDGainExponent, -10.0f, 0.0f) = -1.21f;
 }
 
 SearchParams::SearchParams(const OptionsDict& options)

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -95,6 +95,18 @@ class SearchParams {
   float GetMinimumKLDGainPerNode() const {
     return options_.Get<float>(kMinimumKLDGainPerNode.GetId());
   }
+  float GetAutoKLDGainMoveFraction() const {
+    return options_.Get<float>(kAutoKLDGainMoveFraction.GetId());
+  }
+  float GetAutoKLDGainIntervalRatio() const {
+    return options_.Get<float>(kAutoKLDGainIntervalRatio.GetId());
+  }
+  float GetAutoKLDGainMultiplier() const {
+    return options_.Get<float>(kAutoKLDGainMultiplier.GetId());
+  }
+  float GetAutoKLDGainExponent() const {
+    return options_.Get<float>(kAutoKLDGainExponent.GetId());
+  }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -125,6 +137,10 @@ class SearchParams {
   static const OptionId kHistoryFillId;
   static const OptionId kMinimumKLDGainPerNode;
   static const OptionId kKLDGainAverageInterval;
+  static const OptionId kAutoKLDGainMoveFraction;
+  static const OptionId kAutoKLDGainIntervalRatio;
+  static const OptionId kAutoKLDGainMultiplier;
+  static const OptionId kAutoKLDGainExponent;
 
  private:
   const OptionsDict& options_;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -335,7 +335,7 @@ void Search::UpdateKLDGain() {
     interval = static_cast<int>(target_playouts *
                                 params_.GetAutoKLDGainIntervalRatio());
     threshold = params_.GetAutoKLDGainMultiplier() *
-                std::pow(expected_total_playouts + initial_visits_,
+                std::pow(target_playouts + initial_visits_,
                          params_.GetAutoKLDGainExponent());
   }
   if (total_playouts_ + initial_visits_ >= prev_dist_visits_total_ + interval) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -331,7 +331,7 @@ void Search::UpdateKLDGain() {
     }
     int64_t expected_total_playouts = total_playouts_ + remaining_playouts_;
     double target_playouts =
-        expected_total_playouts * params_.GetAutoKLDGainMoveFraction();
+        expected_total_playouts * params_.GetAutoKLDGainMoveFraction() / limits_.slowmover;
     interval = static_cast<int>(target_playouts *
                                 params_.GetAutoKLDGainIntervalRatio());
     threshold = params_.GetAutoKLDGainMultiplier() *

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -52,6 +52,7 @@ struct SearchLimits {
   optional<std::chrono::steady_clock::time_point> search_deadline;
   bool infinite = false;
   MoveList searchmoves;
+  float slowmover = 1.0;
 
   std::string DebugString() const;
 };


### PR DESCRIPTION
Yay 4 more parameters to tune... heh.

The exponent and multiplier and interval ratio come from my attempt to do some baseline tuning by reversing what threshold is needed to get an average of x nodes.  

Using interval ratio instead of a constant interval should help the algorithm be more stable regardless of time control.  I doubt there is much need to tweak this parameter - could maybe make it a bit smaller I guess.
The multiplier and exponent are likely net specific - as a net gets smarter the multiplier probably drops, not sure if we should expect the exponent to vary much net to net.  I tuned these using latest T40.  I haven't validated these constants for large nodes per move (and the exponent is probably pretty sensitive), but they have been working pretty well as a fit so far in the range of 800 to 6400 nodes per move.

The main thing that needs tuning is the auto-kldgain-move-fraction - I vaguely think it probably should be something in the range of 1/slowmover to 0.5/slowmover - and maybe slow mover should go way up.

So if someone has time, a clop of move-fraction and slowmover together could be good. 