### PR TITLE
Remove logit q.

### DIFF
--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -39,7 +39,6 @@
 #include "neural/encoder.h"
 #include "neural/writer.h"
 #include "proto/net.pb.h"
-#include "utils/fastmath.h"
 #include "utils/mutex.h"
 
 namespace lczero {

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -377,13 +377,8 @@ class EdgeAndNode {
   Node* node() const { return node_; }
 
   // Proxy functions for easier access to node/edge.
-  float GetQ(float default_q, float draw_score, bool logit_q) const {
-    return (node_ && node_->GetN() > 0)
-               ?
-               // Scale Q slightly to avoid logit(1) = infinity.
-               (logit_q ? FastLogit(0.9999999f * node_->GetQ(draw_score))
-                        : node_->GetQ(draw_score))
-               : default_q;
+  float GetQ(float default_q, float draw_score) const {
+    return (node_ && node_->GetN() > 0) ? node_->GetQ(draw_score) : default_q;
   }
   float GetWL(float default_wl) const {
     return (node_ && node_->GetN() > 0) ? node_->GetWL() : default_wl;

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -53,10 +53,6 @@ const OptionId SearchParams::kMaxPrefetchBatchId{
     "When the engine cannot gather a large enough batch for immediate use, try "
     "to prefetch up to X positions which are likely to be useful soon, and put "
     "them into cache."};
-const OptionId SearchParams::kLogitQId{
-    "logit-q", "LogitQ",
-    "Apply logit to Q when determining Q+U best child. This makes the U term "
-    "less dominant when Q is near -1 or +1."};
 const OptionId SearchParams::kCpuctId{
     "cpuct", "CPuct",
     "cpuct_init constant from \"UCT search\" algorithm. Higher values promote "
@@ -269,7 +265,6 @@ void SearchParams::Populate(OptionsParser* options) {
   // Many of them are overridden with training specific values in tournament.cc.
   options->Add<IntOption>(kMiniBatchSizeId, 1, 1024) = 256;
   options->Add<IntOption>(kMaxPrefetchBatchId, 0, 1024) = 32;
-  options->Add<BoolOption>(kLogitQId) = false;
   options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 2.147f;
   options->Add<FloatOption>(kCpuctAtRootId, 0.0f, 100.0f) = 2.147f;
   options->Add<FloatOption>(kCpuctBaseId, 1.0f, 1000000000.0f) = 18368.0f;
@@ -349,7 +344,6 @@ void SearchParams::Populate(OptionsParser* options) {
 
 SearchParams::SearchParams(const OptionsDict& options)
     : options_(options),
-      kLogitQ(options.Get<bool>(kLogitQId)),
       kCpuct(options.Get<float>(kCpuctId)),
       kCpuctAtRoot(options.Get<float>(
           options.Get<bool>(kRootHasOwnCpuctParamsId) ? kCpuctAtRootId

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -46,7 +46,6 @@ class SearchParams {
   int GetMaxPrefetchBatch() const {
     return options_.Get<int>(kMaxPrefetchBatchId);
   }
-  bool GetLogitQ() const { return kLogitQ; }
   float GetCpuct(bool at_root) const { return at_root ? kCpuctAtRoot : kCpuct; }
   float GetCpuctBase(bool at_root) const {
     return at_root ? kCpuctBaseAtRoot : kCpuctBase;
@@ -115,7 +114,6 @@ class SearchParams {
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
   static const OptionId kMaxPrefetchBatchId;
-  static const OptionId kLogitQId;
   static const OptionId kCpuctId;
   static const OptionId kCpuctAtRootId;
   static const OptionId kCpuctBaseId;
@@ -173,7 +171,6 @@ class SearchParams {
   // 2. Parameter has to stay the say during the search.
   // TODO(crem) Some of those parameters can be converted to be dynamic after
   //            trivial search optimizations.
-  const bool kLogitQ;
   const float kCpuct;
   const float kCpuctAtRoot;
   const float kCpuctBase;

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -132,7 +132,6 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   defaults->Set<std::string>(SearchParams::kHistoryFillId, "no");
   defaults->Set<std::string>(NetworkFactory::kBackendId, "multiplexing");
   defaults->Set<bool>(SearchParams::kStickyEndgamesId, false);
-  defaults->Set<bool>(SearchParams::kLogitQId, false);
 }
 
 SelfPlayTournament::SelfPlayTournament(

--- a/src/utils/fastmath.h
+++ b/src/utils/fastmath.h
@@ -77,9 +77,4 @@ inline float FastLog(const float a) {
 // Fast approximate exp(x). Does only limited range checking.
 inline float FastExp(const float a) { return FastPow2(1.442695040f * a); }
 
-// Fast logit for more readable code.
-inline float FastLogit(const float a) {
-  return 0.5f * FastLog((1.0f + a) / (1.0f - a));
-}
-
 }  // namespace lczero


### PR DESCRIPTION
Profiling on windows with LTO enabled, I noticed that edge.GetQ was not being inlined in our hottest loop. If I removed the nested logit_q path it was inlined and there was a dramatic performance increase in CPU limited scenarios. (Combined with one other small change it was ~15% increase in nps over a 5 million node search).
Given that logit-q has failed to prove itself in practice, having the potential for this much CPU bottleneck when the feature is disabled doesn't seem a worthwhile situation.
Until such time as there seems a new reason for it - it seems prudent to remove it entirely.