### PR TITLE
Also make parents Terminal if any move is a win or all moves are loss or draw.

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -393,6 +393,9 @@ void NodeTree::MakeMove(Move move) {
   for (auto& n : current_head_->Edges()) {
     if (n.GetMove() == move) {
       new_head = n.GetOrSpawnNode(current_head_);
+      // Ensure head is not terminal, so search can extend or visit children of
+      // "terminal" positions, e.g., WDL hits, converted terminals, 3-fold draw.
+      if (new_head->IsTerminal()) new_head->MakeNotTerminal();
       break;
     }
   }
@@ -442,11 +445,6 @@ bool NodeTree::ResetToPosition(const std::string& starting_fen,
   // retain old n_ and q_ (etc) data, even though its old children were
   // previously trimmed; we need to reset current_head_ in that case.
   if (!seen_old_head) TrimTreeAtHead();
-
-  // Make sure the head is not terminal, so search can extend or visit children
-  // of "terminal" positions, e.g., WDL hits, converted terminals, 3-fold draw.
-  if (current_head_->IsTerminal()) current_head_->MakeNotTerminal();
-
   return seen_old_head;
 }
 

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -241,12 +241,13 @@ void Node::MakeNotTerminal() {
       const auto n = child.GetN();
       if (n > 0) {
         n_ += n;
-        q_ -= child.GetQ(0.0f) * n;
+        // Flip Q for opponent.
+        q_ += -child.GetQ(0.0f) * n;
         d_ += child.GetD() * n;
       }
     }
 
-    // Recompute with current eval (instead of network's) and children's eval
+    // Recompute with current eval (instead of network's) and children's eval.
     q_ /= n_;
     d_ /= n_;
   }

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -237,7 +237,18 @@ void Node::MakeNotTerminal() {
   // If we have edges, we've been extended (1 visit), so include children too.
   if (edges_) {
     n_++;
-    for (const auto& child : Edges()) n_ += child.GetN();
+    for (const auto& child : Edges()) {
+      const auto n = child.GetN();
+      if (n > 0) {
+        n_ += n;
+        q_ -= child.GetQ(0.0f) * n;
+        d_ += child.GetD() * n;
+      }
+    }
+
+    // Recompute with current eval (instead of network's) and children's eval
+    q_ /= n_;
+    d_ /= n_;
   }
 }
 

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -162,6 +162,8 @@ class Node {
 
   // Makes the node terminal and sets it's score.
   void MakeTerminal(GameResult result);
+  // Makes the node not terminal and updates its visits.
+  void MakeNotTerminal();
 
   // If this node is not in the process of being expanded by another thread
   // (which can happen only if n==0 and n-in-flight==1), mark the node as

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -152,6 +152,13 @@ const OptionId SearchParams::kOutOfOrderEvalId{
     "in the cache or is terminal, evaluate it right away without sending the "
     "batch to the NN. When off, this may only happen with the very first node "
     "of a batch; when on, this can happen with any node."};
+const OptionId SearchParams::kStickyEndgamesId{
+    "sticky-endgames", "StickyEndgames",
+    "When an end of game position is found during search, allow the eval of "
+    "the previous move's position to stick to something more accurate. For "
+    "example, if at least one move results in checkmate, then the position "
+    "should stick as checkmated. Similarly, if all moves are drawn or "
+    "checkmated, the position should stick as drawn or checkmate."};
 const OptionId SearchParams::kSyzygyFastPlayId{
     "syzygy-fast-play", "SyzygyFastPlay",
     "With DTZ tablebase files, only allow the network pick from winning moves "
@@ -209,6 +216,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kMaxCollisionEventsId, 1, 1024) = 32;
   options->Add<IntOption>(kMaxCollisionVisitsId, 1, 1000000) = 9999;
   options->Add<BoolOption>(kOutOfOrderEvalId) = true;
+  options->Add<BoolOption>(kStickyEndgamesId) = false;
   options->Add<BoolOption>(kSyzygyFastPlayId) = true;
   options->Add<IntOption>(kMultiPvId, 1, 500) = 1;
   std::vector<std::string> score_type = {"centipawn", "win_percentage", "Q"};
@@ -244,6 +252,7 @@ SearchParams::SearchParams(const OptionsDict& options)
       kMaxCollisionEvents(options.Get<int>(kMaxCollisionEventsId.GetId())),
       kMaxCollisionVisits(options.Get<int>(kMaxCollisionVisitsId.GetId())),
       kOutOfOrderEval(options.Get<bool>(kOutOfOrderEvalId.GetId())),
+      kStickyEndgames(options.Get<bool>(kStickyEndgamesId.GetId())),
       kSyzygyFastPlay(options.Get<bool>(kSyzygyFastPlayId.GetId())),
       kHistoryFill(
           EncodeHistoryFill(options.Get<std::string>(kHistoryFillId.GetId()))),

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -85,6 +85,7 @@ class SearchParams {
   int GetMaxCollisionEvents() const { return kMaxCollisionEvents; }
   int GetMaxCollisionVisitsId() const { return kMaxCollisionVisits; }
   bool GetOutOfOrderEval() const { return kOutOfOrderEval; }
+  bool GetStickyEndgames() const { return kStickyEndgames; }
   bool GetSyzygyFastPlay() const { return kSyzygyFastPlay; }
   int GetMultiPv() const { return options_.Get<int>(kMultiPvId.GetId()); }
   std::string GetScoreType() const {
@@ -123,6 +124,7 @@ class SearchParams {
   static const OptionId kMaxCollisionEventsId;
   static const OptionId kMaxCollisionVisitsId;
   static const OptionId kOutOfOrderEvalId;
+  static const OptionId kStickyEndgamesId;
   static const OptionId kSyzygyFastPlayId;
   static const OptionId kMultiPvId;
   static const OptionId kScoreTypeId;
@@ -152,6 +154,7 @@ class SearchParams {
   const int kMaxCollisionEvents;
   const int kMaxCollisionVisits;
   const bool kOutOfOrderEval;
+  const bool kStickyEndgames;
   const bool kSyzygyFastPlay;
   const FillEmptyHistory kHistoryFill;
   const int kMiniBatchSize;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1301,10 +1301,9 @@ void SearchWorker::DoBackupUpdateSingleNode(
 
     // A non-winning terminal move needs all other moves to have the same value.
     if (can_convert && v != 1.0f) {
-      auto edges = p->Edges();
-      can_convert = std::all_of(edges.begin(), edges.end(), [&](const auto& e) {
-        return e.IsTerminal() && e.GetQ(0.0f) == v;
-      });
+      for (const auto& edge : p->Edges()) {
+        can_convert = can_convert && edge.IsTerminal() && edge.GetQ(0.0f) == v;
+      }
     }
 
     // Convert the parent to a terminal loss if at least one move is winning or

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1279,7 +1279,8 @@ void SearchWorker::DoBackupUpdateSingleNode(
   }
 
   // For the first visit to a terminal, maybe convert ancestors to terminal too.
-  auto can_convert = node->IsTerminal() && !node->GetN();
+  auto can_convert =
+      params_.GetStickyEndgames() && node->IsTerminal() && !node->GetN();
 
   // Backup V value up to a root. After 1 visit, V = Q.
   float v = node_to_process.v;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -906,12 +906,8 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
       return NodeToProcess::Collision(node, depth, collision_limit);
     }
     // Either terminal or unexamined leaf node -- the end of this playout.
-    if (!node->HasChildren()) {
-      if (node->IsTerminal()) {
-        return NodeToProcess::TerminalHit(node, depth, 1);
-      } else {
-        return NodeToProcess::Extension(node, depth);
-      }
+    if (node->IsTerminal() || !node->HasChildren()) {
+      return NodeToProcess::Visit(node, depth);
     }
     Node* possible_shortcut_child = node->GetCachedBestChild();
     if (possible_shortcut_child) {
@@ -1282,18 +1278,48 @@ void SearchWorker::DoBackupUpdateSingleNode(
     return;
   }
 
+  // For the first visit to a terminal, maybe convert ancestors to terminal too.
+  auto can_convert = node->IsTerminal() && !node->GetN();
+
   // Backup V value up to a root. After 1 visit, V = Q.
   float v = node_to_process.v;
   float d = node_to_process.d;
-  for (Node* n = node; n != search_->root_node_->GetParent();
-       n = n->GetParent()) {
+  for (Node *n = node, *p; n != search_->root_node_->GetParent(); n = p) {
+    p = n->GetParent();
+
+    // Current node might have become terminal from some other descendant, so
+    // backup the rest of the way with more accurate values.
+    if (n->IsTerminal()) {
+      v = n->GetQ();
+      d = n->GetD();
+    }
     n->FinalizeScoreUpdate(v, d, node_to_process.multivisit);
+
+    // Convert parents to terminals except the root or those already converted.
+    can_convert = can_convert && p != search_->root_node_ && !p->IsTerminal();
+
+    // A non-winning terminal move needs all other moves to have the same value.
+    if (can_convert && v != 1.0f) {
+      auto edges = p->Edges();
+      can_convert = std::all_of(edges.begin(), edges.end(), [&](const auto& e) {
+        return e.IsTerminal() && e.GetQ(0.0f) == v;
+      });
+    }
+
+    // Convert the parent to a terminal loss if at least one move is winning or
+    // to a terminal win or draw if all moves are loss or draw respectively.
+    if (can_convert) {
+      p->MakeTerminal(v == 1.0f ? GameResult::BLACK_WON
+                                : v == -1.0f ? GameResult::WHITE_WON
+                                             : GameResult::DRAW);
+    }
+
     // Q will be flipped for opponent.
     v = -v;
 
     // Update the stats.
     // Best move.
-    if (n->GetParent() == search_->root_node_ &&
+    if (p == search_->root_node_ &&
         search_->current_best_edge_.GetN() <= n->GetN()) {
       search_->current_best_edge_ =
           search_->GetBestChildNoTemperature(search_->root_node_);

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -271,12 +271,8 @@ class SearchWorker {
                                    int collision_count) {
       return NodeToProcess(node, depth, true, collision_count);
     }
-    static NodeToProcess Extension(Node* node, uint16_t depth) {
+    static NodeToProcess Visit(Node* node, uint16_t depth) {
       return NodeToProcess(node, depth, false, 1);
-    }
-    static NodeToProcess TerminalHit(Node* node, uint16_t depth,
-                                     int visit_count) {
-      return NodeToProcess(node, depth, false, visit_count);
     }
 
    private:


### PR DESCRIPTION
r?@mooskagh Not as feature-full as #700, but this behaves more like TB terminals. Convert a node when search notices children have terminal behavior so future search can stop sooner. Slight refactoring of NodeToProcess to as TerminalHit behaved the same as Extension(1).

Example:
![Screen Shot 2019-03-29 at 2 27 33 PM](https://user-images.githubusercontent.com/438537/55263790-71575480-522f-11e9-8347-fd49afed2d30.png)

```
./lc0 -w 11258 --verbose-move-stats --fpu-strategy-at-root=absolute --minibatch-size=1 --smart-pruning-factor=0
position fen 3k4/p4Q2/3N3p/1p1B4/8/1P2P3/2R2PPP/6K1 w - - 1 31 moves f7a7

# just loading the position
go nodes 1    
h6h5 N:       0 (+ 0) (P: 47.68%) (Q:  1.00000) (V:  -.----)
b5b4 N:       0 (+ 0) (P: 52.32%) (Q:  1.00000) (V:  -.----)

# root fpu=1 visit both; nothing special
go nodes 2
h6h5 N:       1 (+ 0) (P: 47.68%) (Q: -0.97491) (V: -0.9749)
b5b4 N:       1 (+ 0) (P: 52.32%) (Q: -0.97261) (V: -0.9726)

# b5b4 finds c2c8#
go nodes 3
h6h5 N:       1 (+ 0) (P: 47.68%) (Q: -0.97491) (V: -0.9749)
b5b4 N:       2 (+ 0) (P: 52.32%) (Q: -0.98630) (V: -0.9726)

# b5b4 c2c8# converts b5b4 into a loss
go nodes 5
h6h5 N:       2 (+ 0) (P: 47.68%) (Q: -0.98746) (V: -0.9749)
b5b4 N:       3 (+ 0) (P: 52.32%) (Q: -1.00000) (V: -1.0000) (T)

# h6h5 c2c8# converts h6h5 into a loss
go nodes 7
h6h5 N:       3 (+ 0) (P: 47.68%) (Q: -1.00000) (V: -1.0000) (T)
b5b4 N:       4 (+ 0) (P: 52.32%) (Q: -1.00000) (V: -1.0000) (T)
```

Then looking at one move before:
![Screen Shot 2019-03-29 at 1 50 47 PM](https://user-images.githubusercontent.com/438537/55263143-48ce5b00-522d-11e9-8241-0fe7cdb93682.png)

```
position fen 3k4/p4Q2/3N3p/1p1B4/8/1P2P3/2R2PPP/6K1 w - - 1 31

# just normal out of order finding checkmate moves
go nodes 10
c2c6 N:       0 (+ 0) (P:  1.94%) (Q:  1.00000) (V:  -.----)
f7c7 N:       0 (+ 0) (P:  1.97%) (Q:  1.00000) (V:  -.----)
d6c8 N:       0 (+ 0) (P:  1.98%) (Q:  1.00000) (V:  -.----)
d5e4 N:       0 (+ 0) (P:  2.06%) (Q:  1.00000) (V:  -.----)
d5b7 N:       1 (+ 0) (P:  2.21%) (Q:  0.97211) (V:  0.9721)
d5c6 N:       1 (+ 0) (P:  2.16%) (Q:  0.97785) (V:  0.9778)
c2c7 N:       1 (+ 0) (P:  2.24%) (Q:  0.97764) (V:  0.9776)
d6b7 N:       1 (+ 0) (P:  3.93%) (Q:  1.00000) (V:  1.0000) (T)
f7e8 N:       2 (+ 0) (P:  4.16%) (Q:  1.00000) (V:  1.0000) (T)
c2c8 N:       3 (+ 0) (P:  7.86%) (Q:  1.00000) (V:  1.0000) (T)

# just normal search visits
go nodes 400
d6c8 N:       8 (+ 0) (P:  1.98%) (Q:  0.98583) (V:  0.9752)
d5e4 N:       8 (+ 0) (P:  2.06%) (Q:  0.98539) (V:  0.9736)
f7c7 N:       9 (+ 0) (P:  1.97%) (Q:  1.00000) (V:  1.0000) (T)
d5b7 N:       9 (+ 0) (P:  2.21%) (Q:  0.98568) (V:  0.9721)
d5c6 N:       9 (+ 0) (P:  2.16%) (Q:  0.99107) (V:  0.9778)
c2c7 N:       9 (+ 0) (P:  2.24%) (Q:  0.98915) (V:  0.9776)
d5e6 N:      11 (+ 0) (P:  2.53%) (Q:  0.99073) (V:  0.9777)
d6b7 N:      18 (+ 0) (P:  3.93%) (Q:  1.00000) (V:  1.0000) (T)
f7e8 N:      20 (+ 0) (P:  4.16%) (Q:  1.00000) (V:  1.0000) (T)
c2c8 N:      37 (+ 0) (P:  7.86%) (Q:  1.00000) (V:  1.0000) (T)

# f7a7 (from first example) has enough visits that all its moves are losses, so convert to win
go nodes 500
f7a7 N:       9 (+ 0) (P:  1.52%) (Q:  1.00000) (V:  1.0000) (T)
f7f6 N:      10 (+ 0) (P:  1.74%) (Q:  1.00000) (V:  1.0000) (T)
f7c7 N:      11 (+ 0) (P:  1.97%) (Q:  1.00000) (V:  1.0000) (T)
d5b7 N:      11 (+ 0) (P:  2.21%) (Q:  0.98829) (V:  0.9721)
d5c6 N:      11 (+ 0) (P:  2.16%) (Q:  0.99269) (V:  0.9778)
c2c7 N:      12 (+ 0) (P:  2.24%) (Q:  0.99186) (V:  0.9776)
d5e6 N:      13 (+ 0) (P:  2.53%) (Q:  0.99216) (V:  0.9777)
d6b7 N:      23 (+ 0) (P:  3.93%) (Q:  1.00000) (V:  1.0000) (T)
f7e8 N:      24 (+ 0) (P:  4.16%) (Q:  1.00000) (V:  1.0000) (T)
c2c8 N:      46 (+ 0) (P:  7.86%) (Q:  1.00000) (V:  1.0000) (T)

# lots of moves converting to win
go nodes 600
f7a7 N:      10 (+ 0) (P:  1.52%) (Q:  1.00000) (V:  1.0000) (T)
f7f6 N:      12 (+ 0) (P:  1.74%) (Q:  1.00000) (V:  1.0000) (T)
b3b4 N:      13 (+ 0) (P:  1.87%) (Q:  1.00000) (V:  1.0000) (T)
f7c7 N:      13 (+ 0) (P:  1.97%) (Q:  1.00000) (V:  1.0000) (T)
d5c6 N:      15 (+ 0) (P:  2.16%) (Q:  1.00000) (V:  1.0000) (T)
d5b7 N:      15 (+ 0) (P:  2.21%) (Q:  1.00000) (V:  1.0000) (T)
c2c7 N:      15 (+ 0) (P:  2.24%) (Q:  1.00000) (V:  1.0000) (T)
d5e6 N:      17 (+ 0) (P:  2.53%) (Q:  1.00000) (V:  1.0000) (T)
d6b7 N:      27 (+ 0) (P:  3.93%) (Q:  1.00000) (V:  1.0000) (T)
f7e8 N:      28 (+ 0) (P:  4.16%) (Q:  1.00000) (V:  1.0000) (T)
c2c8 N:      54 (+ 0) (P:  7.86%) (Q:  1.00000) (V:  1.0000) (T)
```