### PR TITLE
Flatten policy at specified ratio every 2^13 = ~10k visits.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -161,6 +161,11 @@ const OptionId SearchParams::kCacheHistoryLengthId{
     "this value is less than history that NN uses to eval a position, it's "
     "possble that the search will use eval of the same position with different "
     "history taken from cache."};
+const OptionId SearchParams::kPolicyFlattenRatioId{
+    "policy-flatten-ratio", "PolicyFlattenRatio",
+    "Ratio to move policy towards flat policy for every ~10k visits to a node. "
+    "0 means no flattening, 0.5 means moving halfway to flat, 1 means flatten "
+    "at 10k visits."};
 const OptionId SearchParams::kPolicySoftmaxTempId{
     "policy-softmax-temp", "PolicyTemperature",
     "Policy softmax temperature. Higher values make priors of move candidates "
@@ -290,6 +295,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kFpuStrategyAtRootId, fpu_strategy) = "same";
   options->Add<FloatOption>(kFpuValueAtRootId, -100.0f, 100.0f) = 1.0f;
   options->Add<IntOption>(kCacheHistoryLengthId, 0, 7) = 0;
+  options->Add<FloatOption>(kPolicyFlattenRatioId, 0.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kPolicySoftmaxTempId, 0.1f, 10.0f) = 1.607f;
   options->Add<IntOption>(kMaxCollisionEventsId, 1, 65536) = 32;
   options->Add<IntOption>(kMaxCollisionVisitsId, 1, 1000000) = 9999;
@@ -367,6 +373,7 @@ SearchParams::SearchParams(const OptionsDict& options)
                           ? kFpuValue
                           : options.Get<float>(kFpuValueAtRootId)),
       kCacheHistoryLength(options.Get<int>(kCacheHistoryLengthId)),
+      kPolicyFlattenRatio(options.Get<float>(kPolicyFlattenRatioId)),
       kPolicySoftmaxTemp(options.Get<float>(kPolicySoftmaxTempId)),
       kMaxCollisionEvents(options.Get<int>(kMaxCollisionEventsId)),
       kMaxCollisionVisits(options.Get<int>(kMaxCollisionVisitsId)),

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -83,6 +83,7 @@ class SearchParams {
     return at_root ? kFpuValueAtRoot : kFpuValue;
   }
   int GetCacheHistoryLength() const { return kCacheHistoryLength; }
+  float GetPolicyFlattenRatio() const { return kPolicyFlattenRatio; }
   float GetPolicySoftmaxTemp() const { return kPolicySoftmaxTemp; }
   float GetShortSightedness() const { return kShortSightedness; }
   int GetMaxCollisionEvents() const { return kMaxCollisionEvents; }
