### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,21 +92,17 @@ Make sure that `~/.local/bin` is in your `PATH` environment variable. You can no
 
 #### Ubuntu 16.04
 
-For Ubuntu 16.04 you need the latest version of meson, ninja and also gcc-8.0 before performing the steps above:
+For Ubuntu 16.04 you need the latest version of meson, ninja, clang-6.0, and libstdc++-8:
 
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+    sudo apt-add-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main'
     sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     sudo apt-get update
-    sudo apt-get install gcc-8 g++-8
-    pip3 install meson --user
-    pip3 install ninja --user
-    CC=gcc-8 CXX=g++-8 INSTALL_PREFIX=~/.local ./build.sh
+    sudo apt-get install clang-6.0 libstdc++-8-dev
+    pip3 install meson ninja --user
+    CC=clang-6.0 CXX=clang++-6.0 INSTALL_PREFIX=~/.local ./build.sh
 
 Make sure that `~/.local/bin` is in your `PATH` environment variable. You can now type `lc0 --help` and start.
-
-If you want to build with clang-6.0 you still need g++-8 for the library. Replace the last line above with:
-
-    sudo apt-get install clang-6.0
-    CC=clang-6.0 CXX=clang++-6.0 INSTALL_PREFIX=~/.local ./build.sh
 
 #### openSUSE (all versions)
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ in ("Deep Learning").
 
 #### Ubuntu 18.04
 
-For Ubuntu 18.04 you need the latest version of meson, g++-8 and clang-6.0 before performing the steps above:
+For Ubuntu 18.04 you need the latest version of meson, libstdc++-8-dev, and clang-6.0 before performing the steps above:
 
-    sudo apt-get install gcc-8 g++-8 clang-6.0 ninja-build pkg-config
+    sudo apt-get install libstdc++-8-dev clang-6.0 ninja-build pkg-config
     pip3 install meson --user
     CC=clang-6.0 CXX=clang++-6.0 INSTALL_PREFIX=~/.local ./build.sh
 


### PR DESCRIPTION
It doesn't make any sense to have to install clang AND g++ on Ubuntu 18.04 when the build instructions explicitly say you're building with clang and the environment variables are enforcing that to the meson call. If you're building with clang, you don't need g++ at all. You DO need one of g++-8.0's dependencies, which is libstdc++-8. So this fix to the documentation makes that more clear and keeps the user from unnecessarily installing a whole compiler when just a library that the compiler depends on will do.