### PR TITLE
Policy decay effect - WIP

### DIFF
--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -398,7 +398,7 @@ class EdgeAndNode {
   // Passed numerator is expected to be equal to (cpuct * sqrt(N[parent])).
   float GetU(float numerator, float childVisits) const {
     const float p = GetP();
-    const float p_dcay = p + (1 - p) * (1 - 1 / std::sqrt(1 + p * childVisits);
+    const float p_dcay = p + (1 - p) * (1 - 1 / std::sqrt(1 + p * (childVisits - 1));
     return numerator * p_dcay / (1 + GetNStarted());
   }
 

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -396,9 +396,10 @@ class EdgeAndNode {
 
   // Returns U = numerator * p / N.
   // Passed numerator is expected to be equal to (cpuct * sqrt(N[parent])).
-  float GetU(float numerator, float childVisits) const {
+  float GetU(float numerator, float childVisits, float shift, float slope) const {
     const float p = GetP();
-    const float p_dcay = p + (1 - p) * (1 - 1 / std::sqrt(1 + p * (childVisits - 1)));
+    const float p_dcay = p + (1 - p) *
+      (1 - 1 / std::pow(1 + shift * p * (childVisits - 1), slope));
     return numerator * p_dcay / (1 + GetNStarted());
   }
 

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -398,7 +398,7 @@ class EdgeAndNode {
   // Passed numerator is expected to be equal to (cpuct * sqrt(N[parent])).
   float GetU(float numerator, float childVisits) const {
     const float p = GetP();
-    const float p_dcay = p + (1 - p) * (1 - 1 / std::sqrt(1 + p * (childVisits - 1));
+    const float p_dcay = p + (1 - p) * (1 - 1 / std::sqrt(1 + p * (childVisits - 1)));
     return numerator * p_dcay / (1 + GetNStarted());
   }
 

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -396,8 +396,10 @@ class EdgeAndNode {
 
   // Returns U = numerator * p / N.
   // Passed numerator is expected to be equal to (cpuct * sqrt(N[parent])).
-  float GetU(float numerator) const {
-    return numerator * GetP() / (1 + GetNStarted());
+  float GetU(float numerator, float childVisits) const {
+    const float p = GetP();
+    const float p_dcay = p + (1 - p) * (1 - 1 / std::sqrt(1 + p * childVisits);
+    return numerator * p_dcay / (1 + GetNStarted());
   }
 
   int GetVisitsToReachU(float target_score, float numerator,

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -57,6 +57,12 @@ const OptionId SearchParams::kLogitQId{
     "logit-q", "LogitQ",
     "Apply logit to Q when determining Q+U best child. This makes the U term "
     "less dominant when Q is near -1 or +1."};
+const OptionId SearchParams::kPolicyDecayShiftId{
+    "policy-decay-shift", "PolicyDecayShift",
+    "Adjusts how soon policy effect starts to decay."};
+const OptionId SearchParams::kPolicyDecaySlopeId{
+    "policy-decay-slope", "PolicyDecaySlope",
+    "Adjusts how fast policy effect decays to 1."};
 const OptionId SearchParams::kCpuctId{
     "cpuct", "CPuct",
     "cpuct_init constant from \"UCT search\" algorithm. Higher values promote "
@@ -259,12 +265,14 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kMiniBatchSizeId, 1, 1024) = 256;
   options->Add<IntOption>(kMaxPrefetchBatchId, 0, 1024) = 32;
   options->Add<BoolOption>(kLogitQId) = false;
+  options->Add<FloatOption>(kPolicyDecayShiftId, 0.0f, 100.0f) = 0.1f;
+  options->Add<FloatOption>(kPolicyDecaySlopeId, 0.0f, 100.0f) = 0.5f;
   options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 2.147f;
   options->Add<FloatOption>(kCpuctAtRootId, 0.0f, 100.0f) = 2.147f;
   options->Add<FloatOption>(kCpuctBaseId, 1.0f, 1000000000.0f) = 18368.0f;
   options->Add<FloatOption>(kCpuctBaseAtRootId, 1.0f, 1000000000.0f) = 18368.0f;
-  options->Add<FloatOption>(kCpuctFactorId, 0.0f, 1000.0f) = 2.815f;
-  options->Add<FloatOption>(kCpuctFactorAtRootId, 0.0f, 1000.0f) = 2.815f;
+  options->Add<FloatOption>(kCpuctFactorId, 0.0f, 1000.0f) = 0.0f;
+  options->Add<FloatOption>(kCpuctFactorAtRootId, 0.0f, 1000.0f) = 0.0f;
   options->Add<BoolOption>(kRootHasOwnCpuctParamsId) = true;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 100) = 0;
@@ -330,6 +338,8 @@ void SearchParams::Populate(OptionsParser* options) {
 SearchParams::SearchParams(const OptionsDict& options)
     : options_(options),
       kLogitQ(options.Get<bool>(kLogitQId)),
+      kPolicyDecayShift(options.Get<float>(kPolicyDecayShiftId)),
+      kPolicyDecaySlope(options.Get<float>(kPolicyDecaySlopeId)),
       kCpuct(options.Get<float>(kCpuctId)),
       kCpuctAtRoot(options.Get<float>(
           options.Get<bool>(kRootHasOwnCpuctParamsId) ? kCpuctAtRootId

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -47,6 +47,8 @@ class SearchParams {
     return options_.Get<int>(kMaxPrefetchBatchId);
   }
   bool GetLogitQ() const { return kLogitQ; }
+  float GetPolicyDecayShift() const { return kPolicyDecayShift; }
+  float GetPolicyDecaySlope() const { return kPolicyDecaySlope; }
   float GetCpuct(bool at_root) const { return at_root ? kCpuctAtRoot : kCpuct; }
   float GetCpuctBase(bool at_root) const {
     return at_root ? kCpuctBaseAtRoot : kCpuctBase;
@@ -114,6 +116,8 @@ class SearchParams {
   static const OptionId kMiniBatchSizeId;
   static const OptionId kMaxPrefetchBatchId;
   static const OptionId kLogitQId;
+  static const OptionId kPolicyDecayShiftId;
+  static const OptionId kPolicyDecaySlopeId;
   static const OptionId kCpuctId;
   static const OptionId kCpuctAtRootId;
   static const OptionId kCpuctBaseId;
@@ -170,6 +174,8 @@ class SearchParams {
   // TODO(crem) Some of those parameters can be converted to be dynamic after
   //            trivial search optimizations.
   const bool kLogitQ;
+  const float kPolicyDecayShift;
+  const float kPolicyDecaySlope;
   const float kCpuct;
   const float kCpuctAtRoot;
   const float kCpuctBase;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -261,7 +261,7 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
 
   std::sort(
       edges.begin(), edges.end(),
-      [&fpu, &U_coeff, &logit_q, &draw_score](EdgeAndNode a, EdgeAndNode b) {
+      [&fpu, &U_coeff, &childVisits, &logit_q, &draw_score](EdgeAndNode a, EdgeAndNode b) {
         return std::forward_as_tuple(
                    a.GetN(),
                    a.GetQ(fpu, draw_score, logit_q) + a.GetU(U_coeff, childVisits)) <

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -263,7 +263,8 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
 
   std::sort(
       edges.begin(), edges.end(),
-      [&fpu, &U_coeff, &childVisits, &logit_q, &draw_score](EdgeAndNode a, EdgeAndNode b) {
+      [&fpu, &U_coeff, &childVisits, &shift, &slope, &logit_q,
+       &draw_score](EdgeAndNode a, EdgeAndNode b) {
         return std::forward_as_tuple(
                    a.GetN(),
                    a.GetQ(fpu, draw_score, logit_q) +
@@ -311,7 +312,7 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
 
     oss << "(Q+U: " << std::setw(8) << std::setprecision(5)
         << edge.GetQ(fpu, draw_score, logit_q) +
-           edge.GetU(U_coeff, childVisits, shift slope) << ") ";
+           edge.GetU(U_coeff, childVisits, shift, slope) << ") ";
 
     oss << "(V: ";
     std::optional<float> v;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -264,7 +264,7 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
       [&fpu, &U_coeff, &logit_q, &draw_score](EdgeAndNode a, EdgeAndNode b) {
         return std::forward_as_tuple(
                    a.GetN(),
-                   a.GetQ(fpu, draw_score, logit_q) + a.GetU(U_coeff, childVisits) <
+                   a.GetQ(fpu, draw_score, logit_q) + a.GetU(U_coeff, childVisits)) <
                std::forward_as_tuple(
                    b.GetN(),
                    b.GetQ(fpu, draw_score, logit_q) + b.GetU(U_coeff, childVisits));

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -331,8 +331,8 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
     oss << "(U: " << std::setw(6) << std::setprecision(5)
         << edge.GetU(U_coeff, childVisits, shift, slope) << ") ";
 
-    oss << "(Q+U: " << std::setw(8) << std::setprecision(5)
-        << Q + edge.GetU(U_coeff, childVisits, shift, slope) + M_effect<< ") ";
+    oss << "(S: " << std::setw(8) << std::setprecision(5)
+        << Q + edge.GetU(U_coeff, childVisits, shift, slope) + M_effect << ") ";
 
     oss << "(V: ";
     std::optional<float> v;


### PR DESCRIPTION
Decay the effect of policy with additional nodes.

Instead of P use:
![image](https://user-images.githubusercontent.com/10537957/80184685-af5cae80-85d0-11ea-85b5-eac7d56b8731.png)

Example P effect:
![image](https://user-images.githubusercontent.com/10537957/80183844-30b34180-85cf-11ea-9398-af816924c4fe.png)

A coefficient c can be multiplied with p inside the square root to tune the onset of decay:
![image](https://user-images.githubusercontent.com/10537957/80186934-6b6ba880-85d4-11ea-8077-aa7822406d11.png)

The steepness can be tuned by using a more generic 1/x^b rather than 1/sqrt(x) (b = 1/2).

![image](https://user-images.githubusercontent.com/10537957/80218581-febdd180-8606-11ea-9e6a-404d750ba924.png)

![image](https://user-images.githubusercontent.com/10537957/80218652-12693800-8607-11ea-9421-c78561ddd803.png)

You can play with these parameters [on Desmos](https://www.desmos.com/calculator/mog28vlimx).