### PR TITLE
minimize max fastmath error considering float32 accuracy

### DIFF
--- a/src/utils/fastmath.h
+++ b/src/utils/fastmath.h
@@ -37,10 +37,8 @@ namespace lczero {
 // Fast approximate log2(x). Does no range checking.
 // The approximation used here is log2(2^N*(1+f)) ~ N+f*(1+k-k*f) where N is the
 // exponent and f the fraction (mantissa), f>=0. The constant k is used to tune
-// the approximation accuracy. Note that the formula used here is transformed to
-// use 1+f for speed reasons: log2(2^N*(1+f)) ~ N+(1+f)*(1+3*k-k*(1+f))-2*k-1.
-// In the final version some constants were slightly modified for better
-// accuracy with 32 bit floating point math.
+// the approximation accuracy. In the final version some constants were slightly
+// modified for better accuracy with 32 bit floating point math.
 inline float FastLog2(const float a) {
   uint32_t tmp;
   std::memcpy(&tmp, &a, sizeof(float));
@@ -48,8 +46,9 @@ inline float FastLog2(const float a) {
   tmp = (tmp & 0x7fffff) | (0x7f << 23);
   float out;
   std::memcpy(&out, &tmp, sizeof(float));
+  out -= 1.0f;
   // Minimize max relative error.
-  return out * (2.0672753f - 0.35575843f * out) - 128.71152f + expb;
+  return out * (1.3557554f - 0.35575548f * out) - 127 + expb;
 }
 
 // Fast approximate 2^x. Does only limited range checking.

--- a/src/utils/fastmath.h
+++ b/src/utils/fastmath.h
@@ -29,12 +29,18 @@
 
 #include <cstring>
 
+
+
 namespace lczero {
 // These stunts are performed by trained professionals, do not try this at home.
 
 // Fast approximate log2(x). Does no range checking.
-// The approximation used here is log2(2^N*(1+f)) ~ N+f*(1.342671-0.342671*f)
-// where N is the integer and f the fractional part, f>=0.
+// The approximation used here is log2(2^N*(1+f)) ~ N+f*(1+k-k*f) where N is the
+// exponent and f the fraction (mantissa), f>=0. The constant k is used to tune
+// the approximation accuracy. Note that the formula used here is transformed to
+// use 1+f for speed reasons: log2(2^N*(1+f)) ~ N+(1+f)*(1+3*k-k*(1+f))-2*k-1.
+// In the final version some constants were slightly modified for better
+// accuracy with 32 bit floating point math.
 inline float FastLog2(const float a) {
   uint32_t tmp;
   std::memcpy(&tmp, &a, sizeof(float));
@@ -42,17 +48,21 @@ inline float FastLog2(const float a) {
   tmp = (tmp & 0x7fffff) | (0x7f << 23);
   float out;
   std::memcpy(&out, &tmp, sizeof(float));
-  return out * (2.028011f - 0.342671f * out) - 128.68534f + expb;
+  // Minimize max relative error.
+  return out * (2.0672753f - 0.35575843f * out) - 128.71152f + expb;
 }
 
 // Fast approximate 2^x. Does only limited range checking.
-// The approximation used here is 2^(N+f) ~ 2^N*(1+f*(0.656366+0.343634*f))
-// where N is the integer and f the fractional part, f>=0.
+// The approximation used here is 2^(N+f) ~ 2^N*(1+f*(1-k+k*f)) where N is the
+// integer and f the fractional part, f>=0. The constant k is used to tune the
+// approximation accuracy. In the final version some constants were slightly
+// modified for better accuracy with 32 bit floating point math.
 inline float FastPow2(const float a) {
   if (a < -126) return 0.0;
   int32_t exp = floor(a);
   float out = a - exp;
-  out = 1.0f + out * (0.656366f + 0.343634f * out);
+  // Minimize max relative error.
+  out = 1.0f + out * (0.6602339f + 0.33976606f * out);
   int32_t tmp;
   std::memcpy(&tmp, &out, sizeof(float));
   tmp += static_cast<int32_t>(static_cast<uint32_t>(exp) << 23);

--- a/src/utils/fastmath.h
+++ b/src/utils/fastmath.h
@@ -47,8 +47,8 @@ inline float FastLog2(const float a) {
   float out;
   std::memcpy(&out, &tmp, sizeof(float));
   out -= 1.0f;
-  // Minimize max relative error.
-  return out * (1.3557554f - 0.35575548f * out) - 127 + expb;
+  // Minimize max absolute error.
+  return out * (1.3465552f - 0.34655523f * out) - 127 + expb;
 }
 
 // Fast approximate 2^x. Does only limited range checking.


### PR DESCRIPTION
The initial fastmath.h functions were optimized analytically to minimize rms error over the full mantissa range. Unfortunately, this was not taking into account the limited float32 accuracy, resulting in a small offset from the desired values. Here I used a numerical optimization approach to tune the constants for minimal error over the full mantissa range, and took the opportunity to minimize max error instead of rms error.

Also improved the comments a bit.