### PR TITLE
Include verbose stats for the node.

### DIFF
--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -135,7 +135,7 @@ class Search {
   std::vector<std::string> GetVerboseStats(Node* node) const;
 
   // Returns NN eval for a given node from cache, if that node is cached.
-  NNCacheLock GetCachedNNEval(Node* node) const;
+  NNCacheLock GetCachedNNEval(const Node* node) const;
 
   // Returns the draw score at the root of the search. At odd depth pass true to
   // the value of @is_odd_depth to change the sign of the draw score.


### PR DESCRIPTION
r?@mooskagh or @Tilps I've noticed it's a bit cumbersome to get the Q/V of a position where currently you can get the cp score with `go nodes 1` or you need to have the previous position and `go nodes 2 searchmoves …`. Also when using `--per-pv-counters`, it's tedious to figure out how many total nodes so far and similarly counting up the possible number of moves.

I've added those stats as `node` in verbose output like the children and set the P to be VisitedPolicy and skipped U and S. ~I wasn't sure if I should flip the WL/Q values to match the children… but not flipping makes move stat of the child match the node stat of opponent move~ see https://github.com/LeelaChessZero/lc0/pull/1268#issuecomment-624254666:

```
position fen 1K//k1r
go nodes 23

uciloop.cc:222] << info nodes 23 score cp -1143 pv b8a8 c6c4 a8b8 a6b6 b8a8
 search.cc:415] === Move stats:
 search.cc:416] b8a8  (1638) N:      22 (+ 0) (P: 100.00%) (WL: -0.95427) (D:  0.046) (M:  1.7) (Q: -0.95427) (U: 0.43851) (S: -0.51576) (V: -0.9997) (L) 
 search.cc:416] node  (   1) N:      23 (+ 0) (P: 100.00%) (WL:  0.95624) (D:  0.044) (M:  2.6) (Q:  0.95624) (V:  0.9996) 
 search.cc:419] --- Opponent moves after: b8a8
 search.cc:423] a6a5  (425 ) N:       0 (+ 0) (P:  6.09%) (WL:  0.00000) (D:  0.000) (M:  0.0) (Q:  0.62028) (U: 0.60049) (S:  1.22077) (V:  -.----) 
 search.cc:423] a6b6  (418 ) N:       0 (+ 0) (P:  6.10%) (WL:  0.00000) (D:  0.000) (M:  0.0) (Q:  0.62028) (U: 0.60079) (S:  1.22107) (V:  -.----) 
 search.cc:423] c6h6  (482 ) N:       0 (+ 0) (P:  6.16%) (WL:  0.00000) (D:  0.000) (M:  0.0) (Q:  0.62028) (U: 0.60725) (S:  1.22754) (V:  -.----) 
 search.cc:423] c6f6  (480 ) N:       0 (+ 0) (P:  6.18%) (WL:  0.00000) (D:  0.000) (M:  0.0) (Q:  0.62028) (U: 0.60936) (S:  1.22964) (V:  -.----) 
 search.cc:423] c6c7  (473 ) N:       0 (+ 0) (P:  6.20%) (WL:  0.00000) (D:  0.000) (M:  0.0) (Q:  0.62028) (U: 0.61041) (S:  1.23069) (V:  -.----) 
 search.cc:423] a6b5  (426 ) N:       0 (+ 0) (P:  6.20%) (WL:  0.00000) (D:  0.000) (M:  0.0) (Q:  0.62028) (U: 0.61086) (S:  1.23114) (V:  -.----) 
 search.cc:423] c6c8  (468 ) N:       0 (+ 0) (P:  6.23%) (WL:  0.00000) (D:  0.000) (M:  0.0) (Q:  0.62028) (U: 0.61357) (S:  1.23385) (V:  -.----) 
 search.cc:423] c6b6  (477 ) N:       1 (+ 0) (P:  6.27%) (WL:  0.00000) (D:  1.000) (M:  0.0) (Q:  0.00000) (U: 0.30911) (S:  0.30911) (V:  0.0000) (T) 
 search.cc:423] c6g6  (481 ) N:       2 (+ 0) (P:  6.23%) (WL:  0.99974) (D:  0.000) (M:  0.5) (Q:  0.99974) (U: 0.20457) (S:  1.20431) (V:  0.9998) 
 search.cc:423] c6d6  (478 ) N:       2 (+ 0) (P:  6.23%) (WL:  0.99972) (D:  0.000) (M:  0.5) (Q:  0.99972) (U: 0.20462) (S:  1.20434) (V:  0.9998) 
 search.cc:423] c6e6  (479 ) N:       2 (+ 0) (P:  6.24%) (WL:  0.99974) (D:  0.000) (M:  0.5) (Q:  0.99974) (U: 0.20497) (S:  1.20472) (V:  0.9998) 
 search.cc:423] c6c2  (495 ) N:       2 (+ 0) (P:  6.34%) (WL:  0.99968) (D:  0.000) (M:  0.5) (Q:  0.99968) (U: 0.20818) (S:  1.20786) (V:  0.9998) 
 search.cc:423] c6c4  (490 ) N:       3 (+ 0) (P:  6.34%) (WL:  0.99972) (D:  0.000) (M:  1.0) (Q:  0.99972) (U: 0.15614) (S:  1.15586) (V:  0.9998) 
 search.cc:423] c6c5  (485 ) N:       3 (+ 0) (P:  6.34%) (WL:  0.99971) (D:  0.000) (M:  1.0) (Q:  0.99971) (U: 0.15621) (S:  1.15592) (V:  0.9997) 
 search.cc:423] c6c3  (493 ) N:       3 (+ 0) (P:  6.37%) (WL:  0.99972) (D:  0.000) (M:  1.0) (Q:  0.99972) (U: 0.15696) (S:  1.15668) (V:  0.9998) 
 search.cc:423] c6c1  (497 ) N:       3 (+ 0) (P:  6.48%) (WL:  0.99967) (D:  0.000) (M:  1.0) (Q:  0.99967) (U: 0.15952) (S:  1.15919) (V:  0.9998) 
 search.cc:423] node  (  16) N:      22 (+ 0) (P: 56.84%) (WL: -0.95427) (D:  0.046) (M:  1.7) (Q: -0.95427) (V: -0.9997) (L) 
uciloop.cc:222] << bestmove b8a8 ponder c6c4


go nodes 1

uciloop.cc:222] << info nodes 24 score mate -1 pv b8a8 c6c8
 search.cc:415] === Move stats:
 search.cc:416] b8a8  (1638) N:      23 (+ 0) (P: 100.00%) (WL: -1.00000) (D:  0.000) (M:  1.0) (Q: -1.00000) (U: 0.42971) (S: -0.57029) (V: -1.0000) (T) 
 search.cc:416] node  (   1) N:      24 (+ 0) (P: 100.00%) (WL:  0.95807) (D:  0.042) (M:  2.5) (Q:  0.95807) (V:  0.9996) 
 search.cc:419] --- Opponent moves after: b8a8
 search.cc:423] a6a5  (425 ) N:       0 (+ 0) (P:  6.09%) (WL:  0.00000) (D:  0.000) (M:  0.0) (Q:  0.64819) (U: 0.61466) (S:  1.26285) (V:  -.----) 
 search.cc:423] a6b6  (418 ) N:       0 (+ 0) (P:  6.10%) (WL:  0.00000) (D:  0.000) (M:  0.0) (Q:  0.64819) (U: 0.61497) (S:  1.26316) (V:  -.----) 
 search.cc:423] c6h6  (482 ) N:       0 (+ 0) (P:  6.16%) (WL:  0.00000) (D:  0.000) (M:  0.0) (Q:  0.64819) (U: 0.62159) (S:  1.26978) (V:  -.----) 
 search.cc:423] c6f6  (480 ) N:       0 (+ 0) (P:  6.18%) (WL:  0.00000) (D:  0.000) (M:  0.0) (Q:  0.64819) (U: 0.62374) (S:  1.27193) (V:  -.----) 
 search.cc:423] c6c7  (473 ) N:       0 (+ 0) (P:  6.20%) (WL:  0.00000) (D:  0.000) (M:  0.0) (Q:  0.64819) (U: 0.62482) (S:  1.27301) (V:  -.----) 
 search.cc:423] a6b5  (426 ) N:       0 (+ 0) (P:  6.20%) (WL:  0.00000) (D:  0.000) (M:  0.0) (Q:  0.64819) (U: 0.62528) (S:  1.27347) (V:  -.----) 
 search.cc:423] c6b6  (477 ) N:       1 (+ 0) (P:  6.27%) (WL:  0.00000) (D:  1.000) (M:  0.0) (Q:  0.00000) (U: 0.31641) (S:  0.31641) (V:  0.0000) (T) 
 search.cc:423] c6c8  (468 ) N:       1 (+ 0) (P:  6.23%) (WL:  1.00000) (D:  0.000) (M:  0.0) (Q:  1.00000) (U: 0.31403) (S:  1.31403) (V:  1.0000) (T) 
 search.cc:423] c6g6  (481 ) N:       2 (+ 0) (P:  6.23%) (WL:  0.99974) (D:  0.000) (M:  0.5) (Q:  0.99974) (U: 0.20940) (S:  1.20914) (V:  0.9998) 
 search.cc:423] c6d6  (478 ) N:       2 (+ 0) (P:  6.23%) (WL:  0.99972) (D:  0.000) (M:  0.5) (Q:  0.99972) (U: 0.20945) (S:  1.20917) (V:  0.9998) 
 search.cc:423] c6e6  (479 ) N:       2 (+ 0) (P:  6.24%) (WL:  0.99974) (D:  0.000) (M:  0.5) (Q:  0.99974) (U: 0.20981) (S:  1.20956) (V:  0.9998) 
 search.cc:423] c6c2  (495 ) N:       2 (+ 0) (P:  6.34%) (WL:  0.99968) (D:  0.000) (M:  0.5) (Q:  0.99968) (U: 0.21310) (S:  1.21277) (V:  0.9998) 
 search.cc:423] c6c4  (490 ) N:       3 (+ 0) (P:  6.34%) (WL:  0.99972) (D:  0.000) (M:  1.0) (Q:  0.99972) (U: 0.15982) (S:  1.15954) (V:  0.9998) 
 search.cc:423] c6c5  (485 ) N:       3 (+ 0) (P:  6.34%) (WL:  0.99971) (D:  0.000) (M:  1.0) (Q:  0.99971) (U: 0.15990) (S:  1.15961) (V:  0.9997) 
 search.cc:423] c6c3  (493 ) N:       3 (+ 0) (P:  6.37%) (WL:  0.99972) (D:  0.000) (M:  1.0) (Q:  0.99972) (U: 0.16067) (S:  1.16038) (V:  0.9998) 
 search.cc:423] c6c1  (497 ) N:       3 (+ 0) (P:  6.48%) (WL:  0.99967) (D:  0.000) (M:  1.0) (Q:  0.99967) (U: 0.16328) (S:  1.16295) (V:  0.9998) 
 search.cc:423] node  (  16) N:      23 (+ 0) (P: 63.07%) (WL: -1.00000) (D:  0.000) (M:  1.0) (Q: -1.00000) (V: -1.0000) (T) 
uciloop.cc:222] << bestmove b8a8 ponder c6c8
```
![1K::k1r](https://user-images.githubusercontent.com/438537/81022208-e4170400-8e21-11ea-90c4-f762ddfb9c69.png)
