### PR TITLE
Check if eigen is availiable before pulling subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -252,7 +252,7 @@ if get_option('build_backends')
 
     endif
 
-    deps += subproject('eigen').get_variable('eigen_dep')
+    deps += dependency('eigen3', fallback: ['eigen', 'eigen_dep'])
 
     ispc = find_program('ispc', required: false)
     ispc_extra_args = []


### PR DESCRIPTION
This enables usage of system eigen library if it is present. Before it was not possible to build without pulling subproject.
Should I [force subproject for windows](https://github.com/LeelaChessZero/lc0/blob/master/meson.build#L471)? 
