### PR TITLE
meson, don't link pthread when host is Android.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -124,6 +124,7 @@ files += [
 ]
 includes += include_directories('src')
 
+deps += dependency('threads')
 
 #############################################################################
 ## Platform specific files
@@ -132,11 +133,6 @@ if host_machine.system() == 'windows'
   files += 'src/utils/filesystem.win32.cc'
 else
   files += 'src/utils/filesystem.posix.cc'
-  if host_machine.system() != 'android'
-    deps += [
-      cc.find_library('pthread'),
-    ]
-  endif
 endif
 
 

--- a/meson.build
+++ b/meson.build
@@ -132,9 +132,11 @@ if host_machine.system() == 'windows'
   files += 'src/utils/filesystem.win32.cc'
 else
   files += 'src/utils/filesystem.posix.cc'
-  deps += [
-    cc.find_library('pthread'),
+  if host_machine.system() != 'android'
+    deps += [
+      cc.find_library('pthread'),
     ]
+  endif
 endif
 
 


### PR DESCRIPTION
Android's `libc, bionic`, provide built-in support for `pthreads`, so no additional linking is necessary.