### PR TITLE
Terminal correction

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -296,6 +296,17 @@ void Node::FinalizeScoreUpdate(float v, float d, float m, int multivisit) {
   best_child_cached_ = nullptr;
 }
 
+void Node::AdjustForTerminal(float v, float d, float m, int multivisit) {
+  // Recompute Q.
+  wl_ += multivisit * v / n_;
+  d_ += multivisit * d / n_;
+  m_ += multivisit * m / n_;
+  // Best child is potentially no longer valid. This shouldn't be needed since
+  // AjdustForTerminal is always called immediately after FinalizeScoreUpdate,
+  // but for safety in case that changes.
+  best_child_cached_ = nullptr;
+}
+
 void Node::UpdateBestChild(const Iterator& best_edge, int visits_allowed) {
   best_child_cached_ = best_edge.node();
   // An edge can point to an unexpanded node with n==0. These nodes don't

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -179,6 +179,8 @@ class Node {
   // * N (+=1)
   // * N-in-flight (-=1)
   void FinalizeScoreUpdate(float v, float d, float m, int multivisit);
+  // Like FinalizeScoreUpdate, but it updates n existing visits by delta amount.
+  void AdjustForTerminal(float v, float d, float m, int multivisit);
   // When search decides to treat one visit as several (in case of collisions
   // or visiting terminal nodes several times), it amplifies the visit by
   // incrementing n_in_flight.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1527,6 +1527,10 @@ void SearchWorker::DoBackupUpdateSingleNode(
   float v = node_to_process.v;
   float d = node_to_process.d;
   float m = node_to_process.m;
+  int n_to_fix = 0;
+  float v_delta = 0.0f;
+  float d_delta = 0.0f;
+  float m_delta = 0.0f;
   int depth = 0;
   for (Node *n = node, *p; n != search_->root_node_->GetParent(); n = p) {
     p = n->GetParent();
@@ -1540,18 +1544,25 @@ void SearchWorker::DoBackupUpdateSingleNode(
     }
     n->FinalizeScoreUpdate(v / (1.0f + params_.GetShortSightedness() * depth),
                            d, m, node_to_process.multivisit);
+    if (n_to_fix > 0) {
+      n->AdjustForTerminal(
+          v_delta / (1.0f + params_.GetShortSightedness() * depth), d_delta,
+          m_delta, n_to_fix);
+    }
 
     // Nothing left to do without ancestors to update.
     if (!p) break;
 
     bool old_update_parent_bounds = update_parent_bounds;
-
+    // If parent already is terminal further adjustment is not required.
+    if (p->IsTerminal()) n_to_fix = 0;
     // Try setting parent bounds except the root or those already terminal.
     update_parent_bounds = update_parent_bounds && p != search_->root_node_ &&
-                           !p->IsTerminal() && MaybeSetBounds(p, m);
+                           !p->IsTerminal() && MaybeSetBounds(p, m, &n_to_fix, &v_delta, &d_delta, &m_delta);
 
     // Q will be flipped for opponent.
     v = -v;
+    v_delta = -v_delta;
     depth++;
     m++;
 
@@ -1576,7 +1587,7 @@ void SearchWorker::DoBackupUpdateSingleNode(
   search_->max_depth_ = std::max(search_->max_depth_, node_to_process.depth);
 }
 
-bool SearchWorker::MaybeSetBounds(Node* p, float m) const {
+bool SearchWorker::MaybeSetBounds(Node* p, float m, int* n_to_fix, float* v_delta, float* d_delta, float* m_delta) const {
   auto losing_m = 0.0f;
   auto prefer_tb = false;
 
@@ -1621,10 +1632,20 @@ bool SearchWorker::MaybeSetBounds(Node* p, float m) const {
   } else if (lower == upper) {
     // Search can stop at the parent if the bounds can't change anymore, so make
     // it terminal preferring shorter wins and longer losses.
+    int old_n_to_fix = *n_to_fix;
+    // This assumes the active visit is a multivist of size 1.
+    *n_to_fix = p->GetN() - 1;
+    assert(*n_to_fix > 0);
+    float cur_v = p->GetWL();
+    float cur_d = p->GetD();
+    float cur_m = p->GetM();
     p->MakeTerminal(
         -upper,
         (upper == GameResult::BLACK_WON ? std::max(losing_m, m) : m) + 1.0f,
         prefer_tb ? Node::Terminal::Tablebase : Node::Terminal::EndOfGame);
+    *v_delta = p->GetWL() - cur_v + old_n_to_fix * *v_delta / *n_to_fix;
+    *d_delta = p->GetD() - cur_d + old_n_to_fix * *d_delta / *n_to_fix;
+    *m_delta = p->GetM() - cur_m + old_n_to_fix * *m_delta / *n_to_fix;
   } else {
     p->SetBounds(-upper, -lower);
   }

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -310,7 +310,7 @@ class SearchWorker {
                              int idx_in_computation);
   void DoBackupUpdateSingleNode(const NodeToProcess& node_to_process);
   // Returns whether a node's bounds were set based on its children.
-  bool MaybeSetBounds(Node* p, float m) const;
+  bool MaybeSetBounds(Node* p, float m, int* n_to_fix, float* v_delta, float* d_delta, float* m_delta) const;
 
   Search* const search_;
   // List of nodes to process.


### PR DESCRIPTION
Adjust parent node Q/D/M values to act as if newly converted terminals always had the Q/D/M values that they now have.
This will 'momentarily' be confusing for search - so may need to be combined with something like crem's recent time management adjustment that waits for best N to catch up with best Q to avoid missing out on taking advantage of the information gain applied.

I've only done minimal validation that the values move the direction I expect them to when terminal status gets determined.
Given this is in the return loop it probably will need nps or check at time control in addition to any proof of improvement at fixed nodes.
But first I'll try to demonstrate at fixed nodes if I can find a spare minute or two on my machine :P