### PR TITLE
Focus search with --two-fold-draw repetition except for root children.

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -494,6 +494,13 @@ bool NodeTree::ResetToPosition(const std::string& starting_fen,
   // retain old n_ and q_ (etc) data, even though its old children were
   // previously trimmed; we need to reset current_head_ in that case.
   if (!seen_old_head) TrimTreeAtHead();
+  // When reusing the tree, the new head might have some two-fold terminals that
+  // don't actually end the game, so make them regular nodes to extend.
+  else if (current_head_->HasChildren()) {
+    for (const auto& child : current_head_->Edges()) {
+      if (child.IsTwoFold()) child.node()->MakeNotTerminal();
+    }
+  }
   return seen_old_head;
 }
 

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -131,7 +131,7 @@ class Node {
   using Iterator = Edge_Iterator<false>;
   using ConstIterator = Edge_Iterator<true>;
 
-  enum class Terminal : uint8_t { NonTerminal, Terminal, Tablebase };
+  enum class Terminal : uint8_t { NonTerminal, Terminal, Tablebase, TwoFold };
 
   // Takes pointer to a parent node and own index in a parent.
   Node(Node* parent, uint16_t index) : parent_(parent), index_(index) {}
@@ -166,6 +166,7 @@ class Node {
   // Returns whether the node is known to be draw/lose/win.
   bool IsTerminal() const { return terminal_type_ != Terminal::NonTerminal; }
   bool IsTbTerminal() const { return terminal_type_ == Terminal::Tablebase; }
+  bool IsTwoFold() const { return terminal_type_ == Terminal::TwoFold; }
   uint16_t GetNumEdges() const { return edges_.size(); }
 
   // Makes the node terminal and sets it's score.
@@ -372,6 +373,7 @@ class EdgeAndNode {
   // Whether the node is known to be terminal.
   bool IsTerminal() const { return node_ ? node_->IsTerminal() : false; }
   bool IsTbTerminal() const { return node_ ? node_->IsTbTerminal() : false; }
+  bool IsTwoFold() const { return node_ ? node_->IsTwoFold() : false; }
 
   // Edge related getters.
   float GetP() const { return edge_->GetP(); }

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -84,6 +84,9 @@ const OptionId SearchParams::kRootHasOwnCpuctParamsId{
     "If enabled, cpuct parameters for root node are taken from *AtRoot "
     "parameters. Otherwise, they are the same as for the rest of nodes. "
     "Temporary flag for transition to a new version."};
+const OptionId SearchParams::kTwoFoldDrawId{
+    "two-fold-draw", "TwoFoldDraw",
+    "Two-fold repetitions are drawn except when picking best move to play."};
 const OptionId SearchParams::kTemperatureId{
     "temperature", "Temperature",
     "Tau value from softmax formula for the first move. If equal to 0, the "
@@ -266,6 +269,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctFactorId, 0.0f, 1000.0f) = 2.815f;
   options->Add<FloatOption>(kCpuctFactorAtRootId, 0.0f, 1000.0f) = 2.815f;
   options->Add<BoolOption>(kRootHasOwnCpuctParamsId) = true;
+  options->Add<BoolOption>(kTwoFoldDrawId) = true;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 100) = 0;
   options->Add<IntOption>(kTemperatureCutoffMoveId, 0, 1000) = 0;

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -54,6 +54,7 @@ class SearchParams {
   float GetCpuctFactor(bool at_root) const {
     return at_root ? kCpuctFactorAtRoot : kCpuctFactor;
   }
+  bool GetTwoFoldDraw() const { return options_.Get<bool>(kTwoFoldDrawId); }
   float GetTemperature() const { return options_.Get<float>(kTemperatureId); }
   float GetTemperatureVisitOffset() const {
     return options_.Get<float>(kTemperatureVisitOffsetId);
@@ -121,6 +122,7 @@ class SearchParams {
   static const OptionId kCpuctFactorId;
   static const OptionId kCpuctFactorAtRootId;
   static const OptionId kRootHasOwnCpuctParamsId;
+  static const OptionId kTwoFoldDrawId;
   static const OptionId kTemperatureId;
   static const OptionId kTempDecayMovesId;
   static const OptionId kTemperatureCutoffMoveId;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1143,7 +1143,15 @@ void SearchWorker::ExtendNode(Node* node) {
       return;
     }
 
-    if (history_.Last().GetRepetitions() >= 2) {
+    const auto repetitions = history_.Last().GetRepetitions();
+    const auto parent = node->GetParent();
+    // Treat two-fold repetitions as draw to help focus search on other moves,
+    // but avoid playing into a losing two-fold thinking it will end the game.
+    if (params_.GetTwoFoldDraw() && parent != search_->root_node_ &&
+        repetitions >= 1) {
+      node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
+      return;
+    } else if (repetitions >= 2) {
       node->MakeTerminal(GameResult::DRAW);
       return;
     }
@@ -1161,7 +1169,6 @@ void SearchWorker::ExtendNode(Node* node) {
       if (state != FAIL) {
         // TB nodes don't have NN evaluation, assign M from parent node.
         float m = 0.0f;
-        auto parent = node->GetParent();
         if (parent) {
           m = std::max(0.0f, parent->GetM() - 1.0f);
         }

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -119,6 +119,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   defaults->Set<int>(SearchParams::kMaxCollisionEventsId, 1);
   defaults->Set<int>(SearchParams::kCacheHistoryLengthId, 7);
   defaults->Set<bool>(SearchParams::kOutOfOrderEvalId, false);
+  defaults->Set<bool>(SearchParams::kTwoFoldDrawId, false);
   defaults->Set<float>(SearchParams::kTemperatureId, 1.0f);
   defaults->Set<float>(SearchParams::kNoiseEpsilonId, 0.25f);
   defaults->Set<float>(SearchParams::kFpuValueId, 0.0f);


### PR DESCRIPTION
r?@mooskagh or @Tilps Improves on #1161 by correctly not playing moves that aren't actually draw. E.g., a dummy situation where white could checkmate but decides to shuffle the rook and the previous PR would have black repeat thinking it's a draw:
![could mate](https://user-images.githubusercontent.com/438537/79039964-d14e3e00-7b99-11ea-9164-56e6d87cc0e7.png)

```
# with 1161 treating any two-fold repetition as draw
position fen k1r5/8/K1R5/8/8/8/8/8 w - - 0 1 moves c6b6 c8b8 b6c6

info string b8b6  (35  ) N:    1365 (+ 0) (P:  7.69%) (WL: -1.00000) (D:  0.000) (M:  5.0) (Q: -1.00000) (U: 0.87158) (Q+U: -0.12842) (V: -1.0000) (T) 
…
info string b8c8  (24  ) N:  108972 (+ 0) (P:  7.69%) (WL:  0.00000) (D:  1.000) (M:  0.0) (Q:  0.00000) (U: 0.01093) (Q+U:  0.01093) (V:  0.0000) (T) 
bestmove b8c8

# with this PR
info string b8c8  (24  ) N:     422 (+ 0) (P:  7.69%) (WL: -1.00000) (D:  0.000) (M:  1.0) (Q: -1.00000) (U: 1.01206) (Q+U:  0.01206) (V: -1.0000) (T) 
info string b8b6  (35  ) N:    1365 (+ 0) (P:  7.69%) (WL: -1.00000) (D:  0.000) (M:  5.0) (Q: -1.00000) (U: 0.31340) (Q+U: -0.68660) (V: -1.0000) (T) 
…
```

Otherwise, the behavior is the same as the previous PR original comment copied below.

---
At CCC13 Heptagonal Game 155, 384x30-t60-3180 blundered the win with 68… Bf6 that allows white to keep checking and shuffling but not mate with the knights:
<img width="1223" alt="2fold" src="https://user-images.githubusercontent.com/438537/77815720-6f121b00-707a-11ea-86f5-47c70727fbf8.png">
https://www.chess.com/computer-chess-championship#event=ccc13-heptagonal&game=155

Here's master (b5bedf4) with 384x30-t60-3180 at various nodes:
```
./lc0 -w 384x30-t60-3180 --multipv=2 --per-pv-counters --smart-pruning-factor=0
position startpos moves e2e4 c7c5 g1f3 b8c6 d2d4 c5d4 c2c3 d4c3 b1c3 e7e6 f1e2 f8e7 e1h1 d7d6 d1b3 g8f6 f1d1 d8c7 c1f4 c7b8 e2b5 e6e5 f4g5 a7a6 g5f6 e7f6 b5c6 b7c6 b3b8 a8b8 d1d6 b8b2 d6c6 c8b7 c6c4 e8h8 c3a4 b2e2 a4c5 b7c8 g1f1 e2b2 c5d3 b2b8 f1e2 f8e8 a2a4 a6a5 c4c5 c8a6 c5a5 b8a8 e2e3 f6d8 a5e5 d8b6 e3d2 e8d8 a1a3 a6c4 d2e2 b6c7 e5g5 h7h6 g5f5 g7g6 f5c5 c7d6 c5c4 d6a3 f3d2 a3d6 e4e5 d6e7 e2e3 d8c8 c4c8 a8c8 e3d4 c8a8 d3b2 a8d8 d4c3 e7c5 b2d3 c5d4 c3c4 d4f2 d2b3 f2a7 a4a5 h6h5 g2g3 g6g5 h2h3 g8g7 g3g4 h5h4 b3c5 g7g6 c4b5 d8b8 b5c6 b8b1 a5a6 g6g7 c6c7 b1b5 c7c6 b5a5 c6d6 a5a2 e5e6 f7e6 c5e6 g7h6 d6e7 a2a5 d3b2 a7c5 e7f7 c5a3 b2d3 a5a6 e6d4 a3d6 d4f5 h6h7 d3f2 d6c7 f2e4 c7d8 e4c5 a6a7 f7e8

go nodes 10000
nodes  9407 score cp 325 multipv 1 pv d8f6 c5e6 h7g8 f5h6 g8h8 h6f5 h8h7 e6f8 h7g8 f5h6 g8h8 h6f5 a7b7 f8d7 f6b2 d7c5 b7a7
nodes   328 score cp 267 multipv 2 pv d8c7 c5e6 c7f4 f5e7 h7h6 e8f7 f4d6 e6g7 a7e7 f7f6

go nodes 30000
nodes 28175 score cp 315 multipv 1 pv d8f6 c5e6 h7g8 f5h6 g8h8 h6f5 h8h7 e6f8 h7g8 f5h6 g8h8 h6f5 a7b7 f8d7 f6b2 d7c5 b7a7 c5e4 b2c1 e8f8
nodes  1100 score cp 263 multipv 2 pv d8c7 c5e6 c7f4 f5e7 h7h6 e8f7 f4d6 f7g8 d6e7 e6g7 h6g6

go nodes 50000
nodes 48057 score cp 309 multipv 1 pv d8f6 c5e6 h7g8 f5h6 g8h8 h6f5 h8h7 e6f8 h7g8 f5h6 g8g7 h6f5 g7h8 f8e6 h8g8 f5h6 g8h7 h6f5 a7b7 e6f8 h7h8 f8d7 f6b2 d7c5 b7a7 c5e4 b2c1
nodes  1327 score cp 267 multipv 2 pv d8c7 c5e6 c7f4 f5e7 h7h6 e8f7 f4d6 e6g7 a7e7 f7f8 e7g7
```

The network's eval incorrectly keeps the Q for Bf6 relatively higher than Bc7 (Houdini's expected black-winning move that SF11+ agrees). Whereas with this 2-fold change, it happens to be enough to lower the score for Bf6 enough for Bc7 to get more visits by 30k nodes and gets pretty much all of the additional visits up to 50k:
```
go nodes 10000
nodes  9591 score cp 287 multipv 1 pv d8f6 c5e6 a7b7 e6f8 h7g8 f5h6 g8g7 h6f5 g7h8 f8d7 f6b2 d7c5 b7a7 c5e4 b2c1 e8f8 a7a3 f8f7 a3h3
nodes   517 score cp 261 multipv 2 pv d8c7 c5e6 c7f4 f5e7 h7h6 e8f7 f4d6 e6g7 d6e7 g7f5

go nodes 30000
nodes 17731 score cp 268 multipv 1 pv d8c7 c5e4 c7f4 e8f8 a7a4 e4f6 h7g6 f6d7 a4a7 f5e7 g6h6 e7f5 h6h7 f8e8 f4d2 d7f8 h7g8 f8e6 a7a3
nodes 11827 score cp 252 multipv 2 pv d8f6 c5e6 a7b7 e6c5 b7c7 c5e6 c7a7 e6f8 h7g8 f5h6 g8g7 h6f5 g7h8 f8e6 a7b7 e6c5 b7b5 c5e4 b5e5 e8f7 f6d8 e4f6 e5e1 f6d7

go nodes 50000
nodes 37156 score cp 275 multipv 1 pv d8c7 c5e4 c7f4 e8f8 a7a4 e4c5 a4c4 c5d7 c4c7 f8e8 c7a7 d7f8 h7h8 f8g6 h8g8 g6e7 g8h7 e8f7
nodes 11827 score cp 252 multipv 2 pv d8f6 c5e6 a7b7 e6c5 b7c7 c5e6 c7a7 e6f8 h7g8 f5h6 g8g7 h6f5 g7h8 f8e6 a7b7 e6c5 b7b5 c5e4 b5e5 e8f7 f6d8 e4f6 e5e1 f6d7
```

This probably helps #1160 as there's more Draw -> CantWin -> CantLose conversions. But this change by itself is enough to at least change the behavior in the above game.