### PR TITLE
Fix and simplify GetVisitsToReachU.

### DIFF
--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -385,15 +385,16 @@ class EdgeAndNode {
     return numerator * GetP() / (1 + GetNStarted());
   }
 
-  int GetVisitsToReachU(float target_score, float numerator, float default_q,
-                        float draw_score, bool logit_q) const {
-    const auto q = GetQ(default_q, draw_score, logit_q);
-    if (q >= target_score) return std::numeric_limits<int>::max();
+  int GetVisitsToReachU(float target_score, float numerator,
+                        float score_without_u) const {
+    if (score_without_u >= target_score) return std::numeric_limits<int>::max();
     const auto n1 = GetNStarted() + 1;
-    return std::max(
-        1.0f,
-        std::min(std::floor(GetP() * numerator / (target_score - q) - n1) + 1,
-                 1e9f));
+    return std::max(1.0f,
+                    std::min(std::floor(GetP() * numerator /
+                                            (target_score - score_without_u) -
+                                        n1) +
+                                 1,
+                             1e9f));
   }
 
   std::string DebugString() const;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -996,8 +996,8 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     const float puct_mult =
         cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
     float best = std::numeric_limits<float>::lowest();
+    float best_without_u = std::numeric_limits<float>::lowest();
     float second_best = std::numeric_limits<float>::lowest();
-    float best_without_u = 0.0f;
     // Root depth is 1 here, while for GetDrawScore() it's 0-based, that's why
     // the weirdness.
     const float draw_score =

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -997,6 +997,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
     float best = std::numeric_limits<float>::lowest();
     float second_best = std::numeric_limits<float>::lowest();
+    float best_without_u = 0.0f;
     // Root depth is 1 here, while for GetDrawScore() it's 0-based, that's why
     // the weirdness.
     const float draw_score =
@@ -1044,6 +1045,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         second_best = best;
         second_best_edge = best_edge;
         best = score;
+        best_without_u = Q + M;
         best_edge = child;
       } else if (score > second_best) {
         second_best = score;
@@ -1052,8 +1054,8 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     }
 
     if (second_best_edge) {
-      int estimated_visits_to_change_best = best_edge.GetVisitsToReachU(
-          second_best, puct_mult, fpu, draw_score, params_.GetLogitQ());
+      int estimated_visits_to_change_best =
+          best_edge.GetVisitsToReachU(second_best, puct_mult, best_without_u);
       // Only cache for n-2 steps as the estimate created by GetVisitsToReachU
       // has potential rounding errors and some conservative logic that can push
       // it up to 2 away from the real value.


### PR DESCRIPTION
Was wrong in the case that M is non-zero for best.

This new parameterisation saves recomputing 'score - u' for the best node at the cost of an extra store when we get a new best.  I think it'll also help with people remembering to update it correctly as they add or change additional terms other than U as part of the score.