### PR TITLE
add alphazero time manager

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -125,6 +125,7 @@ files += [
   'src/mcts/stoppers/common.cc',
   'src/mcts/stoppers/factory.cc',
   'src/mcts/stoppers/legacy.cc',
+  'src/mcts/stoppers/alphazero.cc',
   'src/mcts/stoppers/stoppers.cc',
   'src/mcts/stoppers/timemgr.cc',
   'src/neural/cache.cc',

--- a/src/mcts/stoppers/alphazero.cc
+++ b/src/mcts/stoppers/alphazero.cc
@@ -50,7 +50,7 @@ class AlphazeroTimeManager : public TimeManager {
         alphazerotimevalue_(params.GetOrDefault<float>("alphazero-time-value", 20.0f)),
         spend_saved_time_(params.GetOrDefault<float>("immediate-use", 1.0f)) {}
   std::unique_ptr<SearchStopper> GetStopper(const GoParams& params,
-                                            const Position& position) override;
+                                            const NodeTree& tree) override;
 
  private:
   const int64_t move_overhead_;
@@ -61,7 +61,8 @@ class AlphazeroTimeManager : public TimeManager {
 };
 
 std::unique_ptr<SearchStopper> AlphazeroTimeManager::GetStopper(
-    const GoParams& params, const Position& position) {
+    const GoParams& params, const NodeTree& tree) {
+  const Position& position = tree.HeadPosition();
   const bool is_black = position.IsBlackToMove();
   const std::optional<int64_t>& time = (is_black ? params.btime : params.wtime);
   // If no time limit is given, don't stop on this condition.

--- a/src/mcts/stoppers/alphazero.cc
+++ b/src/mcts/stoppers/alphazero.cc
@@ -35,7 +35,7 @@ class AlphazeroStopper : public TimeLimitStopper {
  public:
   AlphazeroStopper(int64_t deadline_ms, int64_t* time_piggy_bank)
       : TimeLimitStopper(deadline_ms), time_piggy_bank_(time_piggy_bank) {}
-  virtual void OnSearchDone(const IterationStats& stats) override {
+  void OnSearchDone(const IterationStats& stats) override {
     *time_piggy_bank_ += GetTimeLimitMs() - stats.time_since_movestart;
   }
 

--- a/src/mcts/stoppers/alphazero.cc
+++ b/src/mcts/stoppers/alphazero.cc
@@ -1,0 +1,100 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2020 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#include "mcts/stoppers/stoppers.h"
+
+namespace lczero {
+
+namespace {
+
+class AlphazeroStopper : public TimeLimitStopper {
+ public:
+  AlphazeroStopper(int64_t deadline_ms, int64_t* time_piggy_bank)
+      : TimeLimitStopper(deadline_ms), time_piggy_bank_(time_piggy_bank) {}
+  virtual void OnSearchDone(const IterationStats& stats) override {
+    *time_piggy_bank_ += GetTimeLimitMs() - stats.time_since_movestart;
+  }
+
+ private:
+  int64_t* const time_piggy_bank_;
+};
+
+class AlphazeroTimeManager : public TimeManager {
+ public:
+  AlphazeroTimeManager(int64_t move_overhead, const OptionsDict& params)
+      : move_overhead_(move_overhead),
+        alphazerotimevalue_(params.GetOrDefault<float>("alphazero-time-value", 20.0f)),
+        spend_saved_time_(params.GetOrDefault<float>("immediate-use", 1.0f)) {}
+  std::unique_ptr<SearchStopper> GetStopper(const GoParams& params,
+                                            const Position& position) override;
+
+ private:
+  const int64_t move_overhead_;
+  const float alphazerotimevalue_;
+  const float spend_saved_time_;
+  // No need to be atomic as only one thread will update it.
+  int64_t time_spared_ms_ = 0;
+};
+
+std::unique_ptr<SearchStopper> AlphazeroTimeManager::GetStopper(
+    const GoParams& params, const Position& position) {
+  const bool is_black = position.IsBlackToMove();
+  std::optional<int64_t> time = (is_black ? params.btime : params.wtime);
+  // If no time limit is given, don't stop on this condition.
+  if (params.infinite || params.ponder || !time) return nullptr;
+
+  std::optional<int64_t> inc = is_black ? params.binc : params.winc;
+  const int increment = inc ? std::max(int64_t(0), *inc) : 0;
+
+  // How to scale moves time.
+  float this_move_time = 1.0f;
+  int time_to_squander = 0;
+
+  auto total_moves_time = *time - move_overhead_;
+  this_move_time =
+      increment +
+      (total_moves_time / alphazerotimevalue_);
+
+  LOGFILE << "Budgeted time for the move: " << this_move_time << "ms(+"
+          << time_to_squander << "ms to squander). Remaining time " << *time
+          << "ms(-" << move_overhead_ << "ms overhead)";
+  // Use `time_to_squander` time immediately.
+  this_move_time += time_to_squander;
+
+  // Make sure we don't exceed current time limit with what we calculated.
+  auto deadline =
+      std::min(static_cast<int64_t>(this_move_time), *time - move_overhead_);
+  return std::make_unique<AlphazeroStopper>(deadline, &time_spared_ms_);
+}
+
+}  // namespace
+
+std::unique_ptr<TimeManager> MakeAlphazeroTimeManager(int64_t move_overhead,
+                                                   const OptionsDict& params) {
+  return std::make_unique<AlphazeroTimeManager>(move_overhead, params);
+}
+}  // namespace lczero

--- a/src/mcts/stoppers/alphazero.h
+++ b/src/mcts/stoppers/alphazero.h
@@ -1,0 +1,37 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2020 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#pragma once
+
+#include "utils/optionsdict.h"
+
+namespace lczero {
+
+std::unique_ptr<TimeManager> MakeAlphazeroTimeManager(int64_t move_overhead,
+                                                   const OptionsDict& params);
+
+}  // namespace lczero

--- a/src/mcts/stoppers/factory.cc
+++ b/src/mcts/stoppers/factory.cc
@@ -43,29 +43,26 @@ const OptionId kMoveOverheadId{
     "Amount of time, in milliseconds, that the engine subtracts from it's "
     "total available time (to compensate for slow connection, interprocess "
     "communication, etc)."};
-const OptionId kTimeManagerId{"time-manager", "TimeManager",
-                              "Name and config of atime manager."};
-const OptionId kAlphazeroTimeManagerId{"alphazero", "Alphazero",
-    "Makes the engine use AlphaZero time. The alphazero engine always "
+const OptionId kTimeManagerId{
+    "time-manager", "TimeManager",
+    "Name and config of atime manager. "
+    "Default is 'legacy'. "
+    "Optional time manager is 'alphazero' "
+    "'alphazero' Makes the engine use AlphaZero time. The alphazero engine always "
     "budgeted 5 percent of total time left for the first upcoming move, "
-    "thereby "
-    "gradually taking less time for each consecutive move in the game.."};
-const OptionId kAlphazeroTimeValueId{
-    "alphazero-time-value", "AlphazeroTimeValue",
-    "Remaining time is divided by this value. Default value of 20 uses "
-    "alphazero time."
+    "Remaining time is divided by value `alphazero-time-value`. "
+    "Default value of 20 uses (all time / 20 = 5%) 5 percent of all remaining time. "
     "Lower values will spend more time in beginning of game, higher values "
-    "will save more time"
-    "for later in the game"};
+    "will save more time for later in the game." 
+    "Configure as `--time-manager=alphazero(alphazero-time-value=10) "
+    "to go to (all time / 10 = 10%) ten percent of all remaining time per move"};
 }  // namespace
 
 void PopulateTimeManagementOptions(RunType for_what, OptionsParser* options) {
   PopulateCommonStopperOptions(for_what, options);
   if (for_what == RunType::kUci) {
     options->Add<IntOption>(kMoveOverheadId, 0, 100000000) = 200;
-    options->Add<FloatOption>(kAlphazeroTimeValueId, 2.0f, 100.0f) = 20.0f;
     options->Add<StringOption>(kTimeManagerId) = "legacy";
-    options->Add<StringOption>(kAlphazeroTimeManagerId) = "alphazero";
   }
 }
 
@@ -86,7 +83,7 @@ std::unique_ptr<TimeManager> MakeTimeManager(const OptionsDict& options) {
   if (managers[0] == "legacy") {
     time_manager =
         MakeLegacyTimeManager(move_overhead, tm_options.GetSubdict("legacy"));
-  } else if (managers[0] == options.Get<std::string>(kAlphazeroTimeManagerId)) {
+  } else if (managers[0] == "alphazero") {
     time_manager = MakeAlphazeroTimeManager(move_overhead,
                                             tm_options.GetSubdict("alphazero"));
   }

--- a/src/mcts/stoppers/factory.cc
+++ b/src/mcts/stoppers/factory.cc
@@ -47,9 +47,8 @@ const OptionId kMoveOverheadId{
 const OptionId kTimeManagerId{
     "time-manager", "TimeManager",
     "Name and config of a time manager. "
-    "Default is 'legacy'. Optional time manager is 'alphazero' "
-    "Please see http://lczero.org/dev/docs/timemgr for more information"
-    "on configuring the time managers outside of default used values"};
+    "Possible names are 'legacy' (default), 'smooth-experimental' and 'alphazero'."
+    "See https://lc0.org/timemgr for configuration details."};
 }  // namespace
 
 void PopulateTimeManagementOptions(RunType for_what, OptionsParser* options) {

--- a/src/mcts/stoppers/factory.cc
+++ b/src/mcts/stoppers/factory.cc
@@ -45,17 +45,10 @@ const OptionId kMoveOverheadId{
     "communication, etc)."};
 const OptionId kTimeManagerId{
     "time-manager", "TimeManager",
-    "Name and config of atime manager. "
-    "Default is 'legacy'. "
-    "Optional time manager is 'alphazero' "
-    "'alphazero' Makes the engine use AlphaZero time. The alphazero engine always "
-    "budgeted 5 percent of total time left for the first upcoming move, "
-    "Remaining time is divided by value `alphazero-time-value`. "
-    "Default value of 20 uses (all time / 20 = 5%) 5 percent of all remaining time. "
-    "Lower values will spend more time in beginning of game, higher values "
-    "will save more time for later in the game." 
-    "Configure as `--time-manager=alphazero(alphazero-time-value=10) "
-    "to go to (all time / 10 = 10%) ten percent of all remaining time per move"};
+    "Name and config of a time manager. "
+    "Default is 'legacy'. Optional time manager is 'alphazero' "
+    "Please see http://lczero.org/dev/docs/timemgr for more information"
+    "on configuring the time managers outside of default used values"};
 }  // namespace
 
 void PopulateTimeManagementOptions(RunType for_what, OptionsParser* options) {


### PR DESCRIPTION
as per #968 but now on the new time manager factory.

startup with param:
`--time-manager=alphazero`

Comment copied over from #968 below: 

Optionally play with alphazero time settings.

After talking with ASilver on Discord, found the explanation that the original alphazero used some different time setting, which is just use 1/20th (thus 5%) of the remaining time available for the upcoming move.

![image](https://user-images.githubusercontent.com/506830/67107147-2b161280-f1cc-11e9-8976-d205ceec5778.png)

Additionally I just added the wtime (the time increment) for use directly for the upcoming move as well here.

Tests done:
This time setting performs worse than the default lczero time setting. 
- In only 10 games (60sec+1sec) the result was 3 wins for lczero time, 1 for aztime, 6 draws.

- Other 10 games (10sec+0.1sec) the result was even worse:

> Score of lc0.net.42850 vs lc0az.net.42850: 5 - 1 - 4 [0.700]
> Elo difference: 147.19 +/- 197.89
> 
> 10 of 10 games finished.

However, this is just an option that does not affect engine strength if you do not enable it, so might be interesting for people who want to play a bit with the setting. You can alter the value used by Alphazero, dividing remaining time always by 20 to other values from 2: take half the time left for upcoming move, to 100: take 1% of time left for upcoming move, to see what difference that makes...

Have fun testing! :)