### PR TITLE
Use actual rooks instead of rook-like pieces when determining castling.

### DIFF
--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -1031,7 +1031,8 @@ void ChessBoard::SetFromFen(const std::string& fen, int* no_capture_ply,
       const bool is_black = std::islower(c);
       const int king_col = (is_black ? their_king_ : our_king_).col();
       if (!is_black) c = std::tolower(c);
-      const auto rooks = (is_black ? their_pieces_ : our_pieces_) & rooks_;
+      const auto rooks =
+          (is_black ? their_pieces_ : our_pieces_) & ChessBoard::rooks();
       if (c == 'k') {
         // Finding rightmost rook.
         for (right_rook = FILE_H; right_rook > king_col; --right_rook) {

--- a/src/chess/board_test.cc
+++ b/src/chess/board_test.cc
@@ -2102,7 +2102,9 @@ const struct {
     {"rkrnnqbb/p1ppp2p/Qp6/4Pp2/5p2/8/PPPP2PP/RKRNN1BB w CAca - 0 9",
      {35, 929, 32020, 896130, 31272517, 915268405}},  // 959
     {"bbq1nr1r/pppppk1p/2n2p2/6p1/P4P2/4P1P1/1PPP3P/BBQNNRKR w HF - 1 9",
-     {23, 589, 14744, 387556, 10316716, 280056112}}  // 960
+     {23, 589, 14744, 387556, 10316716, 280056112}},  // 960
+    {"bqrkrbnn/ppp1pppp/8/8/8/8/PPP1PPPP/BQRKRBNN w CKeq - 0 1",
+     {19, 342, 6987, 142308, 3294156, 75460468}},  // 961 castling
 };
 }  // namespace
 


### PR DESCRIPTION
r?@mooskagh or @borg323 Wasn't sure if it's preferable to do `this->rooks()` vs `ChessBoard::rooks()` or just have a different local variable name.