### PR TITLE
Fix bug where pv might not update for best move change.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1524,6 +1524,8 @@ void SearchWorker::DoBackupUpdateSingleNode(
     // Nothing left to do without ancestors to update.
     if (!p) break;
 
+    bool old_update_parent_bounds = update_parent_bounds;
+
     // Try setting parent bounds except the root or those already terminal.
     update_parent_bounds = update_parent_bounds && p != search_->root_node_ &&
                            !p->IsTerminal() && MaybeSetBounds(p, m);
@@ -1535,14 +1537,14 @@ void SearchWorker::DoBackupUpdateSingleNode(
 
     // Update the stats.
     // Best move.
-    // If update_parent_bounds is still set, we just adjusted bounds on the
+    // If update_parent_bounds was set, we just adjusted bounds on the
     // previous loop or there was no previous loop, so if n is a terminal, it
     // just became that way and could be a candidate for changing the current
     // best edge. Otherwise a visit can only change best edge if its to an edge
     // that isn't already the best and the new n is equal or greater to the old
     // n.
     if (p == search_->root_node_ &&
-        (update_parent_bounds && n->IsTerminal() ||
+        (old_update_parent_bounds && n->IsTerminal() ||
          n != search_->current_best_edge_.node() &&
              search_->current_best_edge_.GetN() <= n->GetN())) {
       search_->current_best_edge_ =

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1535,8 +1535,16 @@ void SearchWorker::DoBackupUpdateSingleNode(
 
     // Update the stats.
     // Best move.
+    // If update_parent_bounds is still set, we just adjusted bounds on the
+    // previous loop or there was no previous loop, so if n is a terminal, it
+    // just became that way and could be a candidate for changing the current
+    // best edge. Otherwise a visit can only change best edge if its to an edge
+    // that isn't already the best and the new n is equal or greater to the old
+    // n.
     if (p == search_->root_node_ &&
-        search_->current_best_edge_.GetN() <= n->GetN()) {
+        (update_parent_bounds && n->IsTerminal() ||
+         n != search_->current_best_edge_.node() &&
+             search_->current_best_edge_.GetN() <= n->GetN())) {
       search_->current_best_edge_ =
           search_->GetBestChildNoTemperature(search_->root_node_, 0);
     }


### PR DESCRIPTION
Specifically, if a visit proves terminal win status, it should become the best edge even though the n might still be far behind the best.
Also don't recalculate if already the best edge other than in the change to terminal case. Doing this introduces another corner case, but the new logic should handle it. Specifically if a visit proves terminal loss status, it should stop being the best edge even if it has the maximum n.