### PR TITLE
Prefer terminal wins (and avoid loss) when picking best children.

### DIFF
--- a/src/chess/callbacks.h
+++ b/src/chess/callbacks.h
@@ -67,6 +67,8 @@ struct ThinkingInfo {
   int nps = -1;
   // Hash fullness * 1000
   int hashfull = -1;
+  // Moves to mate.
+  optional<int> mate;
   // Win in centipawns.
   optional<int> score;
   // Number of successful TB probes (not the same as playouts ending in TB hit).

--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -247,7 +247,8 @@ void UciLoop::SendInfo(const std::vector<ThinkingInfo>& infos) {
     if (info.seldepth >= 0) res += " seldepth " + std::to_string(info.seldepth);
     if (info.time >= 0) res += " time " + std::to_string(info.time);
     if (info.nodes >= 0) res += " nodes " + std::to_string(info.nodes);
-    if (info.score) res += " score cp " + std::to_string(*info.score);
+    if (info.mate) res += " score mate " + std::to_string(*info.mate);
+    else if (info.score) res += " score cp " + std::to_string(*info.score);
     if (info.hashfull >= 0) res += " hashfull " + std::to_string(info.hashfull);
     if (info.nps >= 0) res += " nps " + std::to_string(info.nps);
     if (info.tb_hits >= 0) res += " tbhits " + std::to_string(info.tb_hits);

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -349,6 +349,7 @@ void EngineController::Go(const GoParams& params) {
         for (const auto& info : infos) {
           if (info.multipv <= 1) {
             ponder_info = info;
+            if (ponder_info.mate) ponder_info.mate = -*ponder_info.mate;
             if (ponder_info.score) ponder_info.score = -*ponder_info.score;
             if (ponder_info.depth > 1) ponder_info.depth--;
             if (ponder_info.seldepth > 1) ponder_info.seldepth--;

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -234,7 +234,9 @@ void Node::MakeNotTerminal() {
   is_terminal_ = false;
   n_ = 0;
 
-  // If we have edges, we've been extended (1 visit), so include children too.
+  // If a child exists on a terminal, this node was previously extended (1
+  // visit), so include children for recalculation too. Otherwise, treat this
+  // node as unvisited to populate from NN computations (including policy data).
   if (child_) {
     n_++;
     for (const auto& child : Edges()) {
@@ -388,6 +390,57 @@ V4TrainingData Node::GetV4TrainingData(GameResult game_result,
 /////////////////////////////////////////////////////////////////////////
 // EdgeAndNode
 /////////////////////////////////////////////////////////////////////////
+
+namespace {
+// Placeholder plies to differentiate actual game end and tablebase.
+const int kTablebaseTerminalPlies = 999;
+
+// Recursively count terminal edges to reach true terminal.
+int CountPliesToTrueTerminal(Node* terminal) {
+  auto ret = 0;
+
+  // Follow "terminals" until a true terminal with no children.
+  if (terminal->HasChildren()) {
+    const auto follow_q = -terminal->GetQ();
+    std::vector<int> plies;
+    for (auto edge : terminal->Edges()) {
+      if (edge.IsTerminal() && edge.GetQ(0.0f) == follow_q) {
+        plies.push_back(CountPliesToTrueTerminal(edge.node()));
+      }
+    }
+
+    // No terminal children, so we have a tablebase position.
+    if (plies.empty()) {
+      ret = kTablebaseTerminalPlies;
+    } else if (follow_q == 1.0f) {
+      // Minimize plies for winning moves.
+      ret = *std::min_element(std::begin(plies), std::end(plies));
+    } else if (follow_q == -1.0f) {
+      // Maximize plies for losing moves.
+      ret = *std::max_element(std::begin(plies), std::end(plies));
+    }
+  }
+
+  // Include the current move in the ply count.
+  return ret + 1;
+}
+}  // namespace
+
+int EdgeAndNode::GetMovesTillCheckmate() const {
+  auto Q = GetQ(0.0f);
+  if (!IsTerminal() || !Q) return 0;
+  return std::copysign((CountPliesToTrueTerminal(node_) + 1) / 2, Q);
+}
+
+int EdgeAndNode::GetTerminalSortingKey() const {
+  auto moves = GetMovesTillCheckmate();
+  if (moves) {
+    // Give shortest winning moves the highest score then tablebase wins while
+    // also avoiding shortest losing moves.
+    moves = std::copysign(kTablebaseTerminalPlies * 2, moves) - moves;
+  }
+  return moves;
+}
 
 std::string EdgeAndNode::DebugString() const {
   if (!edge_) return "(no edge)";

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -235,7 +235,7 @@ void Node::MakeNotTerminal() {
   n_ = 0;
 
   // If we have edges, we've been extended (1 visit), so include children too.
-  if (edges_) {
+  if (child_) {
     n_++;
     for (const auto& child : Edges()) {
       const auto n = child.GetN();

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -329,6 +329,8 @@ class EdgeAndNode {
   bool operator!=(const EdgeAndNode& other) const {
     return edge_ != other.edge_;
   }
+  // Arbitrary ordering just to make it possible to use in tuples.
+  bool operator<(const EdgeAndNode& other) const { return edge_ < other.edge_; }
   bool HasNode() const { return node_ != nullptr; }
   Edge* edge() const { return edge_; }
   Node* node() const { return node_; }
@@ -370,6 +372,10 @@ class EdgeAndNode {
         std::min(std::floor(GetP() * numerator / (target_score - q) - n1) + 1,
                  1e9f));
   }
+
+  // Helpers to determine which terminals to prefer.
+  int GetMovesTillCheckmate() const;
+  int GetTerminalSortingKey() const;
 
   std::string DebugString() const;
 

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -329,8 +329,6 @@ class EdgeAndNode {
   bool operator!=(const EdgeAndNode& other) const {
     return edge_ != other.edge_;
   }
-  // Arbitrary ordering just to make it possible to use in tuples.
-  bool operator<(const EdgeAndNode& other) const { return edge_ < other.edge_; }
   bool HasNode() const { return node_ != nullptr; }
   Edge* edge() const { return edge_; }
   Node* node() const { return node_; }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -126,7 +126,10 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
     ++multipv;
     uci_infos.emplace_back(common_info);
     auto& uci_info = uci_infos.back();
-    if (score_type == "centipawn") {
+    const auto mate = scored.GetMate();
+    if (mate) {
+      uci_info.mate = mate;
+    } else if (score_type == "centipawn") {
       uci_info.score = 295 * edge.GetQ(default_q) /
                        (1 - 0.976953126 * std::pow(edge.GetQ(default_q), 14));
     } else if (score_type == "centipawn_2018") {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -121,7 +121,8 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
 
   int multipv = 0;
   const auto default_q = -root_node_->GetQ();
-  for (const auto& edge : edges) {
+  for (const auto& scored : edges) {
+    const auto& edge = scored.edge;
     ++multipv;
     uci_infos.emplace_back(common_info);
     auto& uci_info = uci_infos.back();
@@ -540,18 +541,19 @@ void Search::EnsureBestMoveKnown() REQUIRES(nodes_mutex_)
 }
 
 // Returns @count children with most visits.
-std::vector<EdgeAndNode> Search::GetBestChildrenNoTemperature(Node* parent,
-                                                              int count) const {
+std::vector<Search::TerminalScore> Search::GetBestChildrenNoTemperature(
+    Node* parent, int count) const {
   MoveList root_limit;
   if (parent == root_node_) {
     PopulateRootMoveLimit(&root_limit);
   }
   // Best child is selected using the following criteria:
+  // * Best terminal score (favor wins, avoid losses).
   // * Largest number of playouts.
   // * If two nodes have equal number:
   //   * If that number is 0, the one with larger prior wins.
   //   * If that number is larger than 0, the one with larger eval wins.
-  using El = std::tuple<uint64_t, float, float, EdgeAndNode>;
+  using El = std::tuple<TerminalScore, uint64_t, float, float>;
   std::vector<El> edges;
   for (auto edge : parent->Edges()) {
     if (parent == root_node_ && !root_limit.empty() &&
@@ -559,23 +561,24 @@ std::vector<EdgeAndNode> Search::GetBestChildrenNoTemperature(Node* parent,
             root_limit.end()) {
       continue;
     }
-    edges.emplace_back(edge.GetN(), edge.GetQ(0), edge.GetP(), edge);
+    edges.emplace_back(TerminalScore(edge), edge.GetN(), edge.GetQ(0),
+                       edge.GetP());
   }
   const auto middle = (static_cast<int>(edges.size()) > count)
                           ? edges.begin() + count
                           : edges.end();
   std::partial_sort(edges.begin(), middle, edges.end(), std::greater<El>());
 
-  std::vector<EdgeAndNode> res;
+  std::vector<TerminalScore> res;
   std::transform(edges.begin(), middle, std::back_inserter(res),
-                 [](const El& x) { return std::get<3>(x); });
+                 [](const El& x) { return std::get<0>(x); });
   return res;
 }
 
 // Returns a child with most visits.
 EdgeAndNode Search::GetBestChildNoTemperature(Node* parent) const {
   auto res = GetBestChildrenNoTemperature(parent, 1);
-  return res.empty() ? EdgeAndNode() : res.front();
+  return res.empty() ? EdgeAndNode() : res.front().edge;
 }
 
 // Returns a child chosen according to weighted-by-temperature visit count.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -914,7 +914,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
       return NodeToProcess::Collision(node, depth, collision_limit);
     }
     // Either terminal or unexamined leaf node -- the end of this playout.
-    if (node->IsTerminal() || !node->HasChildren()) {
+    if (node->IsTerminal() || !node->GetN()) {
       return NodeToProcess::Visit(node, depth);
     }
     Node* possible_shortcut_child = node->GetCachedBestChild();
@@ -1067,7 +1067,6 @@ void SearchWorker::ExtendNode(Node* node) {
           node->MakeTerminal(GameResult::DRAW);
         }
         search_->tb_hits_.fetch_add(1, std::memory_order_acq_rel);
-        return;
       }
     }
   }

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -115,6 +115,7 @@ class Search {
     bool operator<(const TerminalScore& other) const {
       return score_ < other.score_;
     }
+    int GetMate() const { return std::copysign((plies_ + 1) / 2, score_); }
 
    private:
     float score_ = 0.0f;

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -100,13 +100,12 @@ class Search {
   // Computes the best move, maybe with temperature (according to the settings).
   void EnsureBestMoveKnown();
 
-  class TerminalScore;
   // Returns a child with most visits, with or without temperature.
   // NoTemperature is safe to use on non-extended nodes, while WithTemperature
   // accepts only nodes with at least 1 visited child.
   EdgeAndNode GetBestChildNoTemperature(Node* parent) const;
-  std::vector<TerminalScore> GetBestChildrenNoTemperature(Node* parent,
-                                                          int count) const;
+  std::vector<EdgeAndNode> GetBestChildrenNoTemperature(Node* parent,
+                                                        int count) const;
   EdgeAndNode GetBestChildWithTemperature(Node* parent,
                                           float temperature) const;
 
@@ -195,22 +194,6 @@ class Search {
   const SearchParams params_;
 
   friend class SearchWorker;
-};
-
-// Helper to score and sort terminals for preferred moves.
-class Search::TerminalScore {
- public:
-  EdgeAndNode edge;
-
-  TerminalScore(EdgeAndNode edge);
-  bool operator<(const TerminalScore& other) const;
-  int GetMate() const { return std::copysign((plies_ + 1) / 2, score_); }
-
- private:
-  float score_ = 0.0f;
-  int plies_ = 0;
-
-  static int CalcPlies(Node* terminal);
 };
 
 // Single thread worker of the search engine.

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -97,6 +97,23 @@ class Search {
   const SearchParams& GetParams() const { return params_; }
 
  private:
+  // Helper to score and sort terminals for preferred moves.
+  struct TerminalScore {
+    EdgeAndNode edge;
+
+    TerminalScore(EdgeAndNode edge) : edge(edge) {
+      if (edge.IsTerminal()) {
+        score_ = edge.GetQ(0.0f);
+      }
+    }
+    bool operator<(const TerminalScore& other) const {
+      return score_ < other.score_;
+    }
+
+   private:
+    float score_ = 0.0f;
+  };
+
   // Computes the best move, maybe with temperature (according to the settings).
   void EnsureBestMoveKnown();
 
@@ -104,8 +121,8 @@ class Search {
   // NoTemperature is safe to use on non-extended nodes, while WithTemperature
   // accepts only nodes with at least 1 visited child.
   EdgeAndNode GetBestChildNoTemperature(Node* parent) const;
-  std::vector<EdgeAndNode> GetBestChildrenNoTemperature(Node* parent,
-                                                        int count) const;
+  std::vector<TerminalScore> GetBestChildrenNoTemperature(Node* parent,
+                                                          int count) const;
   EdgeAndNode GetBestChildWithTemperature(Node* parent,
                                           float temperature) const;
 

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -103,9 +103,10 @@ class Search {
   // Returns a child with most visits, with or without temperature.
   // NoTemperature is safe to use on non-extended nodes, while WithTemperature
   // accepts only nodes with at least 1 visited child.
-  EdgeAndNode GetBestChildNoTemperature(Node* parent) const;
-  std::vector<EdgeAndNode> GetBestChildrenNoTemperature(Node* parent,
-                                                        int count) const;
+  EdgeAndNode GetBestChildNoTemperature(Node* parent,
+                                        bool calcTerm = false) const;
+  std::vector<EdgeAndNode> GetBestChildrenNoTemperature(Node* parent, int count,
+                                                        bool calcTerm) const;
   EdgeAndNode GetBestChildWithTemperature(Node* parent,
                                           float temperature) const;
 


### PR DESCRIPTION
r?@mooskagh Fix #837. Favor shorter checkmates then longer mates then shorter tablebase wins then … then longer losses then shorter losses then lastly checkmated. Adds a helper `struct TerminalScore` to sort children. Also reports `score mate` instead of `score cp` for terminal wins and losses.

~Not quite #837 but if there's only one mate found, it's quite likely to be the shortest mate as search didn't need to explore more to find deeper mates. But very much dependent on the network if it prefers some moves over others. E.g.,~

![Screen Shot 2019-06-13 at 3 20 19 PM](https://user-images.githubusercontent.com/438537/59471189-3bb61680-8def-11e9-84b3-6762aed8d087.png)
```
./lc0 -w 42100 --verbose-move-stats --smart-pruning-factor=0 --no-syzygy-fast-play --minibatch-size=1
position fen 8/8/8/3Q4/k7/8/2K5/8 w - - 0 1
```


before:
```
go nodes 100
nodes 100 score cp 4532 hashfull 0 nps 90 tbhits 2 pv d5d8 a4b5 d8d7 b5c4 d7e7 c4d5 e7d8
…
c2c3 N:       0 P:  2.00% Q:  0.28611 
…
d5b7 N:       0 P:  2.34% Q:  0.28611 
…
d5d8 N:      59 P: 20.96% Q:  0.99688 
bestmove d5d8 ponder a4b5


go nodes 1000
nodes 1000 score cp 4780 hashfull 3 nps 242 tbhits 2 pv d5d8 a4b5 d8d7 b5c5 d7e7 c5c4 e7d8
…
c2c3 N:      21 P:  2.00% Q:  1.00000 (T) 
…
d5b7 N:      24 P:  2.34% Q:  0.99717 
…
d5d8 N:     221 P: 20.96% Q:  0.99713 
bestmove d5d8 ponder a4b5


go nodes 10000
nodes 10000 score cp 4692 hashfull 12 nps 737 tbhits 2 pv d5d8 a4b5 d8b8 b5a6 b8c8 a6b5 c8d8 b5a6
…
c2c3 N:     227 P:  2.00% Q:  1.00000 (T) 
…
d5b7 N:     266 P:  2.34% Q:  1.00000 (T) 
…
d5d8 N:    2191 P: 20.96% Q:  0.99705 
bestmove d5d8 ponder a4b5
```
after:
```

go nodes 100
nodes 100 score cp 4542 hashfull 0 nps 69 tbhits 2 pv d5d8 a4b5 d8d7 b5c4 d7e7 c4d5 e7d8
…
c2c3 N:       0 P:  2.00% Q:  0.28608 
…
d5b7 N:       0 P:  2.34% Q:  0.28608 
…
d5d8 N:      59 P: 20.96% Q:  0.99689 
bestmove d5d8 ponder a4b5


go nodes 1000
nodes 1000 score mate 2 hashfull 3 nps 204 tbhits 2 pv c2c3 a4a3 d5a8
…
c2c3 N:      21 P:  2.00% Q:  1.00000 (T) 
…
d5b7 N:      24 P:  2.34% Q:  0.99716 
…
d5d8 N:     221 P: 20.96% Q:  0.99712 
bestmove c2c3 ponder a4a3


go nodes 10000
nodes 10000 score mate 2 hashfull 12 nps 663 tbhits 2 pv c2c3 a4a3 d5a8
…
c2c3 N:     227 P:  2.00% Q:  1.00000 (T) 
…
d5b7 N:     266 P:  2.34% Q:  1.00000 (T) 
…
d5d8 N:    2191 P: 20.96% Q:  0.99706 
bestmove c2c3 ponder a4a3
```
