### PR TITLE
Max out of order evals relative to the maximum batch size

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -176,6 +176,9 @@ const OptionId SearchParams::kOutOfOrderEvalId{
     "in the cache or is terminal, evaluate it right away without sending the "
     "batch to the NN. When off, this may only happen with the very first node "
     "of a batch; when on, this can happen with any node."};
+const OptionId SearchParams::kMaxOutOfOrderEvalsId{
+    "max-out-of-order-evals", "MaxOutOfOrderEvals",
+    "Maximum number of out of order evals during gathering of a batch."};
 const OptionId SearchParams::kStickyEndgamesId{
     "sticky-endgames", "StickyEndgames",
     "When an end of game position is found during search, allow the eval of "
@@ -279,6 +282,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kMaxCollisionEventsId, 1, 1024) = 32;
   options->Add<IntOption>(kMaxCollisionVisitsId, 1, 1000000) = 9999;
   options->Add<BoolOption>(kOutOfOrderEvalId) = true;
+  options->Add<IntOption>(kMaxOutOfOrderEvalsId, 1, 10000) = 256;
   options->Add<BoolOption>(kStickyEndgamesId) = true;
   options->Add<BoolOption>(kSyzygyFastPlayId) = true;
   options->Add<IntOption>(kMultiPvId, 1, 500) = 1;
@@ -365,7 +369,8 @@ SearchParams::SearchParams(const OptionsDict& options)
       kDrawScoreOpponent{options.Get<int>(kDrawScoreOpponentId.GetId()) /
                          100.0f},
       kDrawScoreWhite{options.Get<int>(kDrawScoreWhiteId.GetId()) / 100.0f},
-      kDrawScoreBlack{options.Get<int>(kDrawScoreBlackId.GetId()) / 100.0f} {
+      kDrawScoreBlack{options.Get<int>(kDrawScoreBlackId.GetId()) / 100.0f},
+      kMaxOutOfOrderEvals(options.Get<int>(kMaxOutOfOrderEvalsId.GetId())) {
   if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +
           std::max(std::abs(kDrawScoreWhite), std::abs(kDrawScoreBlack)) >
       1.0f) {

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -177,9 +177,9 @@ const OptionId SearchParams::kOutOfOrderEvalId{
     "batch to the NN. When off, this may only happen with the very first node "
     "of a batch; when on, this can happen with any node."};
 const OptionId SearchParams::kMaxOutOfOrderEvalsId{
-    "max-out-of-order-evals", "MaxOutOfOrderEvals",
-    "Maximum number of out of order evals during gathering of a batch relative "
-    "to the maximum batch size."};
+    "max-out-of-order-evals-factor", "MaxOutOfOrderEvalsFactor",
+    "Maximum number of out of order evals during gathering of a batch is "
+    "calculated by multiplying the maximum batch size by this number."};
 const OptionId SearchParams::kStickyEndgamesId{
     "sticky-endgames", "StickyEndgames",
     "When an end of game position is found during search, allow the eval of "

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -178,7 +178,8 @@ const OptionId SearchParams::kOutOfOrderEvalId{
     "of a batch; when on, this can happen with any node."};
 const OptionId SearchParams::kMaxOutOfOrderEvalsId{
     "max-out-of-order-evals", "MaxOutOfOrderEvals",
-    "Maximum number of out of order evals during gathering of a batch."};
+    "Maximum number of out of order evals during gathering of a batch relative "
+    "to the maximum batch size."};
 const OptionId SearchParams::kStickyEndgamesId{
     "sticky-endgames", "StickyEndgames",
     "When an end of game position is found during search, allow the eval of "
@@ -282,7 +283,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kMaxCollisionEventsId, 1, 1024) = 32;
   options->Add<IntOption>(kMaxCollisionVisitsId, 1, 1000000) = 9999;
   options->Add<BoolOption>(kOutOfOrderEvalId) = true;
-  options->Add<IntOption>(kMaxOutOfOrderEvalsId, 1, 10000) = 256;
+  options->Add<FloatOption>(kMaxOutOfOrderEvalsId, 0.0f, 100.0f) = 1.0f;
   options->Add<BoolOption>(kStickyEndgamesId) = true;
   options->Add<BoolOption>(kSyzygyFastPlayId) = true;
   options->Add<IntOption>(kMultiPvId, 1, 500) = 1;
@@ -370,7 +371,9 @@ SearchParams::SearchParams(const OptionsDict& options)
                          100.0f},
       kDrawScoreWhite{options.Get<int>(kDrawScoreWhiteId.GetId()) / 100.0f},
       kDrawScoreBlack{options.Get<int>(kDrawScoreBlackId.GetId()) / 100.0f},
