### PR TITLE
Disaggregated node counts in MultiPV

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -160,6 +160,10 @@ const OptionId SearchParams::kMultiPvId{
     "multipv", "MultiPV",
     "Number of game play lines (principal variations) to show in UCI info "
     "output."};
+const OptionId SearchParams::kMultiPVDisaggregatedNodecountId{
+    "multipv-disaggregated-nodecount", "MultiPVDisaggregatedNodecount",
+    "Report number of subnodes in each Principal Variation when MultiPV "
+    "is greater than one."};
 const OptionId SearchParams::kScoreTypeId{
     "score-type", "ScoreType",
     "What to display as score. Either centipawns (the UCI default), win "
@@ -211,6 +215,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<BoolOption>(kOutOfOrderEvalId) = true;
   options->Add<BoolOption>(kSyzygyFastPlayId) = true;
   options->Add<IntOption>(kMultiPvId, 1, 500) = 1;
+  options->Add<BoolOption>(kMultiPVDisaggregatedNodecountId) = false;
   std::vector<std::string> score_type = {"centipawn", "win_percentage", "Q"};
   options->Add<ChoiceOption>(kScoreTypeId, score_type) = "centipawn";
   std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -87,6 +87,9 @@ class SearchParams {
   bool GetOutOfOrderEval() const { return kOutOfOrderEval; }
   bool GetSyzygyFastPlay() const { return kSyzygyFastPlay; }
   int GetMultiPv() const { return options_.Get<int>(kMultiPvId.GetId()); }
+  bool GetMultiPVDisaggregatedNodecount() const {
+    return options_.Get<bool>(kMultiPVDisaggregatedNodecountId.GetId());
+  }
   std::string GetScoreType() const {
     return options_.Get<std::string>(kScoreTypeId.GetId());
   }
@@ -125,6 +128,7 @@ class SearchParams {
   static const OptionId kOutOfOrderEvalId;
   static const OptionId kSyzygyFastPlayId;
   static const OptionId kMultiPvId;
+  static const OptionId kMultiPVDisaggregatedNodecountId;
   static const OptionId kScoreTypeId;
   static const OptionId kHistoryFillId;
   static const OptionId kMinimumKLDGainPerNode;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -112,7 +112,10 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
   common_info.depth = cum_depth_ / (total_playouts_ ? total_playouts_ : 1);
   common_info.seldepth = max_depth_;
   common_info.time = GetTimeSinceStart();
-  common_info.nodes = total_playouts_ + initial_visits_;
+  if(params_.GetMultiPv() == 1 ||
+     params_.GetMultiPVDisaggregatedNodecount() == false) {
+    common_info.nodes = total_playouts_ + initial_visits_;
+  }
   common_info.hashfull =
       cache_->GetSize() * 1000LL / std::max(cache_->GetCapacity(), 1);
   common_info.nps =
@@ -124,6 +127,9 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
     ++multipv;
     uci_infos.emplace_back(common_info);
     auto& uci_info = uci_infos.back();
+  if(params_.GetMultiPv() > 1 && params_.GetMultiPVDisaggregatedNodecount()) {
+    uci_info.nodes = edge.GetN();
+  }
     if (score_type == "centipawn") {
       uci_info.score = 290.680623072 * tan(1.548090806 * edge.GetQ(0));
     } else if (score_type == "win_percentage") {


### PR DESCRIPTION
Add option MultiPVDisaggregatedNodecount, which defaults to false, to enable per variation nodecounts in MultiPV. Based on code published by @crem on discord.