### PR TITLE
Convert parents that cannot win or cannot lose to help find more draws.

### DIFF
--- a/src/chess/position.cc
+++ b/src/chess/position.cc
@@ -54,6 +54,12 @@ uint64_t Position::Hash() const {
 
 std::string Position::DebugString() const { return us_board_.DebugString(); }
 
+GameResult operator-(const GameResult& res) {
+  return res == GameResult::BLACK_WON
+             ? GameResult::WHITE_WON
+             : res == GameResult::WHITE_WON ? GameResult::BLACK_WON : res;
+}
+
 GameResult PositionHistory::ComputeGameResult() const {
   const auto& board = Last().GetBoard();
   auto legal_moves = board.GenerateLegalMoves();

--- a/src/chess/position.h
+++ b/src/chess/position.h
@@ -77,7 +77,9 @@ class Position {
   int ply_count_ = 0;
 };
 
-enum class GameResult { UNDECIDED, WHITE_WON, DRAW, BLACK_WON };
+// These are ordered so max() prefers the best result.
+enum class GameResult : uint8_t { UNDECIDED, BLACK_WON, DRAW, WHITE_WON };
+GameResult operator-(const GameResult& res);
 
 class PositionHistory {
  public:

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -214,11 +214,14 @@ std::string Node::DebugString() const {
       << " Parent:" << parent_ << " Index:" << index_
       << " Child:" << child_.get() << " Sibling:" << sibling_.get()
       << " WL:" << wl_ << " N:" << n_ << " N_:" << n_in_flight_
-      << " Edges:" << edges_.size();
+      << " Edges:" << edges_.size()
+      << " Bounds:" << static_cast<int>(lower_bound_) - 2 << ","
+      << static_cast<int>(upper_bound_) - 2;
   return oss.str();
 }
 
 void Node::MakeTerminal(GameResult result, float plies_left, Terminal type) {
+  SetBounds(result, result);
   terminal_type_ = type;
   m_ = plies_left;
   if (result == GameResult::DRAW) {
@@ -255,6 +258,11 @@ void Node::MakeNotTerminal() {
     wl_ /= n_;
     d_ /= n_;
   }
+}
+
+void Node::SetBounds(GameResult lower, GameResult upper) {
+  lower_bound_ = lower;
+  upper_bound_ = upper;
 }
 
 bool Node::TryStartScoreUpdate() {

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -131,10 +131,15 @@ class Node {
   using Iterator = Edge_Iterator<false>;
   using ConstIterator = Edge_Iterator<true>;
 
-  enum class Terminal : uint8_t { NonTerminal, Terminal, Tablebase };
+  enum class Terminal : uint8_t { NonTerminal, EndOfGame, Tablebase };
 
   // Takes pointer to a parent node and own index in a parent.
-  Node(Node* parent, uint16_t index) : parent_(parent), index_(index) {}
+  Node(Node* parent, uint16_t index)
+      : parent_(parent),
+        index_(index),
+        terminal_type_(Terminal::NonTerminal),
+        lower_bound_(GameResult::BLACK_WON),
+        upper_bound_(GameResult::WHITE_WON) {}
 
   // Allocates a new edge and a new node. The node has to be no edges before
   // that.
@@ -166,13 +171,16 @@ class Node {
   // Returns whether the node is known to be draw/lose/win.
   bool IsTerminal() const { return terminal_type_ != Terminal::NonTerminal; }
   bool IsTbTerminal() const { return terminal_type_ == Terminal::Tablebase; }
+  typedef std::pair<GameResult, GameResult> Bounds;
+  Bounds GetBounds() const { return {lower_bound_, upper_bound_}; }
   uint16_t GetNumEdges() const { return edges_.size(); }
 
   // Makes the node terminal and sets it's score.
   void MakeTerminal(GameResult result, float plies_left = 0.0f,
-                    Terminal type = Terminal::Terminal);
+                    Terminal type = Terminal::EndOfGame);
   // Makes the node not terminal and updates its visits.
   void MakeNotTerminal();
+  void SetBounds(GameResult lower, GameResult upper);
 
   // If this node is not in the process of being expanded by another thread
   // (which can happen only if n==0 and n-in-flight==1), mark the node as
@@ -301,9 +309,12 @@ class Node {
   // Index of this node is parent's edge list.
   uint16_t index_;
 
-  // 1 byte fields.
+  // Bit fields using parts of uint8_t fields initialized in the constructor.
   // Whether or not this node end game (with a winning of either sides or draw).
-  Terminal terminal_type_ = Terminal::NonTerminal;
+  Terminal terminal_type_ : 2;
+  // Best and worst result for this node.
+  GameResult lower_bound_ : 2;
+  GameResult upper_bound_ : 2;
 
   // TODO(mooskagh) Unfriend NodeTree.
   friend class NodeTree;
@@ -372,6 +383,10 @@ class EdgeAndNode {
   // Whether the node is known to be terminal.
   bool IsTerminal() const { return node_ ? node_->IsTerminal() : false; }
   bool IsTbTerminal() const { return node_ ? node_->IsTbTerminal() : false; }
+  Node::Bounds GetBounds() const {
+    return node_ ? node_->GetBounds()
+                 : Node::Bounds{GameResult::BLACK_WON, GameResult::WHITE_WON};
+  }
 
   // Edge related getters.
   float GetP() const { return edge_->GetP(); }

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -310,6 +310,8 @@ class SearchWorker {
   void FetchSingleNodeResult(NodeToProcess* node_to_process,
                              int idx_in_computation);
   void DoBackupUpdateSingleNode(const NodeToProcess& node_to_process);
+  // Returns whether a node's bounds were set based on its children.
+  bool MaybeSetBounds(Node* p, float m) const;
 
   Search* const search_;
   // List of nodes to process.


### PR DESCRIPTION
r?@mooskagh Use more of the Terminal enum to store CantWin and CantLose states that are used in a more generalized parent conversion behavior. Notably, a child draw makes the parent CantWin, and this then makes it possible to decide if choosing among moves that Draw or CantWin (or Loss), the best move is Draw -- thus a new parent Draw Terminal that otherwise wouldn't have been converted before. Additionally, if all possible moves CantWin, the parent is CantLose and grandparent is also CantWin. E.g.,

https://lichess.org/analysis/5Qk1/6b1/6KR/6p1/8/8/8/8_b_-_-_0_1
![test cant](https://user-images.githubusercontent.com/438537/77806121-0a869a00-7041-11ea-8e11-496bb6b6670b.png)

```
./lc0 -w 591226 -v

position fen 5Qk1/6b1/6KR/6p1/8/8/8/8 b - - 0 1
g7f8 N:     284 (P: 56.96%) (WL: -0.31254) (D:  0.682) (M:  3.7) (L) 
g8f8 N:    4557 (P: 43.04%) (WL: -0.03414) (D:  0.945) (M:  4.6) 

Bxf8 / g7f8 CantWin (L) because…

position fen 5Qk1/6b1/6KR/6p1/8/8/8/8 b - - 0 1 moves g7f8
…
g6f6 N:       2 (P:  2.38%) (WL: -0.48807) (D:  0.502) (M:  0.5) 
g6g5 N:       2 (P:  2.37%) (WL: -0.00017) (D:  0.996) (M:  0.5) (L) 
h6h8 N:       3 (P:  1.68%) (WL:  0.18944) (D:  0.806) (M:  1.0) (W) 
h6h5 N:      15 (P:  9.71%) (WL:  0.18659) (D:  0.810) (M:  1.7) 
…

Rh8 / h6h8 CantLose (W) because…

position fen 5Qk1/6b1/6KR/6p1/8/8/8/8 b - - 0 1 moves g7f8 h6h8
g8h8 N:       2 (P: 100.00%) (WL: -0.00026) (D:  0.998) (M:  0.5) (L) 

Kxh8 / g8h8 is the only move and CantWin (L) because…

position fen 5Qk1/6b1/6KR/6p1/8/8/8/8 b - - 0 1 moves g7f8 h6h8 g8h8
…
g6f5 N:       0 (P: 13.81%) (WL:  0.00000) (D:  0.000) (M:  0.0) 
g6g5 N:       2 (P: 63.82%) (WL:  0.00000) (D:  1.000) (M:  0.0) (T) 

Kxg5 / g6g5 is a terminal Draw with insufficient material
```
