### PR TITLE
Revert "Restore --noise treating as --noise-epsilon=0.25."

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -109,12 +109,6 @@ const OptionId SearchParams::kTemperatureVisitOffsetId{
     "Adjusts visits by this value when picking a move with a temperature. If a "
     "negative offset reduces visits for a particular move below zero, that "
     "move is not picked. If no moves can be picked, no temperature is used."};
-const OptionId SearchParams::kNoiseId{
-    "noise", "DirichletNoise",
-    "Add Dirichlet noise to root node prior probabilities. This allows the "
-    "engine to discover new ideas during training by exploring moves which are "
-    "known to be bad. Not normally used during play.",
-    'n'};
 const OptionId SearchParams::kNoiseEpsilonId{
     "noise-epsilon", "DirichletNoiseEpsilon",
     "Amount of Dirichlet noise to combine with root priors. This allows the "
@@ -265,7 +259,6 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kTemperatureWinpctCutoffId, 0.0f, 100.0f) = 100.0f;
   options->Add<FloatOption>(kTemperatureVisitOffsetId, -1000.0f, 1000.0f) =
       0.0f;
-  options->Add<BoolOption>(kNoiseId) = false;
   options->Add<FloatOption>(kNoiseEpsilonId, 0.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kNoiseAlphaId, 0.0f, 10000000.0f) = 0.3f;
   options->Add<BoolOption>(kVerboseStatsId) = false;
@@ -331,9 +324,7 @@ SearchParams::SearchParams(const OptionsDict& options)
           options.Get<float>(options.Get<bool>(kRootHasOwnCpuctParamsId.GetId())
                                  ? kCpuctFactorAtRootId.GetId()
                                  : kCpuctFactorId.GetId())),
-      kNoiseEpsilon(options.Get<bool>(kNoiseId.GetId())
-                        ? 0.25f
-                        : options.Get<float>(kNoiseEpsilonId.GetId())),
+      kNoiseEpsilon(options.Get<float>(kNoiseEpsilonId.GetId())),
       kNoiseAlpha(options.Get<float>(kNoiseAlphaId.GetId())),
       kFpuAbsolute(options.Get<std::string>(kFpuStrategyId.GetId()) ==
                    "absolute"),

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -132,7 +132,6 @@ class SearchParams {
   static const OptionId kTemperatureEndgameId;
   static const OptionId kTemperatureWinpctCutoffId;
   static const OptionId kTemperatureVisitOffsetId;
-  static const OptionId kNoiseId;
   static const OptionId kNoiseEpsilonId;
   static const OptionId kNoiseAlphaId;
   static const OptionId kVerboseStatsId;


### PR DESCRIPTION
This reverts commit 1753f7c40332121950f818979d9c71bca34ee230.

Followup to #267 but only commit after https://github.com/LeelaChessZero/lc0/commit/8f13ece9698888e5b156c7b2f3d3300832bda004 `has been included in a version which has been made mandatory.` https://github.com/LeelaChessZero/lc0/pull/267#issuecomment-522185245