### PR TITLE
fix weight memory check to be more conservative

### DIFF
--- a/src/neural/cuda/layers.cc
+++ b/src/neural/cuda/layers.cc
@@ -206,7 +206,7 @@ void ConvLayer<float>::LoadWeights(float* pfilter, float* pBias,
     ReportCUDAErrors(
         cudaMemcpy(biases, pBias, blas_size, cudaMemcpyHostToDevice));
   } else {
-    ReportCUDAErrors(cudaMemset(biases, blas_size, 0));
+    ReportCUDAErrors(cudaMemset(biases, 0, blas_size));
   }
 }
 
@@ -375,24 +375,24 @@ void SELayer<half>::LoadWeights(float* w1, float* b1, float* w2, float* b2,
   // Weight for the first FC layer.
   ReportCUDAErrors(
       cudaMemcpy(scratch, w1, weight_size1, cudaMemcpyHostToDevice));
-  copyTypeConverted((half*)w1_, (float*)scratch, num_weights1);
+  copyTypeConverted((half*)w1_, (float*)scratch, (int)num_weights1);
   if (kUseFusedSELayer && nhwc_) {
     // transposed copy for fused SE kernel
     cpuTranspose(temp.data(), w1, numFc1Out_, C);
     ReportCUDAErrors(
         cudaMemcpy(scratch, temp.data(), weight_size1, cudaMemcpyHostToDevice));
-    copyTypeConverted((half*)w1_t_, (float*)scratch, num_weights1);
+    copyTypeConverted((half*)w1_t_, (float*)scratch, (int)num_weights1);
   }
 
   // Weight for the second FC layer.
   ReportCUDAErrors(
       cudaMemcpy(scratch, w2, weight_size2, cudaMemcpyHostToDevice));
-  copyTypeConverted((half*)w2_, (float*)scratch, num_weights2);
+  copyTypeConverted((half*)w2_, (float*)scratch, (int)num_weights2);
   if (kUseFusedSELayer && nhwc_) {
     cpuTranspose(temp.data(), w2, 2 * C, numFc1Out_);
     ReportCUDAErrors(
         cudaMemcpy(scratch, temp.data(), weight_size2, cudaMemcpyHostToDevice));
-    copyTypeConverted((half*)w2_t_, (float*)scratch, num_weights2);
+    copyTypeConverted((half*)w2_t_, (float*)scratch, (int)num_weights2);
   }
 
   // Bias for the first FC layer.
@@ -521,17 +521,17 @@ void FCLayer<half>::LoadWeights(float* cpuWeight, float* cpuBias,
       cudaMemcpy(scratch, cpuWeight, weight_size, cudaMemcpyHostToDevice));
 
   if (nhwc_) {
-    fp32NCHWtofp16NHWC((half*)weights_, (float*)scratch, num_biases,
-                       input_->GetC(), num_biases, input_->GetC(),
+    fp32NCHWtofp16NHWC((half*)weights_, (float*)scratch, (int)num_biases,
+                       input_->GetC(), (int)num_biases, input_->GetC(),
                        input_->GetH(), input_->GetW());
   } else {
-    copyTypeConverted((half*)weights_, (float*)scratch, num_weights);
+    copyTypeConverted((half*)weights_, (float*)scratch, (int)num_weights);
   }
 
   if (cpuBias) {
     ReportCUDAErrors(
         cudaMemcpy(scratch, cpuBias, blas_size, cudaMemcpyHostToDevice));
-    copyTypeConverted((half*)biases_, (float*)scratch, num_biases);
+    copyTypeConverted((half*)biases_, (float*)scratch, (int)num_biases);
   }
 }
 
@@ -795,23 +795,23 @@ void FusedWinogradConvSELayer<DataType>::LoadSEWeights(float* w1, float* b1,
   CpuTranspose(temp_transposed.data(), w1, se_k_, C);
   ReportCUDAErrors(cudaMemcpy(scratch, temp_transposed.data(), num_weights1*sizeof(float),
                               cudaMemcpyHostToDevice));
-  copyTypeConverted((DataType*)w1_, (float*)scratch, num_weights1);
+  copyTypeConverted((DataType*)w1_, (float*)scratch, (int)num_weights1);
 
   CpuTranspose(temp_transposed.data(), w2, 2 * C, se_k_);
   ReportCUDAErrors(cudaMemcpy(scratch, temp_transposed.data(),
                               num_weights2 * sizeof(float),
                               cudaMemcpyHostToDevice));
-  copyTypeConverted((DataType*)w2_, (float*)scratch, num_weights2);
+  copyTypeConverted((DataType*)w2_, (float*)scratch, (int)num_weights2);
 
 
 
   ReportCUDAErrors(cudaMemcpy(scratch, b1, num_biases1 * sizeof(float),
                               cudaMemcpyHostToDevice));
-  copyTypeConverted((DataType*)b1_, (float*)scratch, num_biases1);
+  copyTypeConverted((DataType*)b1_, (float*)scratch, (int)num_biases1);
 
   ReportCUDAErrors(cudaMemcpy(scratch, b2, num_biases2 * sizeof(float),
                               cudaMemcpyHostToDevice));
-  copyTypeConverted((DataType*)b2_, (float*)scratch, num_biases2);
+  copyTypeConverted((DataType*)b2_, (float*)scratch, (int)num_biases2);
 }
 
 template <>

--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -276,8 +276,8 @@ class CudnnNetwork : public Network {
 
     constexpr bool fp16 = std::is_same<half, DataType>::value;
     const int kNumInputPlanes = kInputPlanes;
-    const int kNumFilters = weights.input.biases.size();
-    numBlocks_ = weights.residual.size();
+    const int kNumFilters = (int)weights.input.biases.size();
+    numBlocks_ = (int)weights.residual.size();
 
     // Use our custom winograd for residual tower convolutions for most cases:
     //
@@ -306,34 +306,36 @@ class CudnnNetwork : public Network {
       use_custom_winograd_ = true;
     }
 
-    // Override if set in backend-opts.
-    if (!options.IsDefault<bool>("custom_winograd"))
-      use_custom_winograd_ = options.Get<bool>("custom_winograd");
-
     // Warn if the memory required for storing transformed weights is
-    // going to exceed 60% of total video memory, force custom_winograd off
-    // if it's going to exceed 80% of memory.
+    // going to exceed 40% of total video memory, force custom_winograd off
+    // if it's going to exceed 50% of memory.
     size_t residual_single_layer_weight_size =
         3 * 3 * kNumFilters * kNumFilters * sizeof(DataType);
     size_t residual_weight_size =
         residual_single_layer_weight_size * numBlocks_ * 2;
     size_t transformed_residual_weight_size = residual_weight_size * 4;
+
     if (residual_weight_size > 0.6 * deviceProp.totalGlobalMem) {
       CERR << "Low video memory detected. You may run into OOM errors. Please "
               "consider using a smaller network.";
-      // No hope of using custom winograd - even the fallback path might not run.
+    }
+    if (use_custom_winograd_ &&
+        transformed_residual_weight_size > 0.5 * deviceProp.totalGlobalMem) {
+      CERR << "WARNING: Low GPU video memory. Turning off custom_winograd "
+              "path. You may still run into OOM errors. "
+              "Please consider using a smaller network.";
       use_custom_winograd_ = false;
-    } else if (use_custom_winograd_) {
-      if (transformed_residual_weight_size > 0.8 * deviceProp.totalGlobalMem) {
-        CERR << "WARNING: Low GPU video memory detected. Turning off "
-                "custom_winograd.";
-        use_custom_winograd_ = false;
-      } else if (transformed_residual_weight_size >
-                 0.6 * deviceProp.totalGlobalMem) {
-        CERR << "WARNING: Low GPU video memory. You may run into OOM errors. "
-                "Please consider using a smaller network, or run with "
-                "--backend-opts=custom_winograd=false";
-      }
+    }
+    
+    // Override if set in backend-opts.
+    if (!options.IsDefault<bool>("custom_winograd"))
+      use_custom_winograd_ = options.Get<bool>("custom_winograd");
+    
+    if (use_custom_winograd_ &&
+        transformed_residual_weight_size > 0.4 * deviceProp.totalGlobalMem) {
+      CERR << "WARNING: Low GPU video memory. You may still run into OOM "
+              "errors. Try with backend-opts=custom_winograd=false, or "
+              "using a smaller network.";
     }
 
     // Winograd needs nchw tensor layout.
@@ -387,7 +389,7 @@ class CudnnNetwork : public Network {
         cudnn_, xDesc, wDesc, convDesc, xDesc, conv_algo, &scratch_size_));
 
     // Have some minumum as we also use this for transforming weights.
-    int max_weight_size = 128 * 1024 * 1024;
+    size_t max_weight_size = 128 * 1024 * 1024;
 
     // parts from scratch allocation are suballocated to hold various weights
     // and biases when transforming winograd weights (one layer at a time), 128
@@ -434,7 +436,7 @@ class CudnnNetwork : public Network {
         network_.emplace_back(std::move(conv1));
 
         bool has_se = weights.residual[block].has_se;
-        int se_k = weights.residual[block].se.b1.size();
+        int se_k = (int)weights.residual[block].se.b1.size();
         auto conv2 = std::make_unique<FusedWinogradConvSELayer<DataType>>(
             getLastLayer(), kNumFilters, 8, 8, kNumFilters, true, true, true,
             has_se, se_k, use_gemm_ex);
@@ -468,7 +470,7 @@ class CudnnNetwork : public Network {
         network_.emplace_back(std::move(conv2));
 
         if (weights.residual[block].has_se) {
-          int numFCOut = weights.residual[block].se.b1.size();
+          int numFCOut = (int)weights.residual[block].se.b1.size();
           auto se = std::make_unique<SELayer<DataType>>(getLastLayer(),
                                                         numFCOut, false);
           se->LoadWeights(&weights.residual[block].se.w1[0],
@@ -919,7 +921,7 @@ class CudnnNetwork : public Network {
               "version "
            << major << "." << minor << "." << pl;
     }
-    version = cudnnGetVersion();
+    version = (int)cudnnGetVersion();
     major = version / 1000;
     minor = (version - major * 1000) / 100;
     pl = version - major * 1000 - minor * 100;
@@ -948,7 +950,7 @@ class CudnnNetwork : public Network {
     CERR << "GPU compute capability: " << deviceProp.major << "."
          << deviceProp.minor;
 
-    int version = cudnnGetVersion();
+    int version = (int)cudnnGetVersion();
     if (version < 7301 && (deviceProp.major > 7 ||
                            (deviceProp.major == 7 && deviceProp.minor >= 5))) {
       CERR << "WARNING: CUDNN version 7.3.1 or newer is better for this GPU.";

--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -319,7 +319,10 @@ class CudnnNetwork : public Network {
       CERR << "Low video memory detected. You may run into OOM errors. Please "
               "consider using a smaller network.";
     }
-    if (use_custom_winograd_ &&
+
+    const bool custom_winograd_override = !options.IsDefault<bool>("custom_winograd");
+
+    if (!custom_winograd_override && use_custom_winograd_ &&
         transformed_residual_weight_size > 0.5 * deviceProp.totalGlobalMem) {
       CERR << "WARNING: Low GPU video memory. Turning off custom_winograd "
               "path. You may still run into OOM errors. "
@@ -328,7 +331,7 @@ class CudnnNetwork : public Network {
     }
     
     // Override if set in backend-opts.
-    if (!options.IsDefault<bool>("custom_winograd"))
+    if (custom_winograd_override)
       use_custom_winograd_ = options.Get<bool>("custom_winograd");
     
     if (use_custom_winograd_ &&


### PR DESCRIPTION
- 60% memory usage for transformed weights is too optimistic. Try 40% for warning, and 50% for auto-disable of custom_winograd.
- Address @borg323 's comment for my previous pull request (allow user to override with warning).
- also fix (size_t)->(int) conversion warnings in cudnn backend