### PR TITLE
Moves left head support for blas

### DIFF
--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -47,7 +47,8 @@ namespace {
 class BlasComputation : public NetworkComputation {
  public:
   BlasComputation(const LegacyWeights& weights, const size_t max_batch_size,
-                  const bool wdl, const bool conv_policy, const int blas_cores);
+                  const bool wdl, const bool moves_left, const bool conv_policy,
+                  const int blas_cores);
 
   virtual ~BlasComputation() {}
 
@@ -80,8 +81,12 @@ class BlasComputation : public NetworkComputation {
     }
   }
 
-  float GetMVal(int /* sample */) const override {
-    return 0.0f;
+  float GetMVal(int sample) const override {
+    if (moves_left_) {
+      return m_values_[sample];
+    } else {
+      return 0.0f;
+    }
   }
 
   // Returns P value @move_id of @sample.
@@ -105,7 +110,9 @@ class BlasComputation : public NetworkComputation {
   std::vector<InputPlanes> planes_;
   std::vector<std::vector<float>> policies_;
   std::vector<float> q_values_;
+  std::vector<float> m_values_;
   bool wdl_;
+  bool moves_left_;
   bool conv_policy_;
 };
 
@@ -116,7 +123,8 @@ class BlasNetwork : public Network {
 
   std::unique_ptr<NetworkComputation> NewComputation() override {
     return std::make_unique<BlasComputation>(weights_, max_batch_size_, wdl_,
-                                             conv_policy_, blas_cores_);
+                                             moves_left_, conv_policy_,
+                                             blas_cores_);
   }
 
   const NetworkCapabilities& GetCapabilities() const override {
@@ -131,18 +139,21 @@ class BlasNetwork : public Network {
   LegacyWeights weights_;
   size_t max_batch_size_;
   bool wdl_;
+  bool moves_left_;
   bool conv_policy_;
   int blas_cores_;
 };
 
 BlasComputation::BlasComputation(const LegacyWeights& weights,
                                  const size_t max_batch_size, const bool wdl,
-                                 const bool conv_policy, const int blas_cores)
+                                 const bool moves_left, const bool conv_policy,
+                                 const int blas_cores)
     : weights_(weights),
       max_batch_size_(max_batch_size),
       policies_(0),
       q_values_(0),
       wdl_(wdl),
+      moves_left_(moves_left),
       conv_policy_(conv_policy) {
 #ifdef USE_DNNL
   omp_set_num_threads(blas_cores);
@@ -155,9 +166,11 @@ BlasComputation::BlasComputation(const LegacyWeights& weights,
 void BlasComputation::ComputeBlocking() {
   // Retrieve network key dimensions from the weights structure.
   const auto num_value_channels = weights_.ip1_val_b.size();
+  const auto num_moves_channels = weights_.ip1_mov_b.size();
   const auto num_value_input_planes = weights_.value.biases.size();
   const auto num_policy_input_planes = weights_.policy.biases.size();
-  const auto num_output_policy = kPolicyOutputs;
+  const auto num_moves_input_planes = weights_.moves_left.biases.size();
+  const auto num_output_policy = size_t(kPolicyOutputs);
   const auto output_channels = weights_.input.biases.size();
 
   // max_channels is the maximum number of input channels of any
@@ -188,8 +201,9 @@ void BlasComputation::ComputeBlocking() {
    */
 
   // Allocate data for the whole batch.
-  std::vector<float> output_val(largest_batch_size * num_value_channels);
-  std::vector<float> output_pol(largest_batch_size * num_output_policy);
+  size_t max_fc_channels = std::max(
+      num_value_channels, std::max(num_output_policy, num_value_channels));
+  std::vector<float> output_fc(largest_batch_size * max_fc_channels);
 
   std::vector<float> res_buffer1(largest_batch_size * max_channels * kSquares);
   std::vector<float> res_buffer2(largest_batch_size * output_channels *
@@ -200,10 +214,11 @@ void BlasComputation::ComputeBlocking() {
   WinogradConvolution3 convolve3(largest_batch_size, max_channels,
                                  max_output_channels);
 
-  std::vector<float> policy_buffer(largest_batch_size *
-                                   num_policy_input_planes * kSquares);
-  std::vector<float> value_buffer(largest_batch_size * num_value_input_planes *
-                                  kSquares);
+  size_t max_head_planes =
+      std::max(num_policy_input_planes,
+               std::max(num_value_input_planes, num_moves_input_planes));
+  std::vector<float> head_buffer(largest_batch_size * max_head_planes *
+                                 kSquares);
 
   // These ones will rotate during the computation.
   float* conv_in = res_buffer1.data();
@@ -272,10 +287,10 @@ void BlasComputation::ComputeBlocking() {
 
       convolve3.Forward(batch_size, output_channels, num_policy_input_planes,
                         res, weights_.policy.weights.data(),
-                        policy_buffer.data());
+                        head_buffer.data());
 
       BiasResidualRelu(batch_size, num_policy_input_planes,
-                       &policy_buffer.data()[0], weights_.policy.biases.data(),
+                       &head_buffer.data()[0], weights_.policy.biases.data(),
                        nullptr, false);
 
       // Mapping from convolutional policy to lc0 policy
@@ -283,57 +298,57 @@ void BlasComputation::ComputeBlocking() {
         for (auto i = 0; i < kPolicyUsedPlanes * kSquares; i++) {
           auto j = kConvPolicyMap[i];
           if (j >= 0) {
-            output_pol[batch * num_output_policy + j] =
-                policy_buffer[batch * num_policy_input_planes * kSquares + i];
+            output_fc[batch * num_output_policy + j] =
+                head_buffer[batch * num_policy_input_planes * kSquares + i];
           }
         }
       }
 
     } else {
-      Convolution1::Forward(
-          batch_size, output_channels, num_policy_input_planes, conv_out,
-          weights_.policy.weights.data(), policy_buffer.data());
+      Convolution1::Forward(batch_size, output_channels,
+                            num_policy_input_planes, conv_out,
+                            weights_.policy.weights.data(), head_buffer.data());
 
-      BiasResidualRelu(batch_size, num_policy_input_planes, &policy_buffer[0],
+      BiasResidualRelu(batch_size, num_policy_input_planes, &head_buffer[0],
                        weights_.policy.biases.data());
 
       FullyConnectedLayer::Forward1D(
           batch_size, num_policy_input_planes * kSquares, num_output_policy,
-          policy_buffer.data(), weights_.ip_pol_w.data(),
+          head_buffer.data(), weights_.ip_pol_w.data(),
           weights_.ip_pol_b.data(),
           false,  // Relu Off
-          output_pol.data());
+          output_fc.data());
     }
-
-    // Value head
-    Convolution1::Forward(batch_size, output_channels, num_value_input_planes,
-                          conv_out, weights_.value.weights.data(),
-                          value_buffer.data());
-
-    BiasResidualRelu(batch_size, num_value_input_planes, &value_buffer[0],
-                     weights_.value.biases.data());
-
-    FullyConnectedLayer::Forward1D(
-        batch_size, num_value_input_planes * kSquares, num_value_channels,
-        value_buffer.data(), weights_.ip1_val_w.data(),
-        weights_.ip1_val_b.data(),
-        true,  // Relu On
-        output_val.data());
 
     for (size_t j = 0; j < batch_size; j++) {
       std::vector<float> policy(num_output_policy);
 
       // Get the moves
-      policy.assign(output_pol.begin() + j * num_output_policy,
-                    output_pol.begin() + (j + 1) * num_output_policy);
+      policy.assign(output_fc.begin() + j * num_output_policy,
+                    output_fc.begin() + (j + 1) * num_output_policy);
       policies_.emplace_back(std::move(policy));
     }
+
+    // Value head
+    Convolution1::Forward(batch_size, output_channels, num_value_input_planes,
+                          conv_out, weights_.value.weights.data(),
+                          head_buffer.data());
+
+    BiasResidualRelu(batch_size, num_value_input_planes, &head_buffer[0],
+                     weights_.value.biases.data());
+
+    FullyConnectedLayer::Forward1D(
+        batch_size, num_value_input_planes * kSquares, num_value_channels,
+        head_buffer.data(), weights_.ip1_val_w.data(),
+        weights_.ip1_val_b.data(),
+        true,  // Relu On
+        output_fc.data());
 
     // Now get the score
     if (wdl_) {
       std::vector<float> wdl(3 * batch_size);
       FullyConnectedLayer::Forward1D(
-          batch_size, num_value_channels, 3, output_val.data(),
+          batch_size, num_value_channels, 3, output_fc.data(),
           weights_.ip2_val_w.data(), weights_.ip2_val_b.data(),
           false,  // Relu Off
           wdl.data());
@@ -350,10 +365,36 @@ void BlasComputation::ComputeBlocking() {
       for (size_t j = 0; j < batch_size; j++) {
         double winrate = FullyConnectedLayer::Forward0D(
                              num_value_channels, weights_.ip2_val_w.data(),
-                             &output_val[j * num_value_channels]) +
+                             &output_fc[j * num_value_channels]) +
                          weights_.ip2_val_b[0];
 
         q_values_.emplace_back(std::tanh(winrate));
+      }
+    }
+    if (moves_left_) {
+      Convolution1::Forward(batch_size, output_channels, num_moves_input_planes,
+                            conv_out, weights_.moves_left.weights.data(),
+                            head_buffer.data());
+
+      BiasResidualRelu(batch_size, num_moves_input_planes, &head_buffer[0],
+                       weights_.moves_left.biases.data());
+
+      FullyConnectedLayer::Forward1D(
+          batch_size, num_moves_input_planes * kSquares, num_moves_channels,
+          head_buffer.data(), weights_.ip1_mov_w.data(),
+          weights_.ip1_mov_b.data(),
+          true,  // Relu On
+          output_fc.data());
+
+      std::vector<float> output_moves_left(batch_size);
+      FullyConnectedLayer::Forward1D(
+          batch_size, num_moves_channels, 1, output_fc.data(),
+          weights_.ip2_mov_w.data(), weights_.ip2_mov_b.data(),
+          true,  // Relu On
+          output_moves_left.data());
+
+      for (size_t j = 0; j < batch_size; j++) {
+        m_values_.emplace_back(output_moves_left[j]);
       }
     }
   }
@@ -369,7 +410,7 @@ void BlasComputation::EncodePlanes(const InputPlanes& sample, float* buffer) {
 
 BlasNetwork::BlasNetwork(const WeightsFile& file, const OptionsDict& options)
     : capabilities_{file.format().network_format().input(),
-                    pblczero::NetworkFormat::MOVES_LEFT_NONE},
+                    file.format().network_format().moves_left()},
       weights_(file.weights()) {
 #ifndef USE_EIGEN
   blas_cores_ = options.GetOrDefault<int>("blas_cores", 1);
@@ -379,6 +420,9 @@ BlasNetwork::BlasNetwork(const WeightsFile& file, const OptionsDict& options)
 
   wdl_ = file.format().network_format().value() ==
          pblczero::NetworkFormat::VALUE_WDL;
+
+  moves_left_ = file.format().network_format().moves_left() ==
+                pblczero::NetworkFormat::MOVES_LEFT_V1;
 
   conv_policy_ = file.format().network_format().policy() ==
                  pblczero::NetworkFormat::POLICY_CONVOLUTION;

--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -170,7 +170,7 @@ void BlasComputation::ComputeBlocking() {
   const auto num_value_input_planes = weights_.value.biases.size();
   const auto num_policy_input_planes = weights_.policy.biases.size();
   const auto num_moves_input_planes = weights_.moves_left.biases.size();
-  const auto num_output_policy = size_t(kPolicyOutputs);
+  const auto num_output_policy = static_cast<size_t>(kPolicyOutputs);
   const auto output_channels = weights_.input.biases.size();
 
   // max_channels is the maximum number of input channels of any
@@ -202,7 +202,7 @@ void BlasComputation::ComputeBlocking() {
 
   // Allocate data for the whole batch.
   size_t max_fc_channels = std::max(
-      num_value_channels, std::max(num_output_policy, num_value_channels));
+      num_value_channels, std::max(num_output_policy, num_moves_channels));
   std::vector<float> output_fc(largest_batch_size * max_fc_channels);
 
   std::vector<float> res_buffer1(largest_batch_size * max_channels * kSquares);


### PR DESCRIPTION
Matches cudnn output with the nets I tested with (Some available in #961). Valgrind output also looks clean.