### PR TITLE
bypass wrapdb

### DIFF
--- a/subprojects/eigen.wrap
+++ b/subprojects/eigen.wrap
@@ -4,6 +4,6 @@ source_filename=eigen-eigen-b3f3d4950030.zip
 directory=eigen-eigen-b3f3d4950030
 source_hash=35fa84bc23114b9d37c4597745f8b4e03354a5077579fdba597019f595a602b6
 
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/eigen/3.3.5/1/get_zip
+patch_url = https://github.com/mesonbuild/eigen/releases/download/3.3.5-1/eigen.zip
 patch_filename = eigen-3.3.5-1-wrap.zip
 patch_hash = ef83f81b932ad2d9491648881feeaf422a58edc072f54db32cd08d48660c8e97

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -5,7 +5,7 @@ source_url = https://github.com/google/googletest/archive/release-1.8.1.zip
 source_filename = gtest-1.8.1.zip
 source_hash = 927827c183d01734cc5cfef85e0ff3f5a92ffe6188e0d18e909c5efebf28a0c7
 
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/gtest/1.8.1/1/get_zip
+patch_url = https://github.com/mesonbuild/gtest/releases/download/1.8.1-1/gtest.zip
 patch_filename = gtest-1.8.1-1-wrap.zip
 patch_hash = f79f5fd46e09507b3f2e09a51ea6eb20020effe543335f5aee59f30cc8d15805
 

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -5,6 +5,6 @@ source_url = http://zlib.net/fossils/zlib-1.2.11.tar.gz
 source_filename = zlib-1.2.11.tar.gz
 source_hash = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
 
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/zlib/1.2.11/3/get_zip
+patch_url = https://github.com/mesonbuild/zlib/releases/download/1.2.11-3/zlib.zip
 patch_filename = zlib-1.2.11-3-wrap.zip
 patch_hash = f07dc491ab3d05daf00632a0591e2ae61b470615b5b73bcf9b3f061fff65cff0


### PR DESCRIPTION
From https://github.com/mesonbuild/meson/issues/6446 I get the impression fixing wrapdb will take longer than I was hoping.