### PR TITLE
Add max out of order evals parameter

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -176,6 +176,9 @@ const OptionId SearchParams::kOutOfOrderEvalId{
     "in the cache or is terminal, evaluate it right away without sending the "
     "batch to the NN. When off, this may only happen with the very first node "
     "of a batch; when on, this can happen with any node."};
+const OptionId SearchParams::kMaxOutOfOrderEvalsId{
+    "max-out-of-order-evals", "MaxOutOfOrderEvals",
+    "Maximum number of out of order evals during gathering of a batch."};
 const OptionId SearchParams::kStickyEndgamesId{
     "sticky-endgames", "StickyEndgames",
     "When an end of game position is found during search, allow the eval of "
@@ -279,6 +282,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kMaxCollisionEventsId, 1, 1024) = 32;
   options->Add<IntOption>(kMaxCollisionVisitsId, 1, 1000000) = 9999;
   options->Add<BoolOption>(kOutOfOrderEvalId) = true;
+  options->Add<IntOption>(kMaxOutOfOrderEvalsId, 1, 10000) = 256;
   options->Add<BoolOption>(kStickyEndgamesId) = true;
   options->Add<BoolOption>(kSyzygyFastPlayId) = true;
   options->Add<IntOption>(kMultiPvId, 1, 500) = 1;
@@ -365,7 +369,8 @@ SearchParams::SearchParams(const OptionsDict& options)
       kDrawScoreOpponent{options.Get<int>(kDrawScoreOpponentId.GetId()) /
                          100.0f},
       kDrawScoreWhite{options.Get<int>(kDrawScoreWhiteId.GetId()) / 100.0f},
-      kDrawScoreBlack{options.Get<int>(kDrawScoreBlackId.GetId()) / 100.0f} {
+      kDrawScoreBlack{options.Get<int>(kDrawScoreBlackId.GetId()) / 100.0f},
+      kMaxOutOfOrderEvals(options.Get<int>(kMaxOutOfOrderEvalsId.GetId())) {
   if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +
           std::max(std::abs(kDrawScoreWhite), std::abs(kDrawScoreBlack)) >
       1.0f) {

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -113,6 +113,8 @@ class SearchParams {
   float GetWhiteDrawDelta() const { return kDrawScoreWhite; }
   float GetBlackDrawDelta() const { return kDrawScoreBlack; }
 
+  int GetMaxOutOfOrderEvals() const { return kMaxOutOfOrderEvals; }
+
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
   static const OptionId kMaxPrefetchBatchId;
@@ -160,6 +162,7 @@ class SearchParams {
   static const OptionId kDrawScoreOpponentId;
   static const OptionId kDrawScoreWhiteId;
   static const OptionId kDrawScoreBlackId;
+  static const OptionId kMaxOutOfOrderEvalsId;
 
  private:
   const OptionsDict& options_;
@@ -201,6 +204,7 @@ class SearchParams {
   const float kDrawScoreOpponent;
   const float kDrawScoreWhite;
   const float kDrawScoreBlack;
+  const int kMaxOutOfOrderEvals;
 };
 
 }  // namespace lczero

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -771,7 +771,7 @@ void SearchWorker::GatherMinibatch() {
   // If we had too many (kMiniBatchSize) nodes out of order, also interrupt the
   // iteration so that search can exit.
   while (minibatch_size < params_.GetMiniBatchSize() &&
-         number_out_of_order_ < params_.GetMiniBatchSize()) {
+         number_out_of_order_ < params_.GetMaxOutOfOrderEvals()) {
     // If there's something to process without touching slow neural net, do it.
     if (minibatch_size > 0 && computation_->GetCacheMisses() == 0) return;
     // Pick next node to extend.

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -112,6 +112,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
 
   auto defaults = options->GetMutableDefaultsOptions();
   defaults->Set<int>(SearchParams::kMiniBatchSizeId.GetId(), 32);
+  defaults->Set<int>(SearchParams::kMaxOutOfOrderEvalsId.GetId(), 32);
   defaults->Set<float>(SearchParams::kCpuctId.GetId(), 1.2f);
   defaults->Set<float>(SearchParams::kCpuctFactorId.GetId(), 0.0f);
   defaults->Set<float>(SearchParams::kPolicySoftmaxTempId.GetId(), 1.0f);


### PR DESCRIPTION
For low batch sizes most of the batches are not full because there are too many NNCache hits. This change allows changing the limit on how many out of order evals can happen before non-full batch is submitted.

Tests with 128x10 network on startpos 1M nodes with maximum batch size 68, max-collisions 68, max-prefetch=68.

Before there are many non-full batches:
![bs68_before](https://user-images.githubusercontent.com/544240/76147562-45cb2400-60a6-11ea-98c5-d451b7a65467.png)

After with bigger max out of order evals limit almost all batches are full:
![bs68_after](https://user-images.githubusercontent.com/544240/76147563-4794e780-60a6-11ea-93b6-1b6a6e630168.png)
