### PR TITLE
Always report nps defaulting to all nodes without elapsed time.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -143,15 +143,15 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
     common_info.hashfull =
         cache_->GetSize() * 1000LL / std::max(cache_->GetCapacity(), 1);
   }
-  if (nps_start_time_) {
-    const auto time_since_first_batch_ms =
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now() - *nps_start_time_)
-            .count();
-    if (time_since_first_batch_ms > 0) {
-      common_info.nps = total_playouts_ * 1000 / time_since_first_batch_ms;
-    }
-  }
+  const auto time_since_first_batch_ms =
+      nps_start_time_ ? std::chrono::duration_cast<std::chrono::milliseconds>(
+                            std::chrono::steady_clock::now() - *nps_start_time_)
+                            .count()
+                      : 0;
+  // Report new nodes / elapsed time defaulting to all (i.e., nodes / 1 second).
+  common_info.nps = time_since_first_batch_ms > 0
+                        ? total_playouts_ * 1000 / time_since_first_batch_ms
+                        : total_playouts_;
   common_info.tb_hits = tb_hits_.load(std::memory_order_acquire);
 
   int multipv = 0;


### PR DESCRIPTION
r?@mooskagh Fix #1316 by reporting total new nodes when there's no calculated elapsed time effectively treating the elapsed time as 1 second. Notice before no nps would be reported on the initial info line on a reused-tree search:
```
Before:
go nodes 5
info depth 1 seldepth 2 time 1819 nodes 2 score cp 17 nps 41 tbhits 0 pv e2e4 e7e5
info depth 2 seldepth 3 time 1903 nodes 3 score cp 15 nps 22 tbhits 0 pv e2e4 e7e5 g1f3
info depth 2 seldepth 4 time 1922 nodes 5 score cp 16 nps 33 tbhits 0 pv e2e4 c7c6 b1c3 d7d5
bestmove e2e4 ponder c7c6

go nodes 1
info depth 1 seldepth 0 time 4506 nodes 6 score cp 16 tbhits 0 pv e2e4 e7e5 g1f3 b8c6 b1a3
bestmove e2e4 ponder e7e5

go nodes 10
info depth 3 seldepth 3 time 7144 nodes 8 score cp 16 tbhits 0 pv e2e4 e7e5 g1f3 b8c6 f1b5 a8b8
info depth 4 seldepth 6 time 7174 nodes 9 score cp 16 nps 66 tbhits 0 pv e2e4 e7e5 g1f3 b8c6 f1b5 g8f6
info depth 4 seldepth 6 time 7175 nodes 10 score cp 16 nps 100 tbhits 0 pv e2e4 e7e5 g1f3 b8c6 f1b5 g8f6
bestmove e2e4 ponder e7e5


After:
go nodes 5
info depth 1 seldepth 2 time 1001 nodes 2 score cp 17 nps 38 tbhits 0 pv e2e4 e7e5
info depth 2 seldepth 3 time 1086 nodes 3 score cp 17 nps 21 tbhits 0 pv e2e4 c7c6 b1c3
info depth 2 seldepth 4 time 1112 nodes 5 score cp 16 nps 30 tbhits 0 pv e2e4 e7e5 g1f3 b8c6
bestmove e2e4 ponder e7e5

go nodes 1
info depth 1 seldepth 0 time 3025 nodes 6 score cp 16 nps 0 tbhits 0 pv e2e4 e7e5 g1f3 b8c6
bestmove e2e4 ponder e7e5

go nodes 10
info depth 3 seldepth 3 time 6113 nodes 8 score cp 16 nps 1 tbhits 0 pv e2e4 e7e5 g1f3 b8c6 f1b5 a8b8
info depth 4 seldepth 6 time 6143 nodes 9 score cp 16 nps 66 tbhits 0 pv e2e4 e7e5 g1f3 b8c6 f1b5 g8f6
info depth 4 seldepth 6 time 6143 nodes 10 score cp 16 nps 100 tbhits 0 pv e2e4 e7e5 g1f3 b8c6 f1b5 g8f6
bestmove e2e4 ponder e7e5
```

I filed https://github.com/cutechess/cutechess/issues/571 for cutechess ignoring `nps 0`.