### PR TITLE
Update q to cp conversion formula

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -295,6 +295,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<BoolOption>(kPerPvCountersId) = false;
   std::vector<std::string> score_type = {"centipawn",
                                          "centipawn_with_drawscore",
+                                         "centipawn_2019",
                                          "centipawn_2018",
                                          "win_percentage",
                                          "Q",

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -145,9 +145,11 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
           std::round(edge.GetM(0.0f)) / 2 + (edge.IsTbTerminal() ? 101 : 1),
           wl);
     } else if (score_type == "centipawn_with_drawscore") {
-      uci_info.score = 295 * q / (1 - 0.976953126 * std::pow(q, 14));
+      uci_info.score = 111.714640912 * tan(1.5620688421 * q);
     } else if (score_type == "centipawn") {
-      uci_info.score = 295 * wl / (1 - 0.976953126 * std::pow(q, 14));
+      uci_info.score = 111.714640912 * tan(1.5620688421 * wl);
+    } else if (score_type == "centipawn_2019") {
+      uci_info.score = 295 * wl / (1 - 0.976953126 * std::pow(wl, 14));
     } else if (score_type == "centipawn_2018") {
       uci_info.score = 290.680623072 * tan(1.548090806 * wl);
     } else if (score_type == "win_percentage") {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -145,9 +145,9 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
           std::round(edge.GetM(0.0f)) / 2 + (edge.IsTbTerminal() ? 101 : 1),
           wl);
     } else if (score_type == "centipawn_with_drawscore") {
-      uci_info.score = 111.714640912 * tan(1.5620688421 * q);
+      uci_info.score = 90 * tan(1.5637541897 * q);
     } else if (score_type == "centipawn") {
-      uci_info.score = 111.714640912 * tan(1.5620688421 * wl);
+      uci_info.score = 90 * tan(1.5637541897 * wl);
     } else if (score_type == "centipawn_2019") {
       uci_info.score = 295 * wl / (1 - 0.976953126 * std::pow(wl, 14));
     } else if (score_type == "centipawn_2018") {


### PR DESCRIPTION
Based on the current TCEC games, the Q to centipawn conversion formula seems to be too pessimistic at high Q. lc0 cp evaluations are often much lower than the other engines.

I downloaded the TCEC SUFI evaluations and compared to the lc0 cp evaluations to SF evaluations. Below are the results:

![lc0_q](https://user-images.githubusercontent.com/544240/79003114-8f51d780-7b5a-11ea-8412-7554c6f37d45.png)

The evaluation for Q < 0 comes from only one game and can be ignored. The current formula is the line labeled with centipawn. The first too optimistic conversion function is centipawn_2018 line. I also plotted the conversion function from #841 that used the old equation but fitted to more games. The #841 equation seems to fit very well to the median SF evaluation. I can get slightly better fit with more complex functions, but this one has advantage of being easily invertible which is nice for calculating the Q from centipawns. This PR reverts the conversion function to one from #841.

The average error to median SF eval on this dataset is 0.79 pawns with the current function, 0.28 with this function and 1.85 with the centipawn_2018.

The script for downloading evaluations and plotting the graphs can be found at: https://gist.github.com/Ttl/9926f70800b3fbd7314c150108d4ba61