### PR TITLE
scale mlh bonus with q

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1014,8 +1014,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         const float m_cap = params_.GetMovesLeftMaxEffect();
         const float parent_m = node->GetM();
         const float child_m = child.GetM(parent_m);
-        M = std::clamp(m_slope * (child_m - parent_m), -m_cap, m_cap) *
-            std::copysign(1.0f, node_q);
+        M = std::clamp(m_slope * (child_m - parent_m), -m_cap, m_cap) * node_q;
       }
 
       const float Q = child.GetQ(fpu, draw_score, params_.GetLogitQ());

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1014,11 +1014,11 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         const float m_cap = params_.GetMovesLeftMaxEffect();
         const float parent_m = node->GetM();
         const float child_m = child.GetM(parent_m);
-        M = std::clamp(m_slope * (child_m - parent_m), -m_cap, m_cap) * node_q;
+        M = std::clamp(m_slope * (child_m - parent_m), -m_cap, m_cap);
       }
 
       const float Q = child.GetQ(fpu, draw_score, params_.GetLogitQ());
-      const float score = child.GetU(puct_mult) + Q + M;
+      const float score = child.GetU(puct_mult) + Q * (1.0f + M);
       if (score > best) {
         second_best = best;
         second_best_edge = best_edge;


### PR DESCRIPTION
Basic idea: scale the MLH bonus with the `q` value (of the parent) to allow lower mlh-thresholds, reduce the effect of MLH with lower Q and therefore avoid the discontinuities. 

If child node ~= parent node, this effectively means that the Q value of the child is `Q*(1+M)`; the first commit uses parent_q, while the 2nd commit directly uses the child's Q.