### PR TITLE
Update TempVisitOffset help text and allowed values.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -84,9 +84,9 @@ const OptionId SearchParams::kTemperatureWinpctCutoffId{
     "probability less than X than the best move) are not considered at all."};
 const OptionId SearchParams::kTemperatureVisitOffsetId{
     "temp-visit-offset", "TempVisitOffset",
-    "Reduces visits by this value when picking a move with a temperature. When "
-    "the offset is less than number of visits for a particular move, that move "
-    "is not picked at all."};
+    "Adjusts visits by this value when picking a move with a temperature. If a "
+    "negative offset reduces visits for a particular move below zero, that "
+    "move is not picked. If no moves can be picked, no temperature is used."};
 const OptionId SearchParams::kNoiseId{
     "noise", "DirichletNoise",
     "Add Dirichlet noise to root node prior probabilities. This allows the "
@@ -189,7 +189,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kTemperatureCutoffMoveId, 0, 1000) = 0;
   options->Add<FloatOption>(kTemperatureEndgameId, 0.0f, 100.0f) = 0.0f;
   options->Add<FloatOption>(kTemperatureWinpctCutoffId, 0.0f, 100.0f) = 100.0f;
-  options->Add<FloatOption>(kTemperatureVisitOffsetId, -0.99999f, 1000.0f) =
+  options->Add<FloatOption>(kTemperatureVisitOffsetId, -1000.0f, 1000.0f) =
       0.0f;
   options->Add<BoolOption>(kNoiseId) = false;
   options->Add<BoolOption>(kVerboseStatsId) = false;


### PR DESCRIPTION
r?@mooskagh Cleans up the text and makes the range symmetrical.

@jkormu wanted to test with an offset of -1 but couldn't https://github.com/LeelaChessZero/lc0/pull/750#issuecomment-468019066, and #technical had some confusion about whether the offset should be negative or not.