### PR TITLE
Flat eval at q=0

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -145,7 +145,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
           std::round(edge.GetM(0.0f)) / 2 + (edge.IsTbTerminal() ? 101 : 1),
           wl);
     } else if (score_type == "centipawn_with_drawscore") {
-      uci_info.score = 90 * tan(1.5637541897 * q);
+      uci_info.score = 128 * tan(atan(128 * sqrt(2.0)) * q) * sqrt((q * q) / (q * q + 1));
     } else if (score_type == "centipawn") {
       uci_info.score = 90 * tan(1.5637541897 * wl);
     } else if (score_type == "centipawn_2019") {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -145,7 +145,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
           std::round(edge.GetM(0.0f)) / 2 + (edge.IsTbTerminal() ? 101 : 1),
           wl);
     } else if (score_type == "centipawn_with_drawscore") {
-      uci_info.score = 128 * tan(atan(128 * sqrt(2.0)) * q) * sqrt((q * q) / (q * q + 1));
+      uci_info.score = 128 * tan(atan(100 * sqrt(2.0)) * q) * sqrt((q * q) / (q * q + 1));
     } else if (score_type == "centipawn") {
       uci_info.score = 90 * tan(1.5637541897 * wl);
     } else if (score_type == "centipawn_2019") {


### PR DESCRIPTION
Based on discussion at the TCEC chat, it might be slightly better that the eval curve is flat at q=0 to prevent evals such as 0.09 resulting in drawn out draws.  This slightly different approach:

* uses sqrt(x^2 / (x^2 + 1)) to flatten the eval curve at q = 0.
* rescales the multiplier to the maximum intended cp score, 128 (rather than 90).
* sets the tan() argument range by calculating it with atan(), rather than relying on hard coded magic numbers that happen to be close to pi/2 and could also be mistyped --- presumably any optimizing compiler will evaluate atan() at compile time.

Note well: I merely changed the code as a proof of concept, this is provided as a suggestion for consideration.