### PR TITLE
Save the last sent nps info to use when missing nps.

### DIFF
--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -259,7 +259,11 @@ void UciLoop::SendInfo(const std::vector<ThinkingInfo>& infos) {
              std::to_string(info.wdl->d) + " " + std::to_string(info.wdl->l);
     }
     if (info.hashfull >= 0) res += " hashfull " + std::to_string(info.hashfull);
-    if (info.nps >= 0) res += " nps " + std::to_string(info.nps);
+    if (info.nodes >= 0) {
+      // Always report nps if we report nodes defaulting to the last reported.
+      if (info.nps >= 0) last_nps_ = info.nps;
+      res += " nps " + std::to_string(last_nps_);
+    }
     if (info.tb_hits >= 0) res += " tbhits " + std::to_string(info.tb_hits);
     if (info.multipv >= 0) res += " multipv " + std::to_string(info.multipv);
 

--- a/src/chess/uciloop.h
+++ b/src/chess/uciloop.h
@@ -89,6 +89,7 @@ class UciLoop {
   bool DispatchCommand(
       const std::string& command,
       const std::unordered_map<std::string, std::string>& params);
+  int last_nps_ = 0;
 };
 
 }  // namespace lczero


### PR DESCRIPTION
r?@borg323 or @Tilps  Fix #1316 with a nps cache on `UciLoop`

```
Before:
position fen 6k1/3n2P1/4p3/1pp1p3/r7/P2q1N2/1P4Q1/K6R b - - 2 39
go nodes 2 searchmoves a4a3
info depth 1 seldepth 2 time 1068 nodes 2 score cp -17 nps 25 tbhits 0 pv a4a3 b2a3
bestmove a4a3 ponder b2a3

position fen 6k1/3n2P1/4p3/1pp1p3/r7/P2q1N2/1P4Q1/K6R b - - 2 39 moves a4a3
go nodes 1
info depth 1 seldepth 0 time 0 nodes 1 score cp 17 tbhits 0 pv b2a3
bestmove b2a3


After:
position fen 6k1/3n2P1/4p3/1pp1p3/r7/P2q1N2/1P4Q1/K6R b - - 2 39
go nodes 2 searchmoves a4a3
info depth 1 seldepth 2 time 1071 nodes 2 score cp -17 nps 22 tbhits 0 pv a4a3 b2a3
bestmove a4a3 ponder b2a3

position fen 6k1/3n2P1/4p3/1pp1p3/r7/P2q1N2/1P4Q1/K6R b - - 2 39 moves a4a3
go nodes 1
info depth 1 seldepth 0 time 0 nodes 1 score cp 17 nps 22 tbhits 0 pv b2a3
bestmove b2a3
```