### PR TITLE
Add EdgeDiscardFactor

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -178,6 +178,11 @@ const OptionId SearchParams::kKLDGainAverageInterval{
     "kldgain-average-interval", "KLDGainAverageInterval",
     "Used to decide how frequently to evaluate the average KLDGainPerNode to "
     "check the MinimumKLDGainPerNode, if specified."};
+const OptionId SearchParams::kEdgeDiscardFactor{
+	"edge-discard-factor", "EdgeDiscardFactor",
+	"Factor used for discarding thinking time for moves that can not reach bestmoves nodes. Factor of 1.00 is default "
+	"higher factor will sooner discard other edges thereby saving time for future moves." };
+
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -217,6 +222,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
   options->Add<IntOption>(kKLDGainAverageInterval, 1, 10000000) = 100;
   options->Add<FloatOption>(kMinimumKLDGainPerNode, 0.0f, 1.0f) = 0.0f;
+  options->Add<FloatOption>(kEdgeDiscardFactor, 1.0f, 5.0f) = 1.0f;
 
   options->HideOption(kLogLiveStatsId);
 }

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -97,6 +97,11 @@ class SearchParams {
   float GetMinimumKLDGainPerNode() const {
     return options_.Get<float>(kMinimumKLDGainPerNode.GetId());
   }
+  float GetEdgeDiscardFactor() const {
+	  return options_.Get<float>(kEdgeDiscardFactor.GetId());
+  }
+
+  
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -129,6 +134,7 @@ class SearchParams {
   static const OptionId kHistoryFillId;
   static const OptionId kMinimumKLDGainPerNode;
   static const OptionId kKLDGainAverageInterval;
+  static const OptionId kEdgeDiscardFactor;
 
  private:
   const OptionsDict& options_;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -942,7 +942,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         // To ensure we have at least one node to expand, always include
         // current best node.
         if (child != search_->current_best_edge_ &&
-            search_->remaining_playouts_ < best_node_n - child.GetN()) {
+            search_->remaining_playouts_ < ((best_node_n - child.GetN())* params_.GetEdgeDiscardFactor())) {
           continue;
         }
         // If root move filter exists, make sure move is in the list.


### PR DESCRIPTION
As #812 but now excluding CP, so only having the addition of EdgeDiscardFactor.

Copying text from #812 :

Looking at issues #686 and #753 the issue of how best to use thinking time seems a paramount issue.

One thought here is to discard moves from root in case they are lagging too far behind the best move being considered. When discarding those moves earlier in the process this will save time for future upcoming moves, especially in time limited games where added time is given for each move.

The default setting to discard moves is currently at half the number of nodes, meaning that given the remaining budgeted time of the move you can discard other moves that can never catch up with the best move.

However, discarding even sharper will save time for future moves. This will lead to more thinking time when best_move and second_best are close together in future moves of the game risking the current move of course...

Tested with factor 1.25f, so increasing the discard factor with 25%, including root-strategy absolute and CP enabled gave the following result in 14 test games with CuteChess.
Time settings: 5 seconds the game + 3 sec a move
Results: 5 wins, 3 losses, 6 draws.
Positive result but too low number of games to give confidence.

Might need a lot of CLOP testing to figure out what factor works best.