@@ -140,6 +141,7 @@ class SearchParams {
   static const OptionId kFpuStrategyAtRootId;
   static const OptionId kFpuValueAtRootId;
   static const OptionId kCacheHistoryLengthId;
+  static const OptionId kPolicyFlattenRatioId;
   static const OptionId kPolicySoftmaxTempId;
   static const OptionId kMaxCollisionEventsId;
   static const OptionId kMaxCollisionVisitsId;
@@ -187,6 +189,7 @@ class SearchParams {
   const bool kFpuAbsoluteAtRoot;
   const float kFpuValueAtRoot;
   const int kCacheHistoryLength;
+  const float kPolicyFlattenRatio;
   const float kPolicySoftmaxTemp;
   const int kMaxCollisionEvents;
   const int kMaxCollisionVisits;


### PR DESCRIPTION
Similar to #1251 to fix #743 but different param based on @oscardssmith's suggestion from https://github.com/LeelaChessZero/lc0/pull/1251/files#r417534372

Here's an example with 591226 from startpos and 20k visits triggering the flattening ratio 2 times at root:
```
ucinewgame
setoption name PolicyFlattenRatio value 0.0
go nodes 20000

info g2g4 N:       8 (P:  1.17%) (Q: -0.40427) (U: 0.77386)
info f2f3 N:      10 (P:  1.24%) (Q: -0.30928) (U: 0.67263)
info g1h3 N:      15 (P:  1.46%) (Q: -0.22179) (U: 0.54355)
info b1a3 N:      20 (P:  1.65%) (Q: -0.17104) (U: 0.46847)
info h2h4 N:      22 (P:  1.66%) (Q: -0.15449) (U: 0.43050)
info f2f4 N:      28 (P:  1.83%) (Q: -0.11196) (U: 0.37592)
info b2b4 N:      35 (P:  2.01%) (Q: -0.08764) (U: 0.33301)
info a2a4 N:      53 (P:  2.42%) (Q: -0.04226) (U: 0.26730)
info h2h3 N:      65 (P:  2.60%) (Q: -0.01929) (U: 0.23516)
info a2a3 N:      69 (P:  2.68%) (Q: -0.01709) (U: 0.22789)
info d2d3 N:      78 (P:  2.76%) (Q: -0.00249) (U: 0.20838)
info b2b3 N:     119 (P:  3.28%) (Q:  0.02791) (U: 0.16275)
info b1c3 N:     161 (P:  3.81%) (Q:  0.04232) (U: 0.14020)
info c2c3 N:     242 (P:  4.49%) (Q:  0.06207) (U: 0.11019)
info e2e3 N:     392 (P:  5.59%) (Q:  0.07815) (U: 0.08472)
info c2c4 N:     414 (P:  5.83%) (Q:  0.07877) (U: 0.08367)
info g2g3 N:     507 (P:  6.52%) (Q:  0.08323) (U: 0.07646)
info g1f3 N:     684 (P:  7.90%) (Q:  0.08799) (U: 0.06873)
info d2d4 N:     728 (P:  7.83%) (Q:  0.09085) (U: 0.06401)
info e2e4 N:   16349 (P: 33.25%) (Q:  0.11683) (U: 0.01212)


ucinewgame
setoption name PolicyFlattenRatio value 0.25
go nodes 20000

info g2g4 N:      15 (P:  2.85%) (Q: -0.41301) (U: 1.05955)
info f2f3 N:      20 (P:  2.89%) (Q: -0.29371) (U: 0.81896)
info g1h3 N:      27 (P:  3.01%) (Q: -0.21424) (U: 0.64020)
info b1a3 N:      33 (P:  3.12%) (Q: -0.16921) (U: 0.54608)
info h2h4 N:      35 (P:  3.12%) (Q: -0.15268) (U: 0.51675)
info f2f4 N:      42 (P:  3.22%) (Q: -0.11524) (U: 0.44574)
info b2b4 N:      51 (P:  3.32%) (Q: -0.08295) (U: 0.38031)
info a2a4 N:      72 (P:  3.55%) (Q: -0.03914) (U: 0.28983)
info h2h3 N:      85 (P:  3.65%) (Q: -0.02053) (U: 0.25300)
info a2a3 N:      89 (P:  3.69%) (Q: -0.01676) (U: 0.24448)
info d2d3 N:     102 (P:  3.74%) (Q: -0.00180) (U: 0.21645)
info b2b3 N:     151 (P:  4.03%) (Q:  0.02935) (U: 0.15804)
info b1c3 N:     212 (P:  4.33%) (Q:  0.05003) (U: 0.12119)
info c2c3 N:     283 (P:  4.71%) (Q:  0.06197) (U: 0.09893)
info e2e3 N:     451 (P:  5.33%) (Q:  0.07864) (U: 0.07028)
info c2c4 N:     486 (P:  5.46%) (Q:  0.08039) (U: 0.06686)
info g2g3 N:     553 (P:  5.85%) (Q:  0.08237) (U: 0.06296)
info g1f3 N:     744 (P:  6.63%) (Q:  0.08804) (U: 0.05304)
info d2d4 N:     843 (P:  6.59%) (Q:  0.09276) (U: 0.04654)
info e2e4 N:   15705 (P: 20.89%) (Q:  0.11867) (U: 0.00792)


ucinewgame
setoption name PolicyFlattenRatio value 0.5
go nodes 20000

info g2g4 N:      21 (P:  4.04%) (Q: -0.43151) (U: 1.09480)
info f2f3 N:      30 (P:  4.06%) (Q: -0.27745) (U: 0.78048)
info g1h3 N:      38 (P:  4.12%) (Q: -0.20728) (U: 0.62877)
info b1a3 N:      43 (P:  4.16%) (Q: -0.17813) (U: 0.56373)
info h2h4 N:      48 (P:  4.17%) (Q: -0.14767) (U: 0.50657)
info f2f4 N:      56 (P:  4.21%) (Q: -0.11113) (U: 0.43978)
info b2b4 N:      68 (P:  4.25%) (Q: -0.07786) (U: 0.36725)
info a2a4 N:      93 (P:  4.35%) (Q: -0.03106) (U: 0.27606)
info h2h3 N:     103 (P:  4.40%) (Q: -0.01959) (U: 0.25214)
info a2a3 N:     109 (P:  4.42%) (Q: -0.01326) (U: 0.23938)
info d2d3 N:     118 (P:  4.44%) (Q: -0.00322) (U: 0.22234)
info b2b3 N:     170 (P:  4.57%) (Q:  0.02985) (U: 0.15920)
info b1c3 N:     212 (P:  4.70%) (Q:  0.04389) (U: 0.13156)
info c2c3 N:     302 (P:  4.87%) (Q:  0.06383) (U: 0.09584)
info e2e3 N:     423 (P:  5.15%) (Q:  0.07624) (U: 0.07233)
info c2c4 N:     472 (P:  5.21%) (Q:  0.08022) (U: 0.06559)
info g2g3 N:     535 (P:  5.38%) (Q:  0.08293) (U: 0.05980)
info g1f3 N:     669 (P:  5.73%) (Q:  0.08752) (U: 0.05092)
info d2d4 N:     718 (P:  5.71%) (Q:  0.09032) (U: 0.04730)
info e2e4 N:   15771 (P: 12.06%) (Q:  0.12459) (U: 0.00456)


ucinewgame
setoption name PolicyFlattenRatio value 0.75
go nodes 20000

info g2g4 N:      30 (P:  4.76%) (Q: -0.42360) (U: 0.91510)
info f2f3 N:      40 (P:  4.77%) (Q: -0.28614) (U: 0.69257)
info g1h3 N:      52 (P:  4.78%) (Q: -0.19926) (U: 0.53731)
info b1a3 N:      56 (P:  4.79%) (Q: -0.18385) (U: 0.50088)
info h2h4 N:      64 (P:  4.79%) (Q: -0.14236) (U: 0.43923)
info f2f4 N:      75 (P:  4.80%) (Q: -0.10632) (U: 0.37650)
info b2b4 N:      92 (P:  4.81%) (Q: -0.06718) (U: 0.30836)
info a2a4 N:     120 (P:  4.84%) (Q: -0.02831) (U: 0.23828)
info h2h3 N:     137 (P:  4.85%) (Q: -0.01252) (U: 0.20945)
info a2a3 N:     140 (P:  4.86%) (Q: -0.00908) (U: 0.20519)
info d2d3 N:     146 (P:  4.86%) (Q: -0.00442) (U: 0.19700)
info b2b3 N:     219 (P:  4.89%) (Q:  0.03424) (U: 0.13250)
info b1c3 N:     267 (P:  4.93%) (Q:  0.04692) (U: 0.10952)
info c2c3 N:     352 (P:  4.97%) (Q:  0.06271) (U: 0.08387)
info e2e3 N:     516 (P:  5.04%) (Q:  0.07798) (U: 0.05805)
info c2c4 N:     525 (P:  5.05%) (Q:  0.07808) (U: 0.05723)
info g2g3 N:     591 (P:  5.09%) (Q:  0.08139) (U: 0.05128)
info g1f3 N:     762 (P:  5.18%) (Q:  0.08786) (U: 0.04047)
info d2d4 N:     874 (P:  5.18%) (Q:  0.09206) (U: 0.03526)
info e2e4 N:   14941 (P:  6.77%) (Q:  0.12030) (U: 0.00270)


ucinewgame
setoption name PolicyFlattenRatio value 1.0
go nodes 20000

info g2g4 N:      38 (P:  5.00%) (Q: -0.41758) (U: 0.76399)
info f2f3 N:      52 (P:  5.00%) (Q: -0.27981) (U: 0.56218)
info g1h3 N:      64 (P:  5.00%) (Q: -0.20384) (U: 0.45840)
info b1a3 N:      77 (P:  5.00%) (Q: -0.14931) (U: 0.38200)
info h2h4 N:      80 (P:  5.00%) (Q: -0.14288) (U: 0.36785)
info f2f4 N:      99 (P:  5.00%) (Q: -0.09313) (U: 0.29796)
info b2b4 N:     114 (P:  5.00%) (Q: -0.06561) (U: 0.25909)
info a2a4 N:     144 (P:  5.00%) (Q: -0.02859) (U: 0.20549)
info h2h3 N:     160 (P:  5.00%) (Q: -0.01395) (U: 0.18507)
info a2a3 N:     168 (P:  5.00%) (Q: -0.00827) (U: 0.17631)
info d2d3 N:     176 (P:  5.00%) (Q: -0.00302) (U: 0.16834)
info b2b3 N:     257 (P:  5.00%) (Q:  0.03389) (U: 0.11549)
info b1c3 N:     303 (P:  5.00%) (Q:  0.04621) (U: 0.09801)
info c2c3 N:     389 (P:  5.00%) (Q:  0.06131) (U: 0.07640)
info e2e3 N:     559 (P:  5.00%) (Q:  0.07739) (U: 0.05321)
info c2c4 N:     572 (P:  5.00%) (Q:  0.07800) (U: 0.05200)
info g2g3 N:     605 (P:  5.00%) (Q:  0.08033) (U: 0.04917)
info g1f3 N:     768 (P:  5.00%) (Q:  0.08740) (U: 0.03875)
info d2d4 N:     906 (P:  5.00%) (Q:  0.09148) (U: 0.03285)
info e2e4 N:   14468 (P:  5.00%) (Q:  0.11632) (U: 0.00206)
```