### PR TITLE
Logistic moves left utility for search

### DIFF
--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -96,13 +96,20 @@ class SearchParams {
     return options_.Get<std::string>(kScoreTypeId);
   }
   FillEmptyHistory GetHistoryFill() const { return kHistoryFill; }
-  float GetMovesLeftMaxEffect() const { return kMovesLeftMaxEffect; }
-  float GetMovesLeftThreshold() const { return kMovesLeftThreshold; }
-  float GetMovesLeftSlope() const { return kMovesLeftSlope; }
-  float GetMovesLeftConstantFactor() const { return kMovesLeftConstantFactor; }
-  float GetMovesLeftScaledFactor() const { return kMovesLeftScaledFactor; }
-  float GetMovesLeftQuadraticFactor() const {
-    return kMovesLeftQuadraticFactor;
+  float GetMovesLeftStaticUtilityFactor() const {
+    return kMovesLeftStaticUtilityFactor; 
+  }
+  float GetMovesLeftDynamicUtilityFactor() const {
+    return kMovesLeftDynamicUtilityFactor; 
+  }
+  float GetMovesLeftUtilitySteepness() const {
+    return kMovesLeftUtilitySteepness; 
+  }
+  float GetMovesLeftInitialExpectedValue() const {
+    return kMovesLeftInitialExpectedValue; 
+  }
+  float GetMovesLeftCenterScalingFactor() const {
+    return kMovesLeftCenterScalingFactor; 
   }
   bool GetDisplayCacheUsage() const { return kDisplayCacheUsage; }
   int GetMaxConcurrentSearchers() const { return kMaxConcurrentSearchers; }
@@ -150,12 +157,11 @@ class SearchParams {
   static const OptionId kPerPvCountersId;
   static const OptionId kScoreTypeId;
   static const OptionId kHistoryFillId;
-  static const OptionId kMovesLeftMaxEffectId;
-  static const OptionId kMovesLeftThresholdId;
-  static const OptionId kMovesLeftConstantFactorId;
-  static const OptionId kMovesLeftScaledFactorId;
-  static const OptionId kMovesLeftQuadraticFactorId;
-  static const OptionId kMovesLeftSlopeId;
+  static const OptionId kMovesLeftStaticUtilityFactorId;
+  static const OptionId kMovesLeftDynamicUtilityFactorId;
+  static const OptionId kMovesLeftUtilitySteepnessId;
+  static const OptionId kMovesLeftInitialExpectedValueId;
+  static const OptionId kMovesLeftCenterScalingFactorId;
   static const OptionId kShortSightednessId;
   static const OptionId kDisplayCacheUsageId;
   static const OptionId kMaxConcurrentSearchersId;
@@ -195,12 +201,11 @@ class SearchParams {
   const bool kSyzygyFastPlay;
   const FillEmptyHistory kHistoryFill;
   const int kMiniBatchSize;
-  const float kMovesLeftMaxEffect;
-  const float kMovesLeftThreshold;
-  const float kMovesLeftSlope;
-  const float kMovesLeftConstantFactor;
-  const float kMovesLeftScaledFactor;
-  const float kMovesLeftQuadraticFactor;
+  const float kMovesLeftStaticUtilityFactor;
+  const float kMovesLeftDynamicUtilityFactor;
+  const float kMovesLeftUtilitySteepness;
+  const float kMovesLeftInitialExpectedValue;
+  const float kMovesLeftCenterScalingFactor;
   const float kShortSightedness;
   const bool kDisplayCacheUsage;
   const int kMaxConcurrentSearchers;

--- a/src/utils/fastmath.h
+++ b/src/utils/fastmath.h
@@ -82,4 +82,9 @@ inline float FastLogit(const float a) {
   return 0.5f * FastLog((1.0f + a) / (1.0f - a));
 }
 
+// Fast logistic2 function for more readable code.
+inline float FastLogistic2(const float a) {
+  if (a <= -127) return 0.0f;
+  return 1.0f / (1.0f + FastPow2(-a));
+}
 }  // namespace lczero


### PR DESCRIPTION
Based on the observation in #1236, previous M_effect is replaced with the moves left utility (MLU). The purposes and advantages of this approach are following:

* MLU depends not only on M, but also on Q as well. While the original idea started with Q/M, it is replaced with Q \* logistic(-c \* M) for several reasons.
* This allows the term to distinguish between winning/drawn/losing positions naturally. While the previous M_effect introduces a discontinuity in total score (or utility) Q + U + M_effect with thresholds and behaves dubiously without thresholds, the new MLU can be mixed as an auxiliary utility in search everywhere more comfortably.
* Furthermore, MLU is separated into static and dynamic terms, following the approach of KataGo. While the static utility provides a distinction between positions of nearly the same Q, the dynamic term reacts to the M difference more sensitively, by reducing M effectively to M - M0, which can boost the effect of MLU when M is large and MLU is small accordingly.
* Consequently, I hope this allows the search algorithm to explore moves with smaller M values more actively instead of shuffling, especially when shuffling moves have higher Q than the optimal move which makes some progress on the board. This is not necessarily a Elo-gainer for the time being, but I believe self-playing with the (especially dynamic) MLU will encourage lc0 to have a better understanding in closed or fortress-like positions.

----
Calculation of the static and dynamic utilities

Parameters:
* MovesLeftStaticUtilityFactor = 1.0
* MovesLeftDynamicUtilityFactor = 3.0
* MovesLeftUtilitySteepness = 0.1
* MovesLeftInitialExpectedValue = 110
* MovesLeftCenterScalingFactor = 0.8

Utility calculation (pseudocode):
```
def ml_utility(Q, M, M0, steepness)
  return Q * logistic2(-1 * steepness * (M - M0))

if parent == None // Starting position
  M0 = MovesLeftInitialExpectedValue
else
  M0 = root_node_->GetParent()->GetM() - depth
M0 *= MovesLeftCenterScalingFactor

ML_utility_total = c_static * ML_utility_static + c_dynamic * ML_utility_dynamic
ML_utility_static = ml_utility(Q, M, 0.0, decay_factor)
ML_utility_dynamic = ml_utility(Q, M, M0, decay_factor)
```
Score:
score = Q + U + ML_utility_total

----
Using the network 710078 for T71 match game positions, 800 nodes data are generated and MLU-Q and MLU-M relations are plotted with Steepness=0.1.
![MLU_Q](https://user-images.githubusercontent.com/571680/80472770-2357d780-8980-11ea-991f-9951e22c232e.png)
![MLU_M](https://user-images.githubusercontent.com/571680/80473179-babd2a80-8980-11ea-8156-fcea388fc19b.png)
These figures are showing that this MLU behaves similarly to Q/M initially suggested in #1236. 

![steepness](https://user-images.githubusercontent.com/571680/80473252-d88a8f80-8980-11ea-973e-13e3c7b148cb.png)
The MovesLeftUtilitySteepness parameter controls how fast the MLU decays with respect to M (plotted with Q=0.5).

![centerscale](https://user-images.githubusercontent.com/571680/80473394-0a9bf180-8981-11ea-8f12-153c6db810a5.png)
This figures shows how MovesLeftCenterScalingFactor affects the dynamic utility, with the assumption that Q=0.5 and M0 = M \* MovesLeftCenterScalingFactor. One might think that this parameter is redundant and doing the same thing as steepness, but it is not the case: M0 is not necessarily proportional to M especially in tactical positions, and the purpose of the dynamic utility is for sensitiveness of MLU to the M difference between M0 and M.

----
Some obstacles:
* ~~While one might want to store M from the previous move and utilize it, currently parent M is used instead. I am not good at the internals of lc0 so I had no idea how to store the data while utilizing it depending on the tree depth without breaking things.~~
* ~~Default parameters are somewhat arbitrary, and whether optimizing the parameters for Elo is optimal or not is unclear.~~