### PR TITLE
Add git short revision to version string.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,16 +34,18 @@ endif
 
 # Use git short revision as build identifier.
 git = find_program('git', required: false)
+short_rev = 'unknown'
 if git.found()
   r = run_command(git, 'rev-parse', '--short', 'HEAD')
   if r.returncode() == 0
     short_rev = r.stdout().strip()
-    message('found git short revision ' + short_rev)
-    add_project_arguments('-DBUILD_IDENTIFIER="g' + short_rev + '"', language : 'cpp')
+  else
+    warning('Failed to parse short revision. Use git clone instead of downloading the archive from GitHub.')
   endif
-else
-  warning('Please install git to add short revision to build identifier in version string.')
 endif
+
+message('Using git short revision "' + short_rev + '" as build identifier.')
+add_project_arguments('-DBUILD_IDENTIFIER="g' + short_rev + '"', language : 'cpp')
 
 # Files to compile.
 deps = []

--- a/meson.build
+++ b/meson.build
@@ -37,7 +37,7 @@ r = run_command('git', 'rev-parse', '--short', 'HEAD')
 if r.returncode() == 0
   short_rev = r.stdout().strip()
   message('found git short revision ' + short_rev)
-  add_project_arguments('-DGIT_SHORT_REVISION="' + short_rev + '"', language : 'cpp')
+  add_project_arguments('-DBUILD_IDENTIFIER="g' + short_rev + '"', language : 'cpp')
 endif
 
 # Files to compile.

--- a/meson.build
+++ b/meson.build
@@ -106,6 +106,7 @@ endif
 # Construct build identifier.
 build_identifier = 'git.' + short_rev
 add_project_arguments('-DBUILD_IDENTIFIER="' + build_identifier + '"', language : 'cpp')
+message('Using build identifier "' + build_identifier + '".')
 
 #############################################################################
 ## Main files

--- a/meson.build
+++ b/meson.build
@@ -66,7 +66,6 @@ endif
 gen = generator(protoc, output: ['@BASENAME@.pb.cc', '@BASENAME@.pb.h'],
   arguments : ['--proto_path=@CURRENT_SOURCE_DIR@/libs/lczero-common', '--cpp_out=@BUILD_DIR@', '@INPUT@'])
 
-git = find_program('git', required: false)
 if run_command('checkdir.py', 'libs/lczero-common/proto').returncode() != 0
   if git.found()
     if run_command(git, 'status').returncode() == 0
@@ -87,6 +86,7 @@ files += gen.process('libs/lczero-common/proto/net.proto',
   preserve_path_from : meson.current_source_dir() + '/libs/lczero-common/')
   
 # Extract git short revision.
+git = find_program('git', required: false)
 short_rev = 'unknown'
 if git.found()
   r = run_command(git, 'rev-parse', '--short', 'HEAD')

--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,14 @@ if cc.get_id() == 'clang' or cc.get_id() == 'gcc'
   endif
 endif
 
+# Extract git short revision.
+r = run_command('git', 'rev-parse', '--short', 'HEAD')
+if r.returncode() == 0
+  short_rev = r.stdout().strip()
+  message('found git short revision ' + short_rev)
+  add_project_arguments('-DGIT_SHORT_REVISION="' + short_rev + '"', language : 'cpp')
+endif
+
 # Files to compile.
 deps = []
 files = []

--- a/meson.build
+++ b/meson.build
@@ -42,7 +42,7 @@ if git.found()
     add_project_arguments('-DBUILD_IDENTIFIER="g' + short_rev + '"', language : 'cpp')
   endif
 else
-  warning('Please install git to add short revision to build identifier.')
+  warning('Please install git to add short revision to build identifier in version string.')
 endif
 
 # Files to compile.

--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,8 @@ if git.found()
     message('found git short revision ' + short_rev)
     add_project_arguments('-DBUILD_IDENTIFIER="g' + short_rev + '"', language : 'cpp')
   endif
+else
+  warning('Please install git to add short revision to build identifier.')
 endif
 
 # Files to compile.

--- a/meson.build
+++ b/meson.build
@@ -32,28 +32,6 @@ if cc.get_id() == 'clang' or cc.get_id() == 'gcc'
   endif
 endif
 
-# Extract git short revision.
-git = find_program('git', required: false)
-short_rev = 'unknown'
-if git.found()
-  r = run_command(git, 'rev-parse', '--short', 'HEAD')
-  if r.returncode() == 0
-    # Now let's check if the working directory is clean.
-    if run_command(git, 'diff-index', '--quiet', 'HEAD').returncode() == 0
-      short_rev = r.stdout().strip()
-    else
-      short_rev = 'dirty'
-      warning('Cannot extract valid git short revision from dirty working directory.')
-    endif
-  else
-    warning('Failed to parse short revision. Use git clone instead of downloading the archive from GitHub.')
-  endif
-endif
-
-# Construct build identifier.
-build_identifier = 'git.' + short_rev
-add_project_arguments('-DBUILD_IDENTIFIER="' + build_identifier + '"', language : 'cpp')
-
 # Files to compile.
 deps = []
 files = []
