### PR TITLE
Use info string to display some important information

### DIFF
--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -129,6 +129,12 @@ bool ContainsKey(const std::unordered_map<std::string, std::string>& params,
 }  // namespace
 
 void UciLoop::RunLoop() {
+  LogInfo::logFunc = [=](const std::string& msg) {
+    ThinkingInfo info;
+    info.comment = msg;
+    SendInfo({info});
+  };
+    
   std::cout.setf(std::ios::unitbuf);
   std::string line;
   while (std::getline(std::cin, line)) {

--- a/src/neural/factory.cc
+++ b/src/neural/factory.cc
@@ -121,7 +121,7 @@ std::unique_ptr<Network> NetworkFactory::LoadNetwork(
   } else if (net_path == kEmbed) {
     net_path = CommandLine::BinaryName();
   } else {
-    CERR << "Loading weights file from: " << net_path;
+    LogInfo("Load weights file from: " + net_path);
   }
   std::optional<WeightsFile> weights;
   if (!net_path.empty()) {

--- a/src/neural/loader.cc
+++ b/src/neural/loader.cc
@@ -217,7 +217,7 @@ std::string DiscoverWeightsFile() {
     int val = 0;
     data >> val;
     if (!data.fail() && val == 2) {
-      CERR << "Found txt network file: " << candidate.second;
+      LogInfo("Found txt network file: " + candidate.second);
       return candidate.second;
     }
 
@@ -227,7 +227,7 @@ std::string DiscoverWeightsFile() {
                        (static_cast<uint32_t>(buf[3]) << 16) |
                        (static_cast<uint32_t>(buf[4]) << 24);
     if (magic == kWeightMagic) {
-      CERR << "Found pb network file: " << candidate.second;
+      LogInfo("Found pb network file: " + candidate.second);
       return candidate.second;
     }
   }

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -989,8 +989,9 @@ class SyzygyTablebaseImpl {
     }
 
   finished:
-    CERR << "Found " << num_wdl_ << "WDL, " << num_dtm_ << " DTM and "
-         << num_dtz_ << " DTZ tablebase files.";
+    LogInfo("Syzygy found: " + std::to_string(num_wdl_) + " WDL, " + std::to_string(num_dtm_) + " DTM and "
+    + std::to_string(num_dtz_) + " DTZ tablebase files.");
+
   }
 
   ~SyzygyTablebaseImpl() {

--- a/src/utils/logging.cc
+++ b/src/utils/logging.cc
@@ -68,6 +68,16 @@ void Logging::SetFilename(const std::string& filename) {
   buffer_.clear();
 }
 
+std::function<void(const std::string&)> LogInfo::logFunc = nullptr;
+
+LogInfo::LogInfo(const std::string& msg) {
+    if (logFunc) {
+        (logFunc)(msg);
+    } else {
+        CERR << msg;
+    }
+}
+
 LogMessage::LogMessage(const char* file, int line) {
   *this << FormatTime(std::chrono::system_clock::now()) << ' '
         << std::setfill(' ') << std::this_thread::get_id() << std::setfill('0')

--- a/src/utils/logging.h
+++ b/src/utils/logging.h
@@ -32,6 +32,7 @@
 #include <iomanip>
 #include <sstream>
 #include <string>
+#include <functional>
 
 #include "utils/mutex.h"
 
@@ -55,6 +56,12 @@ class Logging {
 
   Logging() = default;
   friend class LogMessage;
+};
+
+class LogInfo {
+ public:
+  LogInfo(const std::string&);
+  static std::function<void(const std::string&)> logFunc;
 };
 
 class LogMessage : public std::ostringstream {


### PR DESCRIPTION
This PR is a re-implementation of canceled PR #1302.

Whenever there is a UCI loop, it uses command "info string" to display information about numbers of Sygyzy endgames and the network file. Otherwise, it uses cerr to display that information as before.

The technique uses std::function as the suggestion by mooskagh.
