### PR TITLE
Prefer shorter winning mates and report mate score.

### DIFF
--- a/src/chess/callbacks.h
+++ b/src/chess/callbacks.h
@@ -67,6 +67,8 @@ struct ThinkingInfo {
   int nps = -1;
   // Hash fullness * 1000
   int hashfull = -1;
+  // Moves to mate.
+  std::optional<int> mate;
   // Win in centipawns.
   std::optional<int> score;
   // Win/Draw/Lose probability * 1000.

--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -248,6 +248,7 @@ void UciLoop::SendInfo(const std::vector<ThinkingInfo>& infos) {
     if (info.seldepth >= 0) res += " seldepth " + std::to_string(info.seldepth);
     if (info.time >= 0) res += " time " + std::to_string(info.time);
     if (info.nodes >= 0) res += " nodes " + std::to_string(info.nodes);
+    if (info.mate) res += " score mate " + std::to_string(*info.mate);
     if (info.score) res += " score cp " + std::to_string(*info.score);
     if (info.wdl) {
       res += " wdl " + std::to_string(info.wdl->w) + " " +

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -190,6 +190,7 @@ class PonderResponseTransformer : public TransformingUciResponder {
     for (const auto& info : *infos) {
       if (info.multipv <= 1) {
         ponder_info = info;
+        if (ponder_info.mate) ponder_info.mate = -*ponder_info.mate;
         if (ponder_info.score) ponder_info.score = -*ponder_info.score;
         if (ponder_info.depth > 1) ponder_info.depth--;
         if (ponder_info.seldepth > 1) ponder_info.seldepth--;

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -210,15 +210,16 @@ Edge* Node::GetOwnEdge() const { return GetParent()->GetEdgeToNode(this); }
 
 std::string Node::DebugString() const {
   std::ostringstream oss;
-  oss << " Term:" << is_terminal_ << " This:" << this << " Parent:" << parent_
-      << " Index:" << index_ << " Child:" << child_.get()
-      << " Sibling:" << sibling_.get() << " WL:" << wl_ << " N:" << n_
-      << " N_:" << n_in_flight_ << " Edges:" << edges_.size();
+  oss << " Term:" << static_cast<int>(terminal_type_) << " This:" << this
+      << " Parent:" << parent_ << " Index:" << index_
+      << " Child:" << child_.get() << " Sibling:" << sibling_.get()
+      << " WL:" << wl_ << " N:" << n_ << " N_:" << n_in_flight_
+      << " Edges:" << edges_.size();
   return oss.str();
 }
 
-void Node::MakeTerminal(GameResult result, float plies_left) {
-  is_terminal_ = true;
+void Node::MakeTerminal(GameResult result, float plies_left, Terminal type) {
+  terminal_type_ = type;
   m_ = plies_left;
   if (result == GameResult::DRAW) {
     wl_ = 0.0f;
@@ -233,7 +234,7 @@ void Node::MakeTerminal(GameResult result, float plies_left) {
 }
 
 void Node::MakeNotTerminal() {
-  is_terminal_ = false;
+  terminal_type_ = Terminal::NonTerminal;
   n_ = 0;
 
   // If we have edges, we've been extended (1 visit), so include children too.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -138,7 +138,11 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
     const auto d = edge.GetD();
     const int w = static_cast<int>(std::round(500.0 * (1.0 + wl - d)));
     const auto q = edge.GetQ(default_q, draw_score);
-    if (score_type == "centipawn_with_drawscore") {
+    if (edge.IsTerminal() && wl != 0.0f) {
+      uci_info.mate = std::copysign(
+          std::round(edge.GetM(0.0f)) / 2 + (edge.IsTbTerminal() ? 101 : 1),
+          wl);
+    } else if (score_type == "centipawn_with_drawscore") {
       uci_info.score = 295 * q / (1 - 0.976953126 * std::pow(q, 14));
     } else if (score_type == "centipawn") {
       uci_info.score = 295 * wl / (1 - 0.976953126 * std::pow(q, 14));
@@ -478,32 +482,81 @@ std::vector<EdgeAndNode> Search::GetBestChildrenNoTemperature(Node* parent,
     PopulateRootMoveLimit(&root_limit);
   }
   // Best child is selected using the following criteria:
-  // * Is terminal win, e.g., checkmate.
+  // * Prefer shorter terminal wins / avoid shorter terminal losses.
   // * Largest number of playouts.
   // * If two nodes have equal number:
   //   * If that number is 0, the one with larger prior wins.
   //   * If that number is larger than 0, the one with larger eval wins.
-  using El = std::tuple<bool, uint64_t, float, float, EdgeAndNode>;
-  std::vector<El> edges;
+  std::vector<EdgeAndNode> edges;
   for (auto edge : parent->Edges()) {
     if (parent == root_node_ && !root_limit.empty() &&
         std::find(root_limit.begin(), root_limit.end(), edge.GetMove()) ==
             root_limit.end()) {
       continue;
     }
-    const auto WL = edge.GetWL();
-    edges.emplace_back(edge.IsTerminal() && WL > 0.0f, edge.GetN(), WL,
-                       edge.GetP(), edge);
+    edges.push_back(edge);
   }
   const auto middle = (static_cast<int>(edges.size()) > count)
                           ? edges.begin() + count
                           : edges.end();
-  std::partial_sort(edges.begin(), middle, edges.end(), std::greater<El>());
+  std::partial_sort(
+      edges.begin(), middle, edges.end(), [](const auto& a, const auto& b) {
+        // The function returns "true" when a is preferred to b.
 
-  std::vector<EdgeAndNode> res;
-  std::transform(edges.begin(), middle, std::back_inserter(res),
-                 [](const El& x) { return std::get<4>(x); });
-  return res;
+        // Lists edge types from less desirable to more desirable.
+        enum EdgeRank {
+          kTerminalLoss,
+          kTablebaseLoss,
+          kNonTerminal,  // Non terminal or terminal draw.
+          kTablebaseWin,
+          kTerminalWin,
+        };
+
+        auto GetEdgeRank = [](const EdgeAndNode& edge) {
+          const auto wl = edge.GetWL();
+          if (!edge.IsTerminal() || wl) return kNonTerminal;
+          if (edge.IsTbTerminal()) {
+            return wl < 0.0 ? kTablebaseLoss : kTablebaseWin;
+          }
+          return wl < 0.0 ? kTerminalLoss : kTerminalWin;
+        };
+
+        // If moves have different outcomes, prefer better outcome.
+        const auto a_rank = GetEdgeRank(a);
+        const auto b_rank = GetEdgeRank(b);
+        if (a_rank != b_rank) return a > b;
+
+        // If both are terminal draws, try to make it shorter.
+        if (a_rank == kNonTerminal && a.IsTerminal() && b.IsTerminal()) {
+          if (a.IsTbTerminal() != b.IsTbTerminal()) {
+            // Prefer non-tablebase draws.
+            return a.IsTbTerminal() < b.IsTbTerminal();
+          }
+          // Prefer shorter draws.
+          return a.GetM(0.0f) < b.GetM(0.0f);
+        }
+
+        // Neither is terminal, use standard rule.
+        if (a_rank == kNonTerminal) {
+          // Prefer largest playouts then eval then prior.
+          if (a.GetN() != b.GetN()) return a.GetN() > b.GetN();
+          if (a.GetWL() != b.GetWL()) return a.GetWL() > b.GetWL();
+          return a.GetP() > b.GetP();
+        }
+
+        // Both variants are winning, prefer shortest win.
+        if (a_rank > kNonTerminal) {
+          return a.GetM(0.0f) < b.GetM(0.0f);
+        }
+
+        // Both variants are losing, prefer longest losses.
+        return a.GetM(0.0f) > b.GetM(0.0f);
+      });
+
+  if (count < edges.size()) {
+    edges.resize(count);
+  }
+  return edges;
 }
 
 // Returns a child with most visits.
@@ -1057,11 +1110,13 @@ void SearchWorker::ExtendNode(Node* node) {
         }
         // If the colors seem backwards, check the checkmate check above.
         if (wdl == WDL_WIN) {
-          node->MakeTerminal(GameResult::BLACK_WON, m);
+          node->MakeTerminal(GameResult::BLACK_WON, m,
+                             Node::Terminal::Tablebase);
         } else if (wdl == WDL_LOSS) {
-          node->MakeTerminal(GameResult::WHITE_WON, m);
+          node->MakeTerminal(GameResult::WHITE_WON, m,
+                             Node::Terminal::Tablebase);
         } else {  // Cursed wins and blessed losses count as draws.
-          node->MakeTerminal(GameResult::DRAW, m);
+          node->MakeTerminal(GameResult::DRAW, m, Node::Terminal::Tablebase);
         }
         search_->tb_hits_.fetch_add(1, std::memory_order_acq_rel);
         return;
@@ -1332,6 +1387,7 @@ void SearchWorker::DoBackupUpdateSingleNode(
 
     // A non-winning terminal move needs all other moves to be similar.
     auto all_losing = true;
+    auto found_tb = n->IsTbTerminal();
     float losing_m = 0.0f;
     if (can_convert && v <= 0.0f) {
       for (const auto& edge : p->Edges()) {
@@ -1339,6 +1395,7 @@ void SearchWorker::DoBackupUpdateSingleNode(
         can_convert = can_convert && edge.IsTerminal() && WL <= 0.0f;
         if (!can_convert) break;
         all_losing = all_losing && WL < 0.0f;
+        found_tb = found_tb || edge.IsTbTerminal();
         losing_m = std::max(losing_m, edge.GetM(0.0f));
       }
     }
@@ -1355,7 +1412,8 @@ void SearchWorker::DoBackupUpdateSingleNode(
       p->MakeTerminal(
           v > 0.0f ? GameResult::BLACK_WON
                    : all_losing ? GameResult::WHITE_WON : GameResult::DRAW,
-          terminal_m);
+          terminal_m,
+          found_tb ? Node::Terminal::Tablebase : Node::Terminal::Terminal);
     }
 
     // Q will be flipped for opponent.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -514,7 +514,7 @@ std::vector<EdgeAndNode> Search::GetBestChildrenNoTemperature(Node* parent,
 
         auto GetEdgeRank = [](const EdgeAndNode& edge) {
           const auto wl = edge.GetWL();
-          if (!edge.IsTerminal() || wl) return kNonTerminal;
+          if (!edge.IsTerminal() || !wl) return kNonTerminal;
           if (edge.IsTbTerminal()) {
             return wl < 0.0 ? kTablebaseLoss : kTablebaseWin;
           }
@@ -524,7 +524,7 @@ std::vector<EdgeAndNode> Search::GetBestChildrenNoTemperature(Node* parent,
         // If moves have different outcomes, prefer better outcome.
         const auto a_rank = GetEdgeRank(a);
         const auto b_rank = GetEdgeRank(b);
-        if (a_rank != b_rank) return a > b;
+        if (a_rank != b_rank) return a_rank > b_rank;
 
         // If both are terminal draws, try to make it shorter.
         if (a_rank == kNonTerminal && a.IsTerminal() && b.IsTerminal()) {


### PR DESCRIPTION
r?@mooskagh or @Ttl Fix #837 by making use of `GetM()` on terminals to not need to traverse the tree calculating mate distance. Track the type of Terminal when extending a node as well as converting ancestors to differently rank and score.

https://lichess.org/analysis/4r2k/2q2Q2/5KRb/8/8/8/8/8_w_-_-_0_1
![Screen Shot 2020-03-05 at 2 02 48 AM](https://user-images.githubusercontent.com/438537/75970994-00c8a700-5e86-11ea-90ee-d296db2a9762.png)
```
./lc0 -w 59100 -v --multipv=100 --per-pv-counters
position fen 4r2k/2q2Q2/5KRb/8/8/8/8/8 w - - 0 1
go infinite

info nodes 175975 score mate  1 multipv  1 pv g6h6
info nodes 219983 score mate  3 multipv  2 pv f7e8 h6f8 e8f8 h8h7 g6h6
info nodes  53783 score cp 1160 multipv  3 pv f7c7 e8f8 f6e6 f8e8 e6d5 e8e1 c7f7 h6f8 f7g8
…
info nodes     69 score cp -348 multipv 14 pv g6g5 c7d6 f6f5 d6d3 f5f6 d3f3
info nodes     84 score mate -3 multipv 15 pv f7e7 c7e7 f6f5 e7e4 f5f6 e4f4
info nodes    134 score mate -2 multipv 16 pv g6g7 c7f4 f6g6 f4g5
info nodes     93 score mate -2 multipv 17 pv g6g4 c7d6 f6f5 e8e5
info nodes     89 score mate -2 multipv 18 pv f7c4 c7e5 f6f7 e5e7
info nodes     64 score mate -2 multipv 19 pv f7d7 c7e5 f6f7 e8f8
info nodes    157 score mate -1 multipv 20 pv f7a2 c7f4
info nodes     89 score mate -1 multipv 21 pv f7b3 c7f4
info nodes     70 score mate -1 multipv 22 pv f6f5 c7f4
```
Notice the mate-in-1 has fewer visits than the mate-in-3 but is selected as the bestmove. Also pv14+ show not-losses are preferred then longer mates then shorter mates. And within same mate rank, most visits are preferred as before.

(Thanks @Ttl for handling terminals in #961! ~Although unclear what should be done for TB hits.~ Fixed below https://github.com/LeelaChessZero/lc0/pull/1111#issuecomment-595426120)