@@ -106,6 +84,28 @@ endif
 
 files += gen.process('libs/lczero-common/proto/net.proto',
   preserve_path_from : meson.current_source_dir() + '/libs/lczero-common/')
+  
+# Extract git short revision.
+git = find_program('git', required: false)
+short_rev = 'unknown'
+if git.found()
+  r = run_command(git, 'rev-parse', '--short', 'HEAD')
+  if r.returncode() == 0
+    # Now let's check if the working directory is clean.
+    if run_command(git, 'diff-index', '--quiet', 'HEAD').returncode() == 0
+      short_rev = r.stdout().strip()
+    else
+      short_rev = 'dirty'
+      warning('Cannot extract valid git short revision from dirty working directory.')
+    endif
+  else
+    warning('Failed to parse short revision. Use git clone instead of downloading the archive from GitHub.')
+  endif
+endif
+
+# Construct build identifier.
+build_identifier = 'git.' + short_rev
+add_project_arguments('-DBUILD_IDENTIFIER="' + build_identifier + '"', language : 'cpp')
 
 #############################################################################
 ## Main files

--- a/meson.build
+++ b/meson.build
@@ -66,6 +66,8 @@ endif
 gen = generator(protoc, output: ['@BASENAME@.pb.cc', '@BASENAME@.pb.h'],
   arguments : ['--proto_path=@CURRENT_SOURCE_DIR@/libs/lczero-common', '--cpp_out=@BUILD_DIR@', '@INPUT@'])
 
+# Handle submodules.
+git = find_program('git', required: false)
 if run_command('checkdir.py', 'libs/lczero-common/proto').returncode() != 0
   if git.found()
     if run_command(git, 'status').returncode() == 0
@@ -86,7 +88,6 @@ files += gen.process('libs/lczero-common/proto/net.proto',
   preserve_path_from : meson.current_source_dir() + '/libs/lczero-common/')
   
 # Extract git short revision.
-git = find_program('git', required: false)
 short_rev = 'unknown'
 if git.found()
   r = run_command(git, 'rev-parse', '--short', 'HEAD')

--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,7 @@ if cc.get_id() == 'clang' or cc.get_id() == 'gcc'
   endif
 endif
 
-# Extract git short revision.
+# Use git short revision as build identifier.
 r = run_command('git', 'rev-parse', '--short', 'HEAD')
 if r.returncode() == 0
   short_rev = r.stdout().strip()

--- a/meson.build
+++ b/meson.build
@@ -33,11 +33,14 @@ if cc.get_id() == 'clang' or cc.get_id() == 'gcc'
 endif
 
 # Use git short revision as build identifier.
-r = run_command('git', 'rev-parse', '--short', 'HEAD')
-if r.returncode() == 0
-  short_rev = r.stdout().strip()
-  message('found git short revision ' + short_rev)
-  add_project_arguments('-DBUILD_IDENTIFIER="g' + short_rev + '"', language : 'cpp')
+git = find_program('git', required: false)
+if git.found()
+  r = run_command(git, 'rev-parse', '--short', 'HEAD')
+  if r.returncode() == 0
+    short_rev = r.stdout().strip()
+    message('found git short revision ' + short_rev)
+    add_project_arguments('-DBUILD_IDENTIFIER="g' + short_rev + '"', language : 'cpp')
+  endif
 endif
 
 # Files to compile.

--- a/meson.build
+++ b/meson.build
@@ -82,14 +82,18 @@ gen = generator(protoc, output: ['@BASENAME@.pb.cc', '@BASENAME@.pb.h'],
   arguments : ['--proto_path=@CURRENT_SOURCE_DIR@/libs/lczero-common', '--cpp_out=@BUILD_DIR@', '@INPUT@'])
 
 if run_command('checkdir.py', 'libs/lczero-common/proto').returncode() != 0
-  if run_command('git', 'status').returncode() == 0
-    message('updating git submodule libs/lczero-common')
-    run_command('git', 'submodule', 'update', '--init', '--recursive')
+  if git.found()
+    if run_command(git, 'status').returncode() == 0
+      message('updating git submodule libs/lczero-common')
+      run_command(git, 'submodule', 'update', '--init', '--recursive')
+    else
+      message('cloning lczero-common.git into libs/lczero-common')
+      run_command(git, 'clone', '--depth=1',
+                  'https://github.com/LeelaChessZero/lczero-common.git',
+                  'libs/lczero-common/')
+    endif
   else
-    message('cloning lczero-common.git into libs/lczero-common')
-    run_command('git', 'clone', '--depth=1',
-                'https://github.com/LeelaChessZero/lczero-common.git',
-                'libs/lczero-common/')
+    error('Please install git to automatically fetch submodules or download the archives manually from GitHub.')
   endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -32,20 +32,27 @@ if cc.get_id() == 'clang' or cc.get_id() == 'gcc'
   endif
 endif
 
-# Use git short revision as build identifier.
+# Extract git short revision.
 git = find_program('git', required: false)
 short_rev = 'unknown'
 if git.found()
   r = run_command(git, 'rev-parse', '--short', 'HEAD')
   if r.returncode() == 0
