### PR TITLE
Play move with the highest lower confidence bound

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ install:
 - cmd: IF %NAME%==opencl set OPENCL=true
 - cmd: IF %NAME%==blas set BLAS=true
 - cmd: IF %NAME%==blas set GTEST=true
+- cmd: set BOOST_ROOT=C:\Libraries\boost_1_69_0
 - cmd: IF %BLAS%==true IF NOT EXIST C:\cache\OpenBLAS appveyor DownloadFile https://sjeng.org/ftp/OpenBLAS-0.3.3-win-oldthread.zip
 - cmd: IF %BLAS%==true IF NOT EXIST C:\cache\OpenBLAS 7z x OpenBLAS-0.3.3-win-oldthread.zip -oC:\cache\OpenBLAS
 - cmd: IF %OPENCL%==true nuget install opencl-nug -Version 0.777.77 -OutputDirectory C:\cache

--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,9 @@ has_backends = false
 # Third party files.
 includes += include_directories('third_party', is_system: true)
 
+# Boost
+deps += dependency('boost')
+
 # Both protobuf and protoc must be the same version, so couple them together.
 protobuf_lib = cc.find_library('libprotobuf', dirs : get_option('protobuf_libdir'), required : false)
 if not protobuf_lib.found()

--- a/meson.build
+++ b/meson.build
@@ -118,6 +118,7 @@ files += [
   'src/utils/optionsdict.cc',
   'src/utils/optionsparser.cc',
   'src/utils/random.cc',
+  'src/utils/stats.cc',
   'src/utils/string.cc',
   'src/utils/transpose.cc',
   'src/utils/weights_adapter.cc',

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -148,7 +148,7 @@ void EngineController::PopulateOptions(OptionsParser* options) {
   options->Add<BoolOption>(kPonderId) = true;
   options->Add<FloatOption>(kSpendSavedTimeId, 0.0f, 1.0f) = 1.0f;
   options->Add<IntOption>(kRamLimitMbId, 0, 100000000) = 0;
-  options->Add<FloatOption>(kCIAlphaId, 0.0f, 1.0f) = 1e-5f;
+  options->Add<FloatOption>(kCIAlphaId, 0.0f, 1.0f) = 2e-5f;
 
   ConfigFile::PopulateOptions(options);
 

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -243,12 +243,11 @@ void Node::CancelScoreUpdate(int multivisit) {
 
 void Node::FinalizeScoreUpdate(float v, float d, int multivisit) {
   // Recompute Q.
-  float old_delta = (v - q_);
+  // Need to divide by 4 to scale to 0..1 range probability.
+  q_squared_diff_ +=
+      0.25f * (v - q_) * (v - q_) * multivisit * n_ / (n_ + multivisit);
   q_ += multivisit * (v - q_) / (n_ + multivisit);
   d_ += multivisit * (d - d_) / (n_ + multivisit);
-  float new_delta = (v - q_);
-  // Need to divide by 4 to scale to 0..1 range probability.
-  q_squared_diff_ += 0.25f * old_delta * new_delta;
 
   // If first visit, update parent's sum of policies visited at least once.
   if (n_ == 0 && parent_ != nullptr) {

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -243,8 +243,12 @@ void Node::CancelScoreUpdate(int multivisit) {
 
 void Node::FinalizeScoreUpdate(float v, float d, int multivisit) {
   // Recompute Q.
+  float old_delta = (v - q_);
   q_ += multivisit * (v - q_) / (n_ + multivisit);
   d_ += multivisit * (d - d_) / (n_ + multivisit);
+  float new_delta = (v - q_);
+  // Need to divide by 4 to scale to 0..1 range probability.
+  q_squared_diff_ += 0.25f * old_delta * new_delta;
 
   // If first visit, update parent's sum of policies visited at least once.
   if (n_ == 0 && parent_ != nullptr) {

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -178,6 +178,10 @@ const OptionId SearchParams::kKLDGainAverageInterval{
     "kldgain-average-interval", "KLDGainAverageInterval",
     "Used to decide how frequently to evaluate the average KLDGainPerNode to "
     "check the MinimumKLDGainPerNode, if specified."};
+const OptionId SearchParams::kMinimumLCBNRatioId{
+    "minimum-lcb-n-ratio", "MinimumLCBNRatio",
+    "Minimum ratio for nodes of the played move the the move with the most "
+    "nodes."};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -217,6 +221,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
   options->Add<IntOption>(kKLDGainAverageInterval, 1, 10000000) = 100;
   options->Add<FloatOption>(kMinimumKLDGainPerNode, 0.0f, 1.0f) = 0.0f;
+  options->Add<FloatOption>(kMinimumLCBNRatioId, 0.0f, 1.0f) = 0.1f;
 
   options->HideOption(kLogLiveStatsId);
 }

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -221,7 +221,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
   options->Add<IntOption>(kKLDGainAverageInterval, 1, 10000000) = 100;
   options->Add<FloatOption>(kMinimumKLDGainPerNode, 0.0f, 1.0f) = 0.0f;
-  options->Add<FloatOption>(kMinimumLCBNRatioId, 0.0f, 1.0f) = 0.1f;
+  options->Add<FloatOption>(kMinimumLCBNRatioId, 0.0f, 1.0f) = 0.32f;
 
   options->HideOption(kLogLiveStatsId);
 }

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -97,6 +97,9 @@ class SearchParams {
   float GetMinimumKLDGainPerNode() const {
     return options_.Get<float>(kMinimumKLDGainPerNode.GetId());
   }
+  float GetMinimumLCBNRatio() const {
+    return options_.Get<float>(kMinimumLCBNRatioId.GetId());
+  }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -129,6 +132,7 @@ class SearchParams {
   static const OptionId kHistoryFillId;
   static const OptionId kMinimumKLDGainPerNode;
   static const OptionId kKLDGainAverageInterval;
+  static const OptionId kMinimumLCBNRatioId;
 
  private:
   const OptionsDict& options_;

--- a/src/utils/stats.cc
+++ b/src/utils/stats.cc
@@ -1,0 +1,59 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2019 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#include "stats.h"
+#include <boost/math/distributions/students_t.hpp>
+
+namespace lczero {
+
+namespace {
+auto constexpr kzEntries = 1000;
+std::array<float, kzEntries> kzLookup;
+}  // namespace
+
+void CreatezTable(float ci_alpha) {
+  for (auto i = 1; i < kzEntries + 1; i++) {
+    boost::math::students_t dist(i);
+    auto z = boost::math::quantile(boost::math::complement(dist, ci_alpha));
+    kzLookup[i - 1] = z;
+  }
+}
+
+float CachedtQuantile(int v) {
+  if (v < 1) {
+    return kzLookup[0];
+  }
+  if (v < kzEntries) {
+    return kzLookup[v - 1];
+  }
+  // z approaches constant when v is high enough.
+  // With default lookup table size the function is flat enough that we
+  // can just return the last entry for all v bigger than it.
+  return kzLookup[kzEntries - 1];
+}
+
+}  // namespace lczero

--- a/src/utils/stats.h
+++ b/src/utils/stats.h
@@ -1,0 +1,35 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2019 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#pragma once
+
+namespace lczero {
+
+void CreatezTable(float ci_alpha);
+float CachedtQuantile(int v);
+
+}  // namespace lczero


### PR DESCRIPTION
Same as https://github.com/leela-zero/leela-zero/pull/2290. Some features still missing from the LZ PR: ~minimum visit ratio~ and avoiding pruning of the best LCB move in time management.

```
800 node test with network 41724 (MinibatchSize=32 and 5 piece TB)
Score of lc0_lcb vs lc0_master: 85 - 62 - 253  [0.529] 400
Elo difference: 20.00 +/- 20.61, LOS: 97.11 %, DrawRatio: 63.2 %
```