### PR TITLE
enable lto and fast-math - not for merging

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@
 # along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
 
 project('lc0', 'cpp',
-        default_options : ['cpp_std=c++14', 'b_ndebug=if-release'],
+        default_options : ['cpp_std=c++14', 'b_ndebug=if-release', 'b_lto=true'],
         meson_version: '>=0.45')
 
 cc = meson.get_compiler('cpp')
@@ -27,9 +27,24 @@ if cc.get_id() == 'clang' or cc.get_id() == 'gcc'
   add_project_arguments('-Wextra', language : 'cpp')
   add_project_arguments('-pedantic', language : 'cpp')
 
+  if cc.get_id() == 'gcc'
+    add_project_arguments('-ffast-math', language : 'cpp')
+    add_project_arguments('-ftrapping-math', language : 'cpp')
+    add_project_arguments('-fno-associative-math', language : 'cpp')
+  else
+    add_project_arguments('-ffinite-math-only', language : 'cpp')
+    add_project_arguments('-fno-math-errno', language : 'cpp')
+    add_project_arguments('-fno-signed-zeros', language : 'cpp')
+    add_project_arguments('-fassociative-math', language : 'cpp')
+    add_project_arguments('-freciprocal-math', language : 'cpp')
+  endif
+
   if get_option('buildtype') == 'release'
     add_project_arguments('-march=native', language : 'cpp')
   endif
+endif
+if cc.get_id() == 'msvc'
+  add_project_arguments('/fp:fast', language : 'cpp')
 endif
 
 # Files to compile.


### PR DESCRIPTION
A few months ago we tried to enable LTO building by default, which resulted in some obscure crashes with older gcc versions (https://github.com/LeelaChessZero/lc0/issues/585), which had been bugging me since. I managed to trace it (`git bisect` rules) to a bad interaction with `-ffast-math` that we had enabled back then. However `-ffast-math` was also breaking standard builds with clang, so it has been disabled for some time. Therefore enabling LTO builds should be safe. However this is not what this PR does: searching through the fast-math sub-options I think I have isolated the bad ones, so this works for me with all compilers tested (including the `/fp:fast` msvc option, although this is less tested) and hope to get some independent testing.
Note to testers: To reproduce the crash reliably I was playing 1000 games (selfplay but with cutechess to stress the full uci interface as well) with 1 node per move, and the crash was happening in the first 200 games, guesstimating a 0.5% crash probability.