### PR TITLE
cuda winograd fixes

### DIFF
--- a/src/neural/cuda/layers.cc
+++ b/src/neural/cuda/layers.cc
@@ -813,10 +813,11 @@ void FusedWinogradConvSELayer<DataType>::LoadSEWeights(float* w1, float* b1,
 }
 
 template <>
-void FusedWinogradConvSELayer<half>::cublasRowMjaorMatrixMul(
+void FusedWinogradConvSELayer<half>::cublasRowMajorMatrixMul(
     const half* A, const half* B, half* Out, int M, int N, int K, int batchSize,
     cublasHandle_t cublas) {
-
+  // Need to initialize 1.0 and 0.0 as hexadecimal for fp16 because typecasting
+  // float to half type doesn't work before CUDA 10.0
   __half_raw one_h{0x3C00};
   __half_raw zero_h{0};
   half halfOne = one_h;
@@ -835,7 +836,7 @@ void FusedWinogradConvSELayer<half>::cublasRowMjaorMatrixMul(
 }
 
 template <>
-void FusedWinogradConvSELayer<float>::cublasRowMjaorMatrixMul(
+void FusedWinogradConvSELayer<float>::cublasRowMajorMatrixMul(
     const float* A, const float* B, float* Out, int M, int N, int K,
     int batchSize, cublasHandle_t cublas) {
 
@@ -867,7 +868,7 @@ void FusedWinogradConvSELayer<DataType>::Eval(
 
   InputTransform<DataType>(N, C, transformed_input, input);
 
-  cublasRowMjaorMatrixMul(transformed_input, transformed_weights_, transformed_output, N*4, C, c_input_, 36, cublas);  
+  cublasRowMajorMatrixMul(transformed_input, transformed_weights_, transformed_output, N*4, C, c_input_, 36, cublas);  
 
   if (has_se_ && use_relu_ && use_bias_ && skip_add_)
     OutputTransform<DataType, true, true, true, true>(

--- a/src/neural/cuda/layers.h
+++ b/src/neural/cuda/layers.h
@@ -214,8 +214,8 @@ class FusedWinogradConvSELayer : public BaseLayer<DataType> {
 
  public:
   FusedWinogradConvSELayer(BaseLayer<DataType>* ip, int C, int H, int W,
-                         int Cin, bool relu, bool bias, bool skipAdd,
-                         bool se, int se_k);
+                         int Cin, bool relu, bool bias, bool skipAdd, bool se,
+                           int se_k, bool use_gemm_ex);
 
   ~FusedWinogradConvSELayer();
   void LoadWeights(float* pfilter, float* pBias, void* scratch);
@@ -232,6 +232,7 @@ class FusedWinogradConvSELayer : public BaseLayer<DataType> {
   const bool skip_add_;
   const bool has_se_;
   const int se_k_;
+  const bool use_gemm_ex_;
 
   DataType* biases_ = nullptr;
   DataType* weights_ = nullptr;
@@ -242,6 +243,10 @@ class FusedWinogradConvSELayer : public BaseLayer<DataType> {
   DataType* w2_;
   DataType* b1_;
   DataType* b2_;
+
+ void cublasRowMjaorMatrixMul(const DataType* A, const DataType* B,
+                               DataType* Out, int M, int N, int K,
+                               int batchSize, cublasHandle_t cublas);
 };
 
 }  // namespace cudnn_backend

--- a/src/neural/cuda/layers.h
+++ b/src/neural/cuda/layers.h
@@ -244,7 +244,7 @@ class FusedWinogradConvSELayer : public BaseLayer<DataType> {
   DataType* b1_;
   DataType* b2_;
 
- void cublasRowMjaorMatrixMul(const DataType* A, const DataType* B,
+ void cublasRowMajorMatrixMul(const DataType* A, const DataType* B,
                                DataType* Out, int M, int N, int K,
                                int batchSize, cublasHandle_t cublas);
 };

--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -241,7 +241,6 @@ class CudnnNetwork : public Network {
 
     // Default layout is nchw.
     nhwc_ = false;
-
     bool hasTensorCores = false;
 
     if (std::is_same<half, DataType>::value) {
@@ -296,7 +295,6 @@ class CudnnNetwork : public Network {
     if (fp16) {
       int cuda_version;
       cudaRuntimeGetVersion(&cuda_version);
-
       if (!hasTensorCores)
         use_custom_winograd_ = true;
       else if (kNumFilters >= 256 &&
@@ -305,7 +303,6 @@ class CudnnNetwork : public Network {
         use_custom_winograd_ = true;
       else
         use_custom_winograd_ = false;
-
     } else {
       use_custom_winograd_ = true;
     }

--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -280,7 +280,7 @@ class CudnnNetwork : public Network {
     const int kNumFilters = weights.input.biases.size();
     numBlocks_ = weights.residual.size();
 
-    // Use our custom winograd for resudual tower convolutions for most cases:
+    // Use our custom winograd for residual tower convolutions for most cases:
     //
     //  1. Should be always faster than cudnn's winograd that we use for fp32,
     //  and for fp16 on GPUs without tensor cores


### PR DESCRIPTION
- don't typecast directly to half datatype in CPU side code as older CUDA runtime doesn't support that.
- don't use gemmEx version on GPUs older than Maxwell generation (not supported).
- modify the check to enable custom_winograd setting. It should be faster in most cases - except on RTX GPUs when using fp16.