### PR TITLE
Per color settings.

### DIFF
--- a/src/neural/factory.h
+++ b/src/neural/factory.h
@@ -31,8 +31,8 @@
 #include <optional>
 #include <string>
 
-#include "neural/network.h"
 #include "neural/loader.h"
+#include "neural/network.h"
 #include "utils/optionsdict.h"
 #include "utils/optionsparser.h"
 
@@ -85,6 +85,10 @@ class NetworkFactory {
     bool operator!=(const BackendConfiguration& other) const {
       return !operator==(other);
     }
+    bool operator<(const BackendConfiguration& other) const {
+      return std::tie(weights_path, backend, backend_options) <
+             std::tie(other.weights_path, other.backend, other.backend_options);
+    }
   };
 
  private:
@@ -111,12 +115,14 @@ class NetworkFactory {
   friend class Register;
 };
 
-#define REGISTER_NETWORK_WITH_COUNTER2(name, func, priority, counter)       \
-  namespace {                                                               \
-  static NetworkFactory::Register regH38fhs##counter(                       \
-      name, [](const std::optional<WeightsFile>& w, const OptionsDict& o) { \
-        return func(w, o);                                                  \
-      }, priority);                                                         \
+#define REGISTER_NETWORK_WITH_COUNTER2(name, func, priority, counter) \
+  namespace {                                                         \
+  static NetworkFactory::Register regH38fhs##counter(                 \
+      name,                                                           \
+      [](const std::optional<WeightsFile>& w, const OptionsDict& o) { \
+        return func(w, o);                                            \
+      },                                                              \
+      priority);                                                      \
   }
 #define REGISTER_NETWORK_WITH_COUNTER(name, func, priority, counter) \
   REGISTER_NETWORK_WITH_COUNTER2(name, func, priority, counter)

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -69,11 +69,11 @@ void SelfPlayGame::PopulateUciParams(OptionsParser* options) {
   PopulateTimeManagementOptions(RunType::kSelfplay, options);
 }
 
