### PR TITLE
Set probabilities for illegal moves in a loop

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -339,7 +339,9 @@ V4TrainingData Node::GetV4TrainingData(GameResult game_result,
   // Prevent garbage/invalid training data from being uploaded to server.
   if (total_n <= 0.0f) throw Exception("Search generated invalid data!");
   // Set illegal moves to have -1 probability.
-  std::memset(result.probabilities, -1, sizeof(result.probabilities));
+  for (auto& probability : result.probabilities) {
+    probability = -1;
+  }
   for (const auto& child : Edges()) {
     result.probabilities[child.edge()->GetMove().as_nn_index()] =
         child.GetN() / total_n;

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -339,9 +339,8 @@ V4TrainingData Node::GetV4TrainingData(GameResult game_result,
   // Prevent garbage/invalid training data from being uploaded to server.
   if (total_n <= 0.0f) throw Exception("Search generated invalid data!");
   // Set illegal moves to have -1 probability.
-  for (auto& probability : result.probabilities) {
-    probability = -1;
-  }
+  std::fill(std::begin(result.probabilities), std::end(result.probabilities), -1);
+  // Set moves probabilities according to their relative amount of visits.
   for (const auto& child : Edges()) {
     result.probabilities[child.edge()->GetMove().as_nn_index()] =
         child.GetN() / total_n;


### PR DESCRIPTION
Set probabilities for illegal moves in a loop instead of using std::memset.
`std::memset(result.probabilities, -1, sizeof(result.probabilities));` is setting all bytes in `result.probabilites` as `0xffffffff`.