### PR TITLE
Clear policy for terminal loss.

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -232,6 +232,9 @@ void Node::MakeTerminal(GameResult result, float plies_left, Terminal type) {
   } else if (result == GameResult::BLACK_WON) {
     wl_ = -1.0f;
     d_ = 0.0f;
+    // Terminal losses have no uncertainty and no reason for their U value to be
+    // comparable to another non-loss choice. Force this by clearing the policy.
+    if (GetParent() != nullptr) GetOwnEdge()->SetP(0.0f);
   }
 }
 


### PR DESCRIPTION
This probably is worthy of a fixed node elo test to rule out any strange interactions, but I would estimate positive elo in the 0-1 range ;)
This seems a cheaper alternative to adding more logic to the pick node loop with regard to terminals.