### PR TITLE
Ensure not to fully prune before first eval time is set.

### DIFF
--- a/src/mcts/stoppers/stoppers.cc
+++ b/src/mcts/stoppers/stoppers.cc
@@ -192,6 +192,7 @@ bool SmartPruningStopper::ShouldStop(const IterationStats& stats,
     first_eval_time_ = stats.time_since_movestart;
     return false;
   }
+  if (!first_eval_time_) return false;
   if (stats.edge_n.size() == 0) return false;
   if (stats.time_since_movestart <
       *first_eval_time_ + kSmartPruningToleranceMs) {


### PR DESCRIPTION
This appears to have been a regression in the time code refactor.

This is potentially not an identical match for the original behavior, but I'm reasonably confident that it is a good match in all the ways that matter.

Without this fix it is possible that watchdog will terminate search based on an estimate of 1.5k nps (or lower) calculated in smart pruning stopper based on 0 actual nodes over 200ms (or higher).