### PR TITLE
backend option to disable mlh

### DIFF
--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -427,8 +427,9 @@ BlasNetwork<use_eigen>::BlasNetwork(const WeightsFile& file,
   wdl_ = file.format().network_format().value() ==
          pblczero::NetworkFormat::VALUE_WDL;
 
-  moves_left_ = file.format().network_format().moves_left() ==
-                pblczero::NetworkFormat::MOVES_LEFT_V1;
+  moves_left_ = (file.format().network_format().moves_left() ==
+                 pblczero::NetworkFormat::MOVES_LEFT_V1) &&
+                options.GetOrDefault<bool>("mlh", true);
 
   conv_policy_ = file.format().network_format().policy() ==
                  pblczero::NetworkFormat::POLICY_CONVOLUTION;

--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -562,8 +562,9 @@ class CudnnNetwork : public Network {
     value_out_ = getLastLayer();
 
     // Moves left head
-    moves_left_ = file.format().network_format().moves_left() ==
-                  pblczero::NetworkFormat::MOVES_LEFT_V1;
+    moves_left_ = (file.format().network_format().moves_left() ==
+                   pblczero::NetworkFormat::MOVES_LEFT_V1) &&
+                  options.GetOrDefault<bool>("mlh", true);
     if (moves_left_) {
       auto convMov = std::make_unique<ConvLayer<DataType>>(
           resi_last_, weights.moves_left.biases.size(), 8, 8, 1, kNumFilters,

--- a/src/neural/dx/network_dx.cc
+++ b/src/neural/dx/network_dx.cc
@@ -588,8 +588,9 @@ DxNetwork::DxNetwork(const WeightsFile& file, const OptionsDict& options)
   }
 
   // Moves left head
-  moves_left_ = file.format().network_format().moves_left() ==
-                pblczero::NetworkFormat::MOVES_LEFT_V1;
+  moves_left_ = (file.format().network_format().moves_left() ==
+                 pblczero::NetworkFormat::MOVES_LEFT_V1) &&
+                options.GetOrDefault<bool>("mlh", true);
   if (moves_left_) {
     // 1x1 convolution, moves_left biases output filters
     auto convMov = std::make_unique<ConvLayer>(

--- a/src/neural/opencl/network_opencl.cc
+++ b/src/neural/opencl/network_opencl.cc
@@ -251,8 +251,9 @@ class OpenCLNetwork : public Network {
     wdl_ = file.format().network_format().output() ==
            pblczero::NetworkFormat::OUTPUT_WDL;
 
-    moves_left_ = file.format().network_format().moves_left() ==
-                  pblczero::NetworkFormat::MOVES_LEFT_V1;
+    moves_left_ = (file.format().network_format().moves_left() ==
+                   pblczero::NetworkFormat::MOVES_LEFT_V1) &&
+                  options.GetOrDefault<bool>("mlh", true);
 
     auto max_batch_size_ =
         static_cast<size_t>(options.GetOrDefault<int>("batch_size", 16));


### PR DESCRIPTION
For anyone who wants to get back the small MLH overhead, adding `--backend-opts-mlh=false` skips the mlh calculations in the backend.