### PR TITLE
Include the last move that resulted in selfplay resign.

### DIFF
--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -115,10 +115,15 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
           search_->GetParams().GetHistoryFill(), best_q, best_d));
     }
 
+    // Add best move to the tree.
+    const auto move = search_->GetBestMove().first;
+    tree_[0]->MakeMove(move);
+    if (tree_[0] != tree_[1]) tree_[1]->MakeMove(move);
+
     float eval = best_eval.first;
     eval = (eval + 1) / 2;
     if (eval < min_eval_[idx]) min_eval_[idx] = eval;
-    const int move_number = tree_[0]->GetPositionHistory().GetLength() / 2 + 1;
+    const auto move_number = (tree_[0]->GetPositionHistory().GetLength() + 1) / 2;
     auto best_w = (best_eval.first + 1.0f - best_eval.second) / 2.0f;
     auto best_d = best_eval.second;
     auto best_l = best_w - best_eval.first;
@@ -155,10 +160,6 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
       }
     }
 
-    // Add best move to the tree.
-    const Move move = search_->GetBestMove().first;
-    tree_[0]->MakeMove(move);
-    if (tree_[0] != tree_[1]) tree_[1]->MakeMove(move);
     blacks_move = !blacks_move;
   }
 }


### PR DESCRIPTION
r?@Tilps Looks like training data already included the last move triggering resign, but the tree didn't get updated, so selfplay output didn't display the move.

Here's sample output with:
```
./lc0 selfplay --visits=10 --resign-percentage=50.0 --temperature=10 --resign-wdlstyle=true --games=1 -w 50105
```
Before:
```
info player 2 gameid 0 side black depth 3 seldepth 5 time 32 nodes 18 score cp 6 hashfull 1 nps 562 tbhits 0 pv c7c5 d4c5 e7e6 e2b5 d8d7
bestmove f6g4 ponder e2g4 player 2 gameid 0 side black
info player 1 gameid 0 side white depth 2 seldepth 4 time 70 nodes 18 score cp 3727 hashfull 2 nps 257 tbhits 0 pv e2g4 e7e6 c1b2 d8d6
bestmove e2g4 ponder e7e6 player 1 gameid 0 side white
gameready gameid 0 player1 white result whitewon moves d2d4 g8f6 b2b3 d7d5 e2e3 c8g4 f1e2 g4e2 d1e2 f6g4
```
(Last played moves were f6g4 then e2g4 but the `gameready` line ends at f6g4.)

After:
```
info player 2 gameid 0 side black depth 4 seldepth 9 time 14 nodes 10 score cp -64 hashfull 0 nps 714 tbhits 0 pv e7e6 g1f3 b7b6 g2g3 c8b7 f1g2 c7c5 d4d5 e6d5
bestmove f6e4 ponder f2f3 player 2 gameid 0 side black
info player 1 gameid 0 side white depth 5 seldepth 9 time 91 nodes 12 score cp 137 hashfull 1 nps 131 tbhits 0 pv f2f3 e4f6 e2e4 d7d6 b1c3 e7e5 g1e2 f8e7 c1e3
bestmove f2f3 ponder e4f6 player 1 gameid 0 side white
gameready gameid 0 player1 white result whitewon moves d2d4 g8f6 c2c4 f6e4 f2f3
```
(Last played moves were f6e4 then f2f3 and `gameready` line includes both.)