### PR TITLE
Use floats for KLD-related division expressions.

### DIFF
--- a/src/mcts/stoppers/stoppers.cc
+++ b/src/mcts/stoppers/stoppers.cc
@@ -146,7 +146,7 @@ KldGainStopper::KldGainStopper(float min_gain, int average_interval)
 
 bool KldGainStopper::ShouldStop(const IterationStats& stats, StoppersHints*) {
   Mutex::Lock lock(mutex_);
-  const auto new_child_nodes = stats.total_nodes - 1;
+  const auto new_child_nodes = stats.total_nodes - 1.0f;
   if (new_child_nodes < prev_child_nodes_ + average_interval_) return false;
 
   const auto new_visits = stats.edge_n;

--- a/src/mcts/stoppers/stoppers.h
+++ b/src/mcts/stoppers/stoppers.h
@@ -109,11 +109,11 @@ class KldGainStopper : public SearchStopper {
   bool ShouldStop(const IterationStats&, StoppersHints*) override;
 
  private:
-  const int min_gain_;
+  const float min_gain_;
   const int average_interval_;
   Mutex mutex_;
   std::vector<uint32_t> prev_visits_ GUARDED_BY(mutex_);
-  int64_t prev_child_nodes_ GUARDED_BY(mutex_) = 0;
+  float prev_child_nodes_ GUARDED_BY(mutex_) = 0.0f;
 };
 
 // Does many things:


### PR DESCRIPTION
r?@mooskagh or @borg323 or @Tilps Fix #1003 by pre-casting nodes and min_gain to `float` to avoid 2 problems:

These two divisions are integer divisions with the integer 0 result casted to float:
https://github.com/LeelaChessZero/lc0/blob/b7f67acd8b15782b82d770186fa7a65586b1b8b5/src/mcts/stoppers/stoppers.cc#L156-L157

And the comparison against min_gain was always against 0 unless `min_gain` was set to 1:
https://github.com/LeelaChessZero/lc0/blob/b7f67acd8b15782b82d770186fa7a65586b1b8b5/src/mcts/stoppers/stoppers.cc#L160

I realize nodes aren't a float, so the alternative is to `prev_visits_[i] / static_cast<float>(prev_child_nodes_)` or maybe cast outside the `for` loop?