### PR TITLE
Implement weighted average Q backup operator

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -265,10 +265,13 @@ void Node::CancelScoreUpdate(int multivisit) {
   best_child_cached_ = nullptr;
 }
 
-void Node::FinalizeScoreUpdate(float v, float d, int multivisit) {
+void Node::FinalizeScoreUpdate(float v, float d, int multivisit, float alpha) {
   // Recompute Q.
-  q_ += multivisit * (v - q_) / (n_ + multivisit);
-  d_ += multivisit * (d - d_) / (n_ + multivisit);
+  for (int i = 0; i < multivisit; ++i) {
+    float decay = alpha / ( (n_ + i) + alpha );
+    q_ = q_ * (1.0f-decay) + v * decay;
+    d_ = d_ * (1.0f-decay) + d * decay;
+  }
 
   // If first visit, update parent's sum of policies visited at least once.
   if (n_ == 0 && parent_ != nullptr) {

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -178,7 +178,7 @@ class Node {
   // * Q (weighted average of all V in a subtree)
   // * N (+=1)
   // * N-in-flight (-=1)
-  void FinalizeScoreUpdate(float v, float d, int multivisit);
+  void FinalizeScoreUpdate(float v, float d, int multivisit, float alpha);
   // When search decides to treat one visit as several (in case of collisions
   // or visiting terminal nodes several times), it amplifies the visit by
   // incrementing n_in_flight.

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -190,6 +190,11 @@ const OptionId SearchParams::kShortSightednessId{
     "short-sightedness", "ShortSightedness",
     "Used to focus more on short term gains over long term."};
 
+const OptionId SearchParams::kWeightedAverageAlphaId{
+    "weighted-average-alpha", "WeightedAverageAlpha",
+    "1.0 is equivalent to the regular averaging, higher values make the MCTS"
+    "backup to prioritize newer values over older ones."};
+
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
   // Many of them are overridden with training specific values in tournament.cc.
@@ -232,6 +237,7 @@ void SearchParams::Populate(OptionsParser* options) {
   std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
   options->Add<FloatOption>(kShortSightednessId, 0.0f, 1.0f) = 0.0f;
+  options->Add<FloatOption>(kWeightedAverageAlphaId, 1.0f, 10.0f) = 1.0f;
 
   options->HideOption(kNoiseEpsilonId);
   options->HideOption(kNoiseAlphaId);
@@ -269,6 +275,8 @@ SearchParams::SearchParams(const OptionsDict& options)
       kHistoryFill(
           EncodeHistoryFill(options.Get<std::string>(kHistoryFillId.GetId()))),
       kMiniBatchSize(options.Get<int>(kMiniBatchSizeId.GetId())),
-      kShortSightedness(options.Get<float>(kShortSightednessId.GetId())) {}
+      kShortSightedness(options.Get<float>(kShortSightednessId.GetId())),
+      kWeightedAverageAlpha(
+          options.Get<float>(kWeightedAverageAlphaId.GetId())) {}
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -99,6 +99,7 @@ class SearchParams {
     return options_.Get<std::string>(kScoreTypeId.GetId());
   }
   FillEmptyHistory GetHistoryFill() const { return kHistoryFill; }
+  float GetWeightedAverageAlpha() const { return kWeightedAverageAlpha; }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -134,6 +135,7 @@ class SearchParams {
   static const OptionId kScoreTypeId;
   static const OptionId kHistoryFillId;
   static const OptionId kShortSightednessId;
+  static const OptionId kWeightedAverageAlphaId;
 
  private:
   const OptionsDict& options_;
@@ -163,6 +165,7 @@ class SearchParams {
   const FillEmptyHistory kHistoryFill;
   const int kMiniBatchSize;
   const float kShortSightedness;
+  const float kWeightedAverageAlpha;
 };
 
 }  // namespace lczero

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1228,7 +1228,8 @@ void SearchWorker::DoBackupUpdateSingleNode(
       d = n->GetD();
     }
     n->FinalizeScoreUpdate(v / (1.0f + params_.GetShortSightedness() * depth),
-                           d, node_to_process.multivisit);
+                           d, node_to_process.multivisit,
+                           params_.GetWeightedAverageAlpha());
 
     // Nothing left to do without ancestors to update.
     if (!p) break;


### PR DESCRIPTION
Changed the way Q averaging works so newer values have a higher weight than the older ones.
Added a new parameter `WeightedAverageAlpha`. Setting it to 1.0 the old behavior is used, higher values increase the weight newer values have over the older ones.

Attaching graphs showing how the two different backup algorithms adapt to a simulated visit distribution.

WeightedAverageAlpha=2.0: 
![w2_0](https://user-images.githubusercontent.com/1651950/70956365-9a847300-2052-11ea-9c26-9243c39faa46.png)

WeightedAverageAlpha=5.0:
![w5_0](https://user-images.githubusercontent.com/1651950/70956366-9b1d0980-2052-11ea-94e3-54fc9e2700ef.png)
