### PR TITLE
Match knights() call more cleanly with other piece calls

### DIFF
--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -1113,7 +1113,7 @@ bool ChessBoard::HasMatingMaterial() const {
     // K v K, K+B v K, K+N v K.
     return false;
   }
-  if (!our_knights().empty() || !their_knights().empty()) {
+  if (!(knights().empty())) {
     return true;
   }
 

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -186,11 +186,9 @@ class ChessBoard {
   BitBoard bishops() const { return bishops_ - rooks_; }
   BitBoard rooks() const { return rooks_ - bishops_; }
   BitBoard queens() const { return rooks_ & bishops_; }
-  BitBoard our_knights() const {
-    return our_pieces_ - pawns() - our_king_ - rooks_ - bishops_;
-  }
-  BitBoard their_knights() const {
-    return their_pieces_ - pawns() - their_king_ - rooks_ - bishops_;
+  BitBoard knights() const {
+    return (our_pieces_ | their_pieces_) - pawns() - our_king_ - their_king_ -
+           rooks_ - bishops_;
   }
   BitBoard our_king() const { return 1ull << our_king_.as_int(); }
   BitBoard their_king() const { return 1ull << their_king_.as_int(); }

--- a/src/chess/pgn.h
+++ b/src/chess/pgn.h
@@ -218,7 +218,7 @@ class PgnReader {
       } else if (p == 3) {
         searchBits = (board.bishops() & board.ours());
       } else if (p == 4) {
-        searchBits = board.our_knights();
+        searchBits = (board.knights() & board.ours());
       } else if (p == 5) {
         searchBits = (board.rooks() & board.ours());
       }

--- a/src/neural/encoder.cc
+++ b/src/neural/encoder.cc
@@ -107,14 +107,14 @@ InputPlanes EncodePositionForNN(
 
     const int base = i * kPlanesPerBoard;
     result[base + 0].mask = (board.ours() & board.pawns()).as_int();
-    result[base + 1].mask = (board.our_knights()).as_int();
+    result[base + 1].mask = (board.ours() & board.knights()).as_int();
     result[base + 2].mask = (board.ours() & board.bishops()).as_int();
     result[base + 3].mask = (board.ours() & board.rooks()).as_int();
     result[base + 4].mask = (board.ours() & board.queens()).as_int();
     result[base + 5].mask = (board.our_king()).as_int();
 
     result[base + 6].mask = (board.theirs() & board.pawns()).as_int();
-    result[base + 7].mask = (board.their_knights()).as_int();
+    result[base + 7].mask = (board.theirs() & board.knights()).as_int();
     result[base + 8].mask = (board.theirs() & board.bishops()).as_int();
     result[base + 9].mask = (board.theirs() & board.rooks()).as_int();
     result[base + 10].mask = (board.theirs() & board.queens()).as_int();

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -194,7 +194,7 @@ int count_pieces(const ChessBoard& pos, int type, bool theirs) {
     case BISHOP:
       return (all & pos.bishops()).count_few();
     case KNIGHT:
-      return (theirs ? pos.their_knights() : pos.our_knights()).count_few();
+      return (all & pos.knights()).count_few();
     case PAWN:
       return (all & pos.pawns()).count_few();
     default:
@@ -215,7 +215,7 @@ BitBoard pieces(const ChessBoard& pos, int type, bool theirs) {
     case BISHOP:
       return all & pos.bishops();
     case KNIGHT:
-      return theirs ? pos.their_knights() : pos.our_knights();
+      return all & pos.knights();
     case PAWN:
       return all & pos.pawns();
     default:


### PR DESCRIPTION
I looked at this for a long time and haven't been able to find any reason that having two calls, one for their and one for our knights, does anything but make the code a little bit harder to read (specifically because it looks like there must be some reason). This probably isn't central to how anything works but it seems like it wouldn't interfere with what anyone else is doing and makes this easier to follow, unless I'm missing the reason for it.

Similar changes for kings in #1132

Benchmarks:
```
- Master
Benchmark final time 10.0009s calculating 212417 nodes per second.
Benchmark final time 10.0006s calculating 208707 nodes per second.
Benchmark final time 10.0004s calculating 208102 nodes per second.

- Knights
Benchmark final time 10.0005s calculating 208702 nodes per second.
Benchmark final time 10.0004s calculating 204465 nodes per second.
Benchmark final time 10.0006s calculating 206022 nodes per second.

- Kings
Benchmark final time 10.0005s calculating 206489 nodes per second.
Benchmark final time 10.0005s calculating 207881 nodes per second.
Benchmark final time 10.0006s calculating 206204 nodes per second.```