### PR TITLE
Always report at least 1 depth.

### DIFF
--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -27,6 +27,7 @@
 
 #include "uciloop.h"
 
+#include <algorithm>
 #include <iomanip>
 #include <iostream>
 #include <mutex>

--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -246,7 +246,8 @@ void UciLoop::SendInfo(const std::vector<ThinkingInfo>& infos) {
     if (info.game_id != -1) res += " gameid " + std::to_string(info.game_id);
     if (info.is_black)
       res += " side " + std::string(*info.is_black ? "black" : "white");
-    if (info.depth >= 0) res += " depth " + std::to_string(info.depth);
+    if (info.depth >= 0)
+      res += " depth " + std::to_string(std::max(info.depth, 1));
     if (info.seldepth >= 0) res += " seldepth " + std::to_string(info.seldepth);
     if (info.time >= 0) res += " time " + std::to_string(info.time);
     if (info.nodes >= 0) res += " nodes " + std::to_string(info.nodes);


### PR DESCRIPTION
r? @mooskagh Fix #1176 from `uciloop.cc` to report at least 1 depth as search will always at least visit the search root. Alternative would be updating `search.cc` for both `SendUciInfo` and `MaybeOutputInfo`.

Before:
```
position fen 3k1b1r/3R2pp/3p1n2/pBp1p3/q2B2Q1/2P4P/2P2PP1/6K1 b - - 3 23
go nodes 300
info depth 2 seldepth 7 time 996 nodes 294 score mate -3 nps 2409 tbhits 0 pv d8c8 b5a6 c8b8 d7b7 b8a8 g4c8

position fen 3k1b1r/3R2pp/3p1n2/pBp1p3/q2B2Q1/2P4P/2P2PP1/6K1 b - - 3 23 moves d8c8 b5a6
go nodes 300
info depth 0 seldepth 0 time 0 nodes 300 score mate -2 tbhits 0 pv c8b8 d7b7 b8a8 g4c8

ucinewgame
position fen 3k1b1r/3R2pp/3p1n2/pBp1p3/q2B2Q1/2P4P/2P2PP1/6K1 b - - 3 23 moves d8c8 b5a6
go nodes 300
info depth 1 seldepth 1 time 47 nodes 1 score cp -136 tbhits 0 pv c8b8
```
After:
```
position fen 3k1b1r/3R2pp/3p1n2/pBp1p3/q2B2Q1/2P4P/2P2PP1/6K1 b - - 3 23
go nodes 300
info depth 2 seldepth 7 time 392 nodes 294 score mate -3 nps 3769 tbhits 0 pv d8c8 b5a6 c8b8 d7b7 b8a8 g4c8

position fen 3k1b1r/3R2pp/3p1n2/pBp1p3/q2B2Q1/2P4P/2P2PP1/6K1 b - - 3 23 moves d8c8 b5a6
go nodes 300
info depth 1 seldepth 0 time 0 nodes 7 score mate -2 tbhits 0 pv c8b8 d7b7 b8a8 g4c8

ucinewgame
position fen 3k1b1r/3R2pp/3p1n2/pBp1p3/q2B2Q1/2P4P/2P2PP1/6K1 b - - 3 23 moves d8c8 b5a6
go nodes 300
info depth 1 seldepth 1 time 19 nodes 1 score cp -136 tbhits 0 pv c8b8
```