### PR TITLE
Match kings() call more cleanly with other piece calls

### DIFF
--- a/src/chess/bitboard.h
+++ b/src/chess/bitboard.h
@@ -49,6 +49,7 @@ class BoardSquare {
   BoardSquare(const std::string& str, bool black = false)
       : BoardSquare(black ? '8' - str[1] : str[1] - '1', str[0] - 'a') {}
   constexpr std::uint8_t as_int() const { return square_; }
+  constexpr std::uint8_t as_board() const { return 1ULL << square_; }
   void set(int row, int col) { square_ = row * 8 + col; }
 
   // 0-based, bottom to top.
@@ -221,7 +222,7 @@ class BitBoard {
 
   // Returns bitboard with one bit reset.
   friend BitBoard operator-(const BitBoard& a, const BoardSquare& b) {
-    return {a.board_ & ~(1ULL << b.as_int())};
+    return {a.board_ & ~b.as_board()};
   }
 
   // Returns difference (bitwise AND-NOT) of two boards.

--- a/src/chess/bitboard.h
+++ b/src/chess/bitboard.h
@@ -49,7 +49,7 @@ class BoardSquare {
   BoardSquare(const std::string& str, bool black = false)
       : BoardSquare(black ? '8' - str[1] : str[1] - '1', str[0] - 'a') {}
   constexpr std::uint8_t as_int() const { return square_; }
-  constexpr std::uint8_t as_board() const { return 1ULL << square_; }
+  constexpr std::uint64_t as_board() const { return 1ULL << square_; }
   void set(int row, int col) { square_ = row * 8 + col; }
 
   // 0-based, bottom to top.

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -192,8 +192,9 @@ class ChessBoard {
   BitBoard their_knights() const {
     return their_pieces_ - pawns() - their_king_ - rooks_ - bishops_;
   }
-  BitBoard our_king() const { return 1ull << our_king_.as_int(); }
-  BitBoard their_king() const { return 1ull << their_king_.as_int(); }
+  BitBoard kings() const {
+    return our_king_.as_board() | their_king_.as_board();
+  }
   const Castlings& castlings() const { return castlings_; }
   bool flipped() const { return flipped_; }
 

--- a/src/chess/pgn.h
+++ b/src/chess/pgn.h
@@ -212,7 +212,7 @@ class PgnReader {
       if (p == 0) {
         searchBits = (board.pawns() & board.ours());
       } else if (p == 1) {
-        searchBits = board.our_king();
+        searchBits = (board.kings() & board.ours());
       } else if (p == 2) {
         searchBits = (board.queens() & board.ours());
       } else if (p == 3) {

--- a/src/neural/encoder.cc
+++ b/src/neural/encoder.cc
@@ -111,14 +111,14 @@ InputPlanes EncodePositionForNN(
     result[base + 2].mask = (board.ours() & board.bishops()).as_int();
     result[base + 3].mask = (board.ours() & board.rooks()).as_int();
     result[base + 4].mask = (board.ours() & board.queens()).as_int();
-    result[base + 5].mask = (board.our_king()).as_int();
+    result[base + 5].mask = (board.ours() & board.kings()).as_int();
 
     result[base + 6].mask = (board.theirs() & board.pawns()).as_int();
     result[base + 7].mask = (board.their_knights()).as_int();
     result[base + 8].mask = (board.theirs() & board.bishops()).as_int();
     result[base + 9].mask = (board.theirs() & board.rooks()).as_int();
     result[base + 10].mask = (board.theirs() & board.queens()).as_int();
-    result[base + 11].mask = (board.their_king()).as_int();
+    result[base + 11].mask = (board.theirs() & board.kings()).as_int();
 
     const int repetitions = position.GetRepetitions();
     if (repetitions >= 1) result[base + 12].SetAll();

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -207,7 +207,7 @@ BitBoard pieces(const ChessBoard& pos, int type, bool theirs) {
   const BitBoard all = theirs ? pos.theirs() : pos.ours();
   switch (type) {
     case KING:
-      return theirs ? pos.their_king() : pos.our_king();
+      return all & pos.kings();
     case QUEEN:
       return all & pos.queens();
     case ROOK:
@@ -1321,8 +1321,7 @@ class SyzygyTablebaseImpl {
     const Key key = calc_key_from_position(pos);
 
     // Test for KvK
-    if (type == WDL && pos.ours() == pos.our_king() &&
-        pos.theirs() == pos.their_king()) {
+    if (type == WDL && (pos.ours() | pos.theirs()) == pos.kings()) {
       return 0;
     }
 


### PR DESCRIPTION
same idea as #1131

this also adds an `as_board()` method to BoardSquare to save us from writing `1ULL << *.as_int()` more than once

Benchmarks:
```
- Master
Benchmark final time 10.0009s calculating 212417 nodes per second.
Benchmark final time 10.0006s calculating 208707 nodes per second.
Benchmark final time 10.0004s calculating 208102 nodes per second.

- Knights
Benchmark final time 10.0005s calculating 208702 nodes per second.
Benchmark final time 10.0004s calculating 204465 nodes per second.
Benchmark final time 10.0006s calculating 206022 nodes per second.

- Kings
Benchmark final time 10.0005s calculating 206489 nodes per second.
Benchmark final time 10.0005s calculating 207881 nodes per second.
Benchmark final time 10.0006s calculating 206204 nodes per second.
```