### PR TITLE
Moves left head for OpenCL backend

### DIFF
--- a/src/neural/opencl/OpenCL.h
+++ b/src/neural/opencl/OpenCL.h
@@ -68,6 +68,7 @@ class Layer {
   bool is_policy{false};
   bool is_conv_policy{false};
   bool is_value{false};
+  bool is_moves_left{false};
   std::vector<cl::Buffer> weights;
 };
 
@@ -181,6 +182,24 @@ class OpenCL_Network {
     push_weights(layer, fc_w);
     push_weights(layer, fc_b);
     m_layers[layer].is_value = true;
+    m_layers[layer].outputs = outputs;
+    m_layers[layer].channels = channels;
+    m_layers[layer].ip_in_size = ip_in;
+    m_layers[layer].ip_out_size = ip_out;
+  }
+
+  void push_moves_left(unsigned int channels, unsigned int outputs,
+                       unsigned int ip_in, unsigned int ip_out,
+                       const std::vector<float>& weights,
+                       const std::vector<float>& biases,
+                       const std::vector<float>& fc_w,
+                       const std::vector<float>& fc_b) {
+    size_t layer = get_layer_count();
+    push_weights(layer, weights);
+    push_weights(layer, biases);
+    push_weights(layer, fc_w);
+    push_weights(layer, fc_b);
+    m_layers[layer].is_moves_left = true;
     m_layers[layer].outputs = outputs;
     m_layers[layer].channels = channels;
     m_layers[layer].ip_in_size = ip_in;

--- a/src/neural/opencl/OpenCLBuffers.h
+++ b/src/neural/opencl/OpenCLBuffers.h
@@ -49,7 +49,8 @@ class OpenCLBuffers {
   OpenCLBuffers(const OpenCL_Network& opencl_net);
 
   void forward(const std::vector<net_t>& input, std::vector<net_t>& output_pol,
-               std::vector<net_t>& output_val, const int batch_size);
+               std::vector<net_t>& output_val, std::vector<net_t>& output_mov,
+               const int batch_size);
 
  private:
   using weight_slice_t = std::vector<cl::Buffer>::const_iterator;
@@ -99,4 +100,8 @@ class OpenCLBuffers {
   cl::Buffer m_pool_buffer;
   cl::Buffer m_pinnedOutBuffer_pol;
   cl::Buffer m_pinnedOutBuffer_val;
+  cl::Buffer m_pinnedOutBuffer_mov;
+  size_t m_finalSize_pol;
+  size_t m_finalSize_val;
+  size_t m_finalSize_mov;
 };


### PR DESCRIPTION
Output matches cudnn backend. Nets without moves left head still work as before.