### PR TITLE
Small policy calculation optimization

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1436,6 +1436,7 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
                                     node_to_process->probability_transform)));
   }
   float total = 0.0;
+  int counter = 0;
   for (auto edge : node->Edges()) {
     float p = computation_->GetPVal(
         idx_in_computation,
@@ -1444,16 +1445,15 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
     // Note that we want to calculate (exp(p-max_p))^(1/T) = exp((p-max_p)/T).
     p = FastExp((p - max_p) / params_.GetPolicySoftmaxTemp());
 
-    // Note that p now lies in [0, 1], so it is safe to store it in compressed
-    // format. Normalization happens later.
-    edge.edge()->SetP(p);
+    intermediate_[counter++] = p;
     // Edge::SetP does some rounding, so only add to the total after rounding.
-    total += edge.edge()->GetP();
+    total += p;
   }
+  counter = 0;
   // Normalize P values to add up to 1.0.
   if (total > 0.0f) {
     const float scale = 1.0f / total;
-    for (auto edge : node->Edges()) edge.edge()->SetP(edge.GetP() * scale);
+    for (auto edge : node->Edges()) edge.edge()->SetP(intermediate_[counter++] * scale);
   }
   // Add Dirichlet noise if enabled and at root.
   if (params_.GetNoiseEpsilon() && node == search_->root_node_) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1453,6 +1453,8 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
   if (total > 0.0f) {
     const float scale = 1.0f / total;
     for (auto edge : node->Edges()) edge.edge()->SetP(intermediate_[counter++] * scale);
+  } else {
+    for (auto edge : node->Edges()) edge.edge()->SetP(intermediate_[counter++]);
   }
   // Add Dirichlet noise if enabled and at root.
   if (params_.GetNoiseEpsilon() && node == search_->root_node_) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -35,6 +35,7 @@
 #include <iterator>
 #include <sstream>
 #include <thread>
+#include <array>
 
 #include "mcts/node.h"
 #include "neural/cache.h"

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1446,7 +1446,6 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
     p = FastExp((p - max_p) / params_.GetPolicySoftmaxTemp());
 
     intermediate_[counter++] = p;
-    // Edge::SetP does some rounding, so only add to the total after rounding.
     total += p;
   }
   counter = 0;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1436,11 +1436,8 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
                                     node_to_process->probability_transform)));
   }
   // Intermediate array to store values when processing policy.
-  // According to a lichess developer post:
-  // https://lichess.org/blog/Wqa7GiAAAOIpBLoY/
-  //     developer-update-275-improved-game-compression
-  // there are never more than 256 valid legal moves in any legal position.
-  float intermediate[256];
+  // There are never more than 256 valid legal moves in any legal position.
+  std::array<float, 256> intermediate;
   float total = 0.0;
   int counter = 0;
   for (auto edge : node->Edges()) {

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -328,12 +328,6 @@ class SearchWorker {
   const bool moves_left_support_;
   IterationStats iteration_stats_;
   StoppersHints latest_time_manager_hints_;
-  // Intermediate array to store values when processing policy.
-  // According to a lichess developer post:
-  // https://lichess.org/blog/Wqa7GiAAAOIpBLoY/
-  //     developer-update-275-improved-game-compression
-  // there are never more than 256 valid legal moves in any legal position.
-  float intermediate_[256];
 };
 
 }  // namespace lczero

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -328,7 +328,7 @@ class SearchWorker {
   const bool moves_left_support_;
   IterationStats iteration_stats_;
   StoppersHints latest_time_manager_hints_;
-  // Intermediate array to store values when processing policy temperature decay.
+  // Intermediate array to store values when processing policy.
   // According to a lichess developer post:
   // https://lichess.org/blog/Wqa7GiAAAOIpBLoY/
   //     developer-update-275-improved-game-compression

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -328,6 +328,12 @@ class SearchWorker {
   const bool moves_left_support_;
   IterationStats iteration_stats_;
   StoppersHints latest_time_manager_hints_;
+  // Intermediate array to store values when processing policy temperature decay.
+  // According to a lichess developer post:
+  // https://lichess.org/blog/Wqa7GiAAAOIpBLoY/
+  //     developer-update-275-improved-game-compression
+  // there are never more than 256 valid legal moves in any legal position.
+  float intermediate_[256];
 };
 
 }  // namespace lczero


### PR DESCRIPTION
3-4% speedup in random backend. May be noise or hardware dependent, it would be appreciated if more people could test it.

```
./lc0_policy_optimized benchmark --backend=random
===========================
Total time (ms) : 340446
Nodes searched  : 69693334
Nodes/second    : 204711

./lc0_c4c92f6 benchmark --backend=random
===========================
Total time (ms) : 340487
Nodes searched  : 67522311
Nodes/second    : 198310

./lc0_policy_optimized benchmark (t59)
===========================
Total time (ms) : 340808
Nodes searched  : 42638750
Nodes/second    : 125110

./lc0_c4c92f6 benchmark (t59)
===========================
Total time (ms) : 340724
Nodes searched  : 42673511
Nodes/second    : 125243
```