### PR TITLE
allow using cudnn-fp16 on jetson

### DIFF
--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -224,6 +224,7 @@ class CudnnNetwork : public Network {
       if ((deviceProp.major == 6 && deviceProp.minor != 1) ||
           (deviceProp.major == 5 && deviceProp.minor == 3)) {
         // FP16 without tensor cores supported on GP100 (SM 6.0) and Jetson
+        // (SM 5.3 and 6.2). SM 6.1 GPUs also have FP16, but slower than FP32.
         // nhwc_ remains false.
       } else if (deviceProp.major >= 7) {
         // NHWC layout is faster with Tensor Cores.

--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -221,8 +221,9 @@ class CudnnNetwork : public Network {
     if (std::is_same<half, DataType>::value) {
       // Check if the GPU support FP16.
 
-      if (deviceProp.major == 6 && deviceProp.minor == 0) {
-        // FP16 without tensor cores supported on GP100 (SM 6.0)
+      if ((deviceProp.major == 6 && deviceProp.minor != 1) ||
+          (deviceProp.major == 5 && deviceProp.minor == 3)) {
+        // FP16 without tensor cores supported on GP100 (SM 6.0) and Jetson
         // nhwc_ remains false.
       } else if (deviceProp.major >= 7) {
         // NHWC layout is faster with Tensor Cores.


### PR DESCRIPTION
@jjoshua2 mentioned on <https://github.com/LeelaChessZero/lc0/pull/849#issuecomment-529213807> that nvidia jetson with compute capability 5.3 has fast fp16 performance. A web search suggests this is also true for jetson tx2 with compute capability 6.2, so the relevant check is updated.