### PR TITLE
Add moves left effect scaling factors.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -218,6 +218,18 @@ const OptionId SearchParams::kMovesLeftSlopeId{
     "based on how many moves the move is estimated to shorten/lengthen the "
     "game. The move difference is multiplied with the slope and capped at "
     "MovesLeftMaxEffect."};
+const OptionId SearchParams::kMovesLeftConstantFactorId{
+    "moves-left-constant-factor", "MovesLeftConstantFactor",
+    "A simple multiplier to the moves left effect, can be set to 0 to only use "
+    "an effect scaled by Q."};
+const OptionId SearchParams::kMovesLeftScaledFactorId{
+    "moves-left-scaled-factor", "MovesLeftScaledFactor",
+    "A factor which is multiplied by the absolute Q of parent node and the "
+    "base moves left effect."};
+const OptionId SearchParams::kMovesLeftQuadraticFactorId{
+    "moves-left-quadratic-factor", "MovesLeftQuadraticFactor",
+    "A factor which is multiplied by the square of Q of parent node and the "
+    "base moves left effect."};
 const OptionId SearchParams::kShortSightednessId{
     "short-sightedness", "ShortSightedness",
     "Used to focus more on short term gains over long term."};
@@ -293,6 +305,9 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kMovesLeftMaxEffectId, 0.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kMovesLeftThresholdId, 0.0f, 1.0f) = 1.0f;
   options->Add<FloatOption>(kMovesLeftSlopeId, 0.0f, 1.0f) = 0.001f;
+  options->Add<FloatOption>(kMovesLeftConstantFactorId, 0.0f, 1.0f) = 1.0f;
+  options->Add<FloatOption>(kMovesLeftScaledFactorId, 0.0f, 1.0f) = 0.0f;
+  options->Add<FloatOption>(kMovesLeftQuadraticFactorId, 0.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kShortSightednessId, 0.0f, 1.0f) = 0.0f;
   options->Add<BoolOption>(kDisplayCacheUsageId) = false;
   options->Add<IntOption>(kMaxConcurrentSearchersId, 0, 128) = 1;
@@ -306,6 +321,9 @@ void SearchParams::Populate(OptionsParser* options) {
   options->HideOption(kLogLiveStatsId);
   options->HideOption(kDisplayCacheUsageId);
   options->HideOption(kRootHasOwnCpuctParamsId);
+  options->HideOption(kMovesLeftConstantFactorId);
+  options->HideOption(kMovesLeftScaledFactorId);
+  options->HideOption(kMovesLeftQuadraticFactorId);
 }
 
 SearchParams::SearchParams(const OptionsDict& options)
@@ -346,6 +364,9 @@ SearchParams::SearchParams(const OptionsDict& options)
       kMovesLeftMaxEffect(options.Get<float>(kMovesLeftMaxEffectId)),
       kMovesLeftThreshold(options.Get<float>(kMovesLeftThresholdId)),
       kMovesLeftSlope(options.Get<float>(kMovesLeftSlopeId)),
+      kMovesLeftConstantFactor(options.Get<float>(kMovesLeftConstantFactorId)),
+      kMovesLeftScaledFactor(options.Get<float>(kMovesLeftScaledFactorId)),
+      kMovesLeftQuadraticFactor(options.Get<float>(kMovesLeftQuadraticFactorId)),
       kShortSightedness(options.Get<float>(kShortSightednessId)),
       kDisplayCacheUsage(options.Get<bool>(kDisplayCacheUsageId)),
       kMaxConcurrentSearchers(options.Get<int>(kMaxConcurrentSearchersId)),

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -96,6 +96,11 @@ class SearchParams {
   float GetMovesLeftMaxEffect() const { return kMovesLeftMaxEffect; }
   float GetMovesLeftThreshold() const { return kMovesLeftThreshold; }
   float GetMovesLeftSlope() const { return kMovesLeftSlope; }
+  float GetMovesLeftConstantFactor() const { return kMovesLeftConstantFactor; }
+  float GetMovesLeftScaledFactor() const { return kMovesLeftScaledFactor; }
+  float GetMovesLeftQuadraticFactor() const {
+    return kMovesLeftQuadraticFactor;
+  }
   bool GetDisplayCacheUsage() const { return kDisplayCacheUsage; }
   int GetMaxConcurrentSearchers() const { return kMaxConcurrentSearchers; }
   float GetSidetomoveDrawScore() const { return kDrawScoreSidetomove; }
@@ -143,6 +148,9 @@ class SearchParams {
   static const OptionId kHistoryFillId;
   static const OptionId kMovesLeftMaxEffectId;
   static const OptionId kMovesLeftThresholdId;
+  static const OptionId kMovesLeftConstantFactorId;
+  static const OptionId kMovesLeftScaledFactorId;
+  static const OptionId kMovesLeftQuadraticFactorId;
   static const OptionId kMovesLeftSlopeId;
   static const OptionId kShortSightednessId;
   static const OptionId kDisplayCacheUsageId;
@@ -186,6 +194,9 @@ class SearchParams {
   const float kMovesLeftMaxEffect;
   const float kMovesLeftThreshold;
   const float kMovesLeftSlope;
+  const float kMovesLeftConstantFactor;
+  const float kMovesLeftScaledFactor;
+  const float kMovesLeftQuadraticFactor;
   const float kShortSightedness;
   const bool kDisplayCacheUsage;
   const int kMaxConcurrentSearchers;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1037,6 +1037,10 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         const float child_m = child.GetM(parent_m);
         M = std::clamp(m_slope * (child_m - parent_m), -m_cap, m_cap) *
             std::copysign(1.0f, node_q);
+        const float a = params_.GetMovesLeftConstantFactor();
+        const float b = params_.GetMovesLeftScaledFactor();
+        const float c = params_.GetMovesLeftQuadraticFactor();
+        M *= a + b * std::abs(node_q) + c * node_q * node_q;
       }
 
       const float Q = child.GetQ(fpu, draw_score, params_.GetLogitQ());

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1029,6 +1029,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         }
       }
 
+      const float Q = child.GetQ(fpu, draw_score, params_.GetLogitQ());
       float M = 0.0f;
       if (do_moves_left_adjustment) {
         const float m_slope = params_.GetMovesLeftSlope();
@@ -1036,14 +1037,13 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         const float parent_m = node->GetM();
         const float child_m = child.GetM(parent_m);
         M = std::clamp(m_slope * (child_m - parent_m), -m_cap, m_cap) *
-            std::copysign(1.0f, node_q);
+            std::copysign(1.0f, -Q);
         const float a = params_.GetMovesLeftConstantFactor();
         const float b = params_.GetMovesLeftScaledFactor();
         const float c = params_.GetMovesLeftQuadraticFactor();
-        M *= a + b * std::abs(node_q) + c * node_q * node_q;
+        M *= a + b * std::abs(Q) + c * Q * Q;
       }
 
-      const float Q = child.GetQ(fpu, draw_score, params_.GetLogitQ());
       const float score = child.GetU(puct_mult) + Q + M;
       if (score > best) {
         second_best = best;


### PR DESCRIPTION
An alternative to #1158.
This should give us some decent number of options for messing around with things to try and get good results for training.
All 3 options are hidden for now.  Can unhide them as needed once we've learned some more in training.