### PR TITLE
Display board

### DIFF
--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -59,6 +59,7 @@ const std::unordered_map<std::string, std::unordered_set<std::string>>
         {{"stop"}, {}},
         {{"ponderhit"}, {}},
         {{"quit"}, {}},
+        {{"d"}, {}},
         {{"xyzzy"}, {}},
 };
 
@@ -205,6 +206,8 @@ bool UciLoop::DispatchCommand(
     SendResponse("Nothing happens.");
   } else if (command == "quit") {
     return false;
+  } else if (command == "d") {
+      CmdDisplay();
   } else {
     throw Exception("Unknown command: " + command);
   }

--- a/src/chess/uciloop.h
+++ b/src/chess/uciloop.h
@@ -84,6 +84,7 @@ class UciLoop {
   virtual void CmdStop() { throw Exception("Not supported"); }
   virtual void CmdPonderHit() { throw Exception("Not supported"); }
   virtual void CmdStart() { throw Exception("Not supported"); }
+  virtual void CmdDisplay() const { throw Exception("Not supported"); }
 
  private:
   bool DispatchCommand(

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -110,21 +110,24 @@ void EngineController::PopulateOptions(OptionsParser* options) {
 void EngineController::Display() const {
   auto fen = current_position_->fen.empty() ? ChessBoard::kStartposFen : current_position_->fen;
   ChessBoard board(fen);
+  auto white = true;
+  if (board.flipped()) {
+    board.Mirror();
+    white = false;
+  }
   if (!current_position_->moves.empty()) {
-    bool flipped = board.flipped(), oflipped = flipped;
-    if (flipped) board.Mirror();
     for (const auto& moveString : current_position_->moves) {
       if (moveString.empty()) break;
-      Move move(moveString, flipped);
+      Move move(moveString, board.flipped());
       KingAttackInfo king_attack_info;
       if (!board.IsLegalMove(move, king_attack_info)) break;
       board.ApplyMove(move);
-      flipped = !flipped;
       board.Mirror();
+      white = !white;
     }
-    if (oflipped != flipped) board.Mirror();
+    if (board.flipped()) board.Mirror();
   }
-  std::cout << board.DebugString() << std::endl;
+  std::cout << board.DebugString() << std::endl << "side: " << (white ? "white" : "black") << std::endl;
 }
 
 void EngineController::ResetMoveTimer() {

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -107,6 +107,13 @@ void EngineController::PopulateOptions(OptionsParser* options) {
   options->HideOption(kStrictUciTiming);
 }
 
+void EngineController::Display() const {
+  auto fen = current_position_->fen.empty() ? ChessBoard::kStartposFen : current_position_->fen;
+  ChessBoard board;
+  board.SetFromFen(fen);
+  std::cout << board.DebugString() << std::endl;
+}
+
 void EngineController::ResetMoveTimer() {
   move_start_time_ = std::chrono::steady_clock::now();
 }
@@ -341,5 +348,7 @@ void EngineLoop::CmdGo(const GoParams& params) { engine_.Go(params); }
 void EngineLoop::CmdPonderHit() { engine_.PonderHit(); }
 
 void EngineLoop::CmdStop() { engine_.Stop(); }
+
+void EngineLoop::CmdDisplay() const { engine_.Display(); }
 
 }  // namespace lczero

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -110,7 +110,6 @@ void EngineController::PopulateOptions(OptionsParser* options) {
 void EngineController::Display() const {
   auto fen = current_position_->fen.empty() ? ChessBoard::kStartposFen : current_position_->fen;
   ChessBoard board(fen);
-  auto black = board.flipped();
   if (!current_position_->moves.empty()) {
     for (const auto& moveString : current_position_->moves) {
       if (moveString.empty()) break;
@@ -119,11 +118,11 @@ void EngineController::Display() const {
       if (!board.IsLegalMove(move, king_attack_info)) break;
       board.ApplyMove(move);
       board.Mirror();
-      black = !black;
     }
   }
-  if (board.flipped()) board.Mirror();
-  std::cout << board.DebugString() << std::endl << "side: " << (black ? "black" : "white") << std::endl;
+  auto black = board.flipped();
+  if (black) board.Mirror();
+  std::cout << board.DebugString() << "side: " << (black ? "black" : "white") << std::endl;
 }
 
 void EngineController::ResetMoveTimer() {

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -110,11 +110,7 @@ void EngineController::PopulateOptions(OptionsParser* options) {
 void EngineController::Display() const {
   auto fen = current_position_->fen.empty() ? ChessBoard::kStartposFen : current_position_->fen;
   ChessBoard board(fen);
-  auto white = true;
-  if (board.flipped()) {
-    board.Mirror();
-    white = false;
-  }
+  auto black = board.flipped();
   if (!current_position_->moves.empty()) {
     for (const auto& moveString : current_position_->moves) {
       if (moveString.empty()) break;
@@ -123,11 +119,11 @@ void EngineController::Display() const {
       if (!board.IsLegalMove(move, king_attack_info)) break;
       board.ApplyMove(move);
       board.Mirror();
-      white = !white;
+      black = !black;
     }
-    if (board.flipped()) board.Mirror();
   }
-  std::cout << board.DebugString() << std::endl << "side: " << (white ? "white" : "black") << std::endl;
+  if (board.flipped()) board.Mirror();
+  std::cout << board.DebugString() << std::endl << "side: " << (black ? "black" : "white") << std::endl;
 }
 
 void EngineController::ResetMoveTimer() {

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -109,8 +109,21 @@ void EngineController::PopulateOptions(OptionsParser* options) {
 
 void EngineController::Display() const {
   auto fen = current_position_->fen.empty() ? ChessBoard::kStartposFen : current_position_->fen;
-  ChessBoard board;
-  board.SetFromFen(fen);
+  ChessBoard board(fen);
+  if (!current_position_->moves.empty()) {
+    bool flipped = board.flipped(), oflipped = flipped;
+    if (flipped) board.Mirror();
+    for (const auto& moveString : current_position_->moves) {
+      if (moveString.empty()) break;
+      Move move(moveString, flipped);
+      KingAttackInfo king_attack_info;
+      if (!board.IsLegalMove(move, king_attack_info)) break;
+      board.ApplyMove(move);
+      flipped = !flipped;
+      board.Mirror();
+    }
+    if (oflipped != flipped) board.Mirror();
+  }
   std::cout << board.DebugString() << std::endl;
 }
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -57,6 +57,7 @@ class EngineController {
   }
 
   void PopulateOptions(OptionsParser* options);
+  void Display() const;
 
   // Blocks.
   void EnsureReady();
@@ -129,6 +130,7 @@ class EngineLoop : public UciLoop {
   void CmdGo(const GoParams& params) override;
   void CmdPonderHit() override;
   void CmdStop() override;
+  void CmdDisplay() const override;
 
  private:
   OptionsParser options_;


### PR DESCRIPTION
Add new command "d" to display the current chess board. It is a convenient function for developers.

Discussion: This implementation uses an existent function DebugString() of ChessBoard to display the board in the text form. We may improve later for showing more pretty as well as having more info such as endgame probe result.

<img width="468" alt="Screen Shot 2020-06-19 at 7 21 00 pm" src="https://user-images.githubusercontent.com/1370755/85117418-2b3a4680-b262-11ea-94d4-b05c0966d4c5.png">

