### PR TITLE
Fix time reporting issues.

### DIFF
--- a/src/engine.h
+++ b/src/engine.h
@@ -78,6 +78,7 @@ class EngineController {
 
   void SetupPosition(const std::string& fen,
                      const std::vector<std::string>& moves);
+  void ResetMoveTimer();
 
   const OptionsDict& options_;
 
@@ -105,7 +106,7 @@ class EngineController {
   optional<CurrentPosition> current_position_;
   GoParams go_params_;
 
-  std::chrono::steady_clock::time_point move_start_time_;
+  optional<std::chrono::steady_clock::time_point> move_start_time_;
 };
 
 class EngineLoop : public UciLoop {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -113,9 +113,9 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
         std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - *nps_start_time_)
             .count();
-    common_info.nps = total_playouts_ * 1000 / time_since_first_batch_ms;
-  } else {
-    common_info.nps = 0;
+    if (time_since_first_batch_ms > 0) {
+      common_info.nps = total_playouts_ * 1000 / time_since_first_batch_ms;
+    }
   }
 
   int multipv = 0;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -108,9 +108,15 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
   }
   common_info.hashfull =
       cache_->GetSize() * 1000LL / std::max(cache_->GetCapacity(), 1);
-  common_info.nps =
-      common_info.time ? (total_playouts_ * 1000 / common_info.time) : 0;
-  common_info.tb_hits = tb_hits_.load(std::memory_order_acquire);
+  if (nps_start_time_) {
+    const auto time_since_first_batch_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - *nps_start_time_)
+            .count();
+    common_info.nps = total_playouts_ * 1000 / time_since_first_batch_ms;
+  } else {
+    common_info.nps = 0;
+  }
 
   int multipv = 0;
   const auto default_q = -root_node_->GetQ();
@@ -570,6 +576,9 @@ void Search::PopulateCommonIterationStats(IterationStats* stats) {
   stats->time_since_movestart = GetTimeSinceStart();
 
   SharedMutex::SharedLock nodes_lock(nodes_mutex_);
+  if (!nps_start_time_ && total_playouts_ > 0) {
+    nps_start_time_ = std::chrono::steady_clock::now();
+  }
   stats->total_nodes = total_playouts_ + initial_visits_;
   stats->nodes_since_movestart = total_playouts_;
   stats->average_depth = cum_depth_ / (total_playouts_ ? total_playouts_ : 1);

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -117,6 +117,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
       common_info.nps = total_playouts_ * 1000 / time_since_first_batch_ms;
     }
   }
+  common_info.tb_hits = tb_hits_.load(std::memory_order_acquire);
 
   int multipv = 0;
   const auto default_q = -root_node_->GetQ();

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -173,6 +173,7 @@ class Search {
   uint16_t max_depth_ GUARDED_BY(nodes_mutex_) = 0;
   // Cummulative depth of all paths taken in PickNodetoExtend.
   uint64_t cum_depth_ GUARDED_BY(nodes_mutex_) = 0;
+  optional<std::chrono::steady_clock::time_point> nps_start_time_;
   std::atomic<int> tb_hits_{0};
 
   std::unique_ptr<UciResponder> uci_responder_;


### PR DESCRIPTION
1. Reset move clock on `go` command if there was no ucinewgame or
position before it.
2. For nps, only start timer after the first iteration is done.

Fixes #1012 