### PR TITLE
Use parent Q as a default score instead of 0 for unvisited pv.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -120,16 +120,17 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
   common_info.tb_hits = tb_hits_.load(std::memory_order_acquire);
 
   int multipv = 0;
+  const auto default_q = -root_node_->GetQ();
   for (const auto& edge : edges) {
     ++multipv;
     uci_infos.emplace_back(common_info);
     auto& uci_info = uci_infos.back();
     if (score_type == "centipawn") {
-      uci_info.score = 290.680623072 * tan(1.548090806 * edge.GetQ(0));
+      uci_info.score = 290.680623072 * tan(1.548090806 * edge.GetQ(default_q));
     } else if (score_type == "win_percentage") {
-      uci_info.score = edge.GetQ(0) * 5000 + 5000;
+      uci_info.score = edge.GetQ(default_q) * 5000 + 5000;
     } else if (score_type == "Q") {
-      uci_info.score = edge.GetQ(0) * 10000;
+      uci_info.score = edge.GetQ(default_q) * 10000;
     }
     if (params_.GetMultiPv() > 1) uci_info.multipv = multipv;
     bool flip = played_history_.IsBlackToMove();


### PR DESCRIPTION
r?@mooskagh or @Tilps I just noticed from CCC 7 that lc0 would have eval drop from winning to 0 sometimes. This is because there was only one TB-allowed move, so search stops before finishing a visit to any edge. So just use the root eval as an estimate instead of 0.

E.g., 1418 lc0 vs wasp with one dtz minimizing move
<img width="687" alt="Screen Shot 2019-04-03 at 2 41 30 PM" src="https://user-images.githubusercontent.com/438537/55515773-3e8ed100-5620-11e9-8ce4-50d5dceceff2.png">
```
position fen 3Q4/8/8/4K3/Q7/8/5k2/8 w - - 1 110
go nodes 100

# before PR
info depth 1 seldepth 1 time 34 nodes 1 score cp 0 hashfull 0 nps 29 tbhits 2 pv d8d2 f2g1

# after PR
info depth 1 seldepth 1 time 120 nodes 1 score cp 6923 hashfull 0 nps 8 tbhits 2 pv d8d2 f2g1
```

and 1425 senpai vs lc0 with one winning move
<img width="689" alt="Screen Shot 2019-04-03 at 2 40 33 PM" src="https://user-images.githubusercontent.com/438537/55515840-76961400-5620-11e9-868f-8ebd23b3794b.png">
```
position fen 8/7P/6K1/8/5P2/1b4k1/7r/8 b - - 2 91
go nodes 100

# before PR
info depth 1 seldepth 1 time 132 nodes 1 score cp 0 hashfull 0 nps 7 tbhits 2 pv b3c2 g6g7

# after PR
info depth 1 seldepth 1 time 48 nodes 1 score cp 3093 hashfull 0 nps 20 tbhits 2 pv b3c2 g6g7
```