### PR TITLE
Filter out illegal searchmoves.

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -66,9 +66,15 @@ const OptionId kStrictUciTiming{"strict-uci-timing", "StrictTiming",
 MoveList StringsToMovelist(const std::vector<std::string>& moves,
                            const ChessBoard& board) {
   MoveList result;
-  result.reserve(moves.size());
-  for (const auto& move : moves) {
-    result.emplace_back(board.GetModernMove({move, board.flipped()}));
+  if (moves.size()) {
+    result.reserve(moves.size());
+    const auto legal_moves = board.GenerateLegalMoves();
+    const auto end = legal_moves.end();
+    for (const auto& move : moves) {
+      const auto m = board.GetModernMove({move, board.flipped()});
+      if (std::find(legal_moves.begin(), end, m) != end) result.emplace_back(m);
+    }
+    if (result.empty()) throw Exception("No legal searchmoves.");
   }
   return result;
 }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -48,24 +48,13 @@ namespace {
 // Maximum delay between outputting "uci info" when nothing interesting happens.
 const int kUciInfoMinimumFrequencyMs = 5000;
 
-MoveList MakeRootMoveFilter(MoveList searchmoves, SyzygyTablebase* syzygy_tb,
+MoveList MakeRootMoveFilter(const MoveList& searchmoves,
+                            SyzygyTablebase* syzygy_tb,
                             const PositionHistory& history, bool fast_play,
                             std::atomic<int>* tb_hits) {
   // Search moves overrides tablebase.
+  if (!searchmoves.empty()) return searchmoves;
   const auto& board = history.Last().GetBoard();
-  if (!searchmoves.empty()) {
-    const auto legal_moves = board.GenerateLegalMoves();
-    searchmoves.erase(std::remove_if(searchmoves.begin(), searchmoves.end(),
-                                     [&legal_moves](auto m) {
-                                       return std::find(legal_moves.begin(),
-                                                        legal_moves.end(),
-                                                        m) == legal_moves.end();
-                                     }),
-                      searchmoves.end());
-    if (searchmoves.empty()) throw Exception("No legal searchmoves.");
-    return searchmoves;
-  }
-
   MoveList root_moves;
   if (!syzygy_tb || !board.castlings().no_legal_castle() ||
       (board.ours() | board.theirs()).count() > syzygy_tb->max_cardinality()) {


### PR DESCRIPTION
r? @borg323 Fix #899 filtering using the new `MakeRootMoveFilter` from #1281

```
Before:

go nodes 2 searchmoves a1a2
Segmentation fault: 11

go nodes 2 searchmoves a1a2 a2a3 a3a4
bestmove a2a3 ponder e7e5


After:

go nodes 2 searchmoves a1a2
error No legal searchmoves.

go nodes 2 searchmoves a1a2 a2a3 a3a4
bestmove a2a3 ponder e7e5
```