-SelfPlayGame::SelfPlayGame(PlayerOptions player1, PlayerOptions player2,
+SelfPlayGame::SelfPlayGame(PlayerOptions white, PlayerOptions black,
                            bool shared_tree, const Opening& opening)
-    : options_{player1, player2},
-      chess960_{player1.uci_options->Get<bool>(kUciChess960) ||
-                player2.uci_options->Get<bool>(kUciChess960)} {
+    : options_{white, black},
+      chess960_{white.uci_options->Get<bool>(kUciChess960) ||
+                black.uci_options->Get<bool>(kUciChess960)} {
   orig_fen_ = opening.start_fen;
   tree_[0] = std::make_shared<NodeTree>();
   tree_[0]->ResetToPosition(orig_fen_, {});

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -71,7 +71,7 @@ class SelfPlayGame {
   // If shared_tree is true, search tree is reused between players.
   // (useful for training games). Otherwise the tree is separate for black
   // and white (useful i.e. when they use different networks).
-  SelfPlayGame(PlayerOptions player1, PlayerOptions player2, bool shared_tree,
+  SelfPlayGame(PlayerOptions white, PlayerOptions black, bool shared_tree,
                const Opening& opening);
 
   // Populate command line options that it uses.

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -218,10 +218,10 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
     Mutex::Lock lock(mutex_);
     player1_black = ((game_number % 2) == 1) != first_game_black_;
     if (!openings_.empty()) {
-      if (player_options_[0][!player1_black].Get<bool>(kOpeningsMirroredId)) {
+      if (player_options_[0][0].Get<bool>(kOpeningsMirroredId)) {
         opening = openings_[(game_number / 2) % openings_.size()];
-      } else if (player_options_[0][!player1_black].Get<std::string>(
-                     kOpeningsModeId) == "random") {
+      } else if (player_options_[0][0].Get<std::string>(kOpeningsModeId) ==
+                 "random") {
         opening = openings_[Random::Get().GetInt(0, openings_.size() - 1)];
       } else {
         opening = openings_[game_number % openings_.size()];

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -30,6 +30,7 @@
 #include <list>
 
 #include "chess/pgn.h"
+#include "neural/factory.h"
 #include "selfplay/game.h"
 #include "utils/mutex.h"
 #include "utils/optionsdict.h"
@@ -89,18 +90,18 @@ class SelfPlayTournament {
   Mutex threads_mutex_;
   std::vector<std::thread> threads_ GUARDED_BY(threads_mutex_);
 
-  // All those are [0] for player1 and [1] for player2
-  // Shared pointers for both players may point to the same object.
-  std::shared_ptr<Network> networks_[2];
+  // Map from the backend configuration to a network.
+  std::map<NetworkFactory::BackendConfiguration, std::unique_ptr<Network>>
+      networks_;
   std::shared_ptr<NNCache> cache_[2];
-  const OptionsDict player_options_[2];
+  // [player1 or player2][white or black].
+  const OptionsDict player_options_[2][2];
   SelfPlayLimits search_limits_[2];
 
   CallbackUciResponder::BestMoveCallback best_move_callback_;
   CallbackUciResponder::ThinkingCallback info_callback_;
   GameInfo::Callback game_callback_;
   TournamentInfo::Callback tournament_callback_;
-  const int kThreads[2];
   const int kTotalGames;
   const bool kShareTree;
   const size_t kParallelism;

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -96,7 +96,7 @@ class SelfPlayTournament {
   std::shared_ptr<NNCache> cache_[2];
   // [player1 or player2][white or black].
   const OptionsDict player_options_[2][2];
-  SelfPlayLimits search_limits_[2];
+  SelfPlayLimits search_limits_[2][2];
 
   CallbackUciResponder::BestMoveCallback best_move_callback_;
   CallbackUciResponder::ThinkingCallback info_callback_;

--- a/src/utils/optionsdict.cc
+++ b/src/utils/optionsdict.cc
@@ -26,10 +26,12 @@
 */
 
 #include "utils/optionsdict.h"
+
 #include <cassert>
 #include <cctype>
 #include <sstream>
 #include <string>
+
 #include "utils/exception.h"
 
 namespace lczero {
@@ -56,6 +58,10 @@ OptionsDict* OptionsDict::AddSubdict(const std::string& name) {
     throw Exception("Subdictionary already exists: " + name);
   const auto x = &subdicts_.emplace(name, this).first->second;
   return x;
+}
+
+void OptionsDict::AddAliasDict(const OptionsDict* dict) {
+  aliases_.push_back(dict);
 }
 
 // Returns list of subdictionaries.
@@ -128,7 +134,7 @@ class Lexer {
     }
 
     // Identifier
-    if (std::isalnum(str_[idx_]) || str_[idx_]=='/') {
+    if (std::isalnum(str_[idx_]) || str_[idx_] == '/') {
       ReadIdentifier();
       return;
     }

--- a/src/utils/optionsdict.h
+++ b/src/utils/optionsdict.h
@@ -218,7 +218,6 @@ std::optional<T> OptionsDict::OwnGet(const OptionId& option_id) const {
 
 template <typename T>
 bool OptionsDict::Exists(const std::string& key) const {
-  if (OwnExists<T>(key)) return true;
   for (const auto* alias : aliases_) {
     if (alias->OwnExists<T>(key)) return true;
   }

--- a/src/utils/optionsdict.h
+++ b/src/utils/optionsdict.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <map>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/src/utils/optionsdict.h
+++ b/src/utils/optionsdict.h
@@ -92,7 +92,8 @@ class OptionsDict : TypeDict<bool>,
                     TypeDict<std::string>,
                     TypeDict<float> {
  public:
-  OptionsDict(const OptionsDict* parent = nullptr) : parent_(parent) {}
+  OptionsDict(const OptionsDict* parent = nullptr)
+      : parent_(parent), aliases_{this} {}
 
   // e.g. dict.Get<int>("threads")
   // Returns value of given type. Throws exception if not found.
@@ -101,11 +102,25 @@ class OptionsDict : TypeDict<bool>,
   template <typename T>
   T Get(const OptionId& option_id) const;
 
+  // Returns the own value of given type (doesn't fall back to querying parent).
+  // Returns nullopt if doesn't exist.
+  template <typename T>
+  std::optional<T> OwnGet(const std::string& key) const;
+  template <typename T>
+  std::optional<T> OwnGet(const OptionId& option_id) const;
+
   // Checks whether the given key exists for given type.
   template <typename T>
   bool Exists(const std::string& key) const;
   template <typename T>
   bool Exists(const OptionId& option_id) const;
+
+  // Checks whether the given key exists for given type. Does not fall back to
+  // check parents.
+  template <typename T>
+  bool OwnExists(const std::string& key) const;
+  template <typename T>
+  bool OwnExists(const OptionId& option_id) const;
 
   // Returns value of given type. Returns default if not found.
   template <typename T>
@@ -144,6 +159,9 @@ class OptionsDict : TypeDict<bool>,
   // Returns list of subdictionaries.
   std::vector<std::string> ListSubdicts() const;
 
+  // Adds alias dictionary.
+  void AddAliasDict(const OptionsDict* dict);
+
   // Creates options dict from string. Example of a string:
   // option1=1, option_two = "string val", subdict(option3=3.14)
   //
@@ -165,14 +183,16 @@ class OptionsDict : TypeDict<bool>,
 
   const OptionsDict* parent_ = nullptr;
   std::map<std::string, OptionsDict> subdicts_;
+  // Dictionaries where to search for "own" parameters. By default contains only
+  // this.
+  std::vector<const OptionsDict*> aliases_;
 };
 
 template <typename T>
 T OptionsDict::Get(const std::string& key) const {
-  const auto& dict = TypeDict<T>::dict_;
-  auto iter = dict.find(key);
-  if (iter != dict.end()) {
-    return iter->second.Get();
+  for (const auto* alias : aliases_) {
+    const auto value = alias->OwnGet<T>(key);
+    if (value) return *value;
   }
   if (parent_) return parent_->Get<T>(key);
   throw Exception("Key [" + key + "] was not set in options.");
@@ -181,27 +201,49 @@ template <typename T>
 T OptionsDict::Get(const OptionId& option_id) const {
   return Get<T>(GetOptionId(option_id));
 }
+template <typename T>
+std::optional<T> OptionsDict::OwnGet(const std::string& key) const {
+  const auto& dict = TypeDict<T>::dict_;
+  auto iter = dict.find(key);
+  if (iter != dict.end()) {
+    return iter->second.Get();
+  }
+  return {};
+}
+template <typename T>
+std::optional<T> OptionsDict::OwnGet(const OptionId& option_id) const {
+  return OwnGet<T>(GetOptionId(option_id));
+}
 
 template <typename T>
 bool OptionsDict::Exists(const std::string& key) const {
-  const auto& dict = TypeDict<T>::dict_;
-  auto iter = dict.find(key);
-  if (iter != dict.end()) return true;
-  if (!parent_) return false;
-  return parent_->Exists<T>(key);
+  if (OwnExists<T>(key)) return true;
+  for (const auto* alias : aliases_) {
+    if (alias->OwnExists<T>(key)) return true;
+  }
+  return parent_ && parent_->Exists<T>(key);
 }
 template <typename T>
 bool OptionsDict::Exists(const OptionId& option_id) const {
   return Exists<T>(GetOptionId(option_id));
 }
+template <typename T>
+bool OptionsDict::OwnExists(const std::string& key) const {
+  const auto& dict = TypeDict<T>::dict_;
+  auto iter = dict.find(key);
+  return iter != dict.end();
+}
+template <typename T>
+bool OptionsDict::OwnExists(const OptionId& option_id) const {
+  return OwnExists<T>(GetOptionId(option_id));
+}
 
 template <typename T>
 T OptionsDict::GetOrDefault(const std::string& key,
                             const T& default_val) const {
-  const auto& dict = TypeDict<T>::dict_;
-  auto iter = dict.find(key);
-  if (iter != dict.end()) {
-    return iter->second.Get();
+  for (const auto* alias : aliases_) {
+    const auto value = alias->OwnGet<T>(key);
+    if (value) return *value;
   }
   if (parent_) return parent_->GetOrDefault<T>(key, default_val);
   return default_val;
@@ -233,8 +275,9 @@ T& OptionsDict::GetRef(const OptionId& option_id) {
 template <typename T>
 bool OptionsDict::IsDefault(const std::string& key) const {
   if (!parent_) return true;
-  const auto& dict = TypeDict<T>::dict_;
-  if (dict.find(key) != dict.end()) return false;
+  for (const auto* alias : aliases_) {
+    if (alias->OwnExists<T>(key)) return false;
+  }
   return parent_->IsDefault<T>(key);
 }
 template <typename T>


### PR DESCRIPTION
It's a bit too unwieldy and ugly, but it's the best I could come up with.

So, before:
```
Root_params
  |
  + player1
  |
  + player2
```

After:
```
Root_params
  |
  + player1
  |       |
  |       + white
  |       |
  |       + black
  |       
  + player2
  |       |
  |       + white
  |       |
  |       + black
  |
  + white
  |
  + black
```

`root_params.white` and `root_params.black` are "aliases" (maybe a poor term) for `root_params.player*.white` (and `root_params.player*.black`).

When you e.g. access the parameter `player1.black.backend`, it's looked up in the following order:
1. `(default.root.)player1.black.backend` (self)
2. `(default.root.)black.backend` (alias) Note that parents of the alias are not looked up.
3. `(default.root.)player1.backend` (parent of the self)
4. `(default.root.)backend` (parent of parent of self)
4. `(default.)backend` (parent of parent of parent of self)