### PR TITLE
make it possible to call backend without a net

### DIFF
--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -1,6 +1,6 @@
 /*
  This file is part of Leela Chess Zero.
- Copyright (C) 2018-2019 The LCZero Authors
+ Copyright (C) 2018-2020 The LCZero Authors
 
  Leela Chess is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -515,8 +515,13 @@ BlasNetwork<use_eigen>::BlasNetwork(const WeightsFile& file,
 }
 
 template <bool use_eigen>
-std::unique_ptr<Network> MakeBlasNetwork(const WeightsFile& weights,
+std::unique_ptr<Network> MakeBlasNetwork(const std::optional<WeightsFile>& w,
                                          const OptionsDict& options) {
+  if (!w) {
+    throw Exception("The " + std::string(use_eigen ? "eigen" : "blas") +
+                    " backend requires a network file.");
+  }
+  const WeightsFile& weights = *w;
   if (weights.format().network_format().network() !=
           pblczero::NetworkFormat::NETWORK_CLASSICAL_WITH_HEADFORMAT &&
       weights.format().network_format().network() !=

--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -864,8 +864,15 @@ void CudnnNetworkComputation<DataType>::ComputeBlocking() {
 }
 
 template <typename DataType>
-std::unique_ptr<Network> MakeCudnnNetwork(const WeightsFile& weights,
+std::unique_ptr<Network> MakeCudnnNetwork(const std::optional<WeightsFile>& w,
                                           const OptionsDict& options) {
+  if (!w) {
+    throw Exception(
+        "The cudnn" +
+        std::string(std::is_same<half, DataType>::value ? "-fp16" : "") +
+        " backend requires a network file.");
+  }
+  const WeightsFile& weights = *w;
   if (weights.format().network_format().network() !=
           pblczero::NetworkFormat::NETWORK_CLASSICAL_WITH_HEADFORMAT &&
       weights.format().network_format().network() !=
@@ -903,8 +910,8 @@ std::unique_ptr<Network> MakeCudnnNetwork(const WeightsFile& weights,
   return std::make_unique<CudnnNetwork<DataType>>(weights, options);
 }
 
-std::unique_ptr<Network> MakeCudnnNetworkAuto(const WeightsFile& weights,
-                                              const OptionsDict& options) {
+std::unique_ptr<Network> MakeCudnnNetworkAuto(
+    const std::optional<WeightsFile>& weights, const OptionsDict& options) {
   int gpu_id = options.GetOrDefault<int>("gpu", 0);
   cudaDeviceProp deviceProp = {};
   // No error checking here, this will be repeated later.

--- a/src/neural/dx/network_dx.cc
+++ b/src/neural/dx/network_dx.cc
@@ -1065,8 +1065,12 @@ InputsOutputsDx::~InputsOutputsDx() {
   if (moves_left_) delete[] op_moves_left_mem_final_;
 }
 
-std::unique_ptr<Network> MakeDxNetwork(const WeightsFile& weights,
+std::unique_ptr<Network> MakeDxNetwork(const std::optional<WeightsFile>& w,
                                        const OptionsDict& options) {
+  if (!w) {
+    throw Exception("The dx12 backend requires a network file.");
+  }
+  const WeightsFile& weights = *w;
   return std::make_unique<DxNetwork>(weights, options);
 }
 

--- a/src/neural/factory.cc
+++ b/src/neural/factory.cc
@@ -1,6 +1,6 @@
 /*
   This file is part of Leela Chess Zero.
-  Copyright (C) 2018 The LCZero Authors
+  Copyright (C) 2018-2020 The LCZero Authors
 
   Leela Chess is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -85,9 +85,9 @@ std::vector<std::string> NetworkFactory::GetBackendsList() const {
   return result;
 }
 
-std::unique_ptr<Network> NetworkFactory::Create(const std::string& network,
-                                                const WeightsFile& weights,
-                                                const OptionsDict& options) {
+std::unique_ptr<Network> NetworkFactory::Create(
+    const std::string& network, const std::optional<WeightsFile>& weights,
+    const OptionsDict& options) {
   CERR << "Creating backend [" << network << "]...";
   for (const auto& factory : factories_) {
     if (factory.name == network) {
@@ -123,7 +123,10 @@ std::unique_ptr<Network> NetworkFactory::LoadNetwork(
   } else {
     CERR << "Loading weights file from: " << net_path;
   }
-  const WeightsFile weights = LoadWeightsFromFile(net_path);
+  std::optional<WeightsFile> weights;
+  if (!net_path.empty()) {
+    weights = LoadWeightsFromFile(net_path);
+  }
 
   OptionsDict network_options(&options);
   network_options.AddSubdictFromString(backend_options);

--- a/src/neural/factory.h
+++ b/src/neural/factory.h
@@ -1,6 +1,6 @@
 /*
   This file is part of Leela Chess Zero.
-  Copyright (C) 2018 The LCZero Authors
+  Copyright (C) 2018-2020 The LCZero Authors
 
   Leela Chess is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -28,7 +28,9 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 #include <string>
+
 #include "neural/network.h"
 #include "neural/loader.h"
 #include "utils/optionsdict.h"
@@ -39,7 +41,7 @@ namespace lczero {
 class NetworkFactory {
  public:
   using FactoryFunc = std::function<std::unique_ptr<Network>(
-      const WeightsFile&, const OptionsDict&)>;
+      const std::optional<WeightsFile>&, const OptionsDict&)>;
 
   static NetworkFactory* Get();
 
@@ -61,7 +63,7 @@ class NetworkFactory {
 
   // Creates a backend given name and config.
   std::unique_ptr<Network> Create(const std::string& network,
-                                  const WeightsFile&,
+                                  const std::optional<WeightsFile>&,
                                   const OptionsDict& options);
 
   // Helper function to load the network from the options. Returns nullptr
@@ -109,12 +111,12 @@ class NetworkFactory {
   friend class Register;
 };
 
-#define REGISTER_NETWORK_WITH_COUNTER2(name, func, priority, counter)        \
-  namespace {                                                                \
-  static NetworkFactory::Register regH38fhs##counter(                        \
-      name,                                                                  \
-      [](const WeightsFile& w, const OptionsDict& o) { return func(w, o); }, \
-      priority);                                                             \
+#define REGISTER_NETWORK_WITH_COUNTER2(name, func, priority, counter)       \
+  namespace {                                                               \
+  static NetworkFactory::Register regH38fhs##counter(                       \
+      name, [](const std::optional<WeightsFile>& w, const OptionsDict& o) { \
+        return func(w, o);                                                  \
+      }, priority);                                                         \
   }
 #define REGISTER_NETWORK_WITH_COUNTER(name, func, priority, counter) \
   REGISTER_NETWORK_WITH_COUNTER2(name, func, priority, counter)

--- a/src/neural/loader.cc
+++ b/src/neural/loader.cc
@@ -1,6 +1,6 @@
 /*
   This file is part of Leela Chess Zero.
-  Copyright (C) 2018-2019 The LCZero Authors
+  Copyright (C) 2018-2020 The LCZero Authors
 
   Leela Chess is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -232,7 +232,7 @@ std::string DiscoverWeightsFile() {
     }
   }
 
-  throw Exception("Network weights file not found.");
+  LOGFILE << "Network weights file not found.";
   return {};
 }
 

--- a/src/neural/network_check.cc
+++ b/src/neural/network_check.cc
@@ -1,6 +1,6 @@
 /*
  This file is part of Leela Chess Zero.
- Copyright (C) 2018 The LCZero Authors
+ Copyright (C) 2018-2020 The LCZero Authors
 
  Leela Chess is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -343,8 +343,12 @@ class CheckNetwork : public Network {
   NetworkCapabilities capabilities_;
 };
 
-std::unique_ptr<Network> MakeCheckNetwork(const WeightsFile& weights,
+std::unique_ptr<Network> MakeCheckNetwork(const std::optional<WeightsFile>& w,
                                           const OptionsDict& options) {
+  if (!w) {
+    throw Exception("The check backend requires a network file.");
+  }
+  const WeightsFile& weights = *w;
   return std::make_unique<CheckNetwork>(weights, options);
 }
 

--- a/src/neural/network_check.cc
+++ b/src/neural/network_check.cc
@@ -239,7 +239,8 @@ class CheckNetwork : public Network {
   static constexpr double kDefaultAbsoluteTolerance = 1e-5;
   static constexpr double kDefaultRelativeTolerance = 1e-4;
 
-  CheckNetwork(const WeightsFile& weights, const OptionsDict& options) {
+  CheckNetwork(const std::optional<WeightsFile>& weights,
+               const OptionsDict& options) {
     params_.mode = kDefaultMode;
     params_.absolute_tolerance = kDefaultAbsoluteTolerance;
     params_.relative_tolerance = kDefaultRelativeTolerance;
@@ -343,12 +344,8 @@ class CheckNetwork : public Network {
   NetworkCapabilities capabilities_;
 };
 
-std::unique_ptr<Network> MakeCheckNetwork(const std::optional<WeightsFile>& w,
-                                          const OptionsDict& options) {
-  if (!w) {
-    throw Exception("The check backend requires a network file.");
-  }
-  const WeightsFile& weights = *w;
+std::unique_ptr<Network> MakeCheckNetwork(
+    const std::optional<WeightsFile>& weights, const OptionsDict& options) {
   return std::make_unique<CheckNetwork>(weights, options);
 }
 

--- a/src/neural/network_demux.cc
+++ b/src/neural/network_demux.cc
@@ -102,7 +102,8 @@ class DemuxingComputation : public NetworkComputation {
 
 class DemuxingNetwork : public Network {
  public:
-  DemuxingNetwork(const WeightsFile& weights, const OptionsDict& options) {
+  DemuxingNetwork(const std::optional<WeightsFile>& weights,
+                  const OptionsDict& options) {
     minimum_split_size_ = options.GetOrDefault<int>("minimum-split-size", 0);
     const auto parents = options.ListSubdicts();
     if (parents.empty()) {
@@ -117,7 +118,8 @@ class DemuxingNetwork : public Network {
     }
   }
 
-  void AddBackend(const std::string& name, const WeightsFile& weights,
+  void AddBackend(const std::string& name,
+                  const std::optional<WeightsFile>& weights,
                   const OptionsDict& opts) {
     const int nn_threads = opts.GetOrDefault<int>("threads", 1);
     const std::string backend = opts.GetOrDefault<std::string>("backend", name);
@@ -236,11 +238,7 @@ void DemuxingComputation::ComputeBlocking() {
 }
 
 std::unique_ptr<Network> MakeDemuxingNetwork(
-    const std::optional<WeightsFile>& w, const OptionsDict& options) {
-  if (!w) {
-    throw Exception("The demux backend requires a network file.");
-  }
-  const WeightsFile& weights = *w;
+    const std::optional<WeightsFile>& weights, const OptionsDict& options) {
   return std::make_unique<DemuxingNetwork>(weights, options);
 }
 

--- a/src/neural/network_demux.cc
+++ b/src/neural/network_demux.cc
@@ -1,6 +1,6 @@
 /*
   This file is part of Leela Chess Zero.
-  Copyright (C) 2018 The LCZero Authors
+  Copyright (C) 2018-2020 The LCZero Authors
 
   Leela Chess is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -235,8 +235,12 @@ void DemuxingComputation::ComputeBlocking() {
   dataready_cv_.wait(lock, [this]() { return dataready_ == 0; });
 }
 
-std::unique_ptr<Network> MakeDemuxingNetwork(const WeightsFile& weights,
-                                             const OptionsDict& options) {
+std::unique_ptr<Network> MakeDemuxingNetwork(
+    const std::optional<WeightsFile>& w, const OptionsDict& options) {
+  if (!w) {
+    throw Exception("The demux backend requires a network file.");
+  }
+  const WeightsFile& weights = *w;
   return std::make_unique<DemuxingNetwork>(weights, options);
 }
 

--- a/src/neural/network_mux.cc
+++ b/src/neural/network_mux.cc
@@ -1,6 +1,6 @@
 /*
   This file is part of Leela Chess Zero.
-  Copyright (C) 2018 The LCZero Authors
+  Copyright (C) 2018-2020 The LCZero Authors
 
   Leela Chess is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -222,8 +222,12 @@ void MuxingComputation::ComputeBlocking() {
   dataready_cv_.wait(lock, [this]() { return dataready_; });
 }
 
-std::unique_ptr<Network> MakeMuxingNetwork(const WeightsFile& weights,
+std::unique_ptr<Network> MakeMuxingNetwork(const std::optional<WeightsFile>& w,
                                            const OptionsDict& options) {
+  if (!w) {
+    throw Exception("The multiplexing backend requires a network file.");
+  }
+  const WeightsFile& weights = *w;
   return std::make_unique<MuxingNetwork>(weights, options);
 }
 

--- a/src/neural/network_mux.cc
+++ b/src/neural/network_mux.cc
@@ -88,7 +88,8 @@ class MuxingComputation : public NetworkComputation {
 
 class MuxingNetwork : public Network {
  public:
-  MuxingNetwork(const WeightsFile& weights, const OptionsDict& options) {
+  MuxingNetwork(const std::optional<WeightsFile>& weights,
+                const OptionsDict& options) {
     // int threads, int max_batch)
     //: network_(std::move(network)), max_batch_(max_batch) {
 
@@ -105,7 +106,8 @@ class MuxingNetwork : public Network {
     }
   }
 
-  void AddBackend(const std::string& name, const WeightsFile& weights,
+  void AddBackend(const std::string& name,
+                  const std::optional<WeightsFile>& weights,
                   const OptionsDict& opts) {
     const int nn_threads = opts.GetOrDefault<int>("threads", 1);
     const int max_batch = opts.GetOrDefault<int>("max_batch", 256);
@@ -222,12 +224,8 @@ void MuxingComputation::ComputeBlocking() {
   dataready_cv_.wait(lock, [this]() { return dataready_; });
 }
 
-std::unique_ptr<Network> MakeMuxingNetwork(const std::optional<WeightsFile>& w,
-                                           const OptionsDict& options) {
-  if (!w) {
-    throw Exception("The multiplexing backend requires a network file.");
-  }
-  const WeightsFile& weights = *w;
+std::unique_ptr<Network> MakeMuxingNetwork(
+    const std::optional<WeightsFile>& weights, const OptionsDict& options) {
   return std::make_unique<MuxingNetwork>(weights, options);
 }
 

--- a/src/neural/network_random.cc
+++ b/src/neural/network_random.cc
@@ -1,6 +1,6 @@
 /*
   This file is part of Leela Chess Zero.
-  Copyright (C) 2018 The LCZero Authors
+  Copyright (C) 2018-2020 The LCZero Authors
 
   Leela Chess is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -128,8 +128,8 @@ class RandomNetwork : public Network {
 };
 }  // namespace
 
-std::unique_ptr<Network> MakeRandomNetwork(const WeightsFile& /*weights*/,
-                                           const OptionsDict& options) {
+std::unique_ptr<Network> MakeRandomNetwork(
+    const std::optional<WeightsFile>& /*weights*/, const OptionsDict& options) {
   return std::make_unique<RandomNetwork>(options);
 }
 

--- a/src/neural/network_rr.cc
+++ b/src/neural/network_rr.cc
@@ -37,7 +37,8 @@ namespace {
 
 class RoundRobinNetwork : public Network {
  public:
-  RoundRobinNetwork(const WeightsFile& weights, const OptionsDict& options) {
+  RoundRobinNetwork(const std::optional<WeightsFile>& weights,
+                    const OptionsDict& options) {
     const auto parents = options.ListSubdicts();
     if (parents.empty()) {
       // If options are empty, or multiplexer configured in root object,
@@ -51,7 +52,8 @@ class RoundRobinNetwork : public Network {
     }
   }
 
-  void AddBackend(const std::string& name, const WeightsFile& weights,
+  void AddBackend(const std::string& name,
+                  const std::optional<WeightsFile>& weights,
                   const OptionsDict& opts) {
     const std::string backend = opts.GetOrDefault<std::string>("backend", name);
 
@@ -83,11 +85,7 @@ class RoundRobinNetwork : public Network {
 };
 
 std::unique_ptr<Network> MakeRoundRobinNetwork(
-    const std::optional<WeightsFile>& w, const OptionsDict& options) {
-  if (!w) {
-    throw Exception("The roundrobin backend requires a network file.");
-  }
-  const WeightsFile& weights = *w;
+    const std::optional<WeightsFile>& weights, const OptionsDict& options) {
   return std::make_unique<RoundRobinNetwork>(weights, options);
 }
 

--- a/src/neural/network_rr.cc
+++ b/src/neural/network_rr.cc
@@ -1,6 +1,6 @@
 /*
   This file is part of Leela Chess Zero.
-  Copyright (C) 2018 The LCZero Authors
+  Copyright (C) 2018-2020 The LCZero Authors
 
   Leela Chess is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -82,8 +82,12 @@ class RoundRobinNetwork : public Network {
   NetworkCapabilities capabilities_;
 };
 
-std::unique_ptr<Network> MakeRoundRobinNetwork(const WeightsFile& weights,
-                                               const OptionsDict& options) {
+std::unique_ptr<Network> MakeRoundRobinNetwork(
+    const std::optional<WeightsFile>& w, const OptionsDict& options) {
+  if (!w) {
+    throw Exception("The roundrobin backend requires a network file.");
+  }
+  const WeightsFile& weights = *w;
   return std::make_unique<RoundRobinNetwork>(weights, options);
 }
 

--- a/src/neural/opencl/network_opencl.cc
+++ b/src/neural/opencl/network_opencl.cc
@@ -1,6 +1,6 @@
 /*
  This file is part of Leela Chess Zero.
- Copyright (C) 2018-2019 The LCZero Authors
+ Copyright (C) 2018-2020 The LCZero Authors
 
  Leela Chess is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -418,8 +418,12 @@ class OpenCLNetwork : public Network {
   bool moves_left_;
 };
 
-std::unique_ptr<Network> MakeOpenCLNetwork(const WeightsFile& weights,
+std::unique_ptr<Network> MakeOpenCLNetwork(const std::optional<WeightsFile>& w,
                                            const OptionsDict& options) {
+  if (!w) {
+    throw Exception("The opencl backend requires a network file.");
+  }
+  const WeightsFile& weights = *w;
   if (weights.format().network_format().network() !=
           pblczero::NetworkFormat::NETWORK_CLASSICAL_WITH_HEADFORMAT &&
       weights.format().network_format().network() !=


### PR DESCRIPTION
Changes all backends to make the WeightsFile passed to them optional, with an error if not there in all except random.
Also included is the hack to fix the c++ version incompatibility with tensorflow.