### PR TITLE
Add stop command to selfplay interactive mode to allow for graceful exit.

### DIFF
--- a/src/selfplay/loop.cc
+++ b/src/selfplay/loop.cc
@@ -85,6 +85,11 @@ void SelfPlayLoop::CmdStart() {
       std::make_unique<std::thread>([this]() { tournament_->RunBlocking(); });
 }
 
+void SelfPlayLoop::CmdStop() {
+  tournament_->Stop();
+  tournament_->Wait();
+}
+
 void SelfPlayLoop::SendGameInfo(const GameInfo& info) {
   std::vector<std::string> responses;
   // Send separate resign report before gameready as client gameready parsing

--- a/src/selfplay/loop.h
+++ b/src/selfplay/loop.h
@@ -41,6 +41,7 @@ class SelfPlayLoop : public UciLoop {
 
   void RunLoop() override;
   void CmdStart() override;
+  void CmdStop() override;
   void CmdUci() override;
   void CmdSetOption(const std::string& name, const std::string& value,
                     const std::string& context) override;

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -237,7 +237,8 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
   auto& game = **game_iter;
 
   // If kResignPlaythrough == 0, then this comparison is unconditionally true
-  const bool enable_resign = Random::Get().GetFloat(100.0f) >= kResignPlaythrough;
+  const bool enable_resign =
+      Random::Get().GetFloat(100.0f) >= kResignPlaythrough;
 
   // PLAY GAME!
   game.Play(kThreads[color_idx[0]], kThreads[color_idx[1]], kTraining,
@@ -339,6 +340,11 @@ void SelfPlayTournament::Abort() {
   abort_ = true;
   for (auto& game : games_)
     if (game) game->Abort();
+}
+
+void SelfPlayTournament::Stop() {
+  Mutex::Lock lock(mutex_);
+  abort_ = true;
 }
 
 SelfPlayTournament::~SelfPlayTournament() {

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -59,6 +59,9 @@ class SelfPlayTournament {
   // Tells worker threads to finish ASAP. Does not block.
   void Abort();
 
+  // Stops any more games from starting, in progress games will complete.
+  void Stop();
+
   // If there are ongoing games, aborts and waits.
   ~SelfPlayTournament();
 


### PR DESCRIPTION
Doesn't stop any games in progress as opposed to quit which terminates the app.

If we want to really aggressively go after short game bias we would also need to ensure each thread plays the same number of games, but at least with this in place we can look at migrating the client to use interactive mode to reduce short game bias.  Every thread same number of games could be another flag in future.