### PR TITLE
Add syzygy tablebases for use with selfplay

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -132,6 +132,7 @@ files += [
   'src/mcts/stoppers/factory.cc',
   'src/mcts/stoppers/legacy.cc',
   'src/mcts/stoppers/smooth.cc',
+  'src/mcts/stoppers/alphazero.cc',
   'src/mcts/stoppers/stoppers.cc',
   'src/mcts/stoppers/timemgr.cc',
   'src/neural/cache.cc',

--- a/src/mcts/stoppers/alphazero.cc
+++ b/src/mcts/stoppers/alphazero.cc
@@ -1,0 +1,100 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2020 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#include "mcts/stoppers/stoppers.h"
+
+namespace lczero {
+
+namespace {
+
+class AlphazeroStopper : public TimeLimitStopper {
+ public:
+  AlphazeroStopper(int64_t deadline_ms, int64_t* time_piggy_bank)
+      : TimeLimitStopper(deadline_ms), time_piggy_bank_(time_piggy_bank) {}
+  virtual void OnSearchDone(const IterationStats& stats) override {
+    *time_piggy_bank_ += GetTimeLimitMs() - stats.time_since_movestart;
+  }
+
+ private:
+  int64_t* const time_piggy_bank_;
+};
+
+class AlphazeroTimeManager : public TimeManager {
+ public:
+  AlphazeroTimeManager(int64_t move_overhead, const OptionsDict& params)
+      : move_overhead_(move_overhead),
+        alphazerotimevalue_(params.GetOrDefault<float>("alphazero-time-value", 20.0f)),
+        spend_saved_time_(params.GetOrDefault<float>("immediate-use", 1.0f)) {}
+  std::unique_ptr<SearchStopper> GetStopper(const GoParams& params,
+                                            const Position& position) override;
+
+ private:
+  const int64_t move_overhead_;
+  const float alphazerotimevalue_;
+  const float spend_saved_time_;
+  // No need to be atomic as only one thread will update it.
+  int64_t time_spared_ms_ = 0;
+};
+
+std::unique_ptr<SearchStopper> AlphazeroTimeManager::GetStopper(
+    const GoParams& params, const Position& position) {
+  const bool is_black = position.IsBlackToMove();
+  std::optional<int64_t> time = (is_black ? params.btime : params.wtime);
+  // If no time limit is given, don't stop on this condition.
+  if (params.infinite || params.ponder || !time) return nullptr;
+
+  std::optional<int64_t> inc = is_black ? params.binc : params.winc;
+  const int increment = inc ? std::max(int64_t(0), *inc) : 0;
+
+  // How to scale moves time.
+  float this_move_time = 1.0f;
+  int time_to_squander = 0;
+
+  auto total_moves_time = *time - move_overhead_;
+  this_move_time =
+      increment +
+      (total_moves_time / alphazerotimevalue_);
+
+  LOGFILE << "Budgeted time for the move: " << this_move_time << "ms(+"
+          << time_to_squander << "ms to squander). Remaining time " << *time
+          << "ms(-" << move_overhead_ << "ms overhead)";
+  // Use `time_to_squander` time immediately.
+  this_move_time += time_to_squander;
+
+  // Make sure we don't exceed current time limit with what we calculated.
+  auto deadline =
+      std::min(static_cast<int64_t>(this_move_time), *time - move_overhead_);
+  return std::make_unique<AlphazeroStopper>(deadline, &time_spared_ms_);
+}
+
+}  // namespace
+
+std::unique_ptr<TimeManager> MakeAlphazeroTimeManager(int64_t move_overhead,
+                                                   const OptionsDict& params) {
+  return std::make_unique<AlphazeroTimeManager>(move_overhead, params);
+}
+}  // namespace lczero

--- a/src/mcts/stoppers/alphazero.h
+++ b/src/mcts/stoppers/alphazero.h
@@ -1,0 +1,37 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2020 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#pragma once
+
+#include "utils/optionsdict.h"
+
+namespace lczero {
+
+std::unique_ptr<TimeManager> MakeAlphazeroTimeManager(int64_t move_overhead,
+                                                   const OptionsDict& params);
+
+}  // namespace lczero

--- a/src/mcts/stoppers/factory.cc
+++ b/src/mcts/stoppers/factory.cc
@@ -46,17 +46,10 @@ const OptionId kMoveOverheadId{
     "communication, etc)."};
 const OptionId kTimeManagerId{
     "time-manager", "TimeManager",
-    "Name and config of atime manager. "
-    "Default is 'legacy'. "
-    "Optional time manager is 'alphazero' "
-    "'alphazero' Makes the engine use AlphaZero time. The alphazero engine always "
-    "budgeted 5 percent of total time left for the first upcoming move, "
-    "Remaining time is divided by value `alphazero-time-value`. "
-    "Default value of 20 uses (all time / 20 = 5%) 5 percent of all remaining time. "
-    "Lower values will spend more time in beginning of game, higher values "
-    "will save more time for later in the game." 
-    "Configure as `--time-manager=alphazero(alphazero-time-value=10) "
-    "to go to (all time / 10 = 10%) ten percent of all remaining time per move"};
+    "Name and config of a time manager. "
+    "Default is 'legacy'. Optional time manager is 'alphazero' "
+    "Please see http://lczero.org/dev/docs/timemgr for more information"
+    "on configuring the time managers outside of default used values"};
 }  // namespace
 
 void PopulateTimeManagementOptions(RunType for_what, OptionsParser* options) {

--- a/src/mcts/stoppers/factory.cc
+++ b/src/mcts/stoppers/factory.cc
@@ -44,29 +44,26 @@ const OptionId kMoveOverheadId{
     "Amount of time, in milliseconds, that the engine subtracts from it's "
     "total available time (to compensate for slow connection, interprocess "
     "communication, etc)."};
-const OptionId kTimeManagerId{"time-manager", "TimeManager",
-                              "Name and config of atime manager."};
-const OptionId kAlphazeroTimeManagerId{"alphazero", "Alphazero",
-    "Makes the engine use AlphaZero time. The alphazero engine always "
+const OptionId kTimeManagerId{
+    "time-manager", "TimeManager",
+    "Name and config of atime manager. "
+    "Default is 'legacy'. "
+    "Optional time manager is 'alphazero' "
+    "'alphazero' Makes the engine use AlphaZero time. The alphazero engine always "
     "budgeted 5 percent of total time left for the first upcoming move, "
-    "thereby "
-    "gradually taking less time for each consecutive move in the game.."};
-const OptionId kAlphazeroTimeValueId{
-    "alphazero-time-value", "AlphazeroTimeValue",
-    "Remaining time is divided by this value. Default value of 20 uses "
-    "alphazero time."
+    "Remaining time is divided by value `alphazero-time-value`. "
+    "Default value of 20 uses (all time / 20 = 5%) 5 percent of all remaining time. "
     "Lower values will spend more time in beginning of game, higher values "
-    "will save more time"
-    "for later in the game"};
+    "will save more time for later in the game." 
+    "Configure as `--time-manager=alphazero(alphazero-time-value=10) "
+    "to go to (all time / 10 = 10%) ten percent of all remaining time per move"};
 }  // namespace
 
 void PopulateTimeManagementOptions(RunType for_what, OptionsParser* options) {
   PopulateCommonStopperOptions(for_what, options);
   if (for_what == RunType::kUci) {
     options->Add<IntOption>(kMoveOverheadId, 0, 100000000) = 200;
-    options->Add<FloatOption>(kAlphazeroTimeValueId, 2.0f, 100.0f) = 20.0f;
     options->Add<StringOption>(kTimeManagerId) = "legacy";
-    options->Add<StringOption>(kAlphazeroTimeManagerId) = "alphazero";
   }
 }
 
