### PR TITLE
Shared collisions.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -813,6 +813,9 @@ void SearchWorker::ExecuteOneIteration() {
   // 2. Gather minibatch.
   GatherMinibatch();
 
+  // 2b. Collect collisions.
+  CollectCollisions();
+
   // 3. Prefetch into cache.
   MaybePrefetchIntoCache();
 

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -767,6 +767,16 @@ void Search::Wait() {
 Search::~Search() {
   Abort();
   Wait();
+  {
+    SharedMutex::Lock lock(nodes_mutex_);
+    for (auto& entry : shared_collisions_) {
+      Node* node = entry.first;
+      for (node = node->GetParent(); node != root_node_->GetParent();
+           node = node->GetParent()) {
+        node->CancelScoreUpdate(entry.second);
+      }
+    }
+  }
   LOGFILE << "Search destroyed.";
 }
 

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1411,6 +1411,7 @@ void SearchWorker::DoBackupUpdate() {
       node->CancelScoreUpdate(entry.second);
     }
   }
+  search_->shared_collisions_.clear();
   search_->total_batches_ += 1;
 }
 

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -188,6 +188,9 @@ class Search {
 
   std::atomic<int> pending_searchers_{0};
 
+  std::vector<std::pair<Node*, int>> shared_collisions_
+      GUARDED_BY(nodes_mutex_);
+
   std::unique_ptr<UciResponder> uci_responder_;
   const SearchParams params_;
 
@@ -239,6 +242,9 @@ class SearchWorker {
 
   // 2. Gather minibatch.
   void GatherMinibatch();
+
+  // 2b. Copy collisions into shared_collisions_.
+  void CollectCollisions();
 
   // 3. Prefetch into cache.
   void MaybePrefetchIntoCache();

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -141,6 +141,9 @@ class Search {
   // Depth of a root node is 0 (even number).
   float GetDrawScore(bool is_odd_depth) const;
 
+  // Ensure that all shared collisions are cancelled and clear them out.
+  void CancelSharedCollisions();
+
   mutable Mutex counters_mutex_ ACQUIRED_AFTER(nodes_mutex_);
   // Tells all threads to stop.
   std::atomic<bool> stop_{false};


### PR DESCRIPTION
The idea is any time we're resolving a batch where actual changes to the tree have happened, existing collisions are no longer necessarily useful, and indeed may be a problem, so we should undo them as soon as possible, regardless of which thread used them to gather a batch.

Note this may have a bug where at end of search shared collisions could be left over, I need to add some code to enforce they get cleared out during search destruction.