### PR TITLE
Fix oversight in #1060 to allow book-length amount of games

### DIFF
--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -92,7 +92,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   SearchParams::Populate(options);
 
   options->Add<BoolOption>(kShareTreesId) = true;
-  options->Add<IntOption>(kTotalGamesId, -1, 999999) = -1;
+  options->Add<IntOption>(kTotalGamesId, -2, 999999) = -1;
   options->Add<IntOption>(kParallelGamesId, 1, 256) = 8;
   options->Add<IntOption>(kPlayoutsId, -1, 999999999) = -1;
   options->Add<IntOption>(kVisitsId, -1, 999999999) = -1;


### PR DESCRIPTION
The limit on the `games` setting was not adjusted to allow for the `-2` setting.