### PR TITLE
Implement equilibrium based U formula

### DIFF
--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -367,6 +367,11 @@ class EdgeAndNode {
     return numerator * GetP() / (1 + GetNStarted());
   }
 
+  float GetNewU(float numerator) const {
+    const float x = 1 + GetNStarted();
+    return numerator * GetP() * FastInvSqrt(x) / x;
+  }
+
   int GetVisitsToReachU(float target_score, float numerator, float default_q,
                         bool logit_q) const {
     const auto q = GetQ(default_q, logit_q);
@@ -375,6 +380,18 @@ class EdgeAndNode {
     return std::max(
         1.0f,
         std::min(std::floor(GetP() * numerator / (target_score - q) - n1) + 1,
+                 1e9f));
+  }
+
+  int GetVisitsToReachNewU(float target_score, float numerator,
+                           float default_q, bool logit_q) const {
+    const auto q = GetQ(default_q, logit_q);
+    if (q >= target_score) return std::numeric_limits<int>::max();
+    const auto n1 = GetNStarted() + 1;
+    const float inner = std::pow((GetP() * numerator) / (target_score - q), 2. / 3.);
+    return std::max(
+        1.0f,
+        std::min(std::floor(inner - n1) + 1,
                  1e9f));
   }
 

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -64,6 +64,10 @@ const OptionId SearchParams::kCpuctBaseId{
     "higher growth of Cpuct as number of node visits grows."};
 const OptionId SearchParams::kCpuctFactorId{
     "cpuct-factor", "CPuctFactor", "Multiplier for the cpuct growth formula."};
+const OptionId SearchParams::kNewUEnabledId{
+    "new-u-enabled", "NewUEnabled",
+    "Whether the formula for U is the old AlphaZero or the new equilibrium"
+    "based one."};
 const OptionId SearchParams::kTemperatureId{
     "temperature", "Temperature",
     "Tau value from softmax formula for the first move. If equal to 0, the "
@@ -209,6 +213,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 3.0f;
   options->Add<FloatOption>(kCpuctBaseId, 1.0f, 1000000000.0f) = 19652.0f;
   options->Add<FloatOption>(kCpuctFactorId, 0.0f, 1000.0f) = 2.0f;
+  options->Add<BoolOption>(kNewUEnabledId) = false;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 100) = 0;
   options->Add<IntOption>(kTemperatureCutoffMoveId, 0, 1000) = 0;
@@ -255,6 +260,7 @@ SearchParams::SearchParams(const OptionsDict& options)
       kCpuct(options.Get<float>(kCpuctId.GetId())),
       kCpuctBase(options.Get<float>(kCpuctBaseId.GetId())),
       kCpuctFactor(options.Get<float>(kCpuctFactorId.GetId())),
+      kNewUEnabled(options.Get<bool>(kNewUEnabledId.GetId())),
       kNoiseEpsilon(options.Get<bool>(kNoiseId.GetId())
                         ? 0.25f
                         : options.Get<float>(kNoiseEpsilonId.GetId())),

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -52,6 +52,7 @@ class SearchParams {
   float GetCpuct() const { return kCpuct; }
   float GetCpuctBase() const { return kCpuctBase; }
   float GetCpuctFactor() const { return kCpuctFactor; }
+  bool GetNewUEnabled() const { return kNewUEnabled; }
   float GetTemperature() const {
     return options_.Get<float>(kTemperatureId.GetId());
   }
@@ -108,6 +109,7 @@ class SearchParams {
   static const OptionId kCpuctId;
   static const OptionId kCpuctBaseId;
   static const OptionId kCpuctFactorId;
+  static const OptionId kNewUEnabledId;
   static const OptionId kTemperatureId;
   static const OptionId kTempDecayMovesId;
   static const OptionId kTemperatureCutoffMoveId;
@@ -149,6 +151,7 @@ class SearchParams {
   const float kCpuct;
   const float kCpuctBase;
   const float kCpuctFactor;
+  const bool kNewUEnabled;
   const float kNoiseEpsilon;
   const float kNoiseAlpha;
   const float kSmartPruningFactor;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -212,12 +212,24 @@ std::vector<std::string> Search::GetVerboseStats(Node* node,
   const float fpu = GetFpu(params_, node, node == root_node_);
   const float cpuct = ComputeCpuct(params_, node->GetN());
   const float U_coeff =
-    cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
+    cpuct * (params_.GetNewUEnabled() ?
+      std::max(node->GetChildrenVisits(), 1u) :
+      std::sqrt(std::max(node->GetChildrenVisits(), 1u)));
   const bool logit_q = params_.GetLogitQ();
 
   std::vector<EdgeAndNode> edges;
   for (const auto& edge : node->Edges()) edges.push_back(edge);
 
+  if (params_.GetNewUEnabled()) {
+  std::sort(
+      edges.begin(), edges.end(),
+      [&fpu, &U_coeff, &logit_q](EdgeAndNode a, EdgeAndNode b) {
+        return std::forward_as_tuple(
+          a.GetN(), a.GetQ(fpu, logit_q) + a.GetNewU(U_coeff)) <
+          std::forward_as_tuple(
+          b.GetN(), b.GetQ(fpu, logit_q) + b.GetNewU(U_coeff));
+      });  
+  } else {
   std::sort(
       edges.begin(), edges.end(),
       [&fpu, &U_coeff, &logit_q](EdgeAndNode a, EdgeAndNode b) {
@@ -226,6 +238,7 @@ std::vector<std::string> Search::GetVerboseStats(Node* node,
           std::forward_as_tuple(
           b.GetN(), b.GetQ(fpu, logit_q) + b.GetU(U_coeff));
       });
+  }
 
   std::vector<std::string> infos;
   for (const auto& edge : edges) {
@@ -249,11 +262,12 @@ std::vector<std::string> Search::GetVerboseStats(Node* node,
     oss << "(D: " << std::setw(6) << std::setprecision(3) << edge.GetD()
         << ") ";
 
-    oss << "(U: " << std::setw(6) << std::setprecision(5) << edge.GetU(U_coeff)
+    oss << "(U: " << std::setw(6) << std::setprecision(5)
+        << (params_.GetNewUEnabled() ? edge.GetNewU(U_coeff) : edge.GetU(U_coeff))
         << ") ";
 
     oss << "(Q+U: " << std::setw(8) << std::setprecision(5)
-        << edge.GetQ(fpu, logit_q) + edge.GetU(U_coeff)
+        << edge.GetQ(fpu, logit_q) + (params_.GetNewUEnabled() ? edge.GetNewU(U_coeff) :edge.GetU(U_coeff))
         << ") ";
 
     oss << "(V: ";
@@ -935,7 +949,10 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     // playout remains incomplete; we must go deeper.
     const float cpuct = ComputeCpuct(params_, node->GetN());
     const float puct_mult =
-        cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
+        cpuct * (params_.GetNewUEnabled() ?
+            std::max(node->GetChildrenVisits(), 1u) :
+            std::sqrt(std::max(node->GetChildrenVisits(), 1u)));
+
     float best = std::numeric_limits<float>::lowest();
     float second_best = std::numeric_limits<float>::lowest();
     int possible_moves = 0;
@@ -960,7 +977,10 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         ++possible_moves;
       }
       const float Q = child.GetQ(fpu, params_.GetLogitQ());
-      const float score = child.GetU(puct_mult) + Q;
+      const float score = Q +
+        (params_.GetNewUEnabled() ?
+          child.GetNewU(puct_mult):
+          child.GetU(puct_mult));
       if (score > best) {
         second_best = best;
         second_best_edge = best_edge;
@@ -973,7 +993,9 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     }
 
     if (second_best_edge) {
-      int estimated_visits_to_change_best =
+      int estimated_visits_to_change_best = params_.GetNewUEnabled() ?
+          best_edge.GetVisitsToReachNewU(second_best, puct_mult, fpu,
+                                         params_.GetLogitQ()) :
           best_edge.GetVisitsToReachU(second_best, puct_mult, fpu,
                                       params_.GetLogitQ());
       // Only cache for n-2 steps as the estimate created by GetVisitsToReachU
@@ -1157,12 +1179,16 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget) {
   std::vector<ScoredEdge> scores;
   const float cpuct = ComputeCpuct(params_, node->GetN());
   const float puct_mult =
-      cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
+      cpuct * (params_.GetNewUEnabled() ?
+          std::max(node->GetChildrenVisits(), 1u) :
+          std::sqrt(std::max(node->GetChildrenVisits(), 1u)));
   const float fpu = GetFpu(params_, node, node == search_->root_node_);
   for (auto edge : node->Edges()) {
     if (edge.GetP() == 0.0f) continue;
     // Flip the sign of a score to be able to easily sort.
-    scores.emplace_back(-edge.GetU(puct_mult) - edge.GetQ(fpu), edge);
+    scores.emplace_back(-(params_.GetNewUEnabled() ? edge.GetNewU(puct_mult) :
+                                                     edge.GetU(puct_mult))
+                        - edge.GetQ(fpu), edge);
   }
 
   size_t first_unsorted_index = 0;

--- a/src/utils/fastmath.h
+++ b/src/utils/fastmath.h
@@ -82,4 +82,16 @@ inline float FastLogit(const float a) {
   return 0.5f * FastLog((1.0f + a) / (1.0f - a));
 }
 
+inline float FastInvSqrt(const float number)
+{ 
+  const float x2 = number * 0.5F;
+  const float threehalfs = 1.5F;
+  float f;
+  uint32_t i;
+  memcpy(&i, &number, sizeof(float));
+  i  = 0x5f3759df - ( i >> 1 );
+  memcpy(&f, &i, sizeof(float));
+  return f * ( threehalfs - ( x2 * f * f ) );
+}
+
 }  // namespace lczero


### PR DESCRIPTION
This implements the changes mentioned in issue #913 and reuses the flag introduced by #699.

For given puct and parent_visits values we get a unique stable equilibrium solution of the RL process where `child_visits = p(s,a) * parent_visits` for all moves.
Note, that this change can only be evaluated using a full reinforcement learning run.

Let me know if some of the code can be simplified.

Proposals for parameter values
------------------------------
Moved to #924 

TODO
----

- [x] ~~Identify good values for `cpuct`, `cpuct-base` and `cpuct-factor`~~
- [x] ~~What is the effect of fpu, dirichlet noise etc?~~
- [x] ~~Adjust time management~~