### PR TITLE
Record how many ply in the gameready move output are from before net play starts.

### DIFF
--- a/src/chess/callbacks.h
+++ b/src/chess/callbacks.h
@@ -97,6 +97,8 @@ struct GameInfo {
   std::string training_filename;
   // Game moves.
   std::vector<Move> moves;
+  // Ply within moves that the game actually started.
+  int play_start_ply;
   // Index of the game in the tournament (0-based).
   int game_id = -1;
   // The color of the player1, if known.

--- a/src/selfplay/loop.cc
+++ b/src/selfplay/loop.cc
@@ -105,6 +105,7 @@ void SelfPlayLoop::SendGameInfo(const GameInfo& info) {
   if (!info.training_filename.empty())
     res += " trainingfile " + info.training_filename;
   if (info.game_id != -1) res += " gameid " + std::to_string(info.game_id);
+  res += " play_start_ply " + std::to_string(info.play_start_ply);
   if (info.is_black)
     res += " player1 " + std::string(*info.is_black ? "black" : "white");
   if (info.game_result != GameResult::UNDECIDED) {

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -287,6 +287,7 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
     game_info.is_black = player1_black;
     game_info.game_id = game_number;
     game_info.moves = game.GetMoves();
+    game_info.play_start_ply = opening.size();
     if (!enable_resign) {
       game_info.min_false_positive_threshold =
           game.GetWorstEvalForWinnerOrDraw();


### PR DESCRIPTION
This will allow client to add a pgn move annotation to the last ply of the 'opening' so people can know when the training data actually starts.