### PR TITLE
Fixed issue 'Cannot stat file'

### DIFF
--- a/src/utils/filesystem.h
+++ b/src/utils/filesystem.h
@@ -41,10 +41,10 @@ void CreateDirectory(const std::string& path);
 // Silently returns empty vector on error.
 std::vector<std::string> GetFileList(const std::string& directory);
 
-// Returns size of a file. Throws exception if file doesn't exist.
+// Returns size of a file, 0 if file doesn't exist or can't be read.
 uint64_t GetFileSize(const std::string& filename);
 
-// Returns modification time of a file. Throws exception if file doesn't exist.
+// Returns modification time of a file, 0 if file doesn't exist or can't be read.
 time_t GetFileTime(const std::string& filename);
 
 // Returns the base directory relative to which user specific non-essential data

--- a/src/utils/filesystem.posix.cc
+++ b/src/utils/filesystem.posix.cc
@@ -67,7 +67,7 @@ std::vector<std::string> GetFileList(const std::string& directory) {
 uint64_t GetFileSize(const std::string& filename) {
   struct stat s;
   if (stat(filename.c_str(), &s) < 0) {
-    throw Exception("Cannot stat file: " + filename);
+    return 0;
   }
   return s.st_size;
 }
@@ -75,7 +75,7 @@ uint64_t GetFileSize(const std::string& filename) {
 time_t GetFileTime(const std::string& filename) {
   struct stat s;
   if (stat(filename.c_str(), &s) < 0) {
-    throw Exception("Cannot stat file: " + filename);
+    return 0;
   }
 #ifdef __APPLE__
   return s.st_mtimespec.tv_sec;

--- a/src/utils/filesystem.win32.cc
+++ b/src/utils/filesystem.win32.cc
@@ -57,7 +57,7 @@ std::vector<std::string> GetFileList(const std::string& directory) {
 uint64_t GetFileSize(const std::string& filename) {
   WIN32_FILE_ATTRIBUTE_DATA s;
   if (!GetFileAttributesExA(filename.c_str(), GetFileExInfoStandard, &s)) {
-    throw Exception("Cannot stat file: " + filename);
+    return 0;
   }
   return (static_cast<uint64_t>(s.nFileSizeHigh) << 32) + s.nFileSizeLow;
 }
@@ -65,7 +65,7 @@ uint64_t GetFileSize(const std::string& filename) {
 time_t GetFileTime(const std::string& filename) {
   WIN32_FILE_ATTRIBUTE_DATA s;
   if (!GetFileAttributesExA(filename.c_str(), GetFileExInfoStandard, &s)) {
-    throw Exception("Cannot stat file: " + filename);
+    return 0;
   }
   return (static_cast<uint64_t>(s.ftLastWriteTime.dwHighDateTime) << 32) +
          s.ftLastWriteTime.dwLowDateTime;


### PR DESCRIPTION
Fixed the issue #831
Fixed by returning 0 instead of throwing the exception. Two involved functions are GetFileSize and GetFileTime. All code which called those functions can work well with returns of zero.