### PR TITLE
Treat blessed/cursed as losses/wins with --no-syzygy-50-move-rule.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -188,6 +188,9 @@ const OptionId SearchParams::kStickyEndgamesId{
     "example, if at least one move results in checkmate, then the position "
     "should stick as checkmated. Similarly, if all moves are drawn or "
     "checkmated, the position should stick as drawn or checkmate."};
+const OptionId SearchParams::kSyzygy50MoveRuleId{
+    "syzygy-50-move-rule", "Syzygy50MoveRule",
+    "Use 50-move rule to treat blessed losses and cursed wins as draw."};
 const OptionId SearchParams::kSyzygyFastPlayId{
     "syzygy-fast-play", "SyzygyFastPlay",
     "With DTZ tablebase files, only allow the network pick from winning moves "
@@ -298,6 +301,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<BoolOption>(kOutOfOrderEvalId) = true;
   options->Add<FloatOption>(kMaxOutOfOrderEvalsId, 0.0f, 100.0f) = 1.0f;
   options->Add<BoolOption>(kStickyEndgamesId) = true;
+  options->Add<BoolOption>(kSyzygy50MoveRuleId) = true;
   options->Add<BoolOption>(kSyzygyFastPlayId) = true;
   options->Add<IntOption>(kMultiPvId, 1, 500) = 1;
   options->Add<BoolOption>(kPerPvCountersId) = false;
@@ -374,6 +378,7 @@ SearchParams::SearchParams(const OptionsDict& options)
       kMaxCollisionVisits(options.Get<int>(kMaxCollisionVisitsId)),
       kOutOfOrderEval(options.Get<bool>(kOutOfOrderEvalId)),
       kStickyEndgames(options.Get<bool>(kStickyEndgamesId)),
+      kSyzygy50MoveRule(options.Get<bool>(kSyzygy50MoveRuleId)),
       kSyzygyFastPlay(options.Get<bool>(kSyzygyFastPlayId)),
       kHistoryFill(EncodeHistoryFill(options.Get<std::string>(kHistoryFillId))),
       kMiniBatchSize(options.Get<int>(kMiniBatchSizeId)),

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -88,6 +88,7 @@ class SearchParams {
   int GetMaxCollisionVisitsId() const { return kMaxCollisionVisits; }
   bool GetOutOfOrderEval() const { return kOutOfOrderEval; }
   bool GetStickyEndgames() const { return kStickyEndgames; }
+  bool GetSyzygy50MoveRule() const { return kSyzygy50MoveRule; }
   bool GetSyzygyFastPlay() const { return kSyzygyFastPlay; }
   int GetMultiPv() const { return options_.Get<int>(kMultiPvId); }
   bool GetPerPvCounters() const { return options_.Get<bool>(kPerPvCountersId); }
@@ -145,6 +146,7 @@ class SearchParams {
   static const OptionId kMaxCollisionVisitsId;
   static const OptionId kOutOfOrderEvalId;
   static const OptionId kStickyEndgamesId;
+  static const OptionId kSyzygy50MoveRuleId;
   static const OptionId kSyzygyFastPlayId;
   static const OptionId kMultiPvId;
   static const OptionId kPerPvCountersId;
@@ -192,6 +194,7 @@ class SearchParams {
   const int kMaxCollisionVisits;
   const bool kOutOfOrderEval;
   const bool kStickyEndgames;
+  const bool kSyzygy50MoveRule;
   const bool kSyzygyFastPlay;
   const FillEmptyHistory kHistoryFill;
   const int kMiniBatchSize;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1237,13 +1237,15 @@ void SearchWorker::ExtendNode(Node* node) {
           m = std::max(0.0f, parent->GetM() - 1.0f);
         }
         // If the colors seem backwards, check the checkmate check above.
-        if (wdl == WDL_WIN) {
+        const auto use_50_move_rule = params_.GetSyzygy50MoveRule();
+        if (wdl >= (use_50_move_rule ? WDL_WIN : WDL_CURSED_WIN)) {
           node->MakeTerminal(GameResult::BLACK_WON, m,
                              Node::Terminal::Tablebase);
-        } else if (wdl == WDL_LOSS) {
+        } else if (wdl <= (use_50_move_rule ? WDL_LOSS : WDL_BLESSED_LOSS)) {
           node->MakeTerminal(GameResult::WHITE_WON, m,
                              Node::Terminal::Tablebase);
-        } else {  // Cursed wins and blessed losses count as draws.
+        } else {
+          // Cursed wins and blessed losses also are draws using 50 move rule.
           node->MakeTerminal(GameResult::DRAW, m, Node::Terminal::Tablebase);
         }
         search_->tb_hits_.fetch_add(1, std::memory_order_acq_rel);

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1238,16 +1238,14 @@ void SearchWorker::ExtendNode(Node* node) {
         }
         // If the colors seem backwards, check the checkmate check above.
         const auto use_50_move_rule = params_.GetSyzygy50MoveRule();
-        if (wdl >= (use_50_move_rule ? WDL_WIN : WDL_CURSED_WIN)) {
-          node->MakeTerminal(GameResult::BLACK_WON, m,
-                             Node::Terminal::Tablebase);
-        } else if (wdl <= (use_50_move_rule ? WDL_LOSS : WDL_BLESSED_LOSS)) {
-          node->MakeTerminal(GameResult::WHITE_WON, m,
-                             Node::Terminal::Tablebase);
-        } else {
-          // Cursed wins and blessed losses also are draws using 50 move rule.
-          node->MakeTerminal(GameResult::DRAW, m, Node::Terminal::Tablebase);
-        }
+        // Cursed wins and blessed losses also are draws using 50 move rule.
+        node->MakeTerminal(
+            wdl >= (use_50_move_rule ? WDL_WIN : WDL_CURSED_WIN)
+                ? GameResult::BLACK_WON
+                : wdl <= (use_50_move_rule ? WDL_LOSS : WDL_BLESSED_LOSS)
+                      ? GameResult::WHITE_WON
+                      : GameResult::DRAW,
+            m, Node::Terminal::Tablebase);
         search_->tb_hits_.fetch_add(1, std::memory_order_acq_rel);
         return;
       }


### PR DESCRIPTION
r?@mooskagh or @Tilps Fix #856 with a new option allowing treating blessed losses and cursed wins differently.
  
```
ucinewgame
setoption name syzygy50moverule value true
position fen 8/6B1/8/8/B7/8/K1pk4/8 b
go nodes 2 searchmoves c2c1n

info depth 1 seldepth 2 time 44 nodes 2 score cp 0 nps 2 tbhits 1 pv c2c1n
info c2c1n N: 1 (P: 13.62%) (WL:  0.00000) (D: 1.000) (M:  0.0) (S:  0.14620) (T)  


ucinewgame
setoption name syzygy50moverule value false
position fen 8/6B1/8/8/B7/8/K1pk4/8 b
go nodes 2 searchmoves c2c1n

info depth 1 seldepth 2 time 44 nodes 2 score mate -101 nps 2 tbhits 1 pv c2c1n
info c2c1n N: 1 (P:  0.00%) (WL: -1.00000) (D: 0.000) (M:  0.0) (S: -1.00000) (T) 
```
https://syzygy-tables.info/?fen=8/6B1/8/8/B7/8/K1pk4/8_b_-_-_0_1
![blessed loss](https://user-images.githubusercontent.com/438537/83982186-6d19d300-a8d9-11ea-8b60-7fe53cf5c1bd.png)
