### PR TITLE
memory optimization for cudnn custom_winograd

### DIFF
--- a/src/neural/cuda/layers.h
+++ b/src/neural/cuda/layers.h
@@ -235,7 +235,6 @@ class FusedWinogradConvSELayer : public BaseLayer<DataType> {
   const bool use_gemm_ex_;
 
   DataType* biases_ = nullptr;
-  DataType* weights_ = nullptr;
   DataType* transformed_weights_ = nullptr;  // After winograd transform.
 
   // Weights and Biases for (optional) SE.

--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -316,7 +316,7 @@ class CudnnNetwork : public Network {
     size_t residual_single_layer_weight_size =
         3 * 3 * kNumFilters * kNumFilters * sizeof(DataType);
     size_t residual_weight_size =
-        residual_single_layer_weight_size * numBlocks_;
+        residual_single_layer_weight_size * numBlocks_ * 2;
     size_t transformed_residual_weight_size = residual_weight_size * 4;
     if (residual_weight_size > 0.6 * deviceProp.totalGlobalMem) {
       CERR << "Low video memory detected. You may run into OOM errors. Please "


### PR DESCRIPTION
- don't save untransformed weights
- print warning message when low memory is detected.