### PR TITLE
simple network embedding mechanism

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -502,6 +502,10 @@ if not get_option('pext')
   add_project_arguments('-DNO_PEXT', language : 'cpp')
 endif
 
+if get_option('embed')
+  add_project_arguments('-DEMBED', language : 'cpp')
+endif
+
 executable('lc0', 'src/main.cc',
   files, include_directories: includes, dependencies: deps, install: true)
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -132,3 +132,8 @@ option('gtest',
        type: 'boolean',
        value: true,
        description: 'Build gtest tests')
+
+option('embed',
+       type: 'boolean',
+       value: false,
+       description: 'Use embedded net by default')

--- a/src/neural/factory.cc
+++ b/src/neural/factory.cc
@@ -117,8 +117,7 @@ std::unique_ptr<Network> NetworkFactory::LoadNetwork(
 
   if (net_path == kAutoDiscover) {
     net_path = DiscoverWeightsFile();
-  }
-  else   if (net_path == kEmbed) {
+  } else if (net_path == kEmbed) {
     net_path = CommandLine::BinaryName();
   } else {
     CERR << "Loading weights file from: " << net_path;

--- a/src/neural/factory.cc
+++ b/src/neural/factory.cc
@@ -48,7 +48,7 @@ const OptionId NetworkFactory::kBackendOptionsId{
     "Exact parameters differ per backend.",
     'o'};
 const char* kAutoDiscover = "<autodiscover>";
-const char* kEmbed = "<embed>";
+const char* kEmbed = "<built in>";
 
 NetworkFactory* NetworkFactory::Get() {
   static NetworkFactory factory;

--- a/src/neural/factory.cc
+++ b/src/neural/factory.cc
@@ -61,7 +61,11 @@ NetworkFactory::Register::Register(const std::string& name, FactoryFunc factory,
 }
 
 void NetworkFactory::PopulateOptions(OptionsParser* options) {
+#if defined(EMBED)
+  options->Add<StringOption>(NetworkFactory::kWeightsId) = kEmbed;
+#else
   options->Add<StringOption>(NetworkFactory::kWeightsId) = kAutoDiscover;
+#endif
   const auto backends = NetworkFactory::Get()->GetBackendsList();
   options->Add<ChoiceOption>(NetworkFactory::kBackendId, backends) =
       backends.empty() ? "<none>" : backends[0];

--- a/src/neural/factory.cc
+++ b/src/neural/factory.cc
@@ -29,6 +29,7 @@
 #include "neural/loader.h"
 
 #include <algorithm>
+#include "utils/commandline.h"
 #include "utils/logging.h"
 
 namespace lczero {
@@ -47,6 +48,7 @@ const OptionId NetworkFactory::kBackendOptionsId{
     "Exact parameters differ per backend.",
     'o'};
 const char* kAutoDiscover = "<autodiscover>";
+const char* kEmbed = "<embed>";
 
 NetworkFactory* NetworkFactory::Get() {
   static NetworkFactory factory;
@@ -111,6 +113,9 @@ std::unique_ptr<Network> NetworkFactory::LoadNetwork(
 
   if (net_path == kAutoDiscover) {
     net_path = DiscoverWeightsFile();
+  }
+  else   if (net_path == kEmbed) {
+    net_path = CommandLine::BinaryName();
   } else {
     CERR << "Loading weights file from: " << net_path;
   }

--- a/src/neural/loader.cc
+++ b/src/neural/loader.cc
@@ -120,7 +120,13 @@ std::string DecompressGzip(const std::string& filename) {
   int bytes_read = 0;
 
   // Read whole file into a buffer.
-  const gzFile file = gzopen(filename.c_str(), "rb");
+  gzFile file = gzopen(filename.c_str(), "rb");
+#ifdef _WIN32
+  if (!file && filename == CommandLine::BinaryName()) {
+    // Try again with a .exe suffix.
+    file = gzopen((filename + ".exe").c_str(), "rb");
+  }
+#endif
   if (!file) throw Exception("Cannot read weights from " + filename);
   while (true) {
     const int sz =

--- a/src/neural/loader.cc
+++ b/src/neural/loader.cc
@@ -46,6 +46,8 @@
 
 #ifdef _WIN32
 #include <io.h>
+#else
+#include <unistd.h>
 #endif
 
 namespace lczero {
@@ -65,8 +67,8 @@ std::string DecompressGzip(const std::string& filename) {
     throw Exception("Cannot read weights from " + filename);
   }
   if (filename == CommandLine::BinaryName()) {
-    // The network file is appended at the end of the lc0 executable, followed
-    // by the network file size and a "Lc0!" (0x2130634c) magic.
+    // The network file should be appended at the end of the lc0 executable,
+    // followed by the network file size and a "Lc0!" (0x2130634c) magic.
     int32_t size, magic;
     if (fseek(fp, -8, SEEK_END) || fread(&size, 4, 1, fp) != 1 ||
         fread(&magic, 4, 1, fp) != 1 || magic != 0x2130634c) {

--- a/src/neural/loader.cc
+++ b/src/neural/loader.cc
@@ -52,20 +52,31 @@ uint32_t read_le(const uint8_t *addr) {
   return addr[0] + 256 * addr[1] + 65536 * addr[2] + 16777216 * addr[3];
 }
 
+// Read a .zip file containing a network file (just stored, not compressed a
+// second time) that is appended at the end of the lc0 executable. Such a zip
+// file can be generated using, for example, "zip -0 zipfile.zip net.pb.gz",
+// "7z a -mx=0 zipfile.zip net.pb.gz" or the equivalent options of any other
+// compression utility.
+
 std::string DecompressEmbedded(std::string str) {
   constexpr int MOD_GZIP_ZLIB_WINDOWSIZE = 15;
   constexpr uint8_t eocd_sig[12] = {0x50, 0x4b, 5, 6, 0, 0, 0, 0, 1, 0, 1, 0};
   constexpr uint8_t header_sig[4] = {0x50, 0x4b, 3, 4};
 
-  const uint8_t *eocd_addr =
+  // Check if a zip file "end of central directory record" is there, 22 bytes
+  // before the file end.
+  uint8_t *eocd_addr =
       reinterpret_cast<uint8_t *>(str.data()) + str.size() - 22;
   if (memcmp(eocd_addr, eocd_sig, sizeof(eocd_sig)) != 0) {
     throw Exception("No embeded file detected.");
   }
 
-  uint8_t *start_addr = reinterpret_cast<uint8_t *>(str.data()) + str.size() -
-                        22 - read_le(eocd_addr + 12) - read_le(eocd_addr + 16);
+  // Find the start of the zip file by subtracting the "central directory" size
+  // and offset.
+  uint8_t *start_addr =
+      eocd_addr - read_le(eocd_addr + 12) - read_le(eocd_addr + 16);
 
+  // Check for a local file header.
   if (memcmp(start_addr, header_sig, sizeof(header_sig)) != 0) {
     throw Exception("No embeded file header detected.");
   }
@@ -77,6 +88,7 @@ std::string DecompressEmbedded(std::string str) {
     throw Exception("inflateInit failed while decompressing.");
   }
 
+  // Read the first file in the zip, should be a stored network file.
   uint32_t offsets = read_le(start_addr + 26);
   zs.next_in = reinterpret_cast<Bytef *>(start_addr) + 30 + (offsets >> 16) +
                (offsets & 0xffff);

--- a/src/utils/commandline.cc
+++ b/src/utils/commandline.cc
@@ -35,7 +35,18 @@ std::vector<std::string> CommandLine::arguments_;
 std::vector<std::pair<std::string, std::string>> CommandLine::modes_;
 
 void CommandLine::Init(int argc, const char** argv) {
+#ifdef _WIN32
+  // Under windows argv[0] may not have the extension. Also _get_pgmptr() had
+  // issues in some windows 10 versions, so check returned values carefully.
+  char* pgmptr = nullptr;
+  if (!_get_pgmptr(&pgmptr) && pgmptr != nullptr && *pgmptr) {
+    binary_ = pgmptr;
+  } else {
+    binary_ = argv[0];
+  }
+#else
   binary_ = argv[0];
+#endif
   arguments_.clear();
   std::ostringstream params;
   for (int i = 1; i < argc; ++i) {


### PR DESCRIPTION
This is based on the great work done by @lealgo in <https://github.com/LeelaChessZero/lc0/pull/868>. The main difference is that this version allows embedding after the fact: It looks for a zip file appended at the end of the executable that stores just an uncompressed network file (e.g. one generated by `zip -0`).