### PR TITLE
Randomly play opening moves based on priors

### DIFF
--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -70,7 +70,7 @@ class SelfPlayGame {
 
   // Starts the game and blocks until the game is finished.
   void Play(int white_threads, int black_threads, bool training,
-            bool enable_resign = true);
+            int random_opening_plies, bool enable_resign = true);
   // Aborts the game currently played, doesn't matter if it's synchronous or
   // not.
   void Abort();

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -102,6 +102,7 @@ class SelfPlayTournament {
   const size_t kParallelism;
   const bool kTraining;
   const float kResignPlaythrough;
+  const int kRandomOpeningMaxPlies;
 };
 
 }  // namespace lczero


### PR DESCRIPTION
r?@Tilps or @mooskagh Fixes #342 by adding selfplay `--random-opening-max-plies` that results in a random number of plies doing a single visit to randomly pick a move proportional to the (noised) priors while not saving training data for these early moves. Can also change `--random-opening-temperature` from 1.0 to larger/flatten or smaller/sharper priors.

Not explicitly mentioned in the issue but implemented here is the skipping of adjudication during this random opening to hopefully allow more opening diversity of positions that otherwise would have been overlooked if assuming opponent will play best move -> resign.

This doesn't change the existing default behavior of 0 prior-based random moves, but it allows the server to change it and even in addition to regular temperature settings.

If the game ends while playing randomly, it's treated like an abort.

This includes/supersedes #773 as I needed to move the `MakeMove` earlier anyway (but still after getting training data).