-      kMaxOutOfOrderEvals(options.Get<int>(kMaxOutOfOrderEvalsId.GetId())) {
+      kMaxOutOfOrderEvals(
+          std::max(1, int(options.Get<float>(kMaxOutOfOrderEvalsId.GetId()) *
+                          options.Get<int>(kMiniBatchSizeId.GetId())))) {
   if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +
           std::max(std::abs(kDrawScoreWhite), std::abs(kDrawScoreBlack)) >
       1.0f) {

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -113,6 +113,8 @@ class SearchParams {
   float GetWhiteDrawDelta() const { return kDrawScoreWhite; }
   float GetBlackDrawDelta() const { return kDrawScoreBlack; }
 
+  int GetMaxOutOfOrderEvals() const { return kMaxOutOfOrderEvals; }
+
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
   static const OptionId kMaxPrefetchBatchId;
@@ -160,6 +162,7 @@ class SearchParams {
   static const OptionId kDrawScoreOpponentId;
   static const OptionId kDrawScoreWhiteId;
   static const OptionId kDrawScoreBlackId;
+  static const OptionId kMaxOutOfOrderEvalsId;
 
  private:
   const OptionsDict& options_;
@@ -201,6 +204,7 @@ class SearchParams {
   const float kDrawScoreOpponent;
   const float kDrawScoreWhite;
   const float kDrawScoreBlack;
+  const int kMaxOutOfOrderEvals;
 };
 
 }  // namespace lczero

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -822,8 +822,8 @@ void SearchWorker::GatherMinibatch() {
   number_out_of_order_ = 0;
 
   // Gather nodes to process in the current batch.
-  // If we had too many (kMiniBatchSize) nodes out of order, also interrupt the
-  // iteration so that search can exit.
+  // If we had too many nodes out of order, also interrupt the iteration so
+  // that search can exit.
   while (minibatch_size < params_.GetMiniBatchSize() &&
          number_out_of_order_ < params_.GetMaxOutOfOrderEvals()) {
     // If there's something to process without touching slow neural net, do it.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -771,7 +771,7 @@ void SearchWorker::GatherMinibatch() {
   // If we had too many (kMiniBatchSize) nodes out of order, also interrupt the
   // iteration so that search can exit.
   while (minibatch_size < params_.GetMiniBatchSize() &&
-         number_out_of_order_ < params_.GetMiniBatchSize()) {
+         number_out_of_order_ < params_.GetMaxOutOfOrderEvals()) {
     // If there's something to process without touching slow neural net, do it.
     if (minibatch_size > 0 && computation_->GetCacheMisses() == 0) return;
     // Pick next node to extend.

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -112,6 +112,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
 
   auto defaults = options->GetMutableDefaultsOptions();
   defaults->Set<int>(SearchParams::kMiniBatchSizeId.GetId(), 32);
+  defaults->Set<int>(SearchParams::kMaxOutOfOrderEvalsId.GetId(), 32);
   defaults->Set<float>(SearchParams::kCpuctId.GetId(), 1.2f);
   defaults->Set<float>(SearchParams::kCpuctFactorId.GetId(), 0.0f);
   defaults->Set<float>(SearchParams::kPolicySoftmaxTempId.GetId(), 1.0f);

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -112,7 +112,6 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
 
   auto defaults = options->GetMutableDefaultsOptions();
   defaults->Set<int>(SearchParams::kMiniBatchSizeId.GetId(), 32);
-  defaults->Set<float>(SearchParams::kMaxOutOfOrderEvalsId.GetId(), 1.0f);
   defaults->Set<float>(SearchParams::kCpuctId.GetId(), 1.2f);
   defaults->Set<float>(SearchParams::kCpuctFactorId.GetId(), 0.0f);
   defaults->Set<float>(SearchParams::kPolicySoftmaxTempId.GetId(), 1.0f);

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -112,7 +112,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
 
   auto defaults = options->GetMutableDefaultsOptions();
   defaults->Set<int>(SearchParams::kMiniBatchSizeId.GetId(), 32);
-  defaults->Set<int>(SearchParams::kMaxOutOfOrderEvalsId.GetId(), 32);
+  defaults->Set<float>(SearchParams::kMaxOutOfOrderEvalsId.GetId(), 1.0f);
   defaults->Set<float>(SearchParams::kCpuctId.GetId(), 1.2f);
   defaults->Set<float>(SearchParams::kCpuctFactorId.GetId(), 0.0f);
   defaults->Set<float>(SearchParams::kPolicySoftmaxTempId.GetId(), 1.0f);


### PR DESCRIPTION
Amount of full batches as function of the maximum out of order evals scales similarly with different maximum batch sizes when it's relative to the maximum batch size. This makes it easier to tune the parameters as batch size and max-out-of-order-evals can be adjusted separately.