### PR TITLE
Syzygy tablebase for use with selfplay

### DIFF
--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -76,10 +76,10 @@ class SelfPlayGame {
 
   // Populate command line options that it uses.
   static void PopulateUciParams(OptionsParser* options);
-
+  
   // Starts the game and blocks until the game is finished.
   void Play(int white_threads, int black_threads, bool training,
-            bool enable_resign = true);
+	  SyzygyTablebase* syzygy_tb, bool enable_resign = true);
   // Aborts the game currently played, doesn't matter if it's synchronous or
   // not.
   void Abort();
@@ -119,6 +119,9 @@ class SelfPlayGame {
 
   // Training data to send.
   std::vector<V5TrainingData> training_data_;
+
+  std::unique_ptr<SyzygyTablebase> syzygy_tb_;
+
 };
 
 }  // namespace lczero

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -79,6 +79,12 @@ const OptionId kOpeningsMirroredId{
     "Not really compatible with openings mode random."};
 const OptionId kOpeningsModeId{"openings-mode", "OpeningsMode",
                                "A choice of sequential, shuffled, or random."};
+const OptionId kSyzygyTablebaseId{
+	"syzygy-paths", "SyzygyPath",
+	"List of Syzygy tablebase directories, list entries separated by system "
+	"separator (\";\" for Windows, \":\" for Linux).",
+	's' };
+
 }  // namespace
 
 void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
@@ -114,6 +120,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
                                              "random"};
   options->Add<ChoiceOption>(kOpeningsModeId, openings_modes) = "sequential";
 
+  options->Add<StringOption>(kSyzygyTablebaseId);
   SelfPlayGame::PopulateUciParams(options);
 
   auto defaults = options->GetMutableDefaultsOptions();
@@ -207,6 +214,19 @@ SelfPlayTournament::SelfPlayTournament(
       }
     }
   }
+
+  // Take syzygy tablebases from options.
+  std::string tb_paths =
+	  options.Get<std::string>(kSyzygyTablebaseId);
+  if (!tb_paths.empty()) {
+	  syzygy_tb_ = std::make_unique<SyzygyTablebase>();
+	  CERR << "Loading Syzygy tablebases from " << tb_paths;
+	  if (!syzygy_tb_->init(tb_paths)) {
+		  CERR << "Failed to load Syzygy tablebases!";
+		  syzygy_tb_ = nullptr;
+	  }
+  }
+
 }
 
 void SelfPlayTournament::PlayOneGame(int game_number) {
@@ -328,8 +348,9 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
   // PLAY GAME!
   auto player1_threads = player_options_[0][color_idx[0]].Get<int>(kThreadsId);
   auto player2_threads = player_options_[1][color_idx[1]].Get<int>(kThreadsId);
-  game.Play(player1_threads, player2_threads, kTraining, enable_resign);
-
+  game.Play(player1_threads, player2_threads, kTraining, syzygy_tb_.get(),
+            enable_resign);
+  
   // If game was aborted, it's still undecided.
   if (game.GetGameResult() != GameResult::UNDECIDED) {
     // Game callback.

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -108,6 +108,9 @@ class SelfPlayTournament {
   const bool kTraining;
   const float kResignPlaythrough;
   const float kDiscardedStartChance;
+
+  std::unique_ptr<SyzygyTablebase> syzygy_tb_;
+
 };
 
 }  // namespace lczero


### PR DESCRIPTION
as per #905 now on the c17 version of the code.

Add syzygy tablebases to use these for selfplay games.

The goal is to save time in training and game matches: for example when contributing to leela-training and matches I've seen games prolong between KRvsKR for 200+ moves, just wasting CPU/GPU cycles.
So the goal here is to use tablebases when those exists for clients; it should just use the tablebases available on your system even if that's only 4 or 5 pieces instead of 6 or 7 piece TB.

Seems to work when starting lc0 as follows:
lc0 selfplay --visits=800 --syzygy-paths=c:\path_to\tablebases

After this is merged, this also needs the go-client to pass on the syzygy-path from commandline to lc0 so that local installed client tablebases are indeed being used, or the TB might be configured in lc0.config startup params instead, not sure.