### PR TITLE
Convert moves to FRC-compatible encoding when building searchmoves list.

### DIFF
--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -759,6 +759,13 @@ Move ChessBoard::GetLegacyMove(Move move) const {
   return move;
 }
 
+Move ChessBoard::GetModernMove(Move move) const {
+  if (our_king_ != E1 || move.from() != E1) return move;
+  if (move == Move(E1, G1) && !our_pieces_.get(G1)) return Move(E1, H1);
+  if (move == Move(E1, C1) && !our_pieces_.get(C1)) return Move(E1, A1);
+  return move;
+}
+
 KingAttackInfo ChessBoard::GenerateKingAttackInfo() const {
   KingAttackInfo king_attack_info;
 

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -101,7 +101,7 @@ class ChessBoard {
   bool IsSameMove(Move move1, Move move2) const;
   // Returns the same move but with castling encoded in legacy way.
   Move GetLegacyMove(Move move) const;
-  // Returns the same move but with castling encoded in modern 😎 way.
+  // Returns the same move but with castling encoded in modern way.
   Move GetModernMove(Move move) const;
 
   uint64_t Hash() const {

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -101,6 +101,8 @@ class ChessBoard {
   bool IsSameMove(Move move1, Move move2) const;
   // Returns the same move but with castling encoded in legacy way.
   Move GetLegacyMove(Move move) const;
+  // Returns the same move but with castling encoded in modern 😎 way.
+  Move GetModernMove(Move move) const;
 
   uint64_t Hash() const {
     return HashCat({our_pieces_.as_int(), their_pieces_.as_int(),

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -61,10 +61,12 @@ const OptionId kShowWDL{"show-wdl", "UCI_ShowWDL",
                         "Show win, draw and lose probability."};
 
 MoveList StringsToMovelist(const std::vector<std::string>& moves,
-                           bool is_black) {
+                           const ChessBoard& board) {
   MoveList result;
   result.reserve(moves.size());
-  for (const auto& move : moves) result.emplace_back(move, is_black);
+  for (const auto& move : moves) {
+    result.push_back(board.GetModernMove({move, board.flipped()}));
+  }
   return result;
 }
 
@@ -283,7 +285,7 @@ void EngineController::Go(const GoParams& params) {
       time_manager_->GetStopper(options_, params, tree_->HeadPosition());
   search_ = std::make_unique<Search>(
       *tree_, network_.get(), std::move(responder),
-      StringsToMovelist(params.searchmoves, tree_->IsBlackToMove()),
+      StringsToMovelist(params.searchmoves, tree_->HeadPosition().GetBoard()),
       move_start_time_, std::move(stopper), params.infinite || params.ponder,
       options_, &cache_, syzygy_tb_.get());
 

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -65,7 +65,7 @@ MoveList StringsToMovelist(const std::vector<std::string>& moves,
   MoveList result;
   result.reserve(moves.size());
   for (const auto& move : moves) {
-    result.push_back(board.GetModernMove({move, board.flipped()}));
+    result.emplace_back(board.GetModernMove({move, board.flipped()}));
   }
   return result;
 }

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -418,6 +418,7 @@ void NodeTree::MakeMove(Move move) {
       break;
     }
   }
+  move = board.GetModernMove(move);
   current_head_->ReleaseChildrenExceptOne(new_head);
   current_head_ =
       new_head ? new_head : current_head_->CreateSingleChildNode(move);


### PR DESCRIPTION
(also do that when unvisited move is entered through uci position command, but it worked fine without that too)

Fixes #1001