### PR TITLE
make pawn mask code slightly less disruptive

### DIFF
--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -49,6 +49,8 @@ const char* ChessBoard::kStartposFen =
 
 const ChessBoard ChessBoard::kStartposBoard(ChessBoard::kStartposFen);
 
+const BitBoard ChessBoard::kPawnMask = 0x00FFFFFFFFFFFF00ULL;
+
 void ChessBoard::Clear() {
   std::memset(reinterpret_cast<void*>(this), 0, sizeof(ChessBoard));
 }
@@ -68,8 +70,6 @@ void ChessBoard::Mirror() {
 }
 
 namespace {
-static const BitBoard kPawnMask = 0x00FFFFFFFFFFFF00ULL;
-
 static const std::pair<int, int> kKingMoves[] = {
     {-1, -1}, {-1, 0}, {-1, 1}, {0, -1}, {0, 1}, {1, -1}, {1, 0}, {1, 1}};
 
@@ -426,10 +426,6 @@ void InitializeMagicBitboards() {
   BuildAttacksTable(bishop_magic_params, bishop_attacks_table,
                     kBishopDirections);
 }
-
-BitBoard ChessBoard::pawns() const { return pawns_ & kPawnMask; }
-
-BitBoard ChessBoard::en_passant() const { return pawns_ - pawns(); }
 
 MoveList ChessBoard::GeneratePseudolegalMoves() const {
   MoveList result;

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -64,6 +64,7 @@ class ChessBoard {
 
   static const char* kStartposFen;
   static const ChessBoard kStartposBoard;
+  static const BitBoard kPawnMask;
 
   // Sets position from FEN string.
   // If @no_capture_ply and @moves are not nullptr, they are filled with number
@@ -181,8 +182,8 @@ class ChessBoard {
 
   BitBoard ours() const { return our_pieces_; }
   BitBoard theirs() const { return their_pieces_; }
-  BitBoard pawns() const;
-  BitBoard en_passant() const;
+  BitBoard pawns() const { return pawns_ & kPawnMask; }
+  BitBoard en_passant() const { return pawns_ - kPawnMask; }
   BitBoard bishops() const { return bishops_ - rooks_; }
   BitBoard rooks() const { return rooks_ - bishops_; }
   BitBoard queens() const { return rooks_ & bishops_; }


### PR DESCRIPTION
kPawnMask sitting in board.cc forces us to write just two of this list of functions in board.cc when the rest of them are in board.h, and it seems like that constant should belong to ChessBoard anyway, since en passant bits in the mask are part of the information requires to understand the contents of the class. Declaring the constant in board.h lets us have a clean block for all of the methods that return these bitboards.