### PR TITLE
Recalibrate centipawn formula

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -219,7 +219,8 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<BoolOption>(kStickyEndgamesId) = false;
   options->Add<BoolOption>(kSyzygyFastPlayId) = true;
   options->Add<IntOption>(kMultiPvId, 1, 500) = 1;
-  std::vector<std::string> score_type = {"centipawn", "win_percentage", "Q"};
+  std::vector<std::string> score_type = {"centipawn", "centipawn_2018",
+                                         "win_percentage", "Q"};
   options->Add<ChoiceOption>(kScoreTypeId, score_type) = "centipawn";
   std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -127,6 +127,8 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
     auto& uci_info = uci_infos.back();
     if (score_type == "centipawn") {
       uci_info.score = 111.714640912 * tan(1.5620688421 * edge.GetQ(default_q));
+    } else if (score_type == "centipawn_2018") {
+      uci_info.score = 290.680623072 * tan(1.548090806 * edge.GetQ(default_q));
     } else if (score_type == "win_percentage") {
       uci_info.score = edge.GetQ(default_q) * 5000 + 5000;
     } else if (score_type == "Q") {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -126,7 +126,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
     uci_infos.emplace_back(common_info);
     auto& uci_info = uci_infos.back();
     if (score_type == "centipawn") {
-      uci_info.score = 290.680623072 * tan(1.548090806 * edge.GetQ(default_q));
+      uci_info.score = 111.714640912 * tan(1.5620688421 * edge.GetQ(default_q));
     } else if (score_type == "win_percentage") {
       uci_info.score = edge.GetQ(default_q) * 5000 + 5000;
     } else if (score_type == "Q") {


### PR DESCRIPTION
It is widely agreed that Leela's eval in centipawns is inflated and a headache to viewers in tournaments such as TCEC and CCC. It has led some to believe that Leela "is just too optimistic" or "overestimates positions", or that high evals "is just a characteristic of neural networks". Furthermore, it has made the TCEC and CCC adjudication rules less reliable. All of this can be resolved by a slight tweak to the conversion formula.

The process that led to the current formula `290.680623072 * tan(1.548090806 * Q)` is as follows:
- Evals of Stockfish and Leela (Apr/15/2018) were obtained by removing pieces from the starting position
- Based on correlation analysis, `300 * tan(1.5 * Q)` was found to be a close predictor of SF's eval
- It was agreed to use tan() over logit due to its flatter tails and tendency to give more disparity in evals for winrates above 90%
- The formula was then modified to `290.680623072 * tan(1.548090806 * Q)` in order to reach exactly 12800cp when Q=1 (100% winrate)
- Note that "1.548090806" was calculated from `atan(12800 / 290.680623072)`

This method has a few problems:
- A very outdated version of Leela (test10 at its infancy) was used
- Analysis was done on a low sample size of 15 positions
- Leela would not have come across the start position with pieces removed in her training
- The formula was calibrated to positions that are rarely, if at all, seen in ordinary games

It is likely some of these issues have led to the iconic inflation of Leela's eval. For better calibration, analysis should be done on more "realistic" positions with the latest versions of both engines. To do this, I took the games from the recent TCEC 15 Premier Division and extracted all positions where the evals of Leela and Bluefish (a live spectator engine @ 88C/176T Stockfish 11-Dev no contempt) were available. [The data can be found here.](https://pastebin.com/raw/5PG1aEMv) Weighting was applied to ensure that each game has the same influence regardless of its length, and positions where either engine has over 8x the eval of the other were removed. Stockfish isn't the only traditional engine out there so to avoid specific engine bias, the evals of Bluefish were first compared to that of Komodo, Houdini, and itself:
![Bluefish Graph](https://user-images.githubusercontent.com/8546759/56892264-6dcf1b80-6ac2-11e9-9942-af17b1a45364.png)
The overall trend slope was found to be 0.69894. This was multiplied to all of Bluefish's evals to give what I'll call the "BF-K-H eval". I then ran a script to test Leela's conversion formula `k * tan(atan(12800 / k) * Q)` for all values of k between 0.000000001 and 400.000000000. It was found that when k = 111.714640912, the relationship between BF-K-H eval and Leela's eval becomes a 1:1 ratio. I therefore propose this as the new formula:

`cp = 111.714640912 * tan(1.5620688421 * Q)`

Below is a scatter plot to show its differences to the old formula. The lack of negative evals was due to Leela having no white losses or black wins, except against Ethereal (game 42) but that's when Bluefish decided to go offline...
![Leela Graph](https://user-images.githubusercontent.com/8546759/56892676-b6d39f80-6ac3-11e9-8354-b43c9e270991.png)

And here's a comparison of the old and new formulae:
![Formula Graph](https://user-images.githubusercontent.com/8546759/56892346-b4bd1100-6ac2-11e9-8704-ac909aa6081d.png)
With this change, Leela's eval will shrink by a factor of ~2.6 in most cases. Mate scores will remain at +128.00 or -128.00. +1.10 will become a 75% win percentage, +1.50 will be 80%, and +3.30 will be 90%.