### PR TITLE
Correct allocation size of M matrix in Winograd convolution

### DIFF
--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -146,6 +146,12 @@ void BlasComputation::ComputeBlocking() {
   const auto input_channels = static_cast<size_t>(kInputPlanes);
   const auto max_channels = std::max(output_channels, input_channels);
 
+  // The policy head may increase convolution max output size.
+  const auto max_output_channels =
+      (conv_policy_ && weights_.policy.biases.size() > output_channels)
+          ? weights_.policy.biases.size()
+          : output_channels;
+
   // Determine the largest batch for allocations.
   const auto plane_count = planes_.size();
   const auto largest_batch_size = std::min(max_batch_size_, plane_count);
@@ -171,7 +177,7 @@ void BlasComputation::ComputeBlocking() {
                                  kSquares);
 
   WinogradConvolution3 convolve3(largest_batch_size, max_channels,
-                                 output_channels);
+                                 max_output_channels);
 
   std::vector<float> policy_buffer(largest_batch_size *
                                    num_policy_input_planes * kSquares);

--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -170,7 +170,8 @@ void BlasComputation::ComputeBlocking() {
   std::vector<float> res_buffer3(largest_batch_size * output_channels *
                                  kSquares);
 
-  WinogradConvolution3 convolve3(largest_batch_size, max_channels);
+  WinogradConvolution3 convolve3(largest_batch_size, max_channels,
+                                 output_channels);
 
   std::vector<float> policy_buffer(largest_batch_size *
                                    num_policy_input_planes * kSquares);

--- a/src/neural/blas/winograd_convolution3.cc
+++ b/src/neural/blas/winograd_convolution3.cc
@@ -44,9 +44,10 @@ using ConstEigenMatrixMap =
 #endif
 
 WinogradConvolution3::WinogradConvolution3(const size_t max_batch_size,
-                                           const size_t max_channels)
-    : V_(max_batch_size * kWinogradTile * max_channels * kTiles),
-      M_(max_batch_size * kWinogradTile * max_channels * kTiles) {}
+                                           const size_t max_input_layers,
+                                           const size_t max_output_layers)
+    : V_(max_batch_size * kWinogradTile * max_input_layers * kTiles),
+      M_(max_batch_size * kWinogradTile * max_output_layers * kTiles) {}
 
 void WinogradConvolution3::Forward(const size_t batch_size,
                                    const size_t input_channels,

--- a/src/neural/blas/winograd_convolution3.h
+++ b/src/neural/blas/winograd_convolution3.h
@@ -39,7 +39,9 @@ class WinogradConvolution3 {
   // The instance will allocate memory resources for the
   // largest batch size, and the largest input and output
   // layers.
-  WinogradConvolution3(const size_t max_batch_size, const size_t max_channels);
+  WinogradConvolution3(const size_t max_batch_size,
+                       const size_t max_input_layers,
+                       const size_t max_output_layers);
 
   // Forward inference, batched.
   void Forward(const size_t batch_size, const size_t input_channels,


### PR DESCRIPTION
https://github.com/LeelaChessZero/lc0/pull/864 was the previous attempt at this, but not strictly correct (although working in practice by allocating more than needed). 