### PR TITLE
Use explicit int for printing verbose and debug num edges.

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -213,7 +213,7 @@ std::string Node::DebugString() const {
       << " Parent:" << parent_ << " Index:" << index_
       << " Child:" << child_.get() << " Sibling:" << sibling_.get()
       << " WL:" << wl_ << " N:" << n_ << " N_:" << n_in_flight_
-      << " Edges:" << num_edges_
+      << " Edges:" << static_cast<int>(num_edges_)
       << " Bounds:" << static_cast<int>(lower_bound_) - 2 << ","
       << static_cast<int>(upper_bound_) - 2;
   return oss.str();

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -312,7 +312,7 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
   auto print = [](auto* oss, auto pre, auto v, auto post, auto w, int p = 0) {
     *oss << pre << std::setw(w) << std::setprecision(p) << v << post;
   };
-  auto print_head = [&](auto* oss, auto label, auto i, auto n, auto f, auto p) {
+  auto print_head = [&](auto* oss, auto label, int i, auto n, auto f, auto p) {
     *oss << std::fixed;
     print(oss, "", label, " ", 5);
     print(oss, "(", i, ") ", 4);


### PR DESCRIPTION
r? @mooskagh or @Tilps Fix #1291. This regressed with #1280's:
```diff
-  uint16_t GetNumEdges() const { return edges_.size(); }
+  uint8_t GetNumEdges() const { return num_edges_; }
```

```
After #1291:
info string node  (   ) N:       1 (+ 0) (P:  0.00%) (WL:  0.10861) (D: 0.325) (M:  0.0) (Q:  0.10861) (V:  0.1086) 
Term:0 This:0x7fc1bb004230 Parent:0x0 Index:0 Child:0x0 Sibling:0x0 WL:-0.108615 N:1 N_:0 Edges: Bounds:-1,1


After this PR:
info string node  (  20) N:       1 (+ 0) (P:  0.00%) (WL:  0.10861) (D: 0.325) (M:  0.0) (Q:  0.10861) (V:  0.1086) 
Term:0 This:0x7ffc81f27710 Parent:0x0 Index:0 Child:0x0 Sibling:0x0 WL:-0.108615 N:1 N_:0 Edges:20 Bounds:-1,1
```