### PR TITLE
Lower Android API level requirements for armv7-a build.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,12 +47,12 @@ install:
 - cmd: IF %NAME%==android C:\ProgramData\Microsoft\AndroidNDK64\android-ndk-r17\build\tools\make_standalone_toolchain.py --arch arm64 --api 21 --stl libc++ --install-dir \android-standalone-64
 - cmd: IF %NAME%==android set PATH=C:\android-standalone-64\bin;%PATH%
 - cmd: IF %NAME%==android sed "s/clang+*/&.cmd/" cross-files/aarch64-linux-android >crossfile-aarch64
-- cmd: IF %NAME%==android IF NOT EXIST C:\cache\OpenBLAS\android-aarch64 appveyor DownloadFile https://github.com/borg323/OpenBLAS/releases/download/android-0.3.8/openblas-android-aarch64.zip
+- cmd: IF %NAME%==android IF NOT EXIST C:\cache\OpenBLAS\android-aarch64 appveyor DownloadFile https://github.com/borg323/OpenBLAS/releases/download/android-0.3.8-2/openblas-android-aarch64.zip
 - cmd: IF %NAME%==android IF NOT EXIST C:\cache\OpenBLAS\android-aarch64 7z x openblas-android-aarch64.zip -oC:\cache\OpenBLAS
 - cmd: IF %NAME%==android C:\ProgramData\Microsoft\AndroidNDK64\android-ndk-r17\build\tools\make_standalone_toolchain.py --arch arm --api 21 --stl libc++ --install-dir \android-standalone-32
 - cmd: IF %NAME%==android set PATH=C:\android-standalone-32\bin;%PATH%
 - cmd: IF %NAME%==android sed "s/clang+*/&.cmd/" cross-files/armv7a-linux-android >crossfile-armv7a
-- cmd: IF %NAME%==android IF NOT EXIST C:\cache\OpenBLAS\android-armv7a appveyor DownloadFile https://github.com/borg323/OpenBLAS/releases/download/android-0.3.8/openblas-android-armv7a.zip
+- cmd: IF %NAME%==android IF NOT EXIST C:\cache\OpenBLAS\android-armv7a appveyor DownloadFile https://github.com/borg323/OpenBLAS/releases/download/android-0.3.8-2/openblas-android-armv7a.zip
 - cmd: IF %NAME%==android IF NOT EXIST C:\cache\OpenBLAS\android-armv7a 7z x openblas-android-armv7a.zip -oC:\cache\OpenBLAS
 - cmd: set PKG_FOLDER="C:\cache"
 - cmd: IF NOT EXIST c:\cache mkdir c:\cache
@@ -65,7 +65,7 @@ install:
 - cmd: IF %GTEST%==true IF NOT EXIST KQvKQ.rtbz curl --remote-name-all https://tablebase.lichess.ovh/tables/standard/3-4-5/K{P,N,R,B,Q}vK{P,N,R,B,Q}.rtb{w,z}
 - cmd: cd C:\projects\lc0
 cache:
-  - C:\cache
+  - C:\cache -> appveyor.yml
   - 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0'
   - C:\projects\lc0\subprojects\packagecache
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ install:
 - cmd: IF %NAME%==android sed "s/clang+*/&.cmd/" cross-files/aarch64-linux-android >crossfile-aarch64
 - cmd: IF %NAME%==android IF NOT EXIST C:\cache\OpenBLAS\android-aarch64 appveyor DownloadFile https://github.com/borg323/OpenBLAS/releases/download/android-0.3.8/openblas-android-aarch64.zip
 - cmd: IF %NAME%==android IF NOT EXIST C:\cache\OpenBLAS\android-aarch64 7z x openblas-android-aarch64.zip -oC:\cache\OpenBLAS
-- cmd: IF %NAME%==android C:\ProgramData\Microsoft\AndroidNDK64\android-ndk-r17\build\tools\make_standalone_toolchain.py --arch arm --api 24 --stl libc++ --install-dir \android-standalone-32
+- cmd: IF %NAME%==android C:\ProgramData\Microsoft\AndroidNDK64\android-ndk-r17\build\tools\make_standalone_toolchain.py --arch arm --api 21 --stl libc++ --install-dir \android-standalone-32
 - cmd: IF %NAME%==android set PATH=C:\android-standalone-32\bin;%PATH%
 - cmd: IF %NAME%==android sed "s/clang+*/&.cmd/" cross-files/armv7a-linux-android >crossfile-armv7a
 - cmd: IF %NAME%==android IF NOT EXIST C:\cache\OpenBLAS\android-armv7a appveyor DownloadFile https://github.com/borg323/OpenBLAS/releases/download/android-0.3.8/openblas-android-armv7a.zip

--- a/cross-files/armv7a-linux-android
+++ b/cross-files/armv7a-linux-android
@@ -2,8 +2,11 @@
 # Tested with Android NDK r18, standalone toolchain
 # Targeting API level 21
 #
-# When targeting API levels < 24 must undef _FILE_OFFSET_BITS to addess this issue:
-# https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md
+# When targeting API levels < 24 the build fails unless _FILE_OFFSET_BITS is unset.
+# Meson passes _FILE_OFFSET_BITS=64 but recent NDK toolchains have issues building
+# for 32-bit ABIs when such macro it set. Relevant links:
+#  https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md
+#  https://github.com/mesonbuild/meson/pull/2996#issuecomment-384045808
 #
 # First create the standalone toolchain:
 # ./make_standalone_toolchain.py --arch arm --api 21 --stl libc++ --install-dir android-standalone-32

--- a/cross-files/armv7a-linux-android
+++ b/cross-files/armv7a-linux-android
@@ -1,9 +1,12 @@
 
 # Tested with Android NDK r18, standalone toolchain
-# Targeting API level 24
+# Targeting API level 21
+#
+# When targeting API levels < 24 must undef _FILE_OFFSET_BITS to addess this issue:
+# https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md
 #
 # First create the standalone toolchain:
-# ./make_standalone_toolchain.py --arch arm --api 24 --stl libc++ --install-dir android-standalone-32
+# ./make_standalone_toolchain.py --arch arm --api 21 --stl libc++ --install-dir android-standalone-32
 #
 # Then set the toolchain path on your environment:
 # export PATH="$HOME/.local/share/android-sdk/android-toolchains/android-standalone-32/bin:$PATH"
@@ -15,6 +18,7 @@ cpu = 'armv7a'
 endian = 'little'
 
 [properties]
+cpp_args = ['-U_FILE_OFFSET_BITS']
 cpp_link_args = ['-llog', '-static-libstdc++']
 
 [binaries]


### PR DESCRIPTION
Lowers the API level to 21 (Android 5). Current target is API level 24 (Android 7) which is too high for older armv7-a devices. Like in this issue #1104. The reason it was to high was because of this:

https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md
