### PR TITLE
Option separators

### DIFF
--- a/src/benchmark/benchmark.cc
+++ b/src/benchmark/benchmark.cc
@@ -42,6 +42,7 @@ const OptionId kNodesId{"nodes", "", "Number of nodes to run as a benchmark."};
 const OptionId kMovetimeId{"movetime", "",
                            "Benchmark time allocation, in milliseconds."};
 const OptionId kFenId{"fen", "", "Benchmark initial position FEN."};
+const OptionId kSeparator{"Benchmark options"};
 
 }  // namespace
 
@@ -49,6 +50,8 @@ void Benchmark::Run() {
   OptionsParser options;
   NetworkFactory::PopulateOptions(&options);
   SearchParams::Populate(&options);
+
+  options.Add<Separator>(kSeparator);
 
   options.Add<IntOption>(kThreadsOptionId, 1, 128) = kDefaultThreads;
   options.Add<IntOption>(kNNCacheSizeId, 0, 999999999) = 200000;

--- a/src/benchmark/benchmark.cc
+++ b/src/benchmark/benchmark.cc
@@ -50,11 +50,11 @@ void Benchmark::Run() {
   NetworkFactory::PopulateOptions(&options);
   SearchParams::Populate(&options);
 
+  options.Add<IntOption>(kThreadsOptionId, 1, 128) = kDefaultThreads;
+  options.Add<IntOption>(kNNCacheSizeId, 0, 999999999) = 200000;
   options.Add<IntOption>(kNodesId, -1, 999999999) = -1;
   options.Add<IntOption>(kMovetimeId, -1, 999999999) = 10000;
   options.Add<StringOption>(kFenId) = ChessBoard::kStartposFen;
-  options.Add<IntOption>(kNNCacheSizeId, 0, 999999999) = 200000;
-  options.Add<IntOption>(kThreadsOptionId, 1, 128) = kDefaultThreads;
 
   if (!options.ProcessAllFlags()) return;
 

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -128,6 +128,9 @@ EngineController::EngineController(BestMoveInfo::Callback best_move_callback,
 void EngineController::PopulateOptions(OptionsParser* options) {
   using namespace std::placeholders;
 
+  NetworkFactory::PopulateOptions(options);
+  SearchParams::Populate(options);
+
   options->Add<IntOption>(kThreadsOptionId, 1, 128) = kDefaultThreads;
   options->Add<IntOption>(kNNCacheSizeId, 0, 999999999) = 200000;
   options->Add<FloatOption>(kSlowMoverId, 0.0f, 100.0f) = 1.0f;
@@ -141,13 +144,11 @@ void EngineController::PopulateOptions(OptionsParser* options) {
   options->Add<FloatOption>(kSpendSavedTimeId, 0.0f, 1.0f) = 1.0f;
   options->Add<IntOption>(kRamLimitMbId, 0, 100000000) = 0;
 
+  ConfigFile::PopulateOptions(options);
+
   // Hide time curve options.
   options->HideOption(kTimeMidpointMoveId);
   options->HideOption(kTimeSteepnessId);
-
-  NetworkFactory::PopulateOptions(options);
-  SearchParams::Populate(options);
-  ConfigFile::PopulateOptions(options);
 }
 
 SearchLimits EngineController::PopulateSearchLimits(

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -91,6 +91,7 @@ const OptionId kRamLimitMbId{
     "terminal node counted several times, and the estimation assumes that all "
     "positions have 30 possible moves. When set to 0, no RAM limit is "
     "enforced."};
+const OptionId kSeparator{"Engine options"};
 
 const size_t kAvgNodeSize = sizeof(Node) + kAvgMovesPerPosition * sizeof(Edge);
 const size_t kAvgCacheItemSize =
@@ -130,6 +131,8 @@ void EngineController::PopulateOptions(OptionsParser* options) {
 
   NetworkFactory::PopulateOptions(options);
   SearchParams::Populate(options);
+
+  options->Add<Separator>(kSeparator);
 
   options->Add<IntOption>(kThreadsOptionId, 1, 128) = kDefaultThreads;
   options->Add<IntOption>(kNNCacheSizeId, 0, 999999999) = 200000;

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -173,7 +173,10 @@ const OptionId SearchParams::kKLDGainAverageInterval{
     "Used to decide how frequently to evaluate the average KLDGainPerNode to "
     "check the MinimumKLDGainPerNode, if specified."};
 
+const OptionId kSeparator{"Search options"};
+
 void SearchParams::Populate(OptionsParser* options) {
+  options->Add<Separator>(kSeparator);
   // Here the uci optimized defaults" are set.
   // Many of them are overridden with training specific values in tournament.cc.
   options->Add<IntOption>(kMiniBatchSizeId, 1, 1024) = 256;

--- a/src/selfplay/loop.cc
+++ b/src/selfplay/loop.cc
@@ -44,8 +44,9 @@ SelfPlayLoop::~SelfPlayLoop() {
 }
 
 void SelfPlayLoop::RunLoop() {
-  options_.Add<BoolOption>(kInteractiveId) = false;
   SelfPlayTournament::PopulateOptions(&options_);
+
+  options_.Add<BoolOption>(kInteractiveId) = false;
 
   if (!options_.ProcessAllFlags()) return;
   if (options_.GetOptionsDict().Get<bool>(kInteractiveId.GetId())) {

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -62,6 +62,7 @@ const OptionId kVerboseThinkingId{"verbose-thinking", "VerboseThinking",
 const OptionId kResignPlaythroughId{
     "resign-playthrough", "ResignPlaythrough",
     "The percentage of games which ignore resign."};
+const OptionId kSeparator{"Selfplay options"};
 
 }  // namespace
 
@@ -71,6 +72,8 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
 
   NetworkFactory::PopulateOptions(options);
   SearchParams::Populate(options);
+
+  options->Add<Separator>(kSeparator);
 
   options->Add<IntOption>(kThreadsId, 1, 8) = 1;
   options->Add<IntOption>(kNnCacheSizeId, 0, 999999999) = 200000;

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -69,11 +69,14 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   options->AddContext("player1");
   options->AddContext("player2");
 
+  NetworkFactory::PopulateOptions(options);
+  SearchParams::Populate(options);
+
+  options->Add<IntOption>(kThreadsId, 1, 8) = 1;
+  options->Add<IntOption>(kNnCacheSizeId, 0, 999999999) = 200000;
   options->Add<BoolOption>(kShareTreesId) = true;
   options->Add<IntOption>(kTotalGamesId, -1, 999999) = -1;
   options->Add<IntOption>(kParallelGamesId, 1, 256) = 8;
-  options->Add<IntOption>(kThreadsId, 1, 8) = 1;
-  options->Add<IntOption>(kNnCacheSizeId, 0, 999999999) = 200000;
   options->Add<IntOption>(kPlayoutsId, -1, 999999999) = -1;
   options->Add<IntOption>(kVisitsId, -1, 999999999) = -1;
   options->Add<IntOption>(kTimeMsId, -1, 999999999) = -1;
@@ -81,9 +84,8 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   options->Add<BoolOption>(kVerboseThinkingId) = false;
   options->Add<FloatOption>(kResignPlaythroughId, 0.0f, 100.0f) = 0.0f;
 
-  NetworkFactory::PopulateOptions(options);
-  SearchParams::Populate(options);
   SelfPlayGame::PopulateUciParams(options);
+
   auto defaults = options->GetMutableDefaultsOptions();
   defaults->Set<int>(SearchParams::kMiniBatchSizeId.GetId(), 32);
   defaults->Set<float>(SearchParams::kCpuctId.GetId(), 1.2f);

--- a/src/utils/optionsparser.cc
+++ b/src/utils/optionsparser.cc
@@ -304,11 +304,18 @@ std::string EscapeMd(const std::string& input) {
 }  // namespace
 
 void OptionsParser::ShowHelpMd() const {
+  const std::string kHeader =
+      "\n*Flag*|*UCI option*|Description\n---|---|------\n";
   std::cout << "\n# Lc0 options\n";
-  std::cout << "\n*Flag*|*UCI option*|Description\n---|---|------\n";
+  std::cout << kHeader;
   std::cout << "**--help**, **-h**||Show help and exit.\n";
   for (const auto& option : options_) {
     if (option->hidden_) continue;
+    if (typeid(*option) == typeid(Separator)) {
+      std::cout << "\n## " << option->GetLongFlag() << "\n";
+      std::cout << kHeader;
+      continue;
+    }
     if (!option->GetLongFlag().empty()) {
       std::cout << "**--" << option->GetLongFlag() << "**";
     }

--- a/src/utils/optionsparser.h
+++ b/src/utils/optionsparser.h
@@ -72,10 +72,12 @@ class OptionsParser {
 
    protected:
     std::string GetId() const { return id_.GetId(); }
-    std::string GetUciOption() const { return id_.uci_option; }
+    virtual std::string GetUciOption() const { return id_.uci_option; }
     std::string GetHelpText() const { return id_.help_text; }
     std::string GetLongFlag() const { return id_.long_flag; }
     char GetShortFlag() const { return id_.short_flag; }
+
+    const OptionId& id_;
 
    private:
     virtual std::string GetOptionString(const OptionsDict& dict) const = 0;
@@ -94,7 +96,6 @@ class OptionsParser {
     }
     virtual std::string GetHelp(const OptionsDict& dict) const = 0;
 
-    const OptionId& id_;
     bool hidden_ = false;
     friend class OptionsParser;
   };
@@ -252,6 +253,27 @@ class ChoiceOption : public OptionsParser::Option {
   void SetVal(OptionsDict* dict, const ValueType& val) const;
 
   std::vector<std::string> choices_;
+};
+
+class Separator : public OptionsParser::Option {
+ public:
+  using ValueType = std::string;
+  Separator(const OptionId& id) : Option(id) {}
+
+  void SetValue(const std::string& /*value*/, OptionsDict* /*dict*/) override {}
+
+ protected:
+  std::string GetUciOption() const override {
+    return "--- " + std::string(id_.long_flag) + " ---";
+  }
+
+ private:
+  std::string GetOptionString(const OptionsDict& /*dict*/) const override {
+    return "type combo default --- var ---";
+  }
+  std::string GetHelp(const OptionsDict& /*dict*/) const override {
+    return GetLongFlag() + ":\n";
+  }
 };
 
 }  // namespace lczero


### PR DESCRIPTION
Adds separators to group options in help output. There is also an attempt to separate UCI options using a dummy choice option with just `---`, that I'm not so sure about. An alternative is to use a string option or to skip UCI option grouping.