### PR TITLE
Track number of edges, nodes, etc.

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -169,16 +169,16 @@ SearchLimits EngineController::PopulateSearchLimits(
                                               *params.movetime - move_overhead);
   }
   if (params.nodes) limits.visits = *params.nodes;
-  const int ram_limit = options_.Get<int>(kRamLimitMbId.GetId());
+  const int64_t ram_limit = options_.Get<int>(kRamLimitMbId.GetId());
   if (ram_limit) {
     const auto cache_size =
         options_.Get<int>(kNNCacheSizeId.GetId()) * kAvgCacheItemSize;
-    int64_t limit = (ram_limit * 1000000LL - cache_size) / kAvgNodeSize;
+    limits.ram_limit = ram_limit * 1000000LL - cache_size;
+    if (limits.ram_limit < 0) limits.ram_limit = 0;
+    int64_t approx_nodes_limit = limits.ram_limit / int64_t(kAvgNodeSize);
     LOGFILE << "RAM limit " << ram_limit << "MB. Cache takes "
-            << cache_size / 1000000 << "MB. Remaining memory is enough for "
-            << limit << " nodes.";
-    if (limit < 0) limit = 0;
-    if (limit < limits.visits) limits.visits = limit;
+            << cache_size / 1000000 << "MB. Remaining memory is enough for approximately "
+            << approx_nodes_limit << " nodes.";
   }
   if (params.depth) limits.depth = *params.depth;
   if (limits.infinite || !time) return limits;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -688,10 +688,17 @@ void Search::UpdateTreeSize(Node* n) REQUIRES(nodes_mutex_) {
 void Search::StartThreads(size_t how_many) {
   // Do not double count root if it's not extended yet.
   if (root_node_->HasChildren()) {
+    auto start = std::chrono::steady_clock::now();
     SharedMutex::Lock lock(nodes_mutex_);
     UpdateTreeSize(root_node_);
     initial_num_edges_ = num_edges_;
     initial_num_nodes_ = num_nodes_;
+    auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(
+                   std::chrono::steady_clock::now() - start)
+                   .count();
+    LOGFILE << "UpdateTreeSize took " << dur
+            << "ms. edges:" << initial_num_edges_
+            << " nodes:" << initial_num_nodes_;
   }
   Mutex::Lock lock(threads_mutex_);
   // First thread is a watchdog thread.

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -48,6 +48,7 @@ struct SearchLimits {
   // overflow it.
   std::int64_t visits = 4000000000;
   std::int64_t playouts = -1;
+  std::int64_t ram_limit = -1;
   int depth = -1;
   optional<std::chrono::steady_clock::time_point> search_deadline;
   bool infinite = false;
@@ -153,11 +154,21 @@ class Search {
   // consistent results.
   EdgeAndNode final_bestmove_ GUARDED_BY(counters_mutex_);
   EdgeAndNode final_pondermove_ GUARDED_BY(counters_mutex_);
+  void UpdateTreeSize(Node* n);
 
   Mutex threads_mutex_;
   std::vector<std::thread> threads_ GUARDED_BY(threads_mutex_);
 
   Node* root_node_;
+  uint64_t initial_num_edges_ GUARDED_BY(nodes_mutex_) {0};
+  uint64_t initial_num_nodes_ GUARDED_BY(nodes_mutex_) {0};
+  uint64_t num_edges_ GUARDED_BY(nodes_mutex_) {0};
+  uint64_t num_nodes_ GUARDED_BY(nodes_mutex_) {0};
+  // Number of extra visits to terminal nodes.
+  uint64_t num_terminals_ GUARDED_BY(nodes_mutex_) {0};
+  uint64_t num_cache_hits_ GUARDED_BY(nodes_mutex_) {0};
+  uint64_t num_multivisits_ GUARDED_BY(nodes_mutex_) {0};
+  uint64_t num_prefetches_ GUARDED_BY(nodes_mutex_) {0};
   NNCache* cache_;
   SyzygyTablebase* syzygy_tb_;
   // Fixed positions which happened before the search.


### PR DESCRIPTION
Use them for RAM limit, and print them in verbose stats.

* Still logs the approximation of nodes, but uses an exact edges*edge_size + nodes*node_size for the limit.
* Included a few more stats as well for outputting along with verbose move stats as "info string"
* For now I didn't modify the "real" info. One candidate is to change NPS somehow, e.g. num_nodes_/time.
* Cache hits and prefetch into cache confuse things, especially prefetch isn't tracked to see if they are actually used later or not.
* Most of the code doing this already holds nodes_mutex_. But I did have to add two short sections of taking that lock.
* Overhead of counting tree size was ~20ms on my machine for ~2M node tree.

* I tested a mate in one position, old method stopped very early. This method correctly allows many more playouts since hitting terminals does not create more nodes in memory.
