### PR TITLE
Check for null parent in search backup.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1301,6 +1301,9 @@ void SearchWorker::DoBackupUpdateSingleNode(
     }
     n->FinalizeScoreUpdate(v, d, node_to_process.multivisit);
 
+    // Nothing left to do without ancestors to update.
+    if (!p) break;
+
     // Convert parents to terminals except the root or those already converted.
     can_convert = can_convert && p != search_->root_node_ && !p->IsTerminal();
 


### PR DESCRIPTION
r?@mooskagh or @Tilps Fix a crash for FEN with no move history and no moves.

before
```
position fen 8/8/8/8/8/8/8/8 w - - 0 1
go nodes 1
Segmentation fault: 11

position fen 8/8/8/8/8/8/8/8 w - - 0 1 moves a1a1
go nodes 1
bestmove a1a1
```

after
```
position fen 8/8/8/8/8/8/8/8 w - - 0 1
go nodes 1
bestmove a1a1

position fen 8/8/8/8/8/8/8/8 w - - 0 1 moves a1a1
go nodes 1
bestmove a1a1
```