### PR TITLE
Initialize prev_child_nodes_ to prevent storing of visits without new child nodes.

### DIFF
--- a/src/mcts/stoppers/stoppers.h
+++ b/src/mcts/stoppers/stoppers.h
@@ -113,7 +113,7 @@ class KldGainStopper : public SearchStopper {
   const int average_interval_;
   Mutex mutex_;
   std::vector<uint32_t> prev_visits_ GUARDED_BY(mutex_);
-  int64_t prev_child_nodes_ GUARDED_BY(mutex_);
+  int64_t prev_child_nodes_ GUARDED_BY(mutex_) = 0;
 };
 
 // Does many things:


### PR DESCRIPTION
r?@mooskagh or @borg323. @Tilps noticed `prev_child_nodes_` was uninitialized, so if it was negative, the condition to exit early would be not be satisfied:
https://github.com/LeelaChessZero/lc0/blob/7eb26031c56e27e66d7fdf54afd4aaa98b41acdc/src/mcts/stoppers/stoppers.cc#L150

This results in saving the nodes and visits for subsequent stop checks. If the new child nodes was 0 while saving visits, when the next time the condition to exit early is also skipped (e.g., 100 new nodes with default average_interval), this resulted in the division by 0.