### PR TITLE
Make `wl_` double.

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -194,8 +194,8 @@ void Node::CreateEdges(const MoveList& moves) {
   num_edges_ = moves.size();
 }
 
-Node::ConstIterator Node::Edges() const { return {this, &child_}; }
-Node::Iterator Node::Edges() { return {this, &child_}; }
+Node::ConstIterator Node::Edges() const { return {*this, &child_}; }
+Node::Iterator Node::Edges() { return {*this, &child_}; }
 
 float Node::GetVisitedPolicy() const { return visited_policy_; }
 

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -167,14 +167,11 @@ std::string Edge::DebugString() const {
   return oss.str();
 }
 
-/////////////////////////////////////////////////////////////////////////
-// EdgeList
-/////////////////////////////////////////////////////////////////////////
-
-EdgeList::EdgeList(MoveList moves)
-    : edges_(std::make_unique<Edge[]>(moves.size())), size_(moves.size()) {
-  auto* edge = edges_.get();
-  for (const auto move : moves) edge++->SetMove(move);
+std::unique_ptr<Edge[]> Edge::FromMovelist(const MoveList& moves) {
+  std::unique_ptr<Edge[]> edges = std::make_unique<Edge[]>(moves.size());
+  auto* edge = edges.get();
+  for (const auto move : moves) edge++->move_ = move;
+  return edges;
 }
 
 /////////////////////////////////////////////////////////////////////////
@@ -184,7 +181,8 @@ EdgeList::EdgeList(MoveList moves)
 Node* Node::CreateSingleChildNode(Move move) {
   assert(!edges_);
   assert(!child_);
-  edges_ = EdgeList({move});
+  edges_ = Edge::FromMovelist({move});
+  num_edges_ = 1;
   child_ = std::make_unique<Node>(this, 0);
   return child_.get();
 }
@@ -192,17 +190,18 @@ Node* Node::CreateSingleChildNode(Move move) {
 void Node::CreateEdges(const MoveList& moves) {
   assert(!edges_);
   assert(!child_);
-  edges_ = EdgeList(moves);
+  edges_ = Edge::FromMovelist(moves);
+  num_edges_ = moves.size();
 }
 
-Node::ConstIterator Node::Edges() const { return {edges_, &child_}; }
-Node::Iterator Node::Edges() { return {edges_, &child_}; }
+Node::ConstIterator Node::Edges() const { return {this, &child_}; }
+Node::Iterator Node::Edges() { return {this, &child_}; }
 
 float Node::GetVisitedPolicy() const { return visited_policy_; }
 
 Edge* Node::GetEdgeToNode(const Node* node) const {
   assert(node->parent_ == this);
-  assert(node->index_ < edges_.size());
+  assert(node->index_ < num_edges_);
   return &edges_[node->index_];
 }
 
@@ -214,7 +213,7 @@ std::string Node::DebugString() const {
       << " Parent:" << parent_ << " Index:" << index_
       << " Child:" << child_.get() << " Sibling:" << sibling_.get()
       << " WL:" << wl_ << " N:" << n_ << " N_:" << n_in_flight_
-      << " Edges:" << edges_.size()
+      << " Edges:" << num_edges_
       << " Bounds:" << static_cast<int>(lower_bound_) - 2 << ","
       << static_cast<int>(upper_bound_) - 2;
   return oss.str();
@@ -326,7 +325,10 @@ void Node::ReleaseChildrenExceptOne(Node* node_to_save) {
   // Make saved node the only child. (kills previous siblings).
   gNodeGc.AddToGcQueue(std::move(child_));
   child_ = std::move(saved_node);
-  if (!child_) edges_ = EdgeList();  // Clear edges list.
+  if (!child_) {
+    num_edges_ = 0;
+    edges_.reset();  // Clear edges list.
+  }
 }
 
 V5TrainingData Node::GetV5TrainingData(

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -251,7 +251,7 @@ class Node {
   // to smallest.
 
   // 8 byte fields.
-  // Adday of edges.
+  // Array of edges.
   std::unique_ptr<Edge[]> edges_;
   // Pointer to a parent node. nullptr for the root.
   Node* parent_ = nullptr;

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -251,6 +251,14 @@ class Node {
   // to smallest.
 
   // 8 byte fields.
+  // Average value (from value head of neural network) of all visited nodes in
+  // subtree. For terminal nodes, eval is stored. This is from the perspective
+  // of the player who "just" moved to reach this position, rather than from the
+  // perspective of the player-to-move for the position.
+  // WL stands for "W minus L". Is equal to Q if draw score is 0.
+  double wl_ = 0.0f;
+
+  // 8 byte fields on 64-bit platforms, 4 byte on 32-bit.
   // Array of edges.
   std::unique_ptr<Edge[]> edges_;
   // Pointer to a parent node. nullptr for the root.
@@ -262,13 +270,6 @@ class Node {
   // Cached pointer to best child, valid while n_in_flight <
   // best_child_cache_in_flight_limit_
   Node* best_child_cached_ = nullptr;
-
-  // Average value (from value head of neural network) of all visited nodes in
-  // subtree. For terminal nodes, eval is stored. This is from the perspective
-  // of the player who "just" moved to reach this position, rather than from the
-  // perspective of the player-to-move for the position.
-  // WL stands for "W minus L". Is equal to Q if draw score is 0.
-  double wl_ = 0.0f;
 
   // 4 byte fields.
   // Averaged draw probability. Works similarly to WL, except that D is not

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -433,12 +433,10 @@ class Edge_Iterator : public EdgeAndNode {
   Edge_Iterator() {}
 
   // Creates "begin()" iterator. Also happens to be a range constructor.
-  Edge_Iterator(const Node* parent_ptr, Ptr child_ptr)
-      : EdgeAndNode(
-            parent_ptr->num_edges_ != 0 ? parent_ptr->edges_.get() : nullptr,
-            nullptr),
+  Edge_Iterator(const Node& parent_node, Ptr child_ptr)
+      : EdgeAndNode(parent_node.edges_.get(), nullptr),
         node_ptr_(child_ptr),
-        total_count_(parent_ptr->num_edges_) {
+        total_count_(parent_node.num_edges_) {
     if (edge_) Actualize();
   }
 


### PR DESCRIPTION
And get rid of `EdgeList` (took 6 bytes extra space than it should have).

NPS drop: -1.6% at random backend.
Memory usage: unchanged! \o/ (was offset by EdgeList refactoring)

Fixes #875.