### PR TITLE
Calculate verbose M effect with delta-M like PickNode.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -366,9 +366,9 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
   };
 
   std::vector<std::string> infos;
+  const auto parent_m = node->GetM();
   for (const auto& edge : edges) {
     float Q = edge.GetQ(fpu, draw_score, logit_q);
-    const auto parent_m = node->GetM();
     const auto child_m = edge.GetM(parent_m);
     float M_effect =
         do_moves_left_adjustment

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -368,9 +368,11 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
   std::vector<std::string> infos;
   for (const auto& edge : edges) {
     float Q = edge.GetQ(fpu, draw_score, logit_q);
+    const auto parent_m = node->GetM();
+    const auto child_m = edge.GetM(parent_m);
     float M_effect =
         do_moves_left_adjustment
-            ? (std::clamp(m_slope * edge.GetM(0.0f), -m_cap, m_cap) *
+            ? (std::clamp(m_slope * (child_m - parent_m), -m_cap, m_cap) *
                std::copysign(1.0f, -Q) * (a + b * std::abs(Q) + c * Q * Q))
             : 0.0f;
 


### PR DESCRIPTION
r?@AlexisOlson or @Tilps  Following up from #1230. I do see `child_m - parent_m` is redundant if the child is not visited…