### PR TITLE
Only clear edge list if all children removed.

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -318,7 +318,7 @@ void Node::ReleaseChildrenExceptOne(Node* node_to_save) {
   // Make saved node the only child. (kills previous siblings).
   gNodeGc.AddToGcQueue(std::move(child_));
   child_ = std::move(saved_node);
-  edges_ = EdgeList();  // Clear edges list.
+  if (!child_) edges_ = EdgeList();  // Clear edges list.
 }
 
 namespace {


### PR DESCRIPTION
Fix a crash introduced in #1164.