### PR TITLE
Only short-circuit search with a non-0 SmartPruningFactor.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -982,7 +982,8 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
       second_best_edge.Reset();
     }
 
-    if (is_root_node && possible_moves <= 1 && !search_->limits_.infinite) {
+    if (is_root_node && possible_moves <= 1 && !search_->limits_.infinite &&
+        params_.GetSmartPruningFactor()) {
       // If there is only one move theoretically possible within remaining time,
       // output it.
       Mutex::Lock counters_lock(search_->counters_mutex_);


### PR DESCRIPTION
r?@mooskagh Similar to https://github.com/LeelaChessZero/lc0/commit/82b3f208d33fac38c768f2ad2bd4d45c30599fa9 which fixed `go infinite searchmoves a2a4`… this commit fixes it for `go nodes 100 searchmoves a2a4` where in both cases, the intent of searchmoves is to have search focus on the desired move, so the `possible_moves` short-circuit behavior is undesired.

Before:
```
go nodes 100 searchmoves a2a4
info string a2a4  (207 ) N:       0 (+ 1) (P:  2.42%) (Q:  0.08519) (D:  0.000) (U: 0.03634) (Q+U:  0.12152) (V:  -.----) 
bestmove a2a4 ponder g8f6
```

After:
```
go nodes 100 searchmoves a2a4
info string a2a4  (207 ) N:     108 (+ 9) (P:  2.42%) (Q: -0.05578) (D:  0.000) (U: 0.00642) (Q+U: -0.04936) (V: -0.0646) 
bestmove a2a4 ponder h7h5
```

(One of my use cases is `go nodes 2 searchmoves <move>` to get the network eval V for a specific move from a desired position.)