@@ -91,6 +88,7 @@ std::unique_ptr<TimeManager> MakeTimeManager(const OptionsDict& options) {
     time_manager = MakeSmoothTimeManager(
         move_overhead, tm_options.GetSubdict("smooth-experimental"));
   } else if (managers[0] == options.Get<std::string>(kAlphazeroTimeManagerId)) {
+  } else if (managers[0] == "alphazero") {
     time_manager = MakeAlphazeroTimeManager(move_overhead,
                                             tm_options.GetSubdict("alphazero"));
   }

--- a/src/mcts/stoppers/factory.cc
+++ b/src/mcts/stoppers/factory.cc
@@ -32,6 +32,7 @@
 #include "factory.h"
 #include "mcts/stoppers/legacy.h"
 #include "mcts/stoppers/smooth.h"
+#include "mcts/stoppers/alphazero.h"
 #include "mcts/stoppers/stoppers.h"
 #include "utils/exception.h"
 
@@ -45,14 +46,27 @@ const OptionId kMoveOverheadId{
     "communication, etc)."};
 const OptionId kTimeManagerId{"time-manager", "TimeManager",
                               "Name and config of atime manager."};
-
+const OptionId kAlphazeroTimeManagerId{"alphazero", "Alphazero",
+    "Makes the engine use AlphaZero time. The alphazero engine always "
+    "budgeted 5 percent of total time left for the first upcoming move, "
+    "thereby "
+    "gradually taking less time for each consecutive move in the game.."};
+const OptionId kAlphazeroTimeValueId{
+    "alphazero-time-value", "AlphazeroTimeValue",
+    "Remaining time is divided by this value. Default value of 20 uses "
+    "alphazero time."
+    "Lower values will spend more time in beginning of game, higher values "
+    "will save more time"
+    "for later in the game"};
 }  // namespace
 
 void PopulateTimeManagementOptions(RunType for_what, OptionsParser* options) {
   PopulateCommonStopperOptions(for_what, options);
   if (for_what == RunType::kUci) {
     options->Add<IntOption>(kMoveOverheadId, 0, 100000000) = 200;
+    options->Add<FloatOption>(kAlphazeroTimeValueId, 2.0f, 100.0f) = 20.0f;
     options->Add<StringOption>(kTimeManagerId) = "legacy";
+    options->Add<StringOption>(kAlphazeroTimeManagerId) = "alphazero";
   }
 }
 
@@ -61,6 +75,7 @@ std::unique_ptr<TimeManager> MakeTimeManager(const OptionsDict& options) {
 
   OptionsDict tm_options;
   tm_options.AddSubdictFromString(options.Get<std::string>(kTimeManagerId));
+  
   const auto managers = tm_options.ListSubdicts();
 
   std::unique_ptr<TimeManager> time_manager;
@@ -68,13 +83,18 @@ std::unique_ptr<TimeManager> MakeTimeManager(const OptionsDict& options) {
     throw Exception("Exactly one time manager should be specified, " +
                     std::to_string(managers.size()) + " specified instead.");
   }
+  
   if (managers[0] == "legacy") {
     time_manager =
         MakeLegacyTimeManager(move_overhead, tm_options.GetSubdict("legacy"));
   } else if (managers[0] == "smooth-experimental") {
     time_manager = MakeSmoothTimeManager(
         move_overhead, tm_options.GetSubdict("smooth-experimental"));
+  } else if (managers[0] == options.Get<std::string>(kAlphazeroTimeManagerId)) {
+    time_manager = MakeAlphazeroTimeManager(move_overhead,
+                                            tm_options.GetSubdict("alphazero"));
   }
+  
   if (!time_manager) {
     throw Exception("Unknown time manager: [" + managers[0] + "]");
   }


### PR DESCRIPTION
Add syzygy tablebases to use these for selfplay games.

The goal is to save time in training and game matches: for example when contributing to leela-training and matches I've seen games prolong between KRvsKR for 200+ moves, just wasting CPU/GPU cycles.
So the goal here is to use tablebases when those exists for clients; it should just use the tablebases available on your system even if that's only 4 or 5 pieces instead of 6 or 7 piece TB.

Seems to work when starting lco as follows:
lc0 selfplay --visits=800 --syzygy-paths=c:\path_to\tablebases

After this is merged, we probably also need to enable the go-client to pass on the syzygy-path from commandline to lc0 so that local installed client tablebases are indeed being used. 