### PR TITLE
Add visit-based policy temperature decay

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -272,7 +272,8 @@ void Node::CancelScoreUpdate(int multivisit) {
   best_child_cached_ = nullptr;
 }
 
-void Node::FinalizeScoreUpdate(float v, float d, float m, int multivisit, float policy_temperature, float policy_temp_decay) {
+void Node::FinalizeScoreUpdate(float v, float d, float m, int multivisit, 
+    float policy_temperature, float policy_temp_decay) {
   // Recompute Q.
   wl_ += multivisit * (v - wl_) / (n_ + multivisit);
   d_ += multivisit * (d - d_) / (n_ + multivisit);
@@ -287,13 +288,16 @@ void Node::FinalizeScoreUpdate(float v, float d, float m, int multivisit, float 
 
   // Update the policies of children _if_ the difference is nontrivial
   // Take power only when the difference is nontrivial to minimize error
-  // On a test with P = 0.2 and 0.5, visits = 2m, limiting pow calls
+  // On a test with P = 0.2 and 0.5, visits = 2m, limiting pow calls with 
+  // distance from 1 > 0.0001
   // brings us to 4 decimal places accuracy compared to the correct answer
   // (correct answer = one pow call with the proper scaling exponent).
 
   
-  double old_policy_temp = policy_temperature / (policy_temperature - policy_temp_decay * log2(1 + n_last_temp_));
-  double exponent = old_policy_temp / (policy_temperature - policy_temp_decay * log2(1 + n_));
+  double old_policy_temp = policy_temperature - 
+      policy_temp_decay * log2(1 + n_last_temp_);
+  double exponent = old_policy_temp / (policy_temperature - 
+      policy_temp_decay * log2(1 + n_));
 
   if (abs(exponent - 1.0) > 0.001) {
     int num_edges = GetNumEdges();

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -294,18 +294,18 @@ void Node::FinalizeScoreUpdate(float v, float d, float m, int multivisit,
   // (correct answer = one pow call with the proper scaling exponent).
 
   
-  double old_policy_temp = policy_temperature - 
-      policy_temp_decay * log2(1 + n_last_temp_);
-  double exponent = old_policy_temp / (policy_temperature - 
-      policy_temp_decay * log2(1 + n_));
+  float old_policy_temp = policy_temperature - 
+      policy_temp_decay * log2f(1 + n_last_temp_);
+  float exponent = old_policy_temp / (policy_temperature - 
+      policy_temp_decay * log2f(1 + n_));
 
-  if (abs(exponent - 1.0) > 0.001) {
+  if (abs(exponent - 1.0f) > 0.001f) {
     int num_edges = GetNumEdges();
     float* values = new float[num_edges];
     float total = 0.0f;
     int counter = 0;
     for (auto& child : Edges()) {
-      double new_p = pow(child.GetP(), exponent);
+      float new_p = powf(child.GetP(), exponent);
       values[counter++] = new_p;
       total += new_p;
     }

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -250,6 +250,11 @@ void Node::MakeNotTerminal() {
       }
     }
 
+    // Since this is only used in NodeTree, which is unused in search,
+    // applying the new policy temperature is not really relevant to search 
+    // as much.
+    // Just ignore and fix it up when in FinalizeScoreUpdate.
+
     // Recompute with current eval (instead of network's) and children's eval.
     wl_ /= n_;
     d_ /= n_;
@@ -267,7 +272,7 @@ void Node::CancelScoreUpdate(int multivisit) {
   best_child_cached_ = nullptr;
 }
 
-void Node::FinalizeScoreUpdate(float v, float d, float m, int multivisit) {
+void Node::FinalizeScoreUpdate(float v, float d, float m, int multivisit, float policy_temperature, float policy_temp_decay) {
   // Recompute Q.
   wl_ += multivisit * (v - wl_) / (n_ + multivisit);
   d_ += multivisit * (d - d_) / (n_ + multivisit);
@@ -279,6 +284,41 @@ void Node::FinalizeScoreUpdate(float v, float d, float m, int multivisit) {
   }
   // Increment N.
   n_ += multivisit;
+
+  // Update the policies of children _if_ the difference is nontrivial
+  // Take power only when the difference is nontrivial to minimize error
+  // On a test with P = 0.2 and 0.5, visits = 2m, limiting pow calls
+  // brings us to 4 decimal places accuracy compared to the correct answer
+  // (correct answer = one pow call with the proper scaling exponent).
+
+  
+  double old_policy_temp = policy_temperature / (policy_temperature - policy_temp_decay * log2(1 + n_last_temp_));
+  double exponent = old_policy_temp / (policy_temperature - policy_temp_decay * log2(1 + n_));
+
+  if (abs(exponent - 1.0) > 0.001) {
+    int num_edges = GetNumEdges();
+    float* values = new float[num_edges];
+    float total = 0.0f;
+    int counter = 0;
+    for (auto& child : Edges()) {
+      double new_p = pow(child.GetP(), exponent);
+      values[counter++] = new_p;
+      total += new_p;
+    }
+
+    counter = 0;
+    if (total > 0.0f) {
+      for (auto& child : Edges()) {
+        child.SetP(values[counter++] / total);
+      }  
+    }
+    
+
+    n_last_temp_ = n_;
+    delete[] values;
+  }
+  
+
   // Decrement virtual loss.
   n_in_flight_ -= multivisit;
   // Best child is potentially no longer valid.

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -273,7 +273,7 @@ void Node::CancelScoreUpdate(int multivisit) {
 }
 
 void Node::FinalizeScoreUpdate(float v, float d, float m, int multivisit, 
-    float policy_temperature, float policy_temp_decay) {
+    float policy_temperature, float policy_temp_decay, float intermediate[]) {
   // Recompute Q.
   wl_ += multivisit * (v - wl_) / (n_ + multivisit);
   d_ += multivisit * (d - d_) / (n_ + multivisit);
@@ -300,26 +300,22 @@ void Node::FinalizeScoreUpdate(float v, float d, float m, int multivisit,
       policy_temp_decay * log2f(1 + n_));
 
   if (abs(exponent - 1.0f) > 0.001f) {
-    int num_edges = GetNumEdges();
-    float* values = new float[num_edges];
     float total = 0.0f;
     int counter = 0;
     for (auto& child : Edges()) {
       float new_p = powf(child.GetP(), exponent);
-      values[counter++] = new_p;
+      intermediate[counter++] = new_p;
       total += new_p;
     }
 
     counter = 0;
     if (total > 0.0f) {
       for (auto& child : Edges()) {
-        child.SetP(values[counter++] / total);
+        child.SetP(intermediate[counter++] / total);
       }  
     }
     
-
     n_last_temp_ = n_;
-    delete[] values;
   }
   
 

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -185,7 +185,8 @@ class Node {
   // * Q (weighted average of all V in a subtree)
   // * N (+=1)
   // * N-in-flight (-=1)
-  void FinalizeScoreUpdate(float v, float d, float m, int multivisit, float policy_temperature, float policy_temp_decay);
+  void FinalizeScoreUpdate(float v, float d, float m, int multivisit, 
+      float policy_temperature, float policy_temp_decay);
   // When search decides to treat one visit as several (in case of collisions
   // or visiting terminal nodes several times), it amplifies the visit by
   // incrementing n_in_flight.

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -345,7 +345,7 @@ class EdgeAndNode {
   Node* node() const { return node_; }
 
   // Proxy functions for easier access to node/edge.
-  float GetQ(float default_q, float draw_score, bool logit_q = false) const {
+  float GetQ(float default_q, float draw_score, bool logit_q) const {
     return (node_ && node_->GetN() > 0)
                ?
                // Scale Q slightly to avoid logit(1) = infinity.
@@ -382,8 +382,8 @@ class EdgeAndNode {
   }
 
   int GetVisitsToReachU(float target_score, float numerator, float default_q,
-                        bool logit_q) const {
-    const auto q = GetQ(default_q, logit_q);
+                        float draw_score, bool logit_q) const {
+    const auto q = GetQ(default_q, draw_score, logit_q);
     if (q >= target_score) return std::numeric_limits<int>::max();
     const auto n1 = GetNStarted() + 1;
     return std::max(

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -185,7 +185,7 @@ class Node {
   // * Q (weighted average of all V in a subtree)
   // * N (+=1)
   // * N-in-flight (-=1)
-  void FinalizeScoreUpdate(float v, float d, float m, int multivisit);
+  void FinalizeScoreUpdate(float v, float d, float m, int multivisit, float policy_temperature, float policy_temp_decay);
   // When search decides to treat one visit as several (in case of collisions
   // or visiting terminal nodes several times), it amplifies the visit by
   // incrementing n_in_flight.
@@ -287,6 +287,8 @@ class Node {
   float visited_policy_ = 0.0f;
   // How many completed visits this node had.
   uint32_t n_ = 0;
+  // What the number of visits was at the last time we applied dynamic policy temp.
+  uint32_t n_last_temp_ = 0;
   // (AKA virtual loss.) How many threads currently process this node (started
   // but not finished). This value is added to n during selection which node
   // to pick in MCTS, and also when selecting the best move.
@@ -321,9 +323,9 @@ class Node {
 
 // A basic sanity check. This must be adjusted when Node members are adjusted.
 #if defined(__i386__) || (defined(__arm__) && !defined(__aarch64__))
-static_assert(sizeof(Node) == 56, "Unexpected size of Node for 32bit compile");
+static_assert(sizeof(Node) == 60, "Unexpected size of Node for 32bit compile");
 #else
-static_assert(sizeof(Node) == 80, "Unexpected size of Node");
+static_assert(sizeof(Node) == 88, "Unexpected size of Node");
 #endif
 
 // Contains Edge and Node pair and set of proxy functions to simplify access
@@ -371,6 +373,7 @@ class EdgeAndNode {
 
   // Edge related getters.
   float GetP() const { return edge_->GetP(); }
+  void SetP(float val) { edge_->SetP(val); }
   Move GetMove(bool flip = false) const {
     return edge_ ? edge_->GetMove(flip) : Move();
   }
@@ -386,6 +389,8 @@ class EdgeAndNode {
     const auto q = GetQ(default_q, draw_score, logit_q);
     if (q >= target_score) return std::numeric_limits<int>::max();
     const auto n1 = GetNStarted() + 1;
+
+    // Ignore the policyTempDecay here.
     return std::max(
         1.0f,
         std::min(std::floor(GetP() * numerator / (target_score - q) - n1) + 1,

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -186,7 +186,7 @@ class Node {
   // * N (+=1)
   // * N-in-flight (-=1)
   void FinalizeScoreUpdate(float v, float d, float m, int multivisit, 
-      float policy_temperature, float policy_temp_decay);
+      float policy_temperature, float policy_temp_decay, float intermediate[]);
   // When search decides to treat one visit as several (in case of collisions
   // or visiting terminal nodes several times), it amplifies the visit by
   // incrementing n_in_flight.

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -164,6 +164,11 @@ const OptionId SearchParams::kPolicySoftmaxTempId{
     "policy-softmax-temp", "PolicyTemperature",
     "Policy softmax temperature. Higher values make priors of move candidates "
     "closer to each other, widening the search."};
+const OptionId SearchParams::kPolicyTempDecayId{
+    "policy-temp-decay", "PolicyTemperatureDecay",
+    "Policy softmax temperature decay. Positive values make temperature "
+    "smaller as visits increase, negative values make it larger. Bigger "
+    "magnitude means there is a stronger effect."};
 const OptionId SearchParams::kMaxCollisionVisitsId{
     "max-collision-visits", "MaxCollisionVisits",
     "Total allowed node collision visits, per batch."};
@@ -278,6 +283,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kFpuValueAtRootId, -100.0f, 100.0f) = 1.0f;
   options->Add<IntOption>(kCacheHistoryLengthId, 0, 7) = 0;
   options->Add<FloatOption>(kPolicySoftmaxTempId, 0.1f, 10.0f) = 1.607f;
+  options->Add<FloatOption>(kPolicyTempDecayId, -10.0f, 10.0f) = 0.0f;
   options->Add<IntOption>(kMaxCollisionEventsId, 1, 1024) = 32;
   options->Add<IntOption>(kMaxCollisionVisitsId, 1, 1000000) = 9999;
   options->Add<BoolOption>(kOutOfOrderEvalId) = true;
@@ -348,6 +354,7 @@ SearchParams::SearchParams(const OptionsDict& options)
                           : options.Get<float>(kFpuValueAtRootId.GetId())),
       kCacheHistoryLength(options.Get<int>(kCacheHistoryLengthId.GetId())),
       kPolicySoftmaxTemp(options.Get<float>(kPolicySoftmaxTempId.GetId())),
+      kPolicyTempDecay(options.Get<float>(kPolicyTempDecayId.GetId())),
       kMaxCollisionEvents(options.Get<int>(kMaxCollisionEventsId.GetId())),
       kMaxCollisionVisits(options.Get<int>(kMaxCollisionVisitsId.GetId())),
       kOutOfOrderEval(options.Get<bool>(kOutOfOrderEvalId.GetId())),

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -89,6 +89,7 @@ class SearchParams {
   }
   int GetCacheHistoryLength() const { return kCacheHistoryLength; }
   float GetPolicySoftmaxTemp() const { return kPolicySoftmaxTemp; }
+  float GetPolicyTempDecay() const { return kPolicyTempDecay; }
   float GetShortSightedness() const { return kShortSightedness; }
   int GetMaxCollisionEvents() const { return kMaxCollisionEvents; }
   int GetMaxCollisionVisitsId() const { return kMaxCollisionVisits; }
@@ -143,6 +144,7 @@ class SearchParams {
   static const OptionId kFpuValueAtRootId;
   static const OptionId kCacheHistoryLengthId;
   static const OptionId kPolicySoftmaxTempId;
+  static const OptionId kPolicyTempDecayId;
   static const OptionId kMaxCollisionEventsId;
   static const OptionId kMaxCollisionVisitsId;
   static const OptionId kOutOfOrderEvalId;
@@ -187,6 +189,7 @@ class SearchParams {
   const float kFpuValueAtRoot;
   const int kCacheHistoryLength;
   const float kPolicySoftmaxTemp;
+  const float kPolicyTempDecay;
   const int kMaxCollisionEvents;
   const int kMaxCollisionVisits;
   const bool kOutOfOrderEval;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -137,7 +137,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
     const auto wl = edge.GetWL();
     const auto d = edge.GetD();
     const int w = static_cast<int>(std::round(500.0 * (1.0 + wl - d)));
-    const auto q = edge.GetQ(default_q, draw_score);
+    const auto q = edge.GetQ(default_q, draw_score, /* logit_q= */ false);
     if (edge.IsTerminal() && wl != 0.0f) {
       uci_info.mate = std::copysign(
           std::round(edge.GetM(0.0f)) / 2 + (edge.IsTbTerminal() ? 101 : 1),
@@ -252,13 +252,16 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
   std::vector<EdgeAndNode> edges;
   for (const auto& edge : node->Edges()) edges.push_back(edge);
 
-  std::sort(edges.begin(), edges.end(),
-            [&fpu, &U_coeff, &logit_q](EdgeAndNode a, EdgeAndNode b) {
-              return std::forward_as_tuple(
-                         a.GetN(), a.GetQ(fpu, logit_q) + a.GetU(U_coeff)) <
-                     std::forward_as_tuple(
-                         b.GetN(), b.GetQ(fpu, logit_q) + b.GetU(U_coeff));
-            });
+  std::sort(
+      edges.begin(), edges.end(),
+      [&fpu, &U_coeff, &logit_q, &draw_score](EdgeAndNode a, EdgeAndNode b) {
+        return std::forward_as_tuple(
+                   a.GetN(),
+                   a.GetQ(fpu, draw_score, logit_q) + a.GetU(U_coeff)) <
+               std::forward_as_tuple(
+                   b.GetN(),
+                   b.GetQ(fpu, draw_score, logit_q) + b.GetU(U_coeff));
+      });
 
   std::vector<std::string> infos;
   for (const auto& edge : edges) {
@@ -286,7 +289,7 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
         << ") ";
 
     oss << "(Q: " << std::setw(8) << std::setprecision(5)
-        << edge.GetQ(fpu, draw_score) << ") ";
+        << edge.GetQ(fpu, draw_score, /* logit_q= */ false) << ") ";
 
     oss << "(U: " << std::setw(6) << std::setprecision(5) << edge.GetU(U_coeff)
         << ") ";
@@ -569,7 +572,7 @@ EdgeAndNode Search::GetBestChildNoTemperature(Node* parent) const {
 // count.
 EdgeAndNode Search::GetBestRootChildWithTemperature(float temperature) const {
   // Root is at even depth.
-  const bool draw_score = GetDrawScore(/* is_odd_depth= */ false);
+  const float draw_score = GetDrawScore(/* is_odd_depth= */ false);
   MoveList root_limit;
   PopulateRootMoveLimit(&root_limit);
 
@@ -588,7 +591,7 @@ EdgeAndNode Search::GetBestRootChildWithTemperature(float temperature) const {
     }
     if (edge.GetN() + offset > max_n) {
       max_n = edge.GetN() + offset;
-      max_eval = edge.GetQ(fpu, draw_score);
+      max_eval = edge.GetQ(fpu, draw_score, /* logit_q= */ false);
     }
   }
 
@@ -603,7 +606,7 @@ EdgeAndNode Search::GetBestRootChildWithTemperature(float temperature) const {
                                          edge.GetMove()) == root_limit.end()) {
       continue;
     }
-    if (edge.GetQ(fpu, draw_score) < min_eval) continue;
+    if (edge.GetQ(fpu, draw_score, /* logit_q= */ false) < min_eval) continue;
     sum += std::pow(
         std::max(0.0f, (static_cast<float>(edge.GetN()) + offset) / max_n),
         1 / temperature);
@@ -621,7 +624,7 @@ EdgeAndNode Search::GetBestRootChildWithTemperature(float temperature) const {
                                          edge.GetMove()) == root_limit.end()) {
       continue;
     }
-    if (edge.GetQ(fpu, draw_score) < min_eval) continue;
+    if (edge.GetQ(fpu, draw_score, /* logit_q= */ false) < min_eval) continue;
     if (idx-- == 0) return edge;
   }
   assert(false);
@@ -1028,7 +1031,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
 
     if (second_best_edge) {
       int estimated_visits_to_change_best = best_edge.GetVisitsToReachU(
-          second_best, puct_mult, fpu, params_.GetLogitQ());
+          second_best, puct_mult, fpu, draw_score, params_.GetLogitQ());
       // Only cache for n-2 steps as the estimate created by GetVisitsToReachU
       // has potential rounding errors and some conservative logic that can push
       // it up to 2 away from the real value.
@@ -1222,7 +1225,9 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget, bool is_odd_depth) {
   for (auto edge : node->Edges()) {
     if (edge.GetP() == 0.0f) continue;
     // Flip the sign of a score to be able to easily sort.
-    scores.emplace_back(-edge.GetU(puct_mult) - edge.GetQ(fpu, draw_score),
+    // TODO: should this use logit_q if set??
+    scores.emplace_back(-edge.GetU(puct_mult) -
+                            edge.GetQ(fpu, draw_score, /* logit_q= */ false),
                         edge);
   }
 
@@ -1253,7 +1258,8 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget, bool is_odd_depth) {
     if (i != scores.size() - 1) {
       // Sign of the score was flipped for sorting, so flip it back.
       const float next_score = -scores[i + 1].first;
-      const float q = edge.GetQ(-fpu, draw_score);
+      // TODO: As above - should this use logit_q if set?
+      const float q = edge.GetQ(-fpu, draw_score, /* logit_q= */ false);
       if (next_score > q) {
         budget_to_spend =
             std::min(budget, int(edge.GetP() * puct_mult / (next_score - q) -

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -310,6 +310,12 @@ class SearchWorker {
   const bool moves_left_support_;
   IterationStats iteration_stats_;
   StoppersHints latest_time_manager_hints_;
+  // Intermediate array to store values when processing policy temperature decay.
+  // According to a lichess developer post:
+  // https://lichess.org/blog/Wqa7GiAAAOIpBLoY/
+  //     developer-update-275-improved-game-compression
+  // there are never more than 256 valid legal moves in any legal position.
+  float intermediate[256];
 };
 
 }  // namespace lczero

--- a/src/mcts/stoppers/factory.cc
+++ b/src/mcts/stoppers/factory.cc
@@ -97,9 +97,6 @@ const OptionId kMinimumSmartPruningBatchesId{
     "Only allow smart pruning to stop search after at least this many batches "
     "have been evaluated. It may be useful to have this value greater than the "
     "number of search threads in use."};
-const OptionId kNodesAsPlayoutsId{
-    "nodes-as-playouts", "NodesAsPlayouts",
-    "Treat UCI `go nodes` command as referring to playouts instead of visits."};
 
 }  // namespace
 
@@ -117,7 +114,6 @@ void PopulateTimeManagementOptions(RunType for_what, OptionsParser* options) {
     options->Add<FloatOption>(kTimeMidpointMoveId, 1.0f, 100.0f) = 51.5f;
     options->Add<FloatOption>(kTimeSteepnessId, 1.0f, 100.0f) = 7.0f;
     options->Add<FloatOption>(kSpendSavedTimeId, 0.0f, 1.0f) = 1.0f;
-    options->Add<BoolOption>(kNodesAsPlayoutsId) = false;
 
     // Hide time curve options.
     options->HideOption(kTimeMidpointMoveId);
@@ -163,11 +159,7 @@ void PopulateStoppers(ChainedSearchStopper* stopper, const OptionsDict& options,
 
   // "go nodes" stopper.
   if (params.nodes) {
-    if (options.Get<bool>(kNodesAsPlayoutsId.GetId())) {
-      stopper->AddStopper(std::make_unique<PlayoutsStopper>(*params.nodes));
-    } else {
-      stopper->AddStopper(std::make_unique<VisitsStopper>(*params.nodes));
-    }
+    stopper->AddStopper(std::make_unique<VisitsStopper>(*params.nodes));
   }
 
   // "go movetime" stopper.


### PR DESCRIPTION
Currently policy temperature is static. These changes will make policy temperature dynamic and unique for each node. The policy temperature of edges originating from a node is `i - c * log2(1 + v)`, where `i` is the initial policy temperature (same as PolicyTemperature in the current master implementation), `c` is a constant specified by PolicyTemperatureDecay in UCI and `--policy-temp-decay` as a flag, and `v` is the number of visits of that node.

Tuning and testing are currently in progress and look favorable. 