### PR TITLE
Fix merge conflict between #1204 and #1207.

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -473,7 +473,7 @@ bool NodeTree::ResetToPosition(const std::string& starting_fen,
   starting_board.SetFromFen(starting_fen, &no_capture_ply, &full_moves);
   if (gamebegin_node_ &&
       (history_.Starting().GetBoard() != starting_board ||
-       history_.Starting().GetNoCaptureNoPawnPly() != no_capture_ply)) {
+       history_.Starting().GetRule50Ply() != no_capture_ply)) {
     // Completely different position.
     DeallocateTree();
   }


### PR DESCRIPTION
r? @mooskagh or @Tilps or @AlexisOlson Renaming the `GetNoCaptureNoPawnPly` added in #1204 to the new name `GetRule50Ply` from #1207.