### PR TITLE
Apply short-sightedness value discounting only to non-terminal nodes.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1223,12 +1223,14 @@ void SearchWorker::DoBackupUpdateSingleNode(
 
     // Current node might have become terminal from some other descendant, so
     // backup the rest of the way with more accurate values.
+    auto value_discount = 1.0f;
     if (n->IsTerminal()) {
       v = n->GetQ();
       d = n->GetD();
+    } else {
+      value_discount /= 1.0f + params_.GetShortSightedness() * depth;
     }
-    n->FinalizeScoreUpdate(v / (1.0f + params_.GetShortSightedness() * depth),
-                           d, node_to_process.multivisit);
+    n->FinalizeScoreUpdate(v * value_discount, d, node_to_process.multivisit);
 
     // Nothing left to do without ancestors to update.
     if (!p) break;


### PR DESCRIPTION
r?@Tilps Using short-sightedness caused converted "terminals" to have non ±1 value preventing them from propagating higher up the tree. E.g.,

Before:
```
--short-sightedness=0.02 --sticky-endgames 

position fen 8/8/8/8/8/5K2/R7/7k w - - 0 1 moves f3g3
go nodes 2

h1g1 (P: 100.00%) (V: -0.9902) (T) 
```

After:
```
h1g1 (P: 100.00%) (V: -1.0000) (T) 
```

Additionally with this fix, the move probability training data for playing the mating line can be much improved:
![Screen Shot 2019-11-26 at 10 11 17 AM](https://user-images.githubusercontent.com/438537/69661526-6f03ff00-1037-11ea-808a-d33db71b5ab0.png)
```
position fen 8/8/8/8/8/5K2/R7/7k w - - 0 1
go nodes 800

--short-sightedness=0.02 --sticky-endgames
f3e4 N:      44 P:  5.19% Q:  0.94973 
a2a7 N:      45 P:  5.39% Q:  0.95002 
f3g3 N:     163 P:  5.46% Q:  1.00000 (T) 

--short-sightedness=0.02 --no-sticky-endgames
a2a8 N:      50 P:  5.32% Q:  0.94912 
a2a7 N:      51 P:  5.39% Q:  0.94911 
a2d2 N:      51 P:  5.24% Q:  0.94846 

--short-sightedness=0 --no-sticky-endgames
a2a1 N:      47 P:  5.26% Q:  0.99885 
f3e3 N:      47 P:  5.19% Q:  0.99877 
a2a7 N:      49 P:  5.39% Q:  0.99895 
```