### PR TITLE
update gtest wrap to 1.8.1 rev. 1

### DIFF
--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,10 +1,11 @@
 [wrap-file]
-directory = googletest-release-1.8.0
+directory = googletest-release-1.8.1
 
-source_url = https://github.com/google/googletest/archive/release-1.8.0.zip
-source_filename = gtest-1.8.0.zip
-source_hash = f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf
+source_url = https://github.com/google/googletest/archive/release-1.8.1.zip
+source_filename = gtest-1.8.1.zip
+source_hash = 927827c183d01734cc5cfef85e0ff3f5a92ffe6188e0d18e909c5efebf28a0c7
 
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/gtest/1.8.0/5/get_zip
-patch_filename = gtest-1.8.0-5-wrap.zip
-patch_hash = 7eeaede4aa2610a403313b74e04baf91ccfbaef03203d8f56312e22df1834ec5
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/gtest/1.8.1/1/get_zip
+patch_filename = gtest-1.8.1-1-wrap.zip
+patch_hash = f79f5fd46e09507b3f2e09a51ea6eb20020effe543335f5aee59f30cc8d15805
+


### PR DESCRIPTION
This will be needed for building with c++17 on windows: at least appveyor builds fail with the previous version.