-    short_rev = r.stdout().strip()
+    # Now let's check if the working directory is clean.
+    if run_command(git, 'diff-index', '--quiet', 'HEAD').returncode() == 0
+      short_rev = r.stdout().strip()
+    else
+      short_rev = 'dirty'
+      warning('Cannot extract valid git short revision from dirty working directory.')
+    endif
   else
     warning('Failed to parse short revision. Use git clone instead of downloading the archive from GitHub.')
   endif
 endif
 
-message('Using git short revision "' + short_rev + '" as build identifier.')
-add_project_arguments('-DBUILD_IDENTIFIER="g' + short_rev + '"', language : 'cpp')
+# Construct build identifier.
+build_identifier = 'git.' + short_rev
+add_project_arguments('-DBUILD_IDENTIFIER="' + build_identifier + '"', language : 'cpp')
 
 # Files to compile.
 deps = []

--- a/meson.build
+++ b/meson.build
@@ -66,6 +66,7 @@ endif
 gen = generator(protoc, output: ['@BASENAME@.pb.cc', '@BASENAME@.pb.h'],
   arguments : ['--proto_path=@CURRENT_SOURCE_DIR@/libs/lczero-common', '--cpp_out=@BUILD_DIR@', '@INPUT@'])
 
+git = find_program('git', required: false)
 if run_command('checkdir.py', 'libs/lczero-common/proto').returncode() != 0
   if git.found()
     if run_command(git, 'status').returncode() == 0
@@ -86,7 +87,6 @@ files += gen.process('libs/lczero-common/proto/net.proto',
   preserve_path_from : meson.current_source_dir() + '/libs/lczero-common/')
   
 # Extract git short revision.
-git = find_program('git', required: false)
 short_rev = 'unknown'
 if git.found()
   r = run_command(git, 'rev-parse', '--short', 'HEAD')

--- a/src/version.cc
+++ b/src/version.cc
@@ -35,5 +35,9 @@ std::string GetVersionStr(int major, int minor, int patch,
   auto v = std::to_string(major) + "." + std::to_string(minor) + "." +
            std::to_string(patch);
   if (postfix.empty()) return v;
+#ifdef GIT_SHORT_REVISION
+  if (postfix.compare("dev") == 0)
+    return v + "-" + postfix + "-g" + GIT_SHORT_REVISION;
+#endif
   return v + "-" + postfix;
 }

--- a/src/version.cc
+++ b/src/version.cc
@@ -31,14 +31,10 @@ std::uint32_t GetVersionInt(int major, int minor, int patch) {
 }
 
 std::string GetVersionStr(int major, int minor, int patch,
-                          const std::string& postfix) {
+                          const std::string& postfix,
+                          const std::string& build_id) {
   auto v = std::to_string(major) + "." + std::to_string(minor) + "." +
            std::to_string(patch);
-#ifdef BUILD_IDENTIFIER
-  if (postfix.empty()) return v + "+" BUILD_IDENTIFIER;
-  return v + "-" + postfix + "+" BUILD_IDENTIFIER;
-#else
-  if (postfix.empty()) return v;
-  return v + "-" + postfix;
-#endif
+  if (postfix.empty()) return v + "+" + build_id;
+  return v + "-" + postfix + "+" + build_id;
 }

--- a/src/version.cc
+++ b/src/version.cc
@@ -34,10 +34,11 @@ std::string GetVersionStr(int major, int minor, int patch,
                           const std::string& postfix) {
   auto v = std::to_string(major) + "." + std::to_string(minor) + "." +
            std::to_string(patch);
+#ifdef BUILD_IDENTIFIER
+  if (postfix.empty()) return v + "+" BUILD_IDENTIFIER;
+  return v + "-" + postfix + "+" BUILD_IDENTIFIER;
+#else
   if (postfix.empty()) return v;
-#ifdef GIT_SHORT_REVISION
-  if (postfix.compare("dev") == 0)
-    return v + "-" + postfix + "-g" + GIT_SHORT_REVISION;
-#endif
   return v + "-" + postfix;
+#endif
 }

--- a/src/version.h
+++ b/src/version.h
@@ -39,4 +39,5 @@ std::uint32_t GetVersionInt(int major = LC0_VERSION_MAJOR,
 std::string GetVersionStr(int major = LC0_VERSION_MAJOR,
                           int minor = LC0_VERSION_MINOR,
                           int patch = LC0_VERSION_PATCH,
-                          const std::string& postfix = LC0_VERSION_POSTFIX);
+                          const std::string& postfix = LC0_VERSION_POSTFIX,
+                          const std::string& build_id = BUILD_IDENTIFIER);


### PR DESCRIPTION
Add unique git short revision to version string. Turns

```
       _
|   _ | |
|_ |_ |_| v0.23.0-dev built Aug  8 2019
```

into:

```
       _
|   _ | |
|_ |_ |_| v0.23.0-dev+gad71ed0 built Aug  9 2019
```

Very handy to avoid any confusion during development/benchmarks/comparison of PRs/logs used for future reference.