### PR TITLE
Refactor moves left head parameters into factor and slope

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -206,8 +206,8 @@ const OptionId SearchParams::kHistoryFillId{
     "synthesize them (always, never, or only at non-standard fen position)."};
 const OptionId SearchParams::kMovesLeftFactorId{
     "moves-left-factor", "MovesLeftFactor",
-    "Maximum bonus to add to the score of a node based on how much shorter/longer "
-    "it makes when winning/losing."};
+    "Maximum bonus to add to the score of a node based on how much "
+    "shorter/longer it makes the game when winning/losing."};
 const OptionId SearchParams::kMovesLeftThresholdId{
     "moves-left-threshold", "MovesLeftThreshold",
     "Absolute value of node Q needs to exceed this value before shorter wins "

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -204,8 +204,8 @@ const OptionId SearchParams::kHistoryFillId{
     "one. During the first moves of the game such historical positions don't "
     "exist, but they can be synthesized. This parameter defines when to "
     "synthesize them (always, never, or only at non-standard fen position)."};
-const OptionId SearchParams::kMovesLeftFactorId{
-    "moves-left-factor", "MovesLeftFactor",
+const OptionId SearchParams::kMovesLeftMaxEffectId{
+    "moves-left-max-effect", "MovesLeftMaxEffect",
     "Maximum bonus to add to the score of a node based on how much "
     "shorter/longer it makes the game when winning/losing."};
 const OptionId SearchParams::kMovesLeftThresholdId{
@@ -217,7 +217,7 @@ const OptionId SearchParams::kMovesLeftSlopeId{
     "Controls how the bonus for shorter wins or longer losses is adjusted "
     "based on how many moves the move is estimated to shorten/lengthen the "
     "game. The move difference is multiplied with the slope and capped at "
-    "MovesLeftFactor."};
+    "MovesLeftMaxEffect."};
 const OptionId SearchParams::kShortSightednessId{
     "short-sightedness", "ShortSightedness",
     "Used to focus more on short term gains over long term."};
@@ -290,7 +290,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kScoreTypeId, score_type) = "centipawn";
   std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
-  options->Add<FloatOption>(kMovesLeftFactorId, 0.0f, 1.0f) = 0.0f;
+  options->Add<FloatOption>(kMovesLeftMaxEffectId, 0.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kMovesLeftThresholdId, 0.0f, 1.0f) = 1.0f;
   options->Add<FloatOption>(kMovesLeftSlopeId, 0.0f, 1.0f) = 0.001f;
   options->Add<FloatOption>(kShortSightednessId, 0.0f, 1.0f) = 0.0f;
@@ -351,7 +351,7 @@ SearchParams::SearchParams(const OptionsDict& options)
       kHistoryFill(
           EncodeHistoryFill(options.Get<std::string>(kHistoryFillId.GetId()))),
       kMiniBatchSize(options.Get<int>(kMiniBatchSizeId.GetId())),
-      kMovesLeftFactor(options.Get<float>(kMovesLeftFactorId.GetId())),
+      kMovesLeftMaxEffect(options.Get<float>(kMovesLeftMaxEffectId.GetId())),
       kMovesLeftThreshold(options.Get<float>(kMovesLeftThresholdId.GetId())),
       kMovesLeftSlope(options.Get<float>(kMovesLeftSlopeId.GetId())),
       kShortSightedness(options.Get<float>(kShortSightednessId.GetId())),

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -206,20 +206,18 @@ const OptionId SearchParams::kHistoryFillId{
     "synthesize them (always, never, or only at non-standard fen position)."};
 const OptionId SearchParams::kMovesLeftFactorId{
     "moves-left-factor", "MovesLeftFactor",
-    "Bonus to add to the score of a node based on how much shorter/longer "
+    "Maximum bonus to add to the score of a node based on how much shorter/longer "
     "it makes when winning/losing."};
 const OptionId SearchParams::kMovesLeftThresholdId{
     "moves-left-threshold", "MovesLeftThreshold",
     "Absolute value of node Q needs to exceed this value before shorter wins "
     "or longer losses are considered."};
-const OptionId SearchParams::kMovesLeftScaleId{
-    "moves-left-scale", "MovesLeftScale",
+const OptionId SearchParams::kMovesLeftSlopeId{
+    "moves-left-slope", "MovesLeftSlope",
     "Controls how the bonus for shorter wins or longer losses is adjusted "
     "based on how many moves the move is estimated to shorten/lengthen the "
-    "game. The move shortening/lengthening the game by this amount of plies "
-    "or more compared to the best node, gets the full MovesLeftFactor bonus "
-    "added. Moves shortening/lengthening by less amount of moves have bonus "
-    "scaled linearly."};
+    "game. The move difference is multiplied with the slope and capped at "
+    "MovesLeftFactor."};
 const OptionId SearchParams::kShortSightednessId{
     "short-sightedness", "ShortSightedness",
     "Used to focus more on short term gains over long term."};
@@ -294,7 +292,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
   options->Add<FloatOption>(kMovesLeftFactorId, 0.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kMovesLeftThresholdId, 0.0f, 1.0f) = 1.0f;
-  options->Add<FloatOption>(kMovesLeftScaleId, 1.0f, 100.0f) = 10.0f;
+  options->Add<FloatOption>(kMovesLeftSlopeId, 0.0f, 1.0f) = 0.001f;
   options->Add<FloatOption>(kShortSightednessId, 0.0f, 1.0f) = 0.0f;
   options->Add<BoolOption>(kDisplayCacheUsageId) = false;
   options->Add<IntOption>(kMaxConcurrentSearchersId, 0, 128) = 1;
@@ -355,7 +353,7 @@ SearchParams::SearchParams(const OptionsDict& options)
       kMiniBatchSize(options.Get<int>(kMiniBatchSizeId.GetId())),
       kMovesLeftFactor(options.Get<float>(kMovesLeftFactorId.GetId())),
       kMovesLeftThreshold(options.Get<float>(kMovesLeftThresholdId.GetId())),
-      kMovesLeftScale(options.Get<float>(kMovesLeftScaleId.GetId())),
+      kMovesLeftSlope(options.Get<float>(kMovesLeftSlopeId.GetId())),
       kShortSightedness(options.Get<float>(kShortSightednessId.GetId())),
       kDisplayCacheUsage(options.Get<bool>(kDisplayCacheUsageId.GetId())),
       kMaxConcurrentSearchers(

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -103,7 +103,7 @@ class SearchParams {
     return options_.Get<std::string>(kScoreTypeId.GetId());
   }
   FillEmptyHistory GetHistoryFill() const { return kHistoryFill; }
-  float GetMovesLeftFactor() const { return kMovesLeftFactor; }
+  float GetMovesLeftMaxEffect() const { return kMovesLeftMaxEffect; }
   float GetMovesLeftThreshold() const { return kMovesLeftThreshold; }
   float GetMovesLeftSlope() const { return kMovesLeftSlope; }
   bool GetDisplayCacheUsage() const { return kDisplayCacheUsage; }
@@ -150,7 +150,7 @@ class SearchParams {
   static const OptionId kPerPvCountersId;
   static const OptionId kScoreTypeId;
   static const OptionId kHistoryFillId;
-  static const OptionId kMovesLeftFactorId;
+  static const OptionId kMovesLeftMaxEffectId;
   static const OptionId kMovesLeftThresholdId;
   static const OptionId kMovesLeftSlopeId;
   static const OptionId kShortSightednessId;
@@ -191,7 +191,7 @@ class SearchParams {
   const bool kSyzygyFastPlay;
   const FillEmptyHistory kHistoryFill;
   const int kMiniBatchSize;
-  const float kMovesLeftFactor;
+  const float kMovesLeftMaxEffect;
   const float kMovesLeftThreshold;
   const float kMovesLeftSlope;
   const float kShortSightedness;

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -105,7 +105,7 @@ class SearchParams {
   FillEmptyHistory GetHistoryFill() const { return kHistoryFill; }
   float GetMovesLeftFactor() const { return kMovesLeftFactor; }
   float GetMovesLeftThreshold() const { return kMovesLeftThreshold; }
-  float GetMovesLeftScale() const { return kMovesLeftScale; }
+  float GetMovesLeftSlope() const { return kMovesLeftSlope; }
   bool GetDisplayCacheUsage() const { return kDisplayCacheUsage; }
   int GetMaxConcurrentSearchers() const { return kMaxConcurrentSearchers; }
   float GetSidetomoveDrawScore() const { return kDrawScoreSidetomove; }
@@ -152,7 +152,7 @@ class SearchParams {
   static const OptionId kHistoryFillId;
   static const OptionId kMovesLeftFactorId;
   static const OptionId kMovesLeftThresholdId;
-  static const OptionId kMovesLeftScaleId;
+  static const OptionId kMovesLeftSlopeId;
   static const OptionId kShortSightednessId;
   static const OptionId kDisplayCacheUsageId;
   static const OptionId kMaxConcurrentSearchersId;
@@ -193,7 +193,7 @@ class SearchParams {
   const int kMiniBatchSize;
   const float kMovesLeftFactor;
   const float kMovesLeftThreshold;
-  const float kMovesLeftScale;
+  const float kMovesLeftSlope;
   const float kShortSightedness;
   const bool kDisplayCacheUsage;
   const int kMaxConcurrentSearchers;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -948,10 +948,10 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
       float M = 0.0f;
       if (do_moves_left_adjustment) {
         const float m_slope = params_.GetMovesLeftSlope();
-        const float m_factor = params_.GetMovesLeftFactor();
+        const float m_cap = params_.GetMovesLeftMaxEffect();
         const float parent_m = node->GetM();
         const float child_m = child.GetM(parent_m);
-        M = std::clamp(m_slope * (child_m - parent_m), -m_factor, m_factor) *
+        M = std::clamp(m_slope * (child_m - parent_m), -m_cap, m_cap) *
             std::copysign(1.0f, node_q);
       }
 

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -947,11 +947,12 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
 
       float M = 0.0f;
       if (do_moves_left_adjustment) {
-        const float m_scale = params_.GetMovesLeftScale();
+        const float m_slope = params_.GetMovesLeftSlope();
+        const float m_factor = params_.GetMovesLeftFactor();
         const float parent_m = node->GetM();
         const float child_m = child.GetM(parent_m);
-        M = std::clamp(child_m - parent_m, -m_scale, m_scale) / m_scale *
-            std::copysign(params_.GetMovesLeftFactor(), node_q);
+        M = std::clamp(m_slope * (child_m - parent_m), -m_factor, m_factor) *
+            std::copysign(1.0f, node_q);
       }
 
       const float Q = child.GetQ(fpu, draw_score, params_.GetLogitQ());


### PR DESCRIPTION
As already discussed on Discord after @kiudee posted a tuning result including MLH, the current `MovesLeftScale` parameter from #961 is very hard to interpret. This PR replaces the `MovesLeftScale` parameter with a `MovesLeftSlope` parameter `slope := factor/scale` which gives the direct Q bonus per shorter move, and the maximum effect is capped to `MovesLeftFactor`.

I think this pair of parameters controlling the effect of MLH on search is the combination which on the one hand is the easiest to interpret, and on the other hand is as orthogonal as possible concerning parameter tunings.