### PR TITLE
Check for presence of charconv headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ in ("Deep Learning").
 
 #### Ubuntu 18.04
 
-For Ubuntu 18.04 you need the latest version of meson and clang-6.0 before performing the steps above:
+For Ubuntu 18.04 you need the latest version of meson, g++-8 and clang-6.0 before performing the steps above:
 
-    sudo apt-get install clang-6.0 ninja-build pkg-config protobuf-compiler libprotobuf-dev meson
+    sudo apt-get install gcc-8 g++-8 clang-6.0 ninja-build pkg-config protobuf-compiler libprotobuf-dev meson
     CC=clang-6.0 CXX=clang++-6.0 INSTALL_PREFIX=~/.local ./build.sh
 
 Make sure that `~/.local/bin` is in your `PATH` environment variable. You can now type `lc0 --help` and start.

--- a/meson.build
+++ b/meson.build
@@ -20,8 +20,8 @@ project('lc0', 'cpp',
 
 cc = meson.get_compiler('cpp')
 
-if not cc.has_header('optional') or not cc.has_header('string_view')
-    error('Lc0 requires a compiler supporting C++17, for example g++ v7.0, ' +
+if not cc.has_header('optional') or not cc.has_header('string_view') or not cc.has_header('charconv')
+    error('Lc0 requires a compiler supporting C++17, for example g++ v8.0, ' +
           'clang v4.0 or later (with C++17 stdlib) and Visual Studio 2017 or ' +
           'later.')
 endif


### PR DESCRIPTION
Also update the instructions to indicate Ubuntu 18.04 needs GCC 8 or
later regardless of the clang in use, because clang falls back to the
GCC libstdc++ headers.

Fixes issue #1182.