### PR TITLE
Badgame split

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -514,6 +514,15 @@ bool Search::PopulateRootMoveLimit(MoveList* root_moves) const {
          syzygy_tb_->root_probe_wdl(played_history_.Last(), root_moves);
 }
 
+void Search::ResetBestMove() {
+  SharedMutex::Lock nodes_lock(nodes_mutex_);
+  Mutex::Lock lock(counters_mutex_);
+  bool old_sent = bestmove_is_sent_;
+  bestmove_is_sent_ = false;
+  EnsureBestMoveKnown();
+  bestmove_is_sent_ = old_sent;
+}
+
 // Computes the best move, maybe with temperature (according to the settings).
 void Search::EnsureBestMoveKnown() REQUIRES(nodes_mutex_)
     REQUIRES(counters_mutex_) {

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -96,6 +96,10 @@ class Search {
   // Returns the search parameters.
   const SearchParams& GetParams() const { return params_; }
 
+  // If called after GetBestMove, another call to GetBestMove will have results
+  // from temperature having been applied again.
+  void ResetBestMove();
+
  private:
   // Computes the best move, maybe with temperature (according to the settings).
   void EnsureBestMoveKnown();

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -55,7 +55,7 @@ void SelfPlayGame::PopulateUciParams(OptionsParser* options) {
 }
 
 SelfPlayGame::SelfPlayGame(PlayerOptions player1, PlayerOptions player2,
-                           bool shared_tree)
+                           bool shared_tree, const MoveList& opening)
     : options_{player1, player2} {
   tree_[0] = std::make_shared<NodeTree>();
   tree_[0]->ResetToPosition(ChessBoard::kStartposFen, {});
@@ -66,11 +66,15 @@ SelfPlayGame::SelfPlayGame(PlayerOptions player1, PlayerOptions player2,
     tree_[1] = std::make_shared<NodeTree>();
     tree_[1]->ResetToPosition(ChessBoard::kStartposFen, {});
   }
+  for (Move m : opening) {
+    tree_[0]->MakeMove(m);
+    if (tree_[0] != tree_[1]) tree_[1]->MakeMove(m);
+  }
 }
 
 void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
                         bool enable_resign) {
-  bool blacks_move = false;
+  bool blacks_move = (tree_[0]->GetPlyCount() % 2) == 1;
 
   // Do moves while not end of the game. (And while not abort_)
   while (!abort_) {

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -175,7 +175,7 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
         if (edge.GetN() > max_n) {
           max_n = edge.GetN();
         }
-        if (edge.GetMove() == move) {
+        if (edge.GetMove(tree_[idx]->IsBlackToMove()) == move) {
           cur_n = edge.GetN();
         }
       }

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -183,6 +183,9 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
                                         kMinimumAllowedVistsId.GetId())) {
         break;
       }
+      auto move_list_to_discard = GetMoves();
+      move_list_to_discard.push_back(move);
+      options_[idx].discarded_callback(move_list_to_discard);
       search_->ResetBestMove();
     }
     tree_[0]->MakeMove(move);

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -63,7 +63,8 @@ class SelfPlayGame {
   // If shared_tree is true, search tree is reused between players.
   // (useful for training games). Otherwise the tree is separate for black
   // and white (useful i.e. when they use different networks).
-  SelfPlayGame(PlayerOptions player1, PlayerOptions player2, bool shared_tree);
+  SelfPlayGame(PlayerOptions player1, PlayerOptions player2, bool shared_tree,
+               const MoveList& opening);
 
   // Populate command line options that it uses.
   static void PopulateUciParams(OptionsParser* options);
@@ -101,7 +102,8 @@ class SelfPlayGame {
   // Track minimum eval for each player so that GetWorstEvalForWinnerOrDraw()
   // can be calculated after end of game.
   float min_eval_[2] = {1.0f, 1.0f};
-  // Track the maximum eval for white win, draw, black win for comparison to actual outcome.
+  // Track the maximum eval for white win, draw, black win for comparison to
+  // actual outcome.
   float max_eval_[3] = {0.0f, 0.0f, 0.0f};
   std::mutex mutex_;
 

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -42,12 +42,15 @@ struct SelfPlayLimits : SearchLimits {
 };
 
 struct PlayerOptions {
+  using MoveListCallback = std::function<void(const MoveList&)>;
   // Network to use by the player.
   Network* network;
   // Callback when player moves.
   BestMoveInfo::Callback best_move_callback;
   // Callback when player outputs info.
   ThinkingInfo::Callback info_callback;
+  // Callback when player discards a selected move due to low visits.
+  MoveListCallback discarded_callback;
   // NNcache to use.
   NNCache* cache;
   // User options dictionary.

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -242,6 +242,8 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
           }
         };
     opt.discarded_callback = [this](const MoveList& moves) {
+      // Only track discards if discard start chance is non-zero.
+      if (kDiscardedStartChance == 0.0f) return;
       Mutex::Lock lock(mutex_);
       discard_pile_.push_back(moves);
       // 10k seems it should be enough to keep a good mix and avoid running out

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -185,7 +185,7 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
     player1_black = next_game_black_;
     next_game_black_ = !next_game_black_;
     if (discard_pile_.size() > 0 &&
-        Random ::Get().GetFloat(100.0f) < kDiscardedStartChance) {
+        Random::Get().GetFloat(100.0f) < kDiscardedStartChance) {
       int idx = Random::Get().GetInt(0, discard_pile_.size() - 1);
       if (idx != discard_pile_.size() - 1) {
         std::swap(discard_pile_[idx], discard_pile_.back());
@@ -244,7 +244,8 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
     opt.discarded_callback = [this](const MoveList& moves) {
       Mutex::Lock lock(mutex_);
       discard_pile_.push_back(moves);
-      // 10k seems it should be enough to keep a good mix and avoid running out of ram.
+      // 10k seems it should be enough to keep a good mix and avoid running out
+      // of ram.
       if (discard_pile_.size() > 10000) {
         // Swap a random element to end and pop it to avoid growing.
         int idx = Random::Get().GetInt(0, discard_pile_.size() - 1);

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -62,6 +62,10 @@ const OptionId kVerboseThinkingId{"verbose-thinking", "VerboseThinking",
 const OptionId kResignPlaythroughId{
     "resign-playthrough", "ResignPlaythrough",
     "The percentage of games which ignore resign."};
+const OptionId kDiscardedStartChanceId{
+    "discarded-start-chance", "DiscardedStartChance",
+    "The percentage chance each game will attempt to start from a position "
+    "discarded due to not getting enough visits."};
 
 }  // namespace
 
@@ -83,6 +87,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   options->Add<BoolOption>(kTrainingId) = false;
   options->Add<BoolOption>(kVerboseThinkingId) = false;
   options->Add<FloatOption>(kResignPlaythroughId, 0.0f, 100.0f) = 0.0f;
+  options->Add<FloatOption>(kDiscardedStartChanceId, 0.0f, 100.0f) = 0.0f;
 
   SelfPlayGame::PopulateUciParams(options);
 
@@ -125,7 +130,9 @@ SelfPlayTournament::SelfPlayTournament(const OptionsDict& options,
       kShareTree(options.Get<bool>(kShareTreesId.GetId())),
       kParallelism(options.Get<int>(kParallelGamesId.GetId())),
       kTraining(options.Get<bool>(kTrainingId.GetId())),
-      kResignPlaythrough(options.Get<float>(kResignPlaythroughId.GetId())) {
+      kResignPlaythrough(options.Get<float>(kResignPlaythroughId.GetId())),
+      kDiscardedStartChance(
+          options.Get<float>(kDiscardedStartChanceId.GetId())) {
   // If playing just one game, the player1 is white, otherwise randomize.
   if (kTotalGames != 1) {
     next_game_black_ = Random::Get().GetBool();
@@ -172,10 +179,20 @@ SelfPlayTournament::SelfPlayTournament(const OptionsDict& options,
 
 void SelfPlayTournament::PlayOneGame(int game_number) {
   bool player1_black;  // Whether player1 will player as black in this game.
+  MoveList opening;
   {
     Mutex::Lock lock(mutex_);
     player1_black = next_game_black_;
     next_game_black_ = !next_game_black_;
+    if (discard_pile_.size() > 0 &&
+        Random ::Get().GetFloat(100.0f) < kDiscardedStartChance) {
+      int idx = Random::Get().GetInt(0, discard_pile_.size() - 1);
+      if (idx != discard_pile_.size() - 1) {
+        std::swap(discard_pile_[idx], discard_pile_.back());
+      }
+      opening = discard_pile_.back();
+      discard_pile_.pop_back();
+    }
   }
   const int color_idx[2] = {player1_black ? 1 : 0, player1_black ? 0 : 1};
 
@@ -224,6 +241,10 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
             last_thinking_info = std::move(rich_info);
           }
         };
+    opt.discarded_callback = [this](const MoveList& moves) {
+      Mutex::Lock lock(mutex_);
+      discard_pile_.push_back(moves);
+    };
   }
 
   // Iterator to store the game in. Have to keep it so that later we can
@@ -232,8 +253,8 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
   std::list<std::unique_ptr<SelfPlayGame>>::iterator game_iter;
   {
     Mutex::Lock lock(mutex_);
-    games_.emplace_front(std::make_unique<SelfPlayGame>(
-        options[0], options[1], kShareTree, MoveList()));
+    games_.emplace_front(std::make_unique<SelfPlayGame>(options[0], options[1],
+                                                        kShareTree, opening));
     game_iter = games_.begin();
   }
   auto& game = **game_iter;

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -232,8 +232,8 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
   std::list<std::unique_ptr<SelfPlayGame>>::iterator game_iter;
   {
     Mutex::Lock lock(mutex_);
-    games_.emplace_front(
-        std::make_unique<SelfPlayGame>(options[0], options[1], kShareTree));
+    games_.emplace_front(std::make_unique<SelfPlayGame>(
+        options[0], options[1], kShareTree, MoveList()));
     game_iter = games_.begin();
   }
   auto& game = **game_iter;

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -244,6 +244,15 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
     opt.discarded_callback = [this](const MoveList& moves) {
       Mutex::Lock lock(mutex_);
       discard_pile_.push_back(moves);
+      // 10k seems it should be enough to keep a good mix and avoid running out of ram.
+      if (discard_pile_.size() > 10000) {
+        // Swap a random element to end and pop it to avoid growing.
+        int idx = Random::Get().GetInt(0, discard_pile_.size() - 1);
+        if (idx != discard_pile_.size() - 1) {
+          std::swap(discard_pile_[idx], discard_pile_.back());
+        }
+        discard_pile_.pop_back();
+      }
     };
   }
 

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -72,6 +72,7 @@ class SelfPlayTournament {
   Mutex mutex_;
   // Whether next game will be black for player1.
   bool next_game_black_ GUARDED_BY(mutex_) = false;
+  std::vector<MoveList> discard_pile_ GUARDED_BY(mutex_);
   // Number of games which already started.
   int games_count_ GUARDED_BY(mutex_) = 0;
   bool abort_ GUARDED_BY(mutex_) = false;
@@ -102,6 +103,7 @@ class SelfPlayTournament {
   const size_t kParallelism;
   const bool kTraining;
   const float kResignPlaythrough;
+  const float kDiscardedStartChance;
 };
 
 }  // namespace lczero


### PR DESCRIPTION
Adds two parameters to selfplay.
--minimum-allowed-visits - integer parameter that causes selfplay to discard selected temperature moves that are not best and are less than the limit.
--discarded-start-chance - floating parameter in 0 to 100, that is the percentage chance that a game will attempt to start from the position after a discarded move - if there are any such games that have not yet been played.

Discarded game positions are selected from at random.  In almost every scenario that minimum-allowed-visits is greater than 1 it is likely that the discard pile will grow continuously.  Thus I have put in a hard coded cap to avoid it growing without bound.  I hard coded it as I don't think it will need tuning.