### PR TITLE
Fix macOS meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -235,7 +235,6 @@ if get_option('build_backends')
       has_blas = true
 
     elif get_option('accelerate') and accelerate_lib.found()
-      includes += include_directories('/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Headers')
       deps += [ accelerate_lib ]
       has_blas = true
 
@@ -360,7 +359,9 @@ if get_option('build_backends')
     'src/neural/shared/winograd_filter.cc',
     ]
 
-    includes += include_directories(get_option('opencl_include'))
+    if not opencl_framework.found()
+      includes += include_directories(get_option('opencl_include'))
+    endif
     files += opencl_files
     has_backends = true
 


### PR DESCRIPTION
This commit solves a problem with building lc0 from sources on macOS Mojave 10.14.6:

$ meson mkl1 --buildtype=release -Ddefault_library=static
The Meson build system
Version: 0.51.1
Source dir: /Users/andreas/projects/lc0
Build dir: /Users/andreas/projects/lc0/mkl1
Build type: native build
DEPRECATION: Option uses prefix "build_", which is reserved for Meson. This will become an error in the future.
Project name: lc0
Project version: undefined
C++ compiler for the build machine: c++ (clang 10.0.1 "Apple LLVM version 10.0.1 (clang-1001.0.46.4)")
C++ compiler for the host machine: c++ (clang 10.0.1 "Apple LLVM version 10.0.1 (clang-1001.0.46.4)")
Build machine cpu family: x86_64
Build machine cpu: x86_64
Library libprotobuf found: NO
Found pkg-config: /usr/local/bin/pkg-config (0.29.2)
Run-time dependency protobuf found: YES 3.7.1
Program protoc found: YES (/usr/local/bin/protoc)
Library pthread found: YES
Library dl found: YES
Library libtensorflow_cc found: NO
Found CMake: /usr/local/bin/cmake (3.15.0)
Run-time dependency accelerate found: YES (/Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/Accelerate.framework)
Library mkl_rt found: NO
Library mklml found: YES
Library openblas.dll found: NO
Library openblas found: NO
Program ispc found: YES (/usr/local/bin/ispc)
Library OpenCL found: NO
Run-time dependency opencl found: YES (/Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/OpenCL.framework)

meson.build:330:4: ERROR: Include dir /usr/include/ does not exist.
