### PR TITLE
Value head standard deviation exploration term.

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -242,7 +242,11 @@ void Node::CancelScoreUpdate(int multivisit) {
 }
 
 void Node::FinalizeScoreUpdate(float v, float d, int multivisit) {
-  // Recompute Q.
+  // Update the sum of squared differences.
+  sum_squared_diff_q_ +=
+      (v - q_) * (v - q_) * multivisit * n_ / (n_ + multivisit);
+
+  // Recompute Q and D.
   q_ += multivisit * (v - q_) / (n_ + multivisit);
   d_ += multivisit * (d - d_) / (n_ + multivisit);
 

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -159,7 +159,7 @@ class Node {
   float GetQStdDev() const {
     // Note that we use an unbiased standard deviation estimator (sqrt(n_-1)
     // denominator).
-    return n_ > 0 ? sqrt(sum_squared_diff_q_ / (n_ - 1)) : 0.0f;
+    return n_ > 1 ? sqrt(sum_squared_diff_q_ / (n_ - 1)) : 0.0f;
   }
 
   // Returns whether the node is known to be draw/lose/win.
@@ -364,11 +364,11 @@ class EdgeAndNode {
     return edge_ ? edge_->GetMove(flip) : Move();
   }
 
-  // Returns U = numerator * p / N + stddev_multiplier * GetQStdDev().
+  // Returns U = numerator * p / N + stddev_factor * GetQStdDev().
   // Passed numerator is expected to be equal to (cpuct * sqrt(N[parent])).
-  float GetU(float numerator, float stddev_multiplier) const {
+  float GetU(float numerator, float stddev_factor) const {
     return numerator * GetP() / (1 + GetNStarted()) +
-           stddev_multiplier * GetQStdDev();
+           stddev_factor * GetQStdDev();
   }
 
   int GetVisitsToReachU(float target_score, float numerator,

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -315,7 +315,7 @@ class Node {
 
 // A basic sanity check. This must be adjusted when Node members are adjusted.
 #if defined(__i386__) || (defined(__arm__) && !defined(__aarch64__))
-static_assert(sizeof(Node) == 52, "Unexpected size of Node for 32bit compile");
+static_assert(sizeof(Node) == 56, "Unexpected size of Node for 32bit compile");
 #else
 static_assert(sizeof(Node) == 80, "Unexpected size of Node");
 #endif

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -362,11 +362,11 @@ class EdgeAndNode {
     return edge_ ? edge_->GetMove(flip) : Move();
   }
 
-  // Returns U = numerator * p / N + stddev_factor * GetQStdDev().
+  // Returns U = numerator * p / N + stddev_multiplier * GetQStdDev().
   // Passed numerator is expected to be equal to (cpuct * sqrt(N[parent])).
-  float GetU(float numerator, float stddev_factor) const {
+  float GetU(float numerator, float stddev_multiplier) const {
     return numerator * GetP() / (1 + GetNStarted()) +
-           stddev_factor * GetQStdDev();
+           stddev_multiplier * GetQStdDev();
   }
 
   int GetVisitsToReachU(float target_score, float numerator,

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -157,7 +157,9 @@ class Node {
   float GetD() const { return d_; }
   // Returns standard deviation of value head in subtree.
   float GetQStdDev() const {
-    return n_ > 0 ? sqrt(sum_squared_diff_q_ / n_) : 0.0f;
+    // Note that we use an unbiased standard deviation estimator (sqrt(n_-1)
+    // denominator).
+    return n_ > 0 ? sqrt(sum_squared_diff_q_ / (n_ - 1)) : 0.0f;
   }
 
   // Returns whether the node is known to be draw/lose/win.

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -60,6 +60,10 @@ const OptionId SearchParams::kCpuctBaseId{
     "higher growth of Cpuct as number of node visits grows."};
 const OptionId SearchParams::kCpuctFactorId{
     "cpuct-factor", "CPuctFactor", "Multiplier for the cpuct growth formula."};
+const OptionId SearchParams::kStdDevFactorId{
+    "stddev-factor", "StdDevFactor",
+    "Multiplier for the standard deviation of Q in the uncertainty \"UCT "
+    "search\" term."};
 const OptionId SearchParams::kTemperatureId{
     "temperature", "Temperature",
     "Tau value from softmax formula for the first move. If equal to 0, the "
@@ -172,7 +176,8 @@ const OptionId SearchParams::kHistoryFillId{
     "synthesize them (always, never, or only at non-standard fen position)."};
 const OptionId SearchParams::kMinimumKLDGainPerNode{
     "minimum-kldgain-per-node", "MinimumKLDGainPerNode",
-    "If greater than 0 search will abort unless the last KLDGainAverageInterval "
+    "If greater than 0 search will abort unless the last "
+    "KLDGainAverageInterval "
     "nodes have an average gain per node of at least this much."};
 const OptionId SearchParams::kKLDGainAverageInterval{
     "kldgain-average-interval", "KLDGainAverageInterval",
@@ -187,6 +192,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 3.0f;
   options->Add<FloatOption>(kCpuctBaseId, 1.0f, 1000000000.0f) = 19652.0f;
   options->Add<FloatOption>(kCpuctFactorId, 0.0f, 1000.0f) = 2.0f;
+  options->Add<FloatOption>(kStdDevFactorId, -1000.0f, 1000.0f) = 0.0f;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 100) = 0;
   options->Add<IntOption>(kTemperatureCutoffMoveId, 0, 1000) = 0;
@@ -226,6 +232,7 @@ SearchParams::SearchParams(const OptionsDict& options)
       kCpuct(options.Get<float>(kCpuctId.GetId())),
       kCpuctBase(options.Get<float>(kCpuctBaseId.GetId())),
       kCpuctFactor(options.Get<float>(kCpuctFactorId.GetId())),
+      kStdDevFactor(options.Get<float>(kStdDevFactorId.GetId())),
       kNoise(options.Get<bool>(kNoiseId.GetId())),
       kSmartPruningFactor(options.Get<float>(kSmartPruningFactorId.GetId())),
       kFpuAbsolute(options.Get<std::string>(kFpuStrategyId.GetId()) ==
@@ -247,7 +254,6 @@ SearchParams::SearchParams(const OptionsDict& options)
       kSyzygyFastPlay(options.Get<bool>(kSyzygyFastPlayId.GetId())),
       kHistoryFill(
           EncodeHistoryFill(options.Get<std::string>(kHistoryFillId.GetId()))),
-      kMiniBatchSize(options.Get<int>(kMiniBatchSizeId.GetId())) {
-}
+      kMiniBatchSize(options.Get<int>(kMiniBatchSizeId.GetId())) {}
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -42,15 +42,14 @@ class SearchParams {
   static void Populate(OptionsParser* options);
 
   // Parameter getters.
-  int GetMiniBatchSize() const {
-    return kMiniBatchSize;
-  }
+  int GetMiniBatchSize() const { return kMiniBatchSize; }
   int GetMaxPrefetchBatch() const {
     return options_.Get<int>(kMaxPrefetchBatchId.GetId());
   }
   float GetCpuct() const { return kCpuct; }
   float GetCpuctBase() const { return kCpuctBase; }
   float GetCpuctFactor() const { return kCpuctFactor; }
+  float GetStdDevFactor() const { return kStdDevFactor; }
   float GetTemperature() const {
     return options_.Get<float>(kTemperatureId.GetId());
   }
@@ -78,8 +77,12 @@ class SearchParams {
     return options_.Get<bool>(kLogLiveStatsId.GetId());
   }
   float GetSmartPruningFactor() const { return kSmartPruningFactor; }
-  bool GetFpuAbsolute(bool at_root) const { return at_root ? kFpuAbsoluteAtRoot : kFpuAbsolute; }
-  float GetFpuValue(bool at_root) const { return at_root ? kFpuValueAtRoot : kFpuValue; }
+  bool GetFpuAbsolute(bool at_root) const {
+    return at_root ? kFpuAbsoluteAtRoot : kFpuAbsolute;
+  }
+  float GetFpuValue(bool at_root) const {
+    return at_root ? kFpuValueAtRoot : kFpuValue;
+  }
   int GetCacheHistoryLength() const { return kCacheHistoryLength; }
   float GetPolicySoftmaxTemp() const { return kPolicySoftmaxTemp; }
   int GetMaxCollisionEvents() const { return kMaxCollisionEvents; }
@@ -104,6 +107,7 @@ class SearchParams {
   static const OptionId kCpuctId;
   static const OptionId kCpuctBaseId;
   static const OptionId kCpuctFactorId;
+  static const OptionId kStdDevFactorId;
   static const OptionId kTemperatureId;
   static const OptionId kTempDecayMovesId;
   static const OptionId kTemperatureCutoffMoveId;
@@ -141,6 +145,7 @@ class SearchParams {
   const float kCpuct;
   const float kCpuctBase;
   const float kCpuctFactor;
+  const float kStdDevFactor;
   const bool kNoise;
   const float kSmartPruningFactor;
   const bool kFpuAbsolute;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -209,18 +209,18 @@ std::vector<std::string> Search::GetVerboseStats(Node* node,
   const float cpuct = ComputeCpuct(params_, node->GetN());
   const float U_coeff =
       cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
-  const float stddev_multiplier = cpuct * params_.GetStdDevFactor();
+  const float stddev_factor = params_.GetStdDevFactor();
 
   std::vector<EdgeAndNode> edges;
   for (const auto& edge : node->Edges()) edges.push_back(edge);
 
   std::sort(
       edges.begin(), edges.end(),
-      [&fpu, &U_coeff, &stddev_multiplier](EdgeAndNode a, EdgeAndNode b) {
+      [&fpu, &U_coeff, &stddev_factor](EdgeAndNode a, EdgeAndNode b) {
         return std::forward_as_tuple(
-                   a.GetN(), a.GetQ(fpu) + a.GetU(U_coeff, stddev_multiplier)) <
+                   a.GetN(), a.GetQ(fpu) + a.GetU(U_coeff, stddev_factor)) <
                std::forward_as_tuple(
-                   b.GetN(), b.GetQ(fpu) + b.GetU(U_coeff, stddev_multiplier));
+                   b.GetN(), b.GetQ(fpu) + b.GetU(U_coeff, stddev_factor));
       });
 
   std::vector<std::string> infos;
@@ -246,10 +246,10 @@ std::vector<std::string> Search::GetVerboseStats(Node* node,
         << ") ";
 
     oss << "(U: " << std::setw(6) << std::setprecision(5)
-        << edge.GetU(U_coeff, stddev_multiplier) << ") ";
+        << edge.GetU(U_coeff, stddev_factor) << ") ";
 
     oss << "(Q+U: " << std::setw(8) << std::setprecision(5)
-        << edge.GetQ(fpu) + edge.GetU(U_coeff, stddev_multiplier) << ") ";
+        << edge.GetQ(fpu) + edge.GetU(U_coeff, stddev_factor) << ") ";
 
     oss << "(V: ";
     optional<float> v;


### PR DESCRIPTION
This adds a value head standard deviation exploration term for (hopefully) better tactical capabilities (as proposed in https://github.com/LeelaChessZero/lc0/issues/780#issuecomment-470843033).

The main idea is that the uncertainty term of the UCT search is adapted to (new term in bold):

U(s,a) = cPuct ⋅ P(s,a) ⋅ sqrt(N(s,b)) ⋅ 1/(1+N(s,a)) + **stddev-factor ⋅ S(s,a)**,

with S(s,a) the standard deviation of the raw net value Qs over all visited nodes in the subtree (including multivisits). The backup update step is very efficient (incremental formula even for multivisits) and uses a variant of https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm (extended to the multivisit case).

The goal of this PR is in the first place to investigate the effect on tactical capabilities (as a function of the still unknown stddev-factor). If you have other ideas to include the S(s,a) term in the equation, please share your ideas!

Possible follow-ups:

- Investigate performance for fixed node tests on a standard tactics test suite and compare with master (stddev-factor = 0). Note that the node count at which the best move is found is also an interesting metric (it might be that this PR more quickly finds the best move).
- CLOP the unknown stddev-factor.
- Investigate other ways to include S(s,a) in the U(s,a) term.
- Investigate match play performance for an optimal value of stddev-factor.