### PR TITLE
adjust minibatch-size for appveyor cpu builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,6 +70,8 @@ cache:
   - C:\ndk\android-ndk-r19c\toolchains\llvm\prebuilt\windows-x86_64
 before_build:
 - cmd: git submodule update --init --recursive
+- cmd: IF %BLAS%==true sed -i "/kMiniBatchSizeId/ s/256/4/" src/mcts/params.cc
+- cmd: IF %ANDROID%==true sed -i "/kMiniBatchSizeId/ s/256/7/" src/mcts/params.cc
 - cmd: SET BUILD_BLAS=%BLAS%
 - cmd: IF %OPENCL%==true SET BUILD_BLAS=true
 - cmd: IF %DX%==true SET BUILD_BLAS=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,8 +79,8 @@ cache:
   - C:\ndk\android-ndk-r19c\toolchains\llvm\prebuilt\windows-x86_64
 before_build:
 - cmd: git submodule update --init --recursive
-- cmd: IF %BLAS%==true sed -i "/kMiniBatchSizeId/ s/256/4/" src/mcts/params.cc
-- cmd: IF %ANDROID%==true sed -i "/kMiniBatchSizeId/ s/256/7/" src/mcts/params.cc
+- cmd: IF %BLAS%==true (echo.#define DEFAULT_MINIBATCH_SIZE 1 & echo.#define DEFAULT_MAX_PREFETCH 0) > params_override.h
+- cmd: IF %ANDROID%==true (echo.#define DEFAULT_MINIBATCH_SIZE 1 & echo.#define DEFAULT_MAX_PREFETCH 0) > params_override.h
 - cmd: SET BUILD_BLAS=%BLAS%
 - cmd: IF %OPENCL%==true SET BUILD_BLAS=true
 - cmd: IF %DX%==true SET BUILD_BLAS=true

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -31,6 +31,17 @@
 
 #include "utils/exception.h"
 
+#if __has_include("params_override.h")
+#include "params_override.h"
+#endif
+
+#ifndef DEFAULT_MINIBATCH_SIZE
+#define DEFAULT_MINIBATCH_SIZE 256
+#endif
+#ifndef DEFAULT_MAX_PREFETCH
+#define DEFAULT_MAX_PREFETCH 32
+#endif
+
 namespace lczero {
 
 namespace {
@@ -263,8 +274,8 @@ const OptionId SearchParams::kNpsLimitId{
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
   // Many of them are overridden with training specific values in tournament.cc.
-  options->Add<IntOption>(kMiniBatchSizeId, 1, 1024) = 256;
-  options->Add<IntOption>(kMaxPrefetchBatchId, 0, 1024) = 32;
+  options->Add<IntOption>(kMiniBatchSizeId, 1, 1024) = DEFAULT_MINIBATCH_SIZE;
+  options->Add<IntOption>(kMaxPrefetchBatchId, 0, 1024) = DEFAULT_MAX_PREFETCH;
   options->Add<BoolOption>(kLogitQId) = false;
   options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 2.147f;
   options->Add<FloatOption>(kCpuctAtRootId, 0.0f, 100.0f) = 2.147f;


### PR DESCRIPTION
4 seems a good value for openblas and dnnl, while for android 7 looked better in some tests.