### PR TITLE
demux over all (blas) threads

### DIFF
--- a/src/neural/network_demux.cc
+++ b/src/neural/network_demux.cc
@@ -222,8 +222,8 @@ class DemuxingNetwork : public Network {
 
 void DemuxingComputation::ComputeBlocking() {
   if (GetBatchSize() == 0) return;
-  partial_size_ = (GetBatchSize() + network_->networks_.size() - 1) /
-                  network_->networks_.size();
+  partial_size_ = (GetBatchSize() + network_->threads_.size() - 1) /
+                  network_->threads_.size();
   if (partial_size_ < network_->minimum_split_size_) {
     partial_size_ = std::min(GetBatchSize(), network_->minimum_split_size_);
   }


### PR DESCRIPTION
Allows to do `--backend=demux --backend-opts=backend=blas,threads=32` to split batches over 32 blas threads. This can be taken to the next level with something like `--backend=multiplexing --backend-opts=opencl, demux(backend=blas,threads=32)`.
