### PR TITLE
Allow most parts of fen to be optional.

### DIFF
--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -969,22 +969,34 @@ MoveList ChessBoard::GenerateLegalMoves() const {
   return result;
 }
 
-void ChessBoard::SetFromFen(const std::string& fen, int* rule50_ply,
-                            int* moves) {
+void ChessBoard::SetFromFen(string fen, int* rule50_ply, int* moves) {
   Clear();
   int row = 7;
   int col = 0;
 
+  // Remove any trailing whitespaces to detect eof after the last field.
+  fen.erase(std::find_if(fen.rbegin(), fen.rend(),
+                         [](char c) { return !std::isspace(c); })
+                .base(),
+            fen.end());
+
   std::istringstream fen_str(fen);
   string board;
-  string who_to_move;
-  string castlings;
-  string en_passant;
-  int rule50_halfmoves;
-  int total_moves;
-  fen_str >> board >> who_to_move >> castlings >> en_passant >>
-      rule50_halfmoves >> total_moves;
-
+  fen_str >> board;
+  string who_to_move = "w";
+  if (!fen_str.eof()) fen_str >> who_to_move;
+  // Assume no castling rights. Other engines, e.g., Stockfish, assume kings and
+  // rooks on their initial rows can each castle with the outer-most rook.  Our
+  // implementation currently supports 960 castling where white and black rooks
+  // have matching columns, so it's unclear which rights to assume.
+  string castlings = "-";
+  if (!fen_str.eof()) fen_str >> castlings;
+  string en_passant = "-";
+  if (!fen_str.eof()) fen_str >> en_passant;
+  int rule50_halfmoves = 0;
+  if (!fen_str.eof()) fen_str >> rule50_halfmoves;
+  int total_moves = 1;
+  if (!fen_str.eof()) fen_str >> total_moves;
   if (!fen_str) throw Exception("Bad fen string: " + fen);
 
   for (char c : board) {

--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -42,8 +42,6 @@
 
 namespace lczero {
 
-using std::string;
-
 const char* ChessBoard::kStartposFen =
     "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
@@ -981,17 +979,17 @@ void ChessBoard::SetFromFen(std::string fen, int* rule50_ply, int* moves) {
             fen.end());
 
   std::istringstream fen_str(fen);
-  string board;
+  std::string board;
   fen_str >> board;
-  string who_to_move = "w";
+  std::string who_to_move = "w";
   if (!fen_str.eof()) fen_str >> who_to_move;
   // Assume no castling rights. Other engines, e.g., Stockfish, assume kings and
   // rooks on their initial rows can each castle with the outer-most rook.  Our
   // implementation currently supports 960 castling where white and black rooks
   // have matching columns, so it's unclear which rights to assume.
-  string castlings = "-";
+  std::string castlings = "-";
   if (!fen_str.eof()) fen_str >> castlings;
-  string en_passant = "-";
+  std::string en_passant = "-";
   if (!fen_str.eof()) fen_str >> en_passant;
   int rule50_halfmoves = 0;
   if (!fen_str.eof()) fen_str >> rule50_halfmoves;
@@ -1139,8 +1137,8 @@ bool ChessBoard::HasMatingMaterial() const {
   return light_bishop && dark_bishop;
 }
 
-string ChessBoard::DebugString() const {
-  string result;
+std::string ChessBoard::DebugString() const {
+  std::string result;
   for (int i = 7; i >= 0; --i) {
     for (int j = 0; j < 8; ++j) {
       if (!our_pieces_.get(i, j) && !their_pieces_.get(i, j)) {

--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -969,7 +969,7 @@ MoveList ChessBoard::GenerateLegalMoves() const {
   return result;
 }
 
-void ChessBoard::SetFromFen(string fen, int* rule50_ply, int* moves) {
+void ChessBoard::SetFromFen(std::string fen, int* rule50_ply, int* moves) {
   Clear();
   int row = 7;
   int col = 0;

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -70,7 +70,7 @@ class ChessBoard {
   // If @rule50_ply and @moves are not nullptr, they are filled with number
   // of moves without capture and number of full moves since the beginning of
   // the game.
-  void SetFromFen(const std::string& fen, int* rule50_ply = nullptr,
+  void SetFromFen(std::string fen, int* rule50_ply = nullptr,
                   int* moves = nullptr);
   // Nullifies the whole structure.
   void Clear();

--- a/src/chess/board_test.cc
+++ b/src/chess/board_test.cc
@@ -62,6 +62,30 @@ TEST(ChessBoard, PseudolegalMovesStartingPos) {
   EXPECT_EQ(moves.size(), 20);
 }
 
+TEST(ChessBoard, PartialFen) {
+  ChessBoard board;
+  int rule50ply;
+  int gameply;
+  board.SetFromFen("k/1R//K", &rule50ply, &gameply);
+  auto moves = board.GeneratePseudolegalMoves();
+
+  EXPECT_EQ(moves.size(), 19);
+  EXPECT_EQ(rule50ply, 0);
+  EXPECT_EQ(gameply, 1);
+}
+
+TEST(ChessBoard, PartialFenWithSpaces) {
+  ChessBoard board;
+  int rule50ply;
+  int gameply;
+  board.SetFromFen("   k/1R//K   w   ", &rule50ply, &gameply);
+  auto moves = board.GeneratePseudolegalMoves();
+
+  EXPECT_EQ(moves.size(), 19);
+  EXPECT_EQ(rule50ply, 0);
+  EXPECT_EQ(gameply, 1);
+}
+
 namespace {
 int Perft(const ChessBoard& board, int max_depth, bool dump = false,
           int depth = 0) {

--- a/src/chess/pgn.h
+++ b/src/chess/pgn.h
@@ -65,12 +65,6 @@ class PgnReader {
         if (uc_line.find("[FEN \"", 0) == 0) {
           auto start_trimmed = line.substr(6);
           cur_startpos_ = start_trimmed.substr(0, start_trimmed.find('"'));
-          // Some 'opening books' omit the last 2 fields, so there is only 3
-          // space delimiters.
-          if (std::count(cur_startpos_.begin(), cur_startpos_.end(), ' ') ==
-              3) {
-            cur_startpos_ += " 0 1";
-          }
           cur_board_.SetFromFen(cur_startpos_);
         }
         continue;


### PR DESCRIPTION
r? @Tilps or @mooskagh Fen handling already allows some leeway, so this makes it even more generous assuming white to move, ~all castling (including 960)~ no castling, no en passant, 0 rule50ply, 1 total moves.

Before:
```
position fen K1k1r b
go nodes 1
error Bad fen string: K1k1r b
```

After:
```
position fen K1k1r b
go nodes 1
info … multipv 14 pv e8h8

position fen K1k1r b moves c8e8
go nodes 1
info … multipv 2 pv a8b7
```
~Where the last position shows the castling of black and still supporting "moves"~
![fen castle](https://user-images.githubusercontent.com/438537/80179963-80d1da00-85b6-11ea-9ff8-74f718235b76.png)
