### PR TITLE
Fixed warnings due to mismatched types in for loop in search.cc

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -327,12 +327,12 @@ void Search::UpdateKLDGain() {
     if (prev_dist_.size() != 0) {
       double sum1 = 0.0;
       double sum2 = 0.0;
-      for (int i = 0; i < new_visits.size(); i++) {
+      for (decltype(new_visits.size()) i = 0; i < new_visits.size(); i++) {
         sum1 += prev_dist_[i];
         sum2 += new_visits[i];
       }
       double kldgain = 0.0;
-      for (int i = 0; i < new_visits.size(); i++) {
+      for (decltype(new_visits.size()) i = 0; i < new_visits.size(); i++) {
         double o_p = prev_dist_[i] / sum1;
         double n_p = new_visits[i] / sum2;
         if (prev_dist_[i] != 0) {


### PR DESCRIPTION
Fixed clang warnings due to mismatched types in for loop in search.cc

Was getting 
```
[225/304] Compiling C++ object 'lc0@exe/src_mcts_search.cc.o'.
../src/mcts/search.cc:330:25: warning: comparison of integers of different signs: 'int' and 'std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >::size_type' (aka 'unsigned long') [-Wsign-compare]
      for (int i = 0; i < new_visits.size(); i++) {
                      ~ ^ ~~~~~~~~~~~~~~~~~
../src/mcts/search.cc:335:25: warning: comparison of integers of different signs: 'int' and 'std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >::size_type' (aka 'unsigned long') [-Wsign-compare]
      for (int i = 0; i < new_visits.size(); i++) {
                      ~ ^ ~~~~~~~~~~~~~~~~~
2 warnings generated.
```
