### PR TITLE
Show P: 100.0% instead of P: 100.00% to avoid shifting verbose output.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -320,7 +320,7 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
     *oss << std::right;
     print(oss, "N: ", n, " ", 7);
     print(oss, "(+", f, ") ", 2);
-    print(oss, "(P: ", p * 100, "%) ", 5, 2);
+    print(oss, "(P: ", p * 100, "%) ", 5, p >= 1.0f ? 1 : 2);
   };
   auto print_stats = [&](auto* oss, const auto* n) {
     const auto sign = n == node ? -1 : 1;


### PR DESCRIPTION
r? @mooskagh This has been slightly annoying me for a while for my scripts that combine multiple verbose outputs as things are just slightly out of line for a forced move:
```
Before:
63494  23.5 f5d3  (833 ) N:       0 (+ 0) (P: 81.74%) (WL:  -.-----) (D: -.---) (M:  -.-) (Q: -0.24998) (U: 1.75504) (S:  1.50506) (V:  -.----) 
63494  24.0 b5c6  (942 ) N:       0 (+ 0) (P: 100.00%) (WL:  -.-----) (D: -.---) (M:  -.-) (Q:  0.58810) (U: 2.14715) (S:  2.73525) (V:  -.----) 
63494  24.5 e8a8  (97  ) N:       0 (+ 0) (P: 15.12%) (WL:  -.-----) (D: -.---) (M:  -.-) (Q: -0.49971) (U: 0.32475) (S: -0.17497) (V:  -.----) 
…
63494  33.5 d7d5  (293 ) N:       0 (+ 0) (P: 54.42%) (WL:  -.-----) (D: -.---) (M:  -.-) (Q:  0.23504) (U: 1.16846) (S:  1.40350) (V:  -.----) 
63494  34.0 a5a4  (903 ) N:       0 (+ 0) (P: 100.00%) (WL:  -.-----) (D: -.---) (M:  -.-) (Q: -0.63033) (U: 2.14715) (S:  1.51682) (V:  -.----) 
63494  34.5 d5d4  (761 ) N:       0 (+ 0) (P: 19.50%) (WL:  -.-----) (D: -.---) (M:  -.-) (Q:  0.56942) (U: 0.41871) (S:  0.98813) (V:  -.----) 

After:
63494  23.5 f5d3  (833 ) N:       0 (+ 0) (P: 81.74%) (WL:  -.-----) (D: -.---) (M:  -.-) (Q: -0.24998) (U: 1.75504) (S:  1.50506) (V:  -.----) 
63494  24.0 b5c6  (942 ) N:       0 (+ 0) (P: 100.0%) (WL:  -.-----) (D: -.---) (M:  -.-) (Q:  0.58810) (U: 2.14715) (S:  2.73525) (V:  -.----) 
63494  24.5 e8a8  (97  ) N:       0 (+ 0) (P: 15.12%) (WL:  -.-----) (D: -.---) (M:  -.-) (Q: -0.49971) (U: 0.32475) (S: -0.17497) (V:  -.----) 
…
63494  33.5 d7d5  (293 ) N:       0 (+ 0) (P: 54.42%) (WL:  -.-----) (D: -.---) (M:  -.-) (Q:  0.23504) (U: 1.16846) (S:  1.40350) (V:  -.----) 
63494  34.0 a5a4  (903 ) N:       0 (+ 0) (P: 100.0%) (WL:  -.-----) (D: -.---) (M:  -.-) (Q: -0.63033) (U: 2.14715) (S:  1.51682) (V:  -.----) 
63494  34.5 d5d4  (761 ) N:       0 (+ 0) (P: 19.50%) (WL:  -.-----) (D: -.---) (M:  -.-) (Q:  0.56942) (U: 0.41871) (S:  0.98813) (V:  -.----) 
```

But now it's also more visible with the node line from #1268 usually adding up to 100%:
```
Before:
info string g1f3  (159 ) N:       1 (+23) (P: 18.02%) (WL:  0.09766) (D: 0.353) (M:  0.0) (Q:  0.09766) (U: 0.06932) (S:  0.16698) (V:  0.0977) 
info string e2e4  (322 ) N:       1 (+ 6) (P:  7.98%) (WL:  0.07124) (D: 0.350) (M:  0.0) (Q:  0.07124) (U: 0.09588) (S:  0.16712) (V:  0.0712) 
info string node  (  20) N:      21 (+80) (P: 100.00%) (WL: -0.04702) (D: 0.330) (M:  1.0) (Q: -0.04702) (V:  0.0860) 

After:
info string g1f3  (159 ) N:       1 (+23) (P: 18.02%) (WL:  0.09766) (D: 0.353) (M:  0.0) (Q:  0.09766) (U: 0.06932) (S:  0.16698) (V:  0.0977) 
info string e2e4  (322 ) N:       1 (+ 6) (P:  7.98%) (WL:  0.07124) (D: 0.350) (M:  0.0) (Q:  0.07124) (U: 0.09592) (S:  0.16716) (V:  0.0712) 
info string node  (  20) N:      21 (+80) (P: 100.0%) (WL: -0.04702) (D: 0.330) (M:  1.0) (Q: -0.04702) (V:  0.0860) 
```