### PR TITLE
Adjustable draw avoidance or preference

### DIFF
--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -336,6 +336,10 @@ class EdgeAndNode {
   Node* node() const { return node_; }
 
   // Proxy functions for easier access to node/edge.
+  float GetQD(float default q, float drawScore) const {
+	  float d = drawScore * GetD();
+	  return (node_ && node_->GetN() > 0) ? node_->GetQ() + d : default_q;
+  }
   float GetQ(float default_q) const {
     return (node_ && node_->GetN() > 0) ? node_->GetQ() : default_q;
   }

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -195,6 +195,10 @@ const OptionId SearchParams::kKLDGainAverageInterval{
     "kldgain-average-interval", "KLDGainAverageInterval",
     "Used to decide how frequently to evaluate the average KLDGainPerNode to "
     "check the MinimumKLDGainPerNode, if specified."};
+const OptionId SearchParams::kDrawScoreId{
+    "draw-score", "Draw-Score",
+    "Score to assign for draws in range [-1, 1], where -1 is loss and +1 is win."
+    "Used for choosing the best move."};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -238,7 +242,8 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
   options->Add<IntOption>(kKLDGainAverageInterval, 1, 10000000) = 100;
   options->Add<FloatOption>(kMinimumKLDGainPerNode, 0.0f, 1.0f) = 0.0f;
-
+  options->Add<FloatOption>(kDrawScoreId, -1.0f, 1.0f) = 0.0f;
+  
   options->HideOption(kNoiseEpsilonId);
   options->HideOption(kNoiseAlphaId);
   options->HideOption(kLogLiveStatsId);
@@ -274,6 +279,8 @@ SearchParams::SearchParams(const OptionsDict& options)
       kSyzygyFastPlay(options.Get<bool>(kSyzygyFastPlayId.GetId())),
       kHistoryFill(
           EncodeHistoryFill(options.Get<std::string>(kHistoryFillId.GetId()))),
-      kMiniBatchSize(options.Get<int>(kMiniBatchSizeId.GetId())) {}
+      kMiniBatchSize(options.Get<int>(kMiniBatchSizeId.GetId())),
+      kDrawScore(options.Get<float>(kDrawScoreId.GetId())) {
+      }
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -99,7 +99,8 @@ class SearchParams {
   float GetMinimumKLDGainPerNode() const {
     return options_.Get<float>(kMinimumKLDGainPerNode.GetId());
   }
-
+  float GetDrawScore() const { return kDrawScore; }
+  
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
   static const OptionId kMaxPrefetchBatchId;
@@ -134,6 +135,7 @@ class SearchParams {
   static const OptionId kHistoryFillId;
   static const OptionId kMinimumKLDGainPerNode;
   static const OptionId kKLDGainAverageInterval;
+  static const OptionId kDrawScoreId;
 
  private:
   const OptionsDict& options_;
@@ -162,6 +164,7 @@ class SearchParams {
   const bool kSyzygyFastPlay;
   const FillEmptyHistory kHistoryFill;
   const int kMiniBatchSize;
+  const float kDrawScore;
 };
 
 }  // namespace lczero

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -213,15 +213,16 @@ std::vector<std::string> Search::GetVerboseStats(Node* node,
   const float cpuct = ComputeCpuct(params_, node->GetN());
   const float U_coeff =
       cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
-
+  const float drawScore = params_.GetDrawScore();
+  
   std::vector<EdgeAndNode> edges;
   for (const auto& edge : node->Edges()) edges.push_back(edge);
 
   std::sort(
       edges.begin(), edges.end(),
-      [&fpu, &U_coeff](EdgeAndNode a, EdgeAndNode b) {
-        return std::forward_as_tuple(a.GetN(), a.GetQ(fpu) + a.GetU(U_coeff)) <
-               std::forward_as_tuple(b.GetN(), b.GetQ(fpu) + b.GetU(U_coeff));
+      [&fpu, &U_coeff, &drawScore](EdgeAndNode a, EdgeAndNode b) {
+        return std::forward_as_tuple(a.GetN(), a.GetQD(fpu, drawScore) + a.GetU(U_coeff)) <
+               std::forward_as_tuple(b.GetN(), b.GetQD(fpu, drawScore) + b.GetU(U_coeff));
       });
 
   std::vector<std::string> infos;
@@ -243,10 +244,13 @@ std::vector<std::string> Search::GetVerboseStats(Node* node,
     oss << "(Q: " << std::setw(8) << std::setprecision(5) << edge.GetQ(fpu)
         << ") ";
 
-    oss << "(D: " << std::setw(6) << std::setprecision(3) << edge.GetD()
+    oss << "(D: " << std::setw(8) << std::setprecision(5) << edge.GetD()
         << ") ";
 
     oss << "(U: " << std::setw(6) << std::setprecision(5) << edge.GetU(U_coeff)
+        << ") ";
+    
+    oss << "(QD: " << std::setw(8) << std::setprecision(5) << edge.GetQD(fpu, params_.GetDrawScore())
         << ") ";
 
     oss << "(Q+U: " << std::setw(8) << std::setprecision(5)
@@ -955,8 +959,8 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         }
         ++possible_moves;
       }
-      const float Q = child.GetQ(fpu);
-      const float score = child.GetU(puct_mult) + Q;
+      float QD = child.GetQD(fpu, params_.GetDrawScore());
+      const float score = child.GetU(puct_mult) + QD;
       if (score > best) {
         second_best = best;
         second_best_edge = best_edge;
@@ -1157,7 +1161,7 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget) {
   for (auto edge : node->Edges()) {
     if (edge.GetP() == 0.0f) continue;
     // Flip the sign of a score to be able to easily sort.
-    scores.emplace_back(-edge.GetU(puct_mult) - edge.GetQ(fpu), edge);
+    scores.emplace_back(-edge.GetU(puct_mult) - edge.GetQD(fpu, params_.GetDrawScore()), edge);
   }
 
   size_t first_unsorted_index = 0;
@@ -1187,7 +1191,7 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget) {
     if (i != scores.size() - 1) {
       // Sign of the score was flipped for sorting, so flip it back.
       const float next_score = -scores[i + 1].first;
-      const float q = edge.GetQ(-fpu);
+      const float q = edge.GetQD(-fpu, params_.GetDrawScore());
       if (next_score > q) {
         budget_to_spend =
             std::min(budget, int(edge.GetP() * puct_mult / (next_score - q) -

--- a/src/neural/network.h
+++ b/src/neural/network.h
@@ -60,6 +60,7 @@ class NetworkComputation {
   virtual int GetBatchSize() const = 0;
   // Returns Q value of @sample.
   virtual float GetQVal(int sample) const = 0;
+  // Returns D value of @sample
   virtual float GetDVal(int sample) const = 0;
   // Returns P value @move_id of @sample.
   virtual float GetPVal(int sample, int move_id) const = 0;


### PR DESCRIPTION
This is a preliminary pull request that uses a simple form of draw avoidance/preference implemented by jio. Issues to address include:
1) whether own vs. opponent Q is adjusted appropriately
2) whether to include scaling that changes with absolute Q, such as increasingly avoiding a draw when winning and increasingly preferring a draw when losing
3) the range of the command line option (currently -1 to 1)