### PR TITLE
meson, only add -march=native if compiler supports it.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,7 +24,7 @@ if cc.get_id() == 'clang'
   add_project_arguments('-Wthread-safety', language : 'cpp')
 endif
 if cc.get_id() == 'clang' or cc.get_id() == 'gcc'
-  if get_option('buildtype') == 'release'
+  if get_option('buildtype') == 'release' and cc.has_argument('-march=native')
     add_project_arguments('-march=native', language : 'cpp')
   endif
 endif

--- a/meson.build
+++ b/meson.build
@@ -24,8 +24,8 @@ if cc.get_id() == 'clang'
   add_project_arguments('-Wthread-safety', language : 'cpp')
 endif
 if cc.get_id() == 'clang' or cc.get_id() == 'gcc'
-  if get_option('buildtype') == 'release' and cc.has_argument('-march=native')
-    add_project_arguments('-march=native', language : 'cpp')
+  if get_option('buildtype') == 'release'
+    add_project_arguments(cc.get_supported_arguments(['-march=native']), language : 'cpp')
   endif
 endif
 


### PR DESCRIPTION
There are compilers such as the Android NDK's clang cross-compilers that don't support -march=native. So add a check before adding the flag.