### PR TITLE
Flatten policy when visits reach various powers of 2.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -161,6 +161,11 @@ const OptionId SearchParams::kCacheHistoryLengthId{
     "this value is less than history that NN uses to eval a position, it's "
     "possble that the search will use eval of the same position with different "
     "history taken from cache."};
+const OptionId SearchParams::kPolicyFlattenRateId{
+    "policy-flatten-rate", "PolicyFlattenRate",
+    "Approximate rate at which policy for a node flattens when visits reach "
+    "multiple powers of 2. For example, a value of 10 means roughly every 1024 "
+    "visits, each policy value moves halfway to flat."};
 const OptionId SearchParams::kPolicySoftmaxTempId{
     "policy-softmax-temp", "PolicyTemperature",
     "Policy softmax temperature. Higher values make priors of move candidates "
@@ -290,6 +295,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kFpuStrategyAtRootId, fpu_strategy) = "same";
   options->Add<FloatOption>(kFpuValueAtRootId, -100.0f, 100.0f) = 1.0f;
   options->Add<IntOption>(kCacheHistoryLengthId, 0, 7) = 0;
+  options->Add<IntOption>(kPolicyFlattenRateId, 0, 30) = 0;
   options->Add<FloatOption>(kPolicySoftmaxTempId, 0.1f, 10.0f) = 1.607f;
   options->Add<IntOption>(kMaxCollisionEventsId, 1, 65536) = 32;
   options->Add<IntOption>(kMaxCollisionVisitsId, 1, 1000000) = 9999;
@@ -367,6 +373,10 @@ SearchParams::SearchParams(const OptionsDict& options)
                           ? kFpuValue
                           : options.Get<float>(kFpuValueAtRootId)),
       kCacheHistoryLength(options.Get<int>(kCacheHistoryLengthId)),
+      kPolicyFlattenThreshold(
+          options.Get<int>(kPolicyFlattenRateId)
+              ? (1 << options.Get<int>(kPolicyFlattenRateId)) - 1
+              : 0),
       kPolicySoftmaxTemp(options.Get<float>(kPolicySoftmaxTempId)),
       kMaxCollisionEvents(options.Get<int>(kMaxCollisionEventsId)),
       kMaxCollisionVisits(options.Get<int>(kMaxCollisionVisitsId)),

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -83,6 +83,7 @@ class SearchParams {
     return at_root ? kFpuValueAtRoot : kFpuValue;
   }
   int GetCacheHistoryLength() const { return kCacheHistoryLength; }
+  uint32_t GetPolicyFlattenThreshold() const { return kPolicyFlattenThreshold; }
   float GetPolicySoftmaxTemp() const { return kPolicySoftmaxTemp; }
   float GetShortSightedness() const { return kShortSightedness; }
   int GetMaxCollisionEvents() const { return kMaxCollisionEvents; }
@@ -140,6 +141,7 @@ class SearchParams {
   static const OptionId kFpuStrategyAtRootId;
   static const OptionId kFpuValueAtRootId;
   static const OptionId kCacheHistoryLengthId;
+  static const OptionId kPolicyFlattenRateId;
   static const OptionId kPolicySoftmaxTempId;
   static const OptionId kMaxCollisionEventsId;
   static const OptionId kMaxCollisionVisitsId;
@@ -187,6 +189,7 @@ class SearchParams {
   const bool kFpuAbsoluteAtRoot;
   const float kFpuValueAtRoot;
   const int kCacheHistoryLength;
+  const uint32_t kPolicyFlattenThreshold;
   const float kPolicySoftmaxTemp;
   const int kMaxCollisionEvents;
   const int kMaxCollisionVisits;


### PR DESCRIPTION
Just for testing for now as I don't really know what's a good value for `--policy-flatten-rate`. But functionally it seems to work in flattening policy (or not with 0):
```
ucinewgame
setoption name PolicyFlattenRate value 0
go nodes 1000

info g2g4 N:       1 (P:  1.17%) (Q: -0.41514) (U: 0.42263)
info f2f3 N:       1 (P:  1.24%) (Q: -0.32796) (U: 0.44898)
info g1h3 N:       2 (P:  1.46%) (Q: -0.21255) (U: 0.35183)
info h2h4 N:       2 (P:  1.66%) (Q: -0.17134) (U: 0.40056)
info b1a3 N:       2 (P:  1.65%) (Q: -0.15726) (U: 0.39799)
info f2f4 N:       3 (P:  1.83%) (Q: -0.11068) (U: 0.33077)
info b2b4 N:       4 (P:  2.01%) (Q: -0.10090) (U: 0.29099)
info a2a4 N:       5 (P:  2.42%) (Q: -0.05731) (U: 0.29196)
info h2h3 N:       7 (P:  2.60%) (Q: -0.02674) (U: 0.23546)
info a2a3 N:       7 (P:  2.68%) (Q: -0.02969) (U: 0.24201)
info d2d3 N:       7 (P:  2.76%) (Q: -0.02579) (U: 0.24973)
info b2b3 N:      11 (P:  3.28%) (Q:  0.01255) (U: 0.19752)
info b1c3 N:      14 (P:  3.81%) (Q:  0.02360) (U: 0.18377)
info c2c3 N:      19 (P:  4.49%) (Q:  0.04273) (U: 0.16249)
info e2e3 N:      30 (P:  5.59%) (Q:  0.06729) (U: 0.13035)
info c2c4 N:      32 (P:  5.83%) (Q:  0.06917) (U: 0.12770)
info g2g3 N:      40 (P:  6.52%) (Q:  0.07862) (U: 0.11498)
info d2d4 N:      50 (P:  7.83%) (Q:  0.08160) (U: 0.11104)
info g1f3 N:      51 (P:  7.90%) (Q:  0.08116) (U: 0.10988)
info e2e4 N:     711 (P: 33.25%) (Q:  0.12164) (U: 0.03373)

ucinewgame
setoption name PolicyFlattenRate value 3
go nodes 1000

info g2g4 N:       5 (P:  5.00%) (Q: -0.41396) (U: 0.60250)
info f2f3 N:       6 (P:  5.00%) (Q: -0.31704) (U: 0.51643)
info g1h3 N:       7 (P:  5.00%) (Q: -0.22438) (U: 0.45188)
info h2h4 N:       8 (P:  5.00%) (Q: -0.16463) (U: 0.40167)
info b1a3 N:       9 (P:  5.00%) (Q: -0.15483) (U: 0.36150)
info f2f4 N:      10 (P:  5.00%) (Q: -0.10452) (U: 0.32864)
info b2b4 N:      11 (P:  5.00%) (Q: -0.09469) (U: 0.30125)
info a2a4 N:      13 (P:  5.00%) (Q: -0.05277) (U: 0.25821)
info a2a3 N:      14 (P:  5.00%) (Q: -0.02655) (U: 0.24100)
info h2h3 N:      14 (P:  5.00%) (Q: -0.02622) (U: 0.24100)
info d2d3 N:      15 (P:  5.00%) (Q: -0.01177) (U: 0.22594)
info b2b3 N:      18 (P:  5.00%) (Q:  0.01508) (U: 0.19026)
info b1c3 N:      22 (P:  5.00%) (Q:  0.04513) (U: 0.15717)
info c2c3 N:      23 (P:  5.00%) (Q:  0.05428) (U: 0.15063)
info e2e3 N:      27 (P:  5.00%) (Q:  0.07275) (U: 0.12915)
info g2g3 N:      30 (P:  5.00%) (Q:  0.08257) (U: 0.11665)
info d2d4 N:     180 (P:  5.00%) (Q:  0.14426) (U: 0.01998)
info g1f3 N:     182 (P:  5.00%) (Q:  0.14433) (U: 0.01976)
info c2c4 N:     191 (P:  5.00%) (Q:  0.14020) (U: 0.01883)
info e2e4 N:     214 (P:  5.00%) (Q:  0.12188) (U: 0.01674)

ucinewgame
setoption name PolicyFlattenRate value 6
go nodes 1000

info g2g4 N:       5 (P:  5.00%) (Q: -0.41396) (U: 0.60250)
info f2f3 N:       6 (P:  5.00%) (Q: -0.31704) (U: 0.51643)
info g1h3 N:       7 (P:  5.00%) (Q: -0.22438) (U: 0.45188)
info h2h4 N:       8 (P:  5.00%) (Q: -0.16463) (U: 0.40167)
info b1a3 N:       9 (P:  5.00%) (Q: -0.15483) (U: 0.36150)
info f2f4 N:      10 (P:  5.00%) (Q: -0.10452) (U: 0.32864)
info b2b4 N:      11 (P:  5.00%) (Q: -0.10091) (U: 0.30125)
info a2a4 N:      13 (P:  5.00%) (Q: -0.05050) (U: 0.25821)
info h2h3 N:      15 (P:  5.00%) (Q: -0.02761) (U: 0.22594)
info a2a3 N:      15 (P:  5.00%) (Q: -0.02522) (U: 0.22594)
info d2d3 N:      16 (P:  5.00%) (Q: -0.01210) (U: 0.21265)
info b2b3 N:      19 (P:  5.00%) (Q:  0.01334) (U: 0.18075)
info b1c3 N:      22 (P:  5.00%) (Q:  0.02620) (U: 0.15717)
info c2c3 N:      25 (P:  5.00%) (Q:  0.04705) (U: 0.13904)
info e2e3 N:      32 (P:  5.00%) (Q:  0.06823) (U: 0.10958)
info c2c4 N:      33 (P:  5.00%) (Q:  0.07020) (U: 0.10636)
info g2g3 N:      38 (P:  5.00%) (Q:  0.07822) (U: 0.09272)
info d2d4 N:      39 (P:  5.00%) (Q:  0.07989) (U: 0.09040)
info g1f3 N:      40 (P:  5.00%) (Q:  0.08222) (U: 0.08820)
info e2e4 N:     636 (P:  5.00%) (Q:  0.15080) (U: 0.00567)

ucinewgame
setoption name PolicyFlattenRate value 9
go nodes 1000

info g2g4 N:       3 (P:  3.08%) (Q: -0.42292) (U: 0.55767)
info f2f3 N:       3 (P:  3.12%) (Q: -0.32738) (U: 0.56429)
info g1h3 N:       5 (P:  3.23%) (Q: -0.21543) (U: 0.38935)
info b1a3 N:       5 (P:  3.32%) (Q: -0.16437) (U: 0.40075)
info h2h4 N:       6 (P:  3.33%) (Q: -0.16074) (U: 0.34413)
info f2f4 N:       7 (P:  3.41%) (Q: -0.10783) (U: 0.30870)
info b2b4 N:       7 (P:  3.51%) (Q: -0.09951) (U: 0.31698)
info a2a4 N:      10 (P:  3.71%) (Q: -0.04824) (U: 0.24397)
info h2h3 N:      11 (P:  3.80%) (Q: -0.03115) (U: 0.22916)
info a2a3 N:      11 (P:  3.84%) (Q: -0.03330) (U: 0.23136)
info d2d3 N:      12 (P:  3.88%) (Q: -0.01679) (U: 0.21594)
info b2b3 N:      16 (P:  4.14%) (Q:  0.01446) (U: 0.17604)
info b1c3 N:      20 (P:  4.41%) (Q:  0.02921) (U: 0.15170)
info c2c3 N:      25 (P:  4.75%) (Q:  0.04705) (U: 0.13204)
info c2c4 N:      35 (P:  5.41%) (Q:  0.06864) (U: 0.10875)
info e2e3 N:      36 (P:  5.29%) (Q:  0.07248) (U: 0.10346)
info g2g3 N:      44 (P:  5.76%) (Q:  0.08030) (U: 0.09255)
info d2d4 N:      50 (P:  6.41%) (Q:  0.08164) (U: 0.09096)
info g1f3 N:      51 (P:  6.45%) (Q:  0.08116) (U: 0.08972)
info e2e4 N:     642 (P: 19.13%) (Q:  0.13620) (U: 0.02148)
```

And performance isn't impacted when doing benchmark random:
```
./lc0 benchmark --backend=random --backend-opts=uniform=true --num-positions=10

master / 938615a413f217be6fa8062652649bf4b901a502
Total time (ms) : 100026
Nodes searched  : 9363127
Nodes/second    : 93606

--policy-flatten-rate=0
Total time (ms) : 100025
Nodes searched  : 9361024
Nodes/second    : 93586

--policy-flatten-rate=10
Total time (ms) : 100023
Nodes searched  : 9299657
Nodes/second    : 92974

--policy-flatten-rate=13
Total time (ms) : 100026
Nodes searched  : 9317254
Nodes/second    : 93147
```