### PR TITLE
package android binaries in zip files

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,28 +81,22 @@ build_script:
 - cmd: IF %ANDROID%==false call scripts\appveyor_win_build.cmd
 - cmd: cd build
 - cmd: IF %ANDROID%==true ninja
-- cmd: IF %ANDROID%==true ren lc0 lc0-%NAME%
 - cmd: cd C:\projects\lc0
 after_build:
 - cmd: IF %APPVEYOR_REPO_TAG%==true IF %ANDROID%==false call scripts\appveyor_win_package.cmd
+- cmd: IF %APPVEYOR_REPO_TAG%==true IF %ANDROID%==true 7z a lc0-%APPVEYOR_REPO_TAG_NAME%-%NAME%.zip %APPVEYOR_BUILD_FOLDER%\build\lc0
 artifacts:
   - path: build/lc0.exe
     name: lc0-$(NAME)
-  - path: build/lc0-$(NAME)
+  - path: build/lc0
     name: lc0-$(NAME)
   - path: /lc0*.zip/
-    name: lc0-$(APPVEYOR_REPO_TAG_NAME)-windows-$(NAME)-zip
+    name: lc0-$(APPVEYOR_REPO_TAG_NAME)-$(NAME)-zip
   - path: build/lc0.pdb
     name: lc0-debug-symbols
 deploy:
   - provider: GitHub
     artifact: /.*\.zip/
-    auth_token:
-      secure: USFAdwQKTXqOXQjCYQfzWvzRpUhvqJLBkN4hbOg+j876vDxGZHt9bMYayb5evePp
-    on:
-      appveyor_repo_tag: true
-  - provider: GitHub
-    artifact: /lc0-android.*/
     auth_token:
       secure: USFAdwQKTXqOXQjCYQfzWvzRpUhvqJLBkN4hbOg+j876vDxGZHt9bMYayb5evePp
     on:


### PR DESCRIPTION
In case we don't want to merge #1116 for v0.24.0 (which requires cherry-picking #1105 as well), this is a simpler alternative that packages the android binaries to a versioned zip file, which was the most popular option in a discord poll.