### PR TITLE
Fix policy softmax accuracy if masking is enabled.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1235,10 +1235,20 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
   node_to_process->v = -computation_->GetQVal(idx_in_computation);
   node_to_process->d = computation_->GetDVal(idx_in_computation);
   // ...and secondly, the policy data.
+  // Calculate maximum first.
+  float max_p = -std::numeric_limits<float>::infinity();
+  for (auto edge : node->Edges()) {
+    max_p =
+        std::max(max_p, computation_->GetPVal(idx_in_computation,
+                                              edge.GetMove().as_nn_index()));
+  }
   float total = 0.0;
   for (auto edge : node->Edges()) {
     float p =
         computation_->GetPVal(idx_in_computation, edge.GetMove().as_nn_index());
+    // Perform softmax.
+    p = std::exp(p - max_p);
+
     if (params_.GetPolicySoftmaxTemp() != 1.0f) {
       // Flush denormals to zero.
       p = p < 1.17549435E-38

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1250,6 +1250,8 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
     // Note that we want to calculate (exp(p-max_p))^(1/T) = exp((p-max_p)/T).
     p = FastExp((p - max_p) / params_.GetPolicySoftmaxTemp());
 
+    // Note that p now lies in [0, 1], so it is safe to store it in compressed
+    // format. Normalization happens later.
     edge.edge()->SetP(p);
     // Edge::SetP does some rounding, so only add to the total after rounding.
     total += edge.edge()->GetP();

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1247,7 +1247,7 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
     float p =
         computation_->GetPVal(idx_in_computation, edge.GetMove().as_nn_index());
     // Perform softmax.
-    p = std::exp(p - max_p);
+    p = FastExp(p - max_p);
 
     if (params_.GetPolicySoftmaxTemp() != 1.0f) {
       // Flush denormals to zero.

--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -303,9 +303,8 @@ void BlasComputation::ComputeBlocking() {
       std::vector<float> policy(num_output_policy);
 
       // Get the moves
-      SoftmaxActivation(num_output_policy, &output_pol[j * num_output_policy],
-                        policy.data());
-
+      policy.assign(output_pol.begin() + j * num_output_policy,
+                    output_pol.begin() + (j + 1) * num_output_policy);
       policies_.emplace_back(std::move(policy));
     }
 
@@ -418,8 +417,8 @@ BlasNetwork::BlasNetwork(const WeightsFile& file, const OptionsDict& options)
   CERR << "MKL " << versionbuf << ".";
   MKLVersion version;
   mkl_get_version(&version);
-  CERR << "MKL platform: " << version.Platform << ", processor: "
-       << version.Processor << ".";
+  CERR << "MKL platform: " << version.Platform
+       << ", processor: " << version.Processor << ".";
   CERR << "MKL can use up to " << max_procs << " thread(s).";
   CERR << "MKL using " << blas_cores << " thread(s) for this backend.";
 #endif

--- a/src/neural/network_random.cc
+++ b/src/neural/network_random.cc
@@ -78,9 +78,15 @@ class RandomNetworkComputation : public NetworkComputation {
 
   float GetPVal(int sample, int move_id) const override {
     if (uniform_mode_) return 1.0f;
+
+    // Note that this function returns the policy value *before* softmax.
+    // We choose a uniform distribution over [0; a], implying that the
+    // proportion between the smallest and largest policy value *after* softmax
+    // is equal to S = exp(-a). Choosing a = 3.0 leads to S = 0.05.
+    const float a = 3.0f;
     return (HashCat({inputs_[sample], static_cast<unsigned long>(move_id)}) %
-            10000) /
-           10000.0;
+            10000) *
+           (a / 10000.0f);
   }
 
  private:
@@ -97,7 +103,8 @@ class RandomNetwork : public Network {
         seed_(options.GetOrDefault<int>("seed", 0)),
         uniform_mode_(options.GetOrDefault<bool>("uniform", false)) {}
   std::unique_ptr<NetworkComputation> NewComputation() override {
-    return std::make_unique<RandomNetworkComputation>(delay_ms_, seed_, uniform_mode_);
+    return std::make_unique<RandomNetworkComputation>(delay_ms_, seed_,
+                                                      uniform_mode_);
   }
 
  private:

--- a/src/neural/network_random.cc
+++ b/src/neural/network_random.cc
@@ -80,9 +80,10 @@ class RandomNetworkComputation : public NetworkComputation {
     if (uniform_mode_) return 1.0f;
 
     // Note that this function returns the policy value *before* softmax.
-    // We choose a uniform distribution over [0; a], implying that the
+    // We choose a uniform distribution over [0, a], implying that the
     // proportion between the smallest and largest policy value *after* softmax
-    // is equal to S = exp(-a). Choosing a = 3.0 leads to S = 0.05.
+    // exponentiation (but before normalization) is equal to S = exp(-a).
+    // Choosing a = 3.0 leads to S = 0.05.
     const float a = 3.0f;
     return (HashCat({inputs_[sample], static_cast<unsigned long>(move_id)}) %
             10000) *

--- a/src/neural/network_tf.cc
+++ b/src/neural/network_tf.cc
@@ -144,7 +144,6 @@ std::pair<Output, Output> MakeNetwork(const Scope& scope, Input input,
   ip_pol_w = Reshape(scope, ip_pol_w, Const(scope, {32 * 8 * 8, 1858}));
   auto ip_pol_b = MakeConst(scope, {1858}, weights.ip_pol_b);
   auto policy_fc = Add(scope, MatMul(scope, conv_pol, ip_pol_w), ip_pol_b);
-  auto policy_head = Softmax(scope, policy_fc);
 
   // Value head
   auto conv_val =
@@ -163,7 +162,7 @@ std::pair<Output, Output> MakeNetwork(const Scope& scope, Input input,
   auto value_head =
       Tanh(scope, Add(scope, MatMul(scope, value_flow, ip2_val_w), ip2_val_b));
 
-  return {policy_head, value_head};
+  return {policy_fc, value_head};
 }
 
 template <bool CPU>

--- a/src/neural/opencl/network_opencl.cc
+++ b/src/neural/opencl/network_opencl.cc
@@ -102,12 +102,11 @@ class OpenCLComputation : public NetworkComputation {
       buffers_->forward(input_data, output_pol, output_val, batch_size);
 
       for (size_t j = 0; j < batch_size; j++) {
-        std::vector<float> policy(weights_.num_output_policies);
+        std::vector<float> policy(num_output_policies);
 
         // Get the moves.
-        SoftmaxActivation(num_output_policies,
-                          &output_pol[j * num_output_policies], policy.data());
-
+        policy.assign(output_pol.begin() + j * num_output_policies,
+                      output_pol.begin() + (j + 1) * num_output_policies);
         policies_.emplace_back(std::move(policy));
 
         // Now get the score.

--- a/src/utils/fastmath.h
+++ b/src/utils/fastmath.h
@@ -65,4 +65,7 @@ inline float FastLog(const float a) {
   return 0.6931471805599453f * FastLog2(a);
 }
 
+// Fast approximate exp(x). Does only limited range checking.
+inline float FastExp(const float a) { return FastPow2(1.442695040f * a); }
+
 }  // namespace lczero

--- a/src/utils/fastmath.h
+++ b/src/utils/fastmath.h
@@ -65,7 +65,10 @@ inline float FastLog(const float a) {
   return 0.6931471805599453f * FastLog2(a);
 }
 
-// Fast approximate exp(x). Does only limited range checking.
-inline float FastExp(const float a) { return FastPow2(1.442695040f * a); }
+// Fast approximate exp(x).
+inline float FastExp(const float a) {
+  return (a < 0) ? 1.0f / FastPow2(-1.442695040f * a)
+                 : FastPow2(1.442695040f * a);
+}
 
 }  // namespace lczero

--- a/src/utils/fastmath.h
+++ b/src/utils/fastmath.h
@@ -65,10 +65,7 @@ inline float FastLog(const float a) {
   return 0.6931471805599453f * FastLog2(a);
 }
 
-// Fast approximate exp(x).
-inline float FastExp(const float a) {
-  return (a < 0) ? 1.0f / FastPow2(-1.442695040f * a)
-                 : FastPow2(1.442695040f * a);
-}
+// Fast approximate exp(x). Does only limited range checking.
+inline float FastExp(const float a) { return FastPow2(1.442695040f * a); }
 
 }  // namespace lczero


### PR DESCRIPTION
Perform policy softmax outside backends on set of legal moves.
This should fix the limited accuracy issues observed with CUDA backend FP16 in combination with policy masking enabled in training.

Blas backend has been tested.
Testing of CUDA and OpenCL backend much appreciated!