### PR TITLE
Change variant wl_ in Nodes from double to float

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -430,7 +430,7 @@ V5TrainingData Node::GetV5TrainingData(
   }
 
   // Aggregate evaluation WL.
-  result.root_q = -GetWL();
+  result.root_q = static_cast<float>(-GetWL());
   result.best_q = best_q;
 
   // Draw probability of WDL head.

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -252,14 +252,6 @@ class Node {
   // padding when new fields are added, we arrange the fields by size, largest
   // to smallest.
 
-  // 8 byte fields.
-  // Average value (from value head of neural network) of all visited nodes in
-  // subtree. For terminal nodes, eval is stored. This is from the perspective
-  // of the player who "just" moved to reach this position, rather than from the
-  // perspective of the player-to-move for the position.
-  // WL stands for "W minus L". Is equal to Q if draw score is 0.
-  double wl_ = 0.0f;
-
   // 8 byte fields on 64-bit platforms, 4 byte on 32-bit.
   // Array of edges.
   std::unique_ptr<Edge[]> edges_;
@@ -274,6 +266,13 @@ class Node {
   Node* best_child_cached_ = nullptr;
 
   // 4 byte fields.
+  // Average value (from value head of neural network) of all visited nodes in
+  // subtree. For terminal nodes, eval is stored. This is from the perspective
+  // of the player who "just" moved to reach this position, rather than from the
+  // perspective of the player-to-move for the position.
+  // WL stands for "W minus L". Is equal to Q if draw score is 0.
+  float wl_ = 0.0f;
+
   // Averaged draw probability. Works similarly to WL, except that D is not
   // flipped depending on the side to move.
   float d_ = 0.0f;
@@ -326,7 +325,7 @@ class Node {
 #if defined(__i386__) || (defined(__arm__) && !defined(__aarch64__))
 static_assert(sizeof(Node) == 56, "Unexpected size of Node for 32bit compile");
 #else
-static_assert(sizeof(Node) == 80, "Unexpected size of Node");
+static_assert(sizeof(Node) == 72, "Unexpected size of Node");
 #endif
 
 // Contains Edge and Node pair and set of proxy functions to simplify access

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -323,7 +323,7 @@ class Node {
 
 // A basic sanity check. This must be adjusted when Node members are adjusted.
 #if defined(__i386__) || (defined(__arm__) && !defined(__aarch64__))
-static_assert(sizeof(Node) == 56, "Unexpected size of Node for 32bit compile");
+static_assert(sizeof(Node) == 52, "Unexpected size of Node for 32bit compile");
 #else
 static_assert(sizeof(Node) == 72, "Unexpected size of Node");
 #endif

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -482,12 +482,12 @@ void Search::MaybeTriggerStop(const IterationStats& stats,
 Search::BestEval Search::GetBestEval() const {
   SharedMutex::SharedLock lock(nodes_mutex_);
   Mutex::Lock counters_lock(counters_mutex_);
-  float parent_wl = -root_node_->GetWL();
+  auto parent_wl = -root_node_->GetWL();
   float parent_d = root_node_->GetD();
   float parent_m = root_node_->GetM();
-  if (!root_node_->HasChildren()) return {parent_wl, parent_d, parent_m};
+  if (!root_node_->HasChildren()) return {static_cast<float>(parent_wl), parent_d, parent_m};
   EdgeAndNode best_edge = GetBestChildNoTemperature(root_node_, 0);
-  return {best_edge.GetWL(parent_wl), best_edge.GetD(parent_d),
+  return {static_cast<float>(best_edge.GetWL(parent_wl)), best_edge.GetD(parent_d),
           best_edge.GetM(parent_m - 1) + 1};
 }
 
@@ -1447,7 +1447,7 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
   if (!node_to_process->nn_queried) {
     // Terminal nodes don't involve the neural NetworkComputation, nor do
     // they require any further processing after value retrieval.
-    node_to_process->v = node->GetWL();
+    node_to_process->v = static_cast<float>(node->GetWL());
     node_to_process->d = node->GetD();
     node_to_process->m = node->GetM();
     return;
@@ -1539,7 +1539,7 @@ void SearchWorker::DoBackupUpdateSingleNode(
     // Current node might have become terminal from some other descendant, so
     // backup the rest of the way with more accurate values.
     if (n->IsTerminal()) {
-      v = n->GetWL();
+      v = static_cast<float>(n->GetWL());
       d = n->GetD();
       m = n->GetM();
     }
@@ -1634,7 +1634,7 @@ bool SearchWorker::MaybeSetBounds(Node* p, float m, int* n_to_fix,
     // it terminal preferring shorter wins and longer losses.
     *n_to_fix = p->GetN();
     assert(*n_to_fix > 0);
-    float cur_v = p->GetWL();
+    auto cur_v = p->GetWL();
     float cur_d = p->GetD();
     float cur_m = p->GetM();
     p->MakeTerminal(
@@ -1643,7 +1643,7 @@ bool SearchWorker::MaybeSetBounds(Node* p, float m, int* n_to_fix,
         prefer_tb ? Node::Terminal::Tablebase : Node::Terminal::EndOfGame);
     // Negate v_delta because we're calculating for the parent, but immediately
     // afterwards we'll negate v_delta in case it has come from the child.
-    *v_delta = -(p->GetWL() - cur_v);
+    *v_delta = static_cast<float>(-(p->GetWL() - cur_v));
     *d_delta = p->GetD() - cur_d;
     *m_delta = p->GetM() - cur_m;
   } else {


### PR DESCRIPTION
**Edited:** 
The PR:
- add a warning comment for the variant wl_ in Node class
- changes the return type of the function GetWL from float to double and do clear castings if needed

Discuss: the original function GetWL is a data bottleneck for the variant wl_ since sometimes the engine has to keep converting from double to float then back to double, losing both computing and precision. We should keep the data unchanged type as long as possible to maximize the benefit of changing from float to double for wl_

**Origin:**
Using double for the variant wl_ (in the class Nodes) is redundant both on size and computing (for converting) since all in/out and operations with other variants using floats only.

By changing from double to float the precisions of all functions are almost the same but we can reduce the size of Nodes from 80 (for 64-bit system) to 72 bytes, a 10% decreasing.