### PR TITLE
Fix unsafe comparisons.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -239,8 +239,8 @@ std::vector<std::string> Search::GetVerboseStats(Node* node,
     oss << "(Q: " << std::setw(8) << std::setprecision(5) << edge.GetQ(fpu)
         << ") ";
 
-    oss << "(D: " << std::setw(6) << std::setprecision(3)
-        << edge.GetD() << ") ";
+    oss << "(D: " << std::setw(6) << std::setprecision(3) << edge.GetD()
+        << ") ";
 
     oss << "(U: " << std::setw(6) << std::setprecision(5) << edge.GetU(U_coeff)
         << ") ";
@@ -327,12 +327,12 @@ void Search::UpdateKLDGain() {
     if (prev_dist_.size() != 0) {
       double sum1 = 0.0;
       double sum2 = 0.0;
-      for (int i = 0; i < new_visits.size(); i++) {
+      for (decltype(new_visits)::size_type i = 0; i < new_visits.size(); i++) {
         sum1 += prev_dist_[i];
         sum2 += new_visits[i];
       }
       double kldgain = 0.0;
-      for (int i = 0; i < new_visits.size(); i++) {
+      for (decltype(new_visits)::size_type i = 0; i < new_visits.size(); i++) {
         double o_p = prev_dist_[i] / sum1;
         double n_p = new_visits[i] / sum2;
         if (prev_dist_[i] != 0) {
@@ -422,8 +422,8 @@ void Search::UpdateRemainingMoves() {
     if (time_since_start > kSmartPruningToleranceMs) {
       const auto nps = 1000LL *
                            (total_playouts_ + kSmartPruningToleranceNodes) /
-                     time_since_start +
-                 1;
+                           time_since_start +
+                       1;
       const int64_t remaining_time = GetTimeToDeadline();
       // Put early_exit scaler here so calculation doesn't have to be done on
       // every node.
@@ -439,8 +439,8 @@ void Search::UpdateRemainingMoves() {
     // Add kMiniBatchSize, as it's possible to exceed visits limit by that
     // number.
     const auto remaining_visits = limits_.visits - total_playouts_ -
-                                  initial_visits_ +
-                            params_.GetMiniBatchSize() - 1;
+                                  initial_visits_ + params_.GetMiniBatchSize() -
+                                  1;
 
     if (remaining_visits < remaining_playouts_)
       remaining_playouts_ = remaining_visits;
@@ -498,10 +498,11 @@ bool Search::PopulateRootMoveLimit(MoveList* root_moves) const {
       (board.ours() | board.theirs()).count() > syzygy_tb_->max_cardinality()) {
     return false;
   }
-  return syzygy_tb_->root_probe(played_history_.Last(),
-                                params_.GetSyzygyFastPlay() ||
-                                played_history_.DidRepeatSinceLastZeroingMove(),
-                                root_moves) ||
+  return syzygy_tb_->root_probe(
+             played_history_.Last(),
+             params_.GetSyzygyFastPlay() ||
+                 played_history_.DidRepeatSinceLastZeroingMove(),
+             root_moves) ||
          syzygy_tb_->root_probe_wdl(played_history_.Last(), root_moves);
 }
 
@@ -558,7 +559,7 @@ std::vector<EdgeAndNode> Search::GetBestChildrenNoTemperature(Node* parent,
   }
   const auto middle = (static_cast<int>(edges.size()) > count)
                           ? edges.begin() + count
-                                                         : edges.end();
+                          : edges.end();
   std::partial_sort(edges.begin(), middle, edges.end(), std::greater<El>());
 
   std::vector<EdgeAndNode> res;


### PR DESCRIPTION
Fixes following compiler warnings (gcc 8.3.1):

```[22/114] Compiling C++ object 'lc0@exe/src_mcts_search.cc.o'.
../../src/mcts/search.cc: In member function ‘void lczero::Search::UpdateKLDGain()’:
../../src/mcts/search.cc:330:25: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<unsigned int>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
       for (int i = 0; i < new_visits.size(); i++) {
                       ~~^~~~~~~~~~~~~~~~~~~
../../src/mcts/search.cc:335:25: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<unsigned int>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
       for (int i = 0; i < new_visits.size(); i++) {
                       ~~^~~~~~~~~~~~~~~~~~~
```