### PR TITLE
build improvements

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -25,12 +25,12 @@ echo Deleting build directory:
 rd /s build
 
 if exist "C:\Program Files (x86)\Microsoft Visual Studio\2019" (
-  call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
-  set MSBuild=msbuild
+  where /q cl
+  if errorlevel 1 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
   set backend=vs2019
 ) else (
-  call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
-  set MSBuild="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe"
+  where /q cl
+  if errorlevel 1 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
   set backend=vs2017
 )
 
@@ -58,5 +58,5 @@ pause
 
 cd build
 
-%MSBuild% /m /p:Configuration=Release /p:Platform=x64 /p:WholeProgramOptimization=true ^
+msbuild /m /p:Configuration=Release /p:Platform=x64 /p:WholeProgramOptimization=true ^
 /p:PreferredToolArchitecture=x64 lc0.sln /filelogger

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,11 @@ esac
 
 BUILDDIR=build/${BUILDTYPE}
 
+if ! hash meson 2>/dev/null && [ -x ${HOME}/.local/bin/meson ]
+then
+  export PATH=${PATH}:${HOME}/.local/bin
+fi
+
 if [ -f ${BUILDDIR}/build.ninja ]
 then
   meson configure ${BUILDDIR} -Dbuildtype=${BUILDTYPE} -Dprefix=${INSTALL_PREFIX:-/usr/local} "$@"

--- a/meson.build
+++ b/meson.build
@@ -458,7 +458,13 @@ endif
   ## ~~~~
   # Pick latest from https://wrapdb.mesonbuild.com/zlib and put into
   # subprojects/zlib.wrap
-  deps += dependency('zlib', fallback: ['zlib', 'zlib_dep'])
+  if host_machine.system() == 'windows'
+    # In several cases where a zlib dependency was detected on windows, it
+    # caused trouble (crashes or failed builds). Better safe than sorry.
+    deps += subproject('zlib').get_variable('zlib_dep')
+  else
+    deps += dependency('zlib', fallback: ['zlib', 'zlib_dep'])
+  endif
 
   ## ~~~~~~~~
   ## Profiler


### PR DESCRIPTION
1. On windows check for `cl` on the path before calling `vcvarsall`, in case it is already set up. Also simplify msbuild calling, this was probably a remnant from vs2015.
2. Still on windows, do not look for a zlib dependency, most likely if one is found it won't be the correct one. In the two cases reported, one was from msys2, and the other was crashing for unknown reasons.
3. In `build.sh`, if meson is not on the path, check for an installation in `~/.local` and add it to the path.