### PR TITLE
Investigate checkmoves first

### DIFF
--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -970,18 +970,6 @@ MoveList ChessBoard::GenerateLegalMoves() const {
       std::remove_if(result.begin(), result.end(),
                      [&](Move m) { return !IsLegalMove(m, king_attack_info); }),
       result.end());
-
-  // moves ordering try to put checks first in the list...
-  std::vector<ChessBoard> vec;
-  for (const auto move : result) {
-    ChessBoard board = ChessBoard(*this);
-    board.ApplyMove(move);
-    vec.emplace_back(board);
-  }
-  // following sorts the vector, but not the result..ehh?
-  std::sort(vec.begin(), vec.end(), [](ChessBoard& a, ChessBoard& b) {
-    return (a.IsUnderCheck() == true ? 1 : 0) > (b.IsUnderCheck() == true ? 1 : 0);
-  });
   return result;
 }
 

--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -970,6 +970,18 @@ MoveList ChessBoard::GenerateLegalMoves() const {
       std::remove_if(result.begin(), result.end(),
                      [&](Move m) { return !IsLegalMove(m, king_attack_info); }),
       result.end());
+
+  // moves ordering try to put checks first in the list...
+  std::vector<ChessBoard> vec;
+  for (const auto move : result) {
+    ChessBoard board = ChessBoard(*this);
+    board.ApplyMove(move);
+    vec.emplace_back(board);
+  }
+  // following sorts the vector, but not the result..ehh?
+  std::sort(vec.begin(), vec.end(), [](ChessBoard& a, ChessBoard& b) {
+    return (a.IsUnderCheck() == true ? 1 : 0) > (b.IsUnderCheck() == true ? 1 : 0);
+  });
   return result;
 }
 


### PR DESCRIPTION
What if FetchSingleNodeResult would have a way to boost P in case there are 'check moves'?

The idea is that leela would then investigate check-moves first, when extending edges for a node, so that it can discover things like perpetual checks easier.

An example fen:
7k/5Q2/6pp/8/8/5P2/r2q2PP/6K1 w - - 0 1

![image](https://user-images.githubusercontent.com/506830/72338836-9dac6680-36c5-11ea-8e6f-4d146f319ce1.png)

In this scenario white simply has to keep the black king in checking, by moving f7-f8-f7 etc.

42850 is a net that does not seem to see the danger on low node counts and prefers to play the a losing move, investigates pawn-moves like h2-h4 in default lc0:
```
C:\lc0>lc0 --verbose-move-stats -t 1 --minibatch-size=16 --weights=.\nets\42850  --cache-history-length=5 --history-fill=no --multipv=3
       _
|   _ | |
|_ |_ |_| v0.24.0-dev+git.f83f81d built Jan  5 2020
position fen 7k/5Q2/6pp/8/8/5P2/r2q2PP/6K1 w - - 0 1
go nodes 50
Loading weights file from: .\nets\42850
Creating backend [cudnn-auto]...
Switching to [cudnn]...
CUDA Runtime version: 10.2.0
Cudnn version: 7.3.1
WARNING: CUDNN Runtime version mismatch, was compiled with version 7.4.1
Latest version of CUDA supported by the driver: 10.2.0
GPU: Quadro M1000M
GPU memory: 2 Gb
GPU clock frequency: 1071.5 MHz
GPU compute capability: 5.0
info depth 1 seldepth 2 time 21915 nodes 8 score cp -6068 hashfull 0 nps 119 tbhits 0 multipv 1 pv h2h4 d2g2
info depth 1 seldepth 2 time 21915 nodes 8 score cp -7359 hashfull 0 nps 119 tbhits 0 multipv 2 pv h2h3 d2g2
info depth 1 seldepth 2 time 21915 nodes 8 score cp -9358 hashfull 0 nps 119 tbhits 0 multipv 3 pv g1h1 d2g2
info depth 2 seldepth 3 time 21966 nodes 25 score cp -12800 hashfull 0 nps 211 tbhits 0 multipv 1 pv h2h4 d2g2
info depth 2 seldepth 3 time 21966 nodes 25 score cp -12800 hashfull 0 nps 211 tbhits 0 multipv 2 pv h2h3 d2g2
info depth 2 seldepth 3 time 21966 nodes 25 score cp -12800 hashfull 0 nps 211 tbhits 0 multipv 3 pv g2g3 d2c1
info depth 2 seldepth 4 time 22014 nodes 42 score cp -12800 hashfull 0 nps 253 tbhits 0 multipv 1 pv h2h4 d2g2
info depth 2 seldepth 4 time 22014 nodes 42 score cp -12800 hashfull 0 nps 253 tbhits 0 multipv 2 pv h2h3 d2g2
info depth 2 seldepth 4 time 22014 nodes 42 score cp -12800 hashfull 0 nps 253 tbhits 0 multipv 3 pv g2g3 d2c1
info depth 2 seldepth 5 time 22017 nodes 58 score cp -12800 hashfull 0 nps 343 tbhits 0 multipv 1 pv h2h4 d2g2
info depth 2 seldepth 5 time 22017 nodes 58 score cp -12800 hashfull 0 nps 343 tbhits 0 multipv 2 pv h2h3 d2g2
info depth 2 seldepth 5 time 22017 nodes 58 score cp -12800 hashfull 0 nps 343 tbhits 0 multipv 3 pv g2g3 d2c1
info string f7a2  (1519) N:       0 (+ 0) (P:  0.02%) (Q: -2.19537) (D:  0.000) (U: 0.00458) (Q+U: -2.19080) (V:  -.----)
info string f7b3  (1521) N:       0 (+ 0) (P:  0.02%) (Q: -2.19537) (D:  0.000) (U: 0.00470) (Q+U: -2.19067) (V:  -.----)
info string f7c4  (1523) N:       0 (+ 0) (P:  0.02%) (Q: -2.19537) (D:  0.000) (U: 0.00477) (Q+U: -2.19060) (V:  -.----)
info string f7d5  (1525) N:       0 (+ 0) (P:  0.02%) (Q: -2.19537) (D:  0.000) (U: 0.00517) (Q+U: -2.19021) (V:  -.----)
info string f7g8  (1545) N:       0 (+ 0) (P:  0.03%) (Q: -2.19537) (D:  0.000) (U: 0.00611) (Q+U: -2.18926) (V:  -.----)
info string f7g6  (1533) N:       0 (+ 0) (P:  0.03%) (Q: -2.19537) (D:  0.000) (U: 0.00651) (Q+U: -2.18886) (V:  -.----)
info string f7e8  (1543) N:       0 (+ 0) (P:  0.03%) (Q: -2.19537) (D:  0.000) (U: 0.00681) (Q+U: -2.18856) (V:  -.----)
info string f7e6  (1531) N:       0 (+ 0) (P:  0.03%) (Q: -2.19537) (D:  0.000) (U: 0.00691) (Q+U: -2.18847) (V:  -.----)
info string f7a7  (1535) N:       0 (+ 0) (P:  0.03%) (Q: -2.19537) (D:  0.000) (U: 0.00793) (Q+U: -2.18745) (V:  -.----)
info string f7h7  (1541) N:       0 (+ 0) (P:  0.04%) (Q: -2.19537) (D:  0.000) (U: 0.00797) (Q+U: -2.18740) (V:  -.----)
info string f7b7  (1536) N:       0 (+ 0) (P:  0.04%) (Q: -2.19537) (D:  0.000) (U: 0.00809) (Q+U: -2.18729) (V:  -.----)
info string f7c7  (1537) N:       0 (+ 0) (P:  0.04%) (Q: -2.19537) (D:  0.000) (U: 0.00817) (Q+U: -2.18720) (V:  -.----)
info string f7f4  (1524) N:       0 (+ 0) (P:  0.04%) (Q: -2.19537) (D:  0.000) (U: 0.00859) (Q+U: -2.18679) (V:  -.----)
info string f7d7  (1538) N:       0 (+ 0) (P:  0.04%) (Q: -2.19537) (D:  0.000) (U: 0.00925) (Q+U: -2.18612) (V:  -.----)
info string f7f5  (1527) N:       0 (+ 0) (P:  0.04%) (Q: -2.19537) (D:  0.000) (U: 0.00955) (Q+U: -2.18583) (V:  -.----)
info string f7g7  (1540) N:       0 (+ 0) (P:  0.05%) (Q: -2.19537) (D:  0.000) (U: 0.01056) (Q+U: -2.18481) (V:  -.----)
info string f7f8  (1544) N:       0 (+ 0) (P:  0.05%) (Q: -2.19537) (D:  0.000) (U: 0.01094) (Q+U: -2.18443) (V:  -.----)
info string f7f6  (1532) N:       0 (+ 0) (P:  0.08%) (Q: -2.19537) (D:  0.000) (U: 0.01707) (Q+U: -2.17831) (V:  -.----)
info string f7e7  (1539) N:       0 (+ 0) (P:  0.11%) (Q: -2.19537) (D:  0.000) (U: 0.02528) (Q+U: -2.17010) (V:  -.----)
info string g1f1  (152 ) N:       6 (+ 0) (P: 10.04%) (Q: -1.00000) (D:  0.000) (U: 0.32546) (Q+U: -0.67454) (V: -1.0000) (T)
info string g1h1  (153 ) N:       6 (+ 0) (P: 10.08%) (Q: -1.00000) (D:  0.000) (U: 0.32665) (Q+U: -0.67335) (V: -1.0000) (T)
info string g2g4  (378 ) N:       8 (+ 0) (P: 13.73%) (Q: -1.00000) (D:  0.000) (U: 0.34608) (Q+U: -0.65392) (V: -1.0000) (T)
info string f3f4  (584 ) N:       9 (+ 0) (P: 16.08%) (Q: -1.00000) (D:  0.000) (U: 0.36494) (Q+U: -0.63506) (V: -1.0000) (T)
info string g2g3  (374 ) N:       9 (+ 0) (P: 16.09%) (Q: -1.00000) (D:  0.000) (U: 0.36507) (Q+U: -0.63493) (V: -1.0000) (T)
info string h2h3  (400 ) N:       9 (+ 0) (P: 16.50%) (Q: -1.00000) (D:  0.000) (U: 0.37435) (Q+U: -0.62565) (V: -1.0000) (T)
info string h2h4  (403 ) N:      10 (+ 0) (P: 16.74%) (Q: -1.00000) (D:  0.000) (U: 0.34536) (Q+U: -0.65464) (V: -1.0000) (T)
bestmove h2h4 ponder d2g2
```

Now, boosting P to inspect the check-moves first.

lc0boostp with net 42850 example.
```

C:\lc0>lc0boostp  --verbose-move-stats -t 2 --minibatch-size=32 --multipv=5 --weights=.\nets\42850
       _
|   _ | |
|_ |_ |_| v0.24.0-dev+git.f83f81d built Jan  5 2020
position fen 7k/5Q2/6pp/8/8/5P2/r2q2PP/6K1 w - - 0 1
go nodes 50
Loading weights file from: .\nets\42850
Creating backend [cudnn-auto]...
Switching to [cudnn]...
CUDA Runtime version: 10.2.0
Cudnn version: 7.3.1
WARNING: CUDNN Runtime version mismatch, was compiled with version 7.4.1
Latest version of CUDA supported by the driver: 10.2.0
GPU: Quadro M1000M
GPU memory: 2 Gb
GPU clock frequency: 1071.5 MHz
GPU compute capability: 5.0
info depth 1 seldepth 2 time 5775 nodes 2 score cp 13 hashfull 0 nps 32 tbhits 0 multipv 1 pv f7f8 h8h7
info depth 1 seldepth 2 time 5775 nodes 2 score cp 0 hashfull 0 nps 32 tbhits 0 multipv 2 pv f7e8
info depth 1 seldepth 2 time 5775 nodes 2 score cp 0 hashfull 0 nps 32 tbhits 0 multipv 3 pv f7f6
info depth 1 seldepth 2 time 5775 nodes 2 score cp 0 hashfull 0 nps 32 tbhits 0 multipv 4 pv f7g8
info depth 1 seldepth 2 time 5775 nodes 2 score cp 0 hashfull 0 nps 32 tbhits 0 multipv 5 pv f7g7
info depth 2 seldepth 3 time 5824 nodes 3 score cp 6 hashfull 0 nps 26 tbhits 0 multipv 1 pv f7f8 h8h7 f8f7
info depth 2 seldepth 3 time 5824 nodes 3 score cp 0 hashfull 0 nps 26 tbhits 0 multipv 2 pv f7e8
info depth 2 seldepth 3 time 5824 nodes 3 score cp 0 hashfull 0 nps 26 tbhits 0 multipv 3 pv f7f6
info depth 2 seldepth 3 time 5824 nodes 3 score cp 0 hashfull 0 nps 26 tbhits 0 multipv 4 pv f7g8
info depth 2 seldepth 3 time 5824 nodes 3 score cp 0 hashfull 0 nps 26 tbhits 0 multipv 5 pv f7g7
info depth 2 seldepth 4 time 5887 nodes 4 score cp 5 hashfull 0 nps 22 tbhits 0 multipv 1 pv f7f8 h8h7 f8f7 h7h8
info depth 2 seldepth 4 time 5887 nodes 4 score cp 0 hashfull 0 nps 22 tbhits 0 multipv 2 pv f7e8
info depth 2 seldepth 4 time 5887 nodes 4 score cp 0 hashfull 0 nps 22 tbhits 0 multipv 3 pv f7f6
info depth 2 seldepth 4 time 5887 nodes 4 score cp 0 hashfull 0 nps 22 tbhits 0 multipv 4 pv f7g8
info depth 2 seldepth 4 time 5887 nodes 4 score cp 0 hashfull 0 nps 22 tbhits 0 multipv 5 pv f7g7
info depth 2 seldepth 5 time 5938 nodes 8 score cp 3 hashfull 0 nps 35 tbhits 0 multipv 1 pv f7f8 h8h7 f8f7 h7h8 f7f8
info depth 2 seldepth 5 time 5938 nodes 8 score cp -2 hashfull 0 nps 35 tbhits 0 multipv 2 pv f7e8 h8h7 e8f7
info depth 2 seldepth 5 time 5938 nodes 8 score cp 0 hashfull 0 nps 35 tbhits 0 multipv 3 pv f7f6
info depth 2 seldepth 5 time 5938 nodes 8 score cp 0 hashfull 0 nps 35 tbhits 0 multipv 4 pv f7g8
info depth 2 seldepth 5 time 5938 nodes 8 score cp 0 hashfull 0 nps 35 tbhits 0 multipv 5 pv f7g7
info depth 3 seldepth 5 time 5954 nodes 11 score cp 0 hashfull 0 nps 45 tbhits 0 multipv 1 pv f7e8 h8h7 e8f7 h7h8 f7f8
info depth 3 seldepth 5 time 5954 nodes 11 score cp 3 hashfull 0 nps 45 tbhits 0 multipv 2 pv f7f8 h8h7 f8f7 h7h8 f7f8 h8h7
info depth 3 seldepth 5 time 5954 nodes 11 score cp 0 hashfull 0 nps 45 tbhits 0 multipv 3 pv f7f6
info depth 3 seldepth 5 time 5954 nodes 11 score cp 0 hashfull 0 nps 45 tbhits 0 multipv 4 pv f7g8
info depth 3 seldepth 5 time 5954 nodes 11 score cp 0 hashfull 0 nps 45 tbhits 0 multipv 5 pv f7g7
info depth 3 seldepth 6 time 5990 nodes 12 score cp 0 hashfull 0 nps 43 tbhits 0 multipv 1 pv f7e8 h8h7 e8f7 h7h8 f7f8
info depth 3 seldepth 6 time 5990 nodes 12 score cp 3 hashfull 0 nps 43 tbhits 0 multipv 2 pv f7f8 h8h7 f8f7 h7h8 f7f8 h8h7
info depth 3 seldepth 6 time 5990 nodes 12 score cp 0 hashfull 0 nps 43 tbhits 0 multipv 3 pv f7f6
info depth 3 seldepth 6 time 5990 nodes 12 score cp 0 hashfull 0 nps 43 tbhits 0 multipv 4 pv f7g8
info depth 3 seldepth 6 time 5990 nodes 12 score cp 0 hashfull 0 nps 43 tbhits 0 multipv 5 pv f7g7
info depth 4 seldepth 6 time 6067 nodes 22 score cp 0 hashfull 0 nps 61 tbhits 0 multipv 1 pv f7e8 h8h7 e8e7 h7h8 e7e8 h8g7
info depth 4 seldepth 6 time 6067 nodes 22 score cp 2 hashfull 0 nps 61 tbhits 0 multipv 2 pv f7f8 h8h7 f8f7 h7h8 f7f8 h8h7 f8g7
info depth 4 seldepth 6 time 6067 nodes 22 score cp -45 hashfull 0 nps 61 tbhits 0 multipv 3 pv f7f6 h8g8 f6h8
info depth 4 seldepth 6 time 6067 nodes 22 score cp -1 hashfull 0 nps 61 tbhits 0 multipv 4 pv f7g8
info depth 4 seldepth 6 time 6067 nodes 22 score cp -1 hashfull 0 nps 61 tbhits 0 multipv 5 pv f7g7
info depth 4 seldepth 7 time 6090 nodes 28 score cp 0 hashfull 0 nps 74 tbhits 0 multipv 1 pv f7e8 h8h7 e8f7 h7h8 f7f8 h8h7 f8f7
info depth 4 seldepth 7 time 6090 nodes 28 score cp 2 hashfull 0 nps 74 tbhits 0 multipv 2 pv f7f8 h8h7 f8f7 h7h8 f7f8 h8h7 f8f7
info depth 4 seldepth 7 time 6090 nodes 28 score cp -45 hashfull 0 nps 74 tbhits 0 multipv 3 pv f7f6 h8g8 f6e6
info depth 4 seldepth 7 time 6090 nodes 28 score cp -4 hashfull 0 nps 74 tbhits 0 multipv 4 pv f7g8
info depth 4 seldepth 7 time 6090 nodes 28 score cp -4 hashfull 0 nps 74 tbhits 0 multipv 5 pv f7g7
info depth 5 seldepth 8 time 6181 nodes 42 score cp 0 hashfull 0 nps 89 tbhits 0 multipv 1 pv f7e8 h8h7 e8e7 h7h8 e7e8 h8g7 e8e7
info depth 5 seldepth 8 time 6181 nodes 42 score cp 1 hashfull 0 nps 89 tbhits 0 multipv 2 pv f7f8 h8h7 f8e7 h7h8 e7f8 h8h7 f8f7 h7h8
info depth 5 seldepth 8 time 6181 nodes 42 score cp -93 hashfull 0 nps 89 tbhits 0 multipv 3 pv f7f6 h8g8 f6e6 g8f8
info depth 5 seldepth 8 time 6181 nodes 42 score cp -8 hashfull 0 nps 89 tbhits 0 multipv 4 pv f7g8
info depth 5 seldepth 8 time 6181 nodes 42 score cp -8 hashfull 0 nps 89 tbhits 0 multipv 5 pv f7g7
info string f7c4  (1523) N:       0 (+ 0) (P:  1.24%) (Q: -0.97106) (D:  0.000) (U: 0.23891) (Q+U: -0.73215) (V:  -.----)
info string f7f5  (1527) N:       0 (+ 0) (P:  1.29%) (Q: -0.97106) (D:  0.000) (U: 0.24749) (Q+U: -0.72357) (V:  -.----)
info string f7e6  (1531) N:       0 (+ 0) (P:  1.33%) (Q: -0.97106) (D:  0.000) (U: 0.25637) (Q+U: -0.71469) (V:  -.----)
info string f7b3  (1521) N:       0 (+ 0) (P:  1.34%) (Q: -0.97106) (D:  0.000) (U: 0.25718) (Q+U: -0.71388) (V:  -.----)
info string f7d5  (1525) N:       0 (+ 0) (P:  1.39%) (Q: -0.97106) (D:  0.000) (U: 0.26738) (Q+U: -0.70368) (V:  -.----)
info string f7c7  (1537) N:       0 (+ 0) (P:  1.42%) (Q: -0.97106) (D:  0.000) (U: 0.27281) (Q+U: -0.69825) (V:  -.----)
info string f7f4  (1524) N:       0 (+ 0) (P:  1.44%) (Q: -0.97106) (D:  0.000) (U: 0.27721) (Q+U: -0.69385) (V:  -.----)
info string f7d7  (1538) N:       0 (+ 0) (P:  1.44%) (Q: -0.97106) (D:  0.000) (U: 0.27765) (Q+U: -0.69341) (V:  -.----)
info string f7g6  (1533) N:       0 (+ 0) (P:  1.47%) (Q: -0.97106) (D:  0.000) (U: 0.28220) (Q+U: -0.68886) (V:  -.----)
info string f7a7  (1535) N:       0 (+ 0) (P:  1.50%) (Q: -0.97106) (D:  0.000) (U: 0.28800) (Q+U: -0.68307) (V:  -.----)
info string f3f4  (584 ) N:       0 (+ 0) (P:  1.50%) (Q: -0.97106) (D:  0.000) (U: 0.28925) (Q+U: -0.68182) (V:  -.----)
info string f7e7  (1539) N:       0 (+ 0) (P:  1.51%) (Q: -0.97106) (D:  0.000) (U: 0.29057) (Q+U: -0.68050) (V:  -.----)
info string f7b7  (1536) N:       0 (+ 0) (P:  1.53%) (Q: -0.97106) (D:  0.000) (U: 0.29416) (Q+U: -0.67690) (V:  -.----)
info string g1f1  (152 ) N:       0 (+ 0) (P:  1.68%) (Q: -0.97106) (D:  0.000) (U: 0.32314) (Q+U: -0.64792) (V:  -.----)
info string f7h7  (1541) N:       0 (+ 0) (P:  1.77%) (Q: -0.97106) (D:  0.000) (U: 0.34134) (Q+U: -0.62972) (V:  -.----)
info string h2h3  (400 ) N:       0 (+ 0) (P:  1.78%) (Q: -0.97106) (D:  0.000) (U: 0.34193) (Q+U: -0.62913) (V:  -.----)
info string g1h1  (153 ) N:       0 (+ 0) (P:  1.83%) (Q: -0.97106) (D:  0.000) (U: 0.35264) (Q+U: -0.61842) (V:  -.----)
info string f7a2  (1519) N:       0 (+ 0) (P:  1.85%) (Q: -0.97106) (D:  0.000) (U: 0.35558) (Q+U: -0.61549) (V:  -.----)
info string g2g3  (374 ) N:       0 (+ 0) (P:  1.89%) (Q: -0.97106) (D:  0.000) (U: 0.36379) (Q+U: -0.60727) (V:  -.----)
info string g2g4  (378 ) N:       0 (+ 0) (P:  1.89%) (Q: -0.97106) (D:  0.000) (U: 0.36409) (Q+U: -0.60698) (V:  -.----)
info string h2h4  (403 ) N:       0 (+ 0) (P:  1.98%) (Q: -0.97106) (D:  0.000) (U: 0.38038) (Q+U: -0.59069) (V:  -.----)
info string f7g7  (1540) N:       0 (+ 0) (P:  2.00%) (Q: -0.97106) (D:  0.000) (U: 0.38507) (Q+U: -0.58599) (V:  -.----)
info string f7g8  (1545) N:       0 (+ 0) (P:  3.28%) (Q: -0.97106) (D:  0.000) (U: 0.63015) (Q+U: -0.34092) (V:  -.----)
info string f7f6  (1532) N:       4 (+ 0) (P:  8.94%) (Q: -0.31539) (D:  0.000) (U: 0.34387) (Q+U:  0.02847) (V: -0.1559)
info string f7f8  (1544) N:      15 (+33) (P: 35.79%) (Q:  0.00425) (D:  0.000) (U: 0.14050) (Q+U:  0.14475) (V:  0.0442)
info string f7e8  (1543) N:      22 (+ 0) (P: 16.91%) (Q:  0.00149) (D:  0.000) (U: 0.14144) (Q+U:  0.14294) (V: -0.0095)
bestmove f7e8 ponder h8h7
```
within 50 nodes now sees it has to use the Queen to keep black king in check, saving the game