### PR TITLE
Increased hard limit on batch size in opencl backend to 32

### DIFF
--- a/src/neural/opencl/network_opencl.cc
+++ b/src/neural/opencl/network_opencl.cc
@@ -349,7 +349,7 @@ class OpenCLNetwork : public Network {
   }
 
  private:
-  static constexpr auto kHardMaxBatchSize = 16;
+  static constexpr auto kHardMaxBatchSize = 32;
   static constexpr auto kPolicyUsedPlanes = 73;
   static constexpr auto kPolicyOutputs = 1858;
 


### PR DESCRIPTION
I confess I am uncertain as to why the hard limit was previously set to the default, 16, but I have found that on Mac and with an AMD Vega 56, an OpenCL batch_size of 32 works perfectly well and is about 10% faster than batch_size 16.

I have left the default batch_size unchanged.