### PR TITLE
get system specific directories

### DIFF
--- a/src/utils/filesystem.h
+++ b/src/utils/filesystem.h
@@ -1,6 +1,6 @@
 /*
   This file is part of Leela Chess Zero.
-  Copyright (C) 2018 The LCZero Authors
+  Copyright (C) 2018-2019 The LCZero Authors
 
   Leela Chess is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -46,5 +46,17 @@ uint64_t GetFileSize(const std::string& filename);
 
 // Returns modification time of a file. Throws exception if file doesn't exist.
 time_t GetFileTime(const std::string& filename);
+
+// Returns the base directory relative to which user specific non-essential data
+// files are stored or an empty string if unspecified.
+std::string GetUserCacheDirectory();
+
+// Returns the base directory relative to which user specific configuration
+// files are stored or an empty string if unspecified.
+std::string GetUserConfigDirectory();
+
+// Returns the base directory relative to which user specific data files are
+// stored or an empty string if unspecified.
+std::string GetUserDataDirectory();
 
 }  // namespace lczero

--- a/src/utils/filesystem.posix.cc
+++ b/src/utils/filesystem.posix.cc
@@ -1,6 +1,6 @@
 /*
   This file is part of Leela Chess Zero.
-  Copyright (C) 2018 The LCZero Authors
+  Copyright (C) 2018-2019 The LCZero Authors
 
   Leela Chess is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -82,6 +82,45 @@ time_t GetFileTime(const std::string& filename) {
 #else
   return s.st_mtim.tv_sec;
 #endif
+}
+
+std::string GetUserCacheDirectory() {
+#ifdef __APPLE__
+  constexpr auto kLocalDir = "/Library/Caches";
+#else
+  constexpr auto kLocalDir = "/.cache";
+  const char *xdg_cache_home = std::getenv("XDG_CACHE_HOME");
+  if (xdg_cache_home != NULL) return std::string(xdg_cache_home);
+#endif
+  const char *home = std::getenv("HOME");
+  if (home == NULL) return std::string();
+  return std::string(home) + kLocalDir;
+}
+
+std::string GetUserConfigDirectory() {
+#ifdef __APPLE__
+  constexpr auto kLocalDir = "/Library/Preferences";
+#else
+  constexpr auto kLocalDir = "/.config";
+  const char *xdg_config_home = std::getenv("XDG_CONFIG_HOME");
+  if (xdg_config_home != NULL) return std::string(xdg_config_home);
+#endif
+  const char *home = std::getenv("HOME");
+  if (home == NULL) return std::string();
+  return std::string(home) + kLocalDir;
+}
+
+std::string GetUserDataDirectory() {
+#ifdef __APPLE__
+  constexpr auto kLocalDir = "/Library";
+#else
+  constexpr auto kLocalDir = "/.local/share";
+  const char *xdg_data_home = std::getenv("XDG_DATA_HOME");
+  if (xdg_data_home != NULL) return std::string(xdg_data_home);
+#endif
+  const char *home = std::getenv("HOME");
+  if (home == NULL) return std::string();
+  return std::string(home) + kLocalDir;
 }
 
 }  // namespace lczero

--- a/src/utils/filesystem.posix.cc
+++ b/src/utils/filesystem.posix.cc
@@ -86,41 +86,41 @@ time_t GetFileTime(const std::string& filename) {
 
 std::string GetUserCacheDirectory() {
 #ifdef __APPLE__
-  constexpr auto kLocalDir = "/Library/Caches";
+  constexpr auto kLocalDir = "Library/Caches/";
 #else
-  constexpr auto kLocalDir = "/.cache";
+  constexpr auto kLocalDir = ".cache/";
   const char *xdg_cache_home = std::getenv("XDG_CACHE_HOME");
-  if (xdg_cache_home != NULL) return std::string(xdg_cache_home);
+  if (xdg_cache_home != NULL) return std::string(xdg_cache_home) + "/";
 #endif
   const char *home = std::getenv("HOME");
   if (home == NULL) return std::string();
-  return std::string(home) + kLocalDir;
+  return std::string(home) + "/" + kLocalDir;
 }
 
 std::string GetUserConfigDirectory() {
 #ifdef __APPLE__
-  constexpr auto kLocalDir = "/Library/Preferences";
+  constexpr auto kLocalDir = "Library/Preferences/";
 #else
-  constexpr auto kLocalDir = "/.config";
+  constexpr auto kLocalDir = ".config/";
   const char *xdg_config_home = std::getenv("XDG_CONFIG_HOME");
-  if (xdg_config_home != NULL) return std::string(xdg_config_home);
+  if (xdg_config_home != NULL) return std::string(xdg_config_home) + "/";
 #endif
   const char *home = std::getenv("HOME");
   if (home == NULL) return std::string();
-  return std::string(home) + kLocalDir;
+  return std::string(home) + "/" + kLocalDir;
 }
 
 std::string GetUserDataDirectory() {
 #ifdef __APPLE__
-  constexpr auto kLocalDir = "/Library";
+  constexpr auto kLocalDir = "Library/";
 #else
-  constexpr auto kLocalDir = "/.local/share";
+  constexpr auto kLocalDir = ".local/share/";
   const char *xdg_data_home = std::getenv("XDG_DATA_HOME");
-  if (xdg_data_home != NULL) return std::string(xdg_data_home);
+  if (xdg_data_home != NULL) return std::string(xdg_data_home) + "/";
 #endif
   const char *home = std::getenv("HOME");
   if (home == NULL) return std::string();
-  return std::string(home) + kLocalDir;
+  return std::string(home) + "/" + kLocalDir;
 }
 
 }  // namespace lczero

--- a/src/utils/filesystem.win32.cc
+++ b/src/utils/filesystem.win32.cc
@@ -1,6 +1,6 @@
 /*
   This file is part of Leela Chess Zero.
-  Copyright (C) 2018 The LCZero Authors
+  Copyright (C) 2018-2019 The LCZero Authors
 
   Leela Chess is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -69,6 +69,18 @@ time_t GetFileTime(const std::string& filename) {
   }
   return (static_cast<uint64_t>(s.ftLastWriteTime.dwHighDateTime) << 32) +
          s.ftLastWriteTime.dwLowDateTime;
+}
+
+std::string GetUserCacheDirectory() {
+  return std::string();
+}
+
+std::string GetUserConfigDirectory() {
+  return std::string();
+}
+
+std::string GetUserDataDirectory() {
+  return std::string();
 }
 
 }  // namespace lczero


### PR DESCRIPTION
This is for #976, providing access functions to get the users cache, config and data directories using the `$XDG_*` environment variables, or system specific alternatives. An empty string is returned on windows or when no alternative can be provided.