### PR TITLE
Q value difference pruning

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -944,7 +944,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         // current best node.
         if (child != search_->current_best_edge_ &&
             (search_->remaining_playouts_ < best_node_n - child.GetN() ||
-				(search_->remaining_playouts_ / 3 < best_node_n - child.GetN() && //additional cutoff on big Q difference
+				(search_->remaining_playouts_ / 3 < best_node_n - child.GetN() && //additional cutoff on some Q difference
 					best_node_q > (child.GetQ(fpu) + 0.1f)))) {
           continue;
         }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -944,7 +944,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         // current best node.
         if (child != search_->current_best_edge_ &&
             (search_->remaining_playouts_ < best_node_n - child.GetN() ||
-				(search_->remaining_playouts_ / 2 < best_node_n - child.GetN() && //additional cutoff on big Q difference
+				(search_->remaining_playouts_ / 3 < best_node_n - child.GetN() && //additional cutoff on big Q difference
 					best_node_q > (child.GetQ(fpu) + 0.1f)))) {
           continue;
         }


### PR DESCRIPTION
This is a test-pull request on trying to improve smart pruning by using the known Q value of the best root-move.

The idea here is that if the best root-move is clearly better than all the other root-moves being considered to just make that move quicker and thus save some time for future moves.

Why?
- Suppose your opponent goes for a queen exchange and takes your queen. The logical move to do is to take back your opponents queen and don't think about that all too much. This way you save some time for future moves.

Additional information:
Within the search there already exists smart pruning as well as a cut-off when the best found move has such a large number of playouts that no other root move can catch up. That is still in place. The only addition in this PR is that there will be a slightly faster cutoff in case the number of playouts has reached a certain threshhold AND there is a slight Q difference with all the other root moves.

The current values for this earlier cut-off have been tested on very short time controls and very low node counts. It's a known fact that on low node counts, higher values for smart pruning are very effective, so this PR should also be tested with Longer Time Controls (LTC) with higher node counts to see if this improves strength, if at all. 

A test is running currently for 100 games at +1.5 sec but as I do not have a good GPU would like to see if others can test, just to check if this improves strength or not.

Thoughts on strength:
- The cutoff early as shown here has a higher risk of playing a _worse_ move and this should be weighted against the advantage for saving time for those cases where more thinking is useful _in future_. 
- I believe that eventually the TimeControls should be directed by the net outputs instead of trying to handcraft within the search like in this PR.