### PR TITLE
Allow showing per-pv node counts instead of total nodes.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -173,6 +173,9 @@ const OptionId SearchParams::kMultiPvId{
     "multipv", "MultiPV",
     "Number of game play lines (principal variations) to show in UCI info "
     "output."};
+const OptionId SearchParams::kPerPvCountersId{
+    "per-pv-counters", "PerPVCounters",
+    "Show node counts per principal variation instead of total nodes in UCI."};
 const OptionId SearchParams::kScoreTypeId{
     "score-type", "ScoreType",
     "What to display as score. Either centipawns (the UCI default), win "
@@ -222,6 +225,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<BoolOption>(kStickyEndgamesId) = true;
   options->Add<BoolOption>(kSyzygyFastPlayId) = true;
   options->Add<IntOption>(kMultiPvId, 1, 500) = 1;
+  options->Add<BoolOption>(kPerPvCountersId) = false;
   std::vector<std::string> score_type = {"centipawn", "centipawn_2018",
                                          "win_percentage", "Q"};
   options->Add<ChoiceOption>(kScoreTypeId, score_type) = "centipawn";

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -92,6 +92,9 @@ class SearchParams {
   bool GetStickyEndgames() const { return kStickyEndgames; }
   bool GetSyzygyFastPlay() const { return kSyzygyFastPlay; }
   int GetMultiPv() const { return options_.Get<int>(kMultiPvId.GetId()); }
+  bool GetPerPvCounters() const {
+    return options_.Get<bool>(kPerPvCountersId.GetId());
+  }
   std::string GetScoreType() const {
     return options_.Get<std::string>(kScoreTypeId.GetId());
   }
@@ -127,6 +130,7 @@ class SearchParams {
   static const OptionId kStickyEndgamesId;
   static const OptionId kSyzygyFastPlayId;
   static const OptionId kMultiPvId;
+  static const OptionId kPerPvCountersId;
   static const OptionId kScoreTypeId;
   static const OptionId kHistoryFillId;
   static const OptionId kShortSightednessId;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -91,8 +91,10 @@ void ApplyDirichletNoise(Node* node, float eps, double alpha) {
 }  // namespace
 
 void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
-  auto edges = GetBestChildrenNoTemperature(root_node_, params_.GetMultiPv());
+  const auto max_pv = params_.GetMultiPv();
+  const auto edges = GetBestChildrenNoTemperature(root_node_, max_pv);
   const auto score_type = params_.GetScoreType();
+  const auto per_pv_counters = params_.GetPerPvCounters();
 
   std::vector<ThinkingInfo> uci_infos;
 
@@ -101,7 +103,9 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
   common_info.depth = cum_depth_ / (total_playouts_ ? total_playouts_ : 1);
   common_info.seldepth = max_depth_;
   common_info.time = GetTimeSinceStart();
-  common_info.nodes = total_playouts_ + initial_visits_;
+  if (!per_pv_counters) {
+    common_info.nodes = total_playouts_ + initial_visits_;
+  }
   common_info.hashfull =
       cache_->GetSize() * 1000LL / std::max(cache_->GetCapacity(), 1);
   common_info.nps =
@@ -124,7 +128,8 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
     } else if (score_type == "Q") {
       uci_info.score = edge.GetQ(default_q) * 10000;
     }
-    if (params_.GetMultiPv() > 1) uci_info.multipv = multipv;
+    if (max_pv > 1) uci_info.multipv = multipv;
+    if (per_pv_counters) uci_info.nodes = edge.GetN();
     bool flip = played_history_.IsBlackToMove();
     for (auto iter = edge; iter;
          iter = GetBestChildNoTemperature(iter.node()), flip = !flip) {


### PR DESCRIPTION
r?@mooskagh This also allows showing the default single primary pv with actual nodes visited to that child. Also very small factoring out `params_.GetMultiPv()` to avoid calling per loop and reuse the initial call at the very top of `SendUciInfo`.

@jjoshua2 Looks like you were asking for this last week:
> it appears multipv outputs total node count
is there a way to get to print multipv node count?
could that be a simple flag im missing? or simple source code change? or do we not even keep track of that?

Before:
```
--multipv=5
go nodes 40

info depth 4 seldepth 11 time 6998 nodes 39 score cp 30 hashfull 1 nps 5 tbhits 0 multipv 1 pv e2e4 c7c6 d2d3 g8f6 g1f3 d7d6
info depth 4 seldepth 11 time 6998 nodes 39 score cp 20 hashfull 1 nps 5 tbhits 0 multipv 2 pv d2d4 g8f6 c2c4 e7e6 g2g3 f8b4
info depth 4 seldepth 11 time 6998 nodes 39 score cp 20 hashfull 1 nps 5 tbhits 0 multipv 3 pv g1f3 d7d5 d2d4 g8f6 c2c4
info depth 4 seldepth 11 time 6998 nodes 39 score cp 17 hashfull 1 nps 5 tbhits 0 multipv 4 pv c2c4 e7e5 g2g3
info depth 4 seldepth 11 time 6998 nodes 39 score cp 26 hashfull 1 nps 5 tbhits 0 multipv 5 pv e2e3
```

After:
```
--multipv=5 --per-pv-counters
go nodes 40

info depth 4 seldepth 11 time 5556 nodes 25 score cp 30 hashfull 1 nps 7 tbhits 0 multipv 1 pv e2e4 c7c6 d2d3 g8f6 f2f4 d7d6
info depth 4 seldepth 11 time 5556 nodes 7 score cp 21 hashfull 1 nps 7 tbhits 0 multipv 2 pv d2d4 g8f6 c2c4 e7e6 g1f3 d7d5
info depth 4 seldepth 11 time 5556 nodes 4 score cp 19 hashfull 1 nps 7 tbhits 0 multipv 3 pv g1f3 d7d5 d2d4 g8f6 c2c4
info depth 4 seldepth 11 time 5556 nodes 2 score cp 15 hashfull 1 nps 7 tbhits 0 multipv 4 pv c2c4 e7e5 g2g3
info depth 4 seldepth 11 time 5556 nodes 0 score cp 26 hashfull 1 nps 7 tbhits 0 multipv 5 pv e2e3
```