### PR TITLE
Remove selfplay override for root has own cpuct params

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -77,6 +77,8 @@ const OptionId SearchParams::kCpuctFactorId{
 const OptionId SearchParams::kCpuctFactorAtRootId{
     "cpuct-factor-at-root", "CPuctFactorAtRoot",
     "Multiplier for the cpuct growth formula at root."};
+// Remove this option after 0.25 has been made mandatory in training and the
+// training server stops sending it.
 const OptionId SearchParams::kRootHasOwnCpuctParamsId{
     "root-has-own-cpuct-params", "RootHasOwnCpuctParams",
     "If enabled, cpuct parameters for root node are taken from *AtRoot "

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -127,7 +127,6 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
                              "multiplexing");
   defaults->Set<bool>(SearchParams::kStickyEndgamesId.GetId(), false);
   defaults->Set<bool>(SearchParams::kLogitQId.GetId(), false);
-  defaults->Set<bool>(SearchParams::kRootHasOwnCpuctParamsId.GetId(), false);
 }
 
 SelfPlayTournament::SelfPlayTournament(


### PR DESCRIPTION
no longer needed as its always sent by training server.