### PR TITLE
Use the best move eval instead of highest eval for temperature cutoff.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -599,8 +599,10 @@ EdgeAndNode Search::GetBestChildWithTemperature(Node* parent,
             root_limit.end()) {
       continue;
     }
-    if (edge.GetN() + offset > max_n) max_n = edge.GetN() + offset;
-    if (edge.GetQ(fpu) > max_eval) max_eval = edge.GetQ(fpu);
+    if (edge.GetN() + offset > max_n) {
+      max_n = edge.GetN() + offset;
+      max_eval = edge.GetQ(fpu);
+    }
   }
 
   // No move had enough visits for temperature, so use default child criteria


### PR DESCRIPTION
r?@mooskagh The current implementation didn't seem like it supports AlphaZero's `by softmax sam- pling with a temperature of 10.0 among moves for which the value was no more than 1% away from the best move for the first 30 plies`

In particular, a random single visit with high eval towards the end of limited node search could prevent selecting moves that got more visits.