### PR TITLE
Divide by a slightly smaller divisor to truncate to +/-12800.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -127,7 +127,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
     auto& uci_info = uci_infos.back();
     if (score_type == "centipawn") {
       uci_info.score = 295 * edge.GetQ(default_q) /
-                       (1 - 0.976953125 * std::pow(edge.GetQ(default_q), 14));
+                       (1 - 0.976953126 * std::pow(edge.GetQ(default_q), 14));
     } else if (score_type == "centipawn_2018") {
       uci_info.score = 290.680623072 * tan(1.548090806 * edge.GetQ(default_q));
     } else if (score_type == "win_percentage") {


### PR DESCRIPTION
r?@mooskagh Alternative to #879 Followup to https://github.com/LeelaChessZero/lc0/pull/860#issuecomment-500189165

before:
```
position fen r2qk2r/ppp2p2/3p4/2b1p1pp/2BnP1nP/3P1PB1/PPP3P1/RN1Q1RK1 b kq - 0 13 moves d4e2
go nodes 2
info depth 2 seldepth 3 time 20 nodes 257 score cp -12799 hashfull 0 nps 12850 tbhits 0 pv g1h1 e2g3

position fen r2qk2r/ppp2p2/3p4/2b1p1pp/2BnP1nP/3P1PB1/PPP3P1/RN1Q1RK1 b kq - 0 13 moves d4e2 g1h1
go nodes 2
info depth 1 seldepth 2 time 50 nodes 123 score cp 12799 hashfull 0 nps 2460 tbhits 0 pv e2g3
```

after:
```
position fen r2qk2r/ppp2p2/3p4/2b1p1pp/2BnP1nP/3P1PB1/PPP3P1/RN1Q1RK1 b kq - 0 13 moves d4e2
go nodes 2
info depth 2 seldepth 3 time 0 nodes 77 score cp -12800 hashfull 0 nps 0 tbhits 0 pv g1h1 e2g3

position fen r2qk2r/ppp2p2/3p4/2b1p1pp/2BnP1nP/3P1PB1/PPP3P1/RN1Q1RK1 b kq - 0 13 moves d4e2 g1h1
go nodes 2
info depth 2 seldepth 2 time 0 nodes 20 score cp 12800 hashfull 0 nps 0 tbhits 0 pv e2g3
```