### PR TITLE
Twofold repetition draw scoring

### DIFF
--- a/src/chess/position.cc
+++ b/src/chess/position.cc
@@ -117,7 +117,6 @@ int PositionHistory::ComputePliesSinceFirstRepetition() const {
   for (int idx = positions_.size() - 3; idx >= 0; idx -= 2) {
     const auto& pos = positions_[idx];
     if (pos.GetBoard() == last.GetBoard()) {
-      print(std::fixed, "twofold rep found", positions_.size(), idx)
       return positions_.size() - 1 - idx;
     }
     if (pos.GetRule50Ply() < 2) return 0;

--- a/src/chess/position.cc
+++ b/src/chess/position.cc
@@ -117,6 +117,7 @@ int PositionHistory::ComputePliesSinceFirstRepetition() const {
   for (int idx = positions_.size() - 3; idx >= 0; idx -= 2) {
     const auto& pos = positions_[idx];
     if (pos.GetBoard() == last.GetBoard()) {
+      print(std::fixed, "twofold rep found", positions_.size(), idx)
       return positions_.size() - 1 - idx;
     }
     if (pos.GetRule50Ply() < 2) return 0;

--- a/src/chess/position.cc
+++ b/src/chess/position.cc
@@ -109,6 +109,21 @@ int PositionHistory::ComputeLastMoveRepetitions() const {
   return 0;
 }
 
+int PositionHistory::ComputePliesSinceFirstRepetition() const {
+  const auto& last = positions_.back();
+  // TODO(crem) implement hash/cache based solution.
+  if (last.GetRule50Ply() < 4) return 0;
+
+  for (int idx = positions_.size() - 3; idx >= 0; idx -= 2) {
+    const auto& pos = positions_[idx];
+    if (pos.GetBoard() == last.GetBoard()) {
+      return positions_.size() - 1 - idx;
+    }
+    if (pos.GetRule50Ply() < 2) return 0;
+  }
+  return 0;
+}
+
 bool PositionHistory::DidRepeatSinceLastZeroingMove() const {
   for (auto iter = positions_.rbegin(), end = positions_.rend(); iter != end;
        ++iter) {

--- a/src/chess/position.cc
+++ b/src/chess/position.cc
@@ -111,7 +111,7 @@ int PositionHistory::ComputeLastMoveRepetitions() const {
 
 int PositionHistory::ComputePliesSinceFirstRepetition() const {
   const auto& last = positions_.back();
-  // TODO(crem) implement hash/cache based solution.
+  // copied TODO(crem) implement hash/cache based solution.
   if (last.GetRule50Ply() < 4) return 0;
 
   for (int idx = positions_.size() - 3; idx >= 0; idx -= 2) {

--- a/src/chess/position.cc
+++ b/src/chess/position.cc
@@ -91,10 +91,13 @@ void PositionHistory::Append(Move m) {
   //                has a bug in implementation of emplace_back, when
   //                reallocation happens. (it also reallocates Last())
   positions_.push_back(Position(Last(), m));
-  positions_.back().SetRepetitions(ComputeLastMoveRepetitions());
+  int cycle_length;
+  int repetitions = ComputeLastMoveRepetitions(&cycle_length);
+  positions_.back().SetRepetitions(repetitions, cycle_length);
 }
 
-int PositionHistory::ComputeLastMoveRepetitions() const {
+int PositionHistory::ComputeLastMoveRepetitions(int* cycle_length) const {
+  *cycle_length = 0;
   const auto& last = positions_.back();
   // TODO(crem) implement hash/cache based solution.
   if (last.GetRule50Ply() < 4) return 0;
@@ -102,22 +105,8 @@ int PositionHistory::ComputeLastMoveRepetitions() const {
   for (int idx = positions_.size() - 3; idx >= 0; idx -= 2) {
     const auto& pos = positions_[idx];
     if (pos.GetBoard() == last.GetBoard()) {
+      *cycle_length = positions_.size() - 1 - idx;
       return 1 + pos.GetRepetitions();
-    }
-    if (pos.GetRule50Ply() < 2) return 0;
-  }
-  return 0;
-}
-
-int PositionHistory::ComputePliesSinceFirstRepetition() const {
-  const auto& last = positions_.back();
-  // copied TODO(crem) implement hash/cache based solution.
-  if (last.GetRule50Ply() < 4) return 0;
-
-  for (int idx = positions_.size() - 3; idx >= 0; idx -= 2) {
-    const auto& pos = positions_[idx];
-    if (pos.GetBoard() == last.GetBoard()) {
-      return positions_.size() - 1 - idx;
     }
     if (pos.GetRule50Ply() < 2) return 0;
   }

--- a/src/chess/position.h
+++ b/src/chess/position.h
@@ -132,9 +132,7 @@ class PositionHistory {
   // Checks for any repetitions since the last time 50 move rule was reset.
   bool DidRepeatSinceLastZeroingMove() const;
 
-
  private:
-  int ComputeLastMoveRepetitions() const;
   int ComputeLastMoveRepetitions(int* cycle_length) const;
 
   std::vector<Position> positions_;

--- a/src/chess/position.h
+++ b/src/chess/position.h
@@ -54,7 +54,10 @@ class Position {
 
   // Someone outside that class knows better about repetitions, so they can
   // set it.
-  void SetRepetitions(int repetitions) { repetitions_ = repetitions; }
+  void SetRepetitions(int repetitions, int cycle_length) {
+    repetitions_ = repetitions;
+    cycle_length_ = cycle_length;
+  }
 
   // Number of ply with no captures and pawn moves.
   int GetRule50Ply() const { return rule50_ply_; }

--- a/src/chess/position.h
+++ b/src/chess/position.h
@@ -50,7 +50,7 @@ class Position {
   int GetRepetitions() const { return repetitions_; }
 
   // How many half-moves since the same position appeared in the game before.
-  int GetPliesSinceFirstRepetition() const { return cycle_length_; }
+  int GetPliesSincePrevRepetition() const { return cycle_length_; }
 
   // Someone outside that class knows better about repetitions, so they can
   // set it.

--- a/src/chess/position.h
+++ b/src/chess/position.h
@@ -49,6 +49,9 @@ class Position {
   // How many time the same position appeared in the game before.
   int GetRepetitions() const { return repetitions_; }
 
+  // How many half-moves since the same position appeared in the game before.
+  int GetPliesSinceFirstRepetition() const { return cycle_length_; }
+
   // Someone outside that class knows better about repetitions, so they can
   // set it.
   void SetRepetitions(int repetitions) { repetitions_ = repetitions; }
@@ -73,6 +76,8 @@ class Position {
   int rule50_ply_ = 0;
   // How many repetitions this position had before. For new positions it's 0.
   int repetitions_;
+  // How many half-moves since the position was repeated or 0.
+  int cycle_length_;
   // number of half-moves since beginning of the game.
   int ply_count_ = 0;
 };
@@ -124,11 +129,10 @@ class PositionHistory {
   // Checks for any repetitions since the last time 50 move rule was reset.
   bool DidRepeatSinceLastZeroingMove() const;
 
-  int ComputePliesSinceFirstRepetition() const;
-
 
  private:
   int ComputeLastMoveRepetitions() const;
+  int ComputeLastMoveRepetitions(int* cycle_length) const;
 
   std::vector<Position> positions_;
 };

--- a/src/chess/position.h
+++ b/src/chess/position.h
@@ -124,9 +124,11 @@ class PositionHistory {
   // Checks for any repetitions since the last time 50 move rule was reset.
   bool DidRepeatSinceLastZeroingMove() const;
 
+  int ComputePliesSinceFirstRepetition() const;
+
+
  private:
   int ComputeLastMoveRepetitions() const;
-  int ComputePliesSinceFirstRepetition() const;
 
   std::vector<Position> positions_;
 };

--- a/src/chess/position.h
+++ b/src/chess/position.h
@@ -126,6 +126,7 @@ class PositionHistory {
 
  private:
   int ComputeLastMoveRepetitions() const;
+  int ComputePliesSinceFirstRepetition() const;
 
   std::vector<Position> positions_;
 };

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -307,13 +307,11 @@ void Node::MakeTerminal(GameResult result, float plies_left, Terminal type) {
     d_ = 0.0f;
     // Terminal losses have no uncertainty and no reason for their U value to be
     // comparable to another non-loss choice. Force this by clearing the policy.
-    if (GetParent() != nullptr)
-            GetOwnEdge()->SetP(0.0f);
+    if (GetParent() != nullptr) GetOwnEdge()->SetP(0.0f);
   }
 }
 
 void Node::MakeNotTerminal() {
-  // SetBounds(GameResult::BLACK_WON, GameResult::WHITE_WON);
   terminal_type_ = Terminal::NonTerminal;
   n_ = 0;
 

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -312,6 +312,7 @@ void Node::MakeTerminal(GameResult result, float plies_left, Terminal type) {
 }
 
 void Node::MakeNotTerminal() {
+  SetBounds(GameResult::BLACK_WON, GameResult::WHITE_WON);
   terminal_type_ = Terminal::NonTerminal;
   n_ = 0;
 

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -307,7 +307,10 @@ void Node::MakeTerminal(GameResult result, float plies_left, Terminal type) {
     d_ = 0.0f;
     // Terminal losses have no uncertainty and no reason for their U value to be
     // comparable to another non-loss choice. Force this by clearing the policy.
-    if (GetParent() != nullptr) GetOwnEdge()->SetP(0.0f);
+    // However, don't set policy of twofold draws to zero as this only is a
+    // heuristic for more accurate eval
+    if (GetParent() != nullptr && terminal_type_ != Node::Terminal::TwoFold)
+            GetOwnEdge()->SetP(0.0f);
   }
 }
 

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -324,7 +324,7 @@ void Node::MakeNotTerminal() {
     const auto wl = wl_;
     const auto d = d_;
     const auto m = m_;
-    for (Node node = this; node = node->GetParent(); node != nullptr ) {
+    for (Node* node = this; node = node->GetParent(); node != nullptr ) {
       // Revert all visits on twofold terminal when making it non terminal.
       node.RevertTerminalVisits(wl, d, m + (float)depth, n);
       depth++;

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -326,6 +326,8 @@ void Node::MakeNotTerminal() {
     const auto m = m_;
     const auto terminal_visits = n_;
     for (Node* node = this; node != nullptr; node = node->GetParent()) {
+      // Logging stuff for debugging purposes
+      LOGFILE << "Reverted " << terminal_visits << " visits at depth " << depth;
       // Revert all visits on twofold terminal when making it non terminal.
       node->RevertTerminalVisits(wl, d, m + (float)depth, terminal_visits);
       depth++;

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -293,7 +293,7 @@ void Node::SortEdges() {
 }
 
 void Node::MakeTerminal(GameResult result, float plies_left, Terminal type) {
-  SetBounds(result, result);
+  if (type != Terminal::TwoFold) { SetBounds(result, result); }
   terminal_type_ = type;
   m_ = plies_left;
   if (result == GameResult::DRAW) {
@@ -313,7 +313,7 @@ void Node::MakeTerminal(GameResult result, float plies_left, Terminal type) {
 }
 
 void Node::MakeNotTerminal() {
-  SetBounds(GameResult::BLACK_WON, GameResult::WHITE_WON);
+  // SetBounds(GameResult::BLACK_WON, GameResult::WHITE_WON);
   terminal_type_ = Terminal::NonTerminal;
   n_ = 0;
 

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -293,7 +293,7 @@ void Node::SortEdges() {
 }
 
 void Node::MakeTerminal(GameResult result, float plies_left, Terminal type) {
-  if (type != Terminal::TwoFold) { SetBounds(result, result); }
+  if (type != Terminal::TwoFold) SetBounds(result, result);
   terminal_type_ = type;
   m_ = plies_left;
   if (result == GameResult::DRAW) {
@@ -312,8 +312,21 @@ void Node::MakeTerminal(GameResult result, float plies_left, Terminal type) {
 }
 
 void Node::MakeNotTerminal() {
+  if (terminal_type_ == Terminal::TwoFold) {
+    /* under construction
+    for (auto node = this; node=node->parent_; node != ) {
+      // Revert all visits on twofold terminal when making it non terminal.
+      node.RevertVisits(visits, wl, d, m);
+      // Best edge cache etc needs to be invalidated.
+    }
+    */
+    // Currently, only visits to the node itself are reset, making the tree
+    // inconsistent.
+    n_ = 0;
+  } else {
+    n_ = 0;
+  }
   terminal_type_ = Terminal::NonTerminal;
-  n_ = 0;
 
   // If we have edges, we've been extended (1 visit), so include children too.
   if (edges_) {

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -324,16 +324,15 @@ void Node::MakeNotTerminal() {
     const auto wl = wl_;
     const auto d = d_;
     const auto m = m_;
+    const auto terminal_visits = n_;
     for (Node* node = this; node = node->GetParent(); node != nullptr ) {
       // Revert all visits on twofold terminal when making it non terminal.
-      node.RevertTerminalVisits(wl, d, m + (float)depth, n);
+      node->RevertTerminalVisits(wl, d, m + (float)depth, terminal_visits);
       depth++;
       // If wl != 0, we would have to switch signs at each depth.
     }
-    // Currently, only visits to the node itself are reset, making the tree
-    // inconsistent.
-    n_ = 0;
   } else {
+    // Any other case, just setting n_ = 0 is sufficient, as parent is root.
     n_ = 0;
   }
   terminal_type_ = Terminal::NonTerminal;

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -307,9 +307,7 @@ void Node::MakeTerminal(GameResult result, float plies_left, Terminal type) {
     d_ = 0.0f;
     // Terminal losses have no uncertainty and no reason for their U value to be
     // comparable to another non-loss choice. Force this by clearing the policy.
-    // However, don't set policy of twofold draws to zero as this only is a
-    // heuristic for more accurate eval
-    if (GetParent() != nullptr && terminal_type_ != Node::Terminal::TwoFold)
+    if (GetParent() != nullptr)
             GetOwnEdge()->SetP(0.0f);
   }
 }

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -325,7 +325,7 @@ void Node::MakeNotTerminal() {
     const auto d = d_;
     const auto m = m_;
     const auto terminal_visits = n_;
-    for (Node* node = this; node = node->GetParent(); node != nullptr ) {
+    for (Node* node = this; node != nullptr; node = node->GetParent()) {
       // Revert all visits on twofold terminal when making it non terminal.
       node->RevertTerminalVisits(wl, d, m + (float)depth, terminal_visits);
       depth++;

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -327,9 +327,9 @@ void Node::MakeNotTerminal() {
     const auto terminal_visits = n_;
     for (Node* node = this; node != nullptr; node = node->GetParent()) {
       // Logging stuff for debugging purposes
-      LOGFILE << "Reverted " << terminal_visits << " visits at depth " << depth;
       // Revert all visits on twofold terminal when making it non terminal.
       node->RevertTerminalVisits(wl, d, m + (float)depth, terminal_visits);
+      LOGFILE << "Successfully everted " << terminal_visits << " visits at depth " << depth;
       depth++;
       // If wl != 0, we would have to switch signs at each depth.
     }

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -327,7 +327,7 @@ void Node::MakeNotTerminal() {
     const auto terminal_visits = n_;
     // Logging stuff for debugging purposes
     LOGFILE << "Attempting to revert terminal visits";
-    for (Node* node = this; node != nullptr; node = node->GetParent()) {
+/*    for (Node* node = this; node != nullptr; node = node->GetParent()) {
       // Logging stuff for debugging purposes
       LOGFILE << "Attempting to revert " << terminal_visits << " visits at depth " << depth;
       // Revert all visits on twofold terminal when making it non terminal.
@@ -335,8 +335,8 @@ void Node::MakeNotTerminal() {
       LOGFILE << "Successfully reverted " << terminal_visits << " visits at depth " << depth;
       depth++;
       // If wl != 0, we would have to switch signs at each depth.
-    }
-    // n_ = 0;
+    } */
+    n_ = 0;
   } else {
     // Any other case, just setting n_ = 0 is sufficient, as parent is root.
     n_ = 0;

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -326,8 +326,8 @@ void Node::MakeNotTerminal() {
     const auto m = m_;
     const auto terminal_visits = n_;
     // Logging stuff for debugging purposes
-    // LOGFILE << "Attempting to revert terminal visits";
-/*    for (Node* node = this; node != nullptr; node = node->GetParent()) {
+    LOGFILE << "Attempting to revert terminal visits";
+    for (Node* node = this; node != nullptr; node = node->GetParent()) {
       // Logging stuff for debugging purposes
       LOGFILE << "Attempting to revert " << terminal_visits << " visits at depth " << depth;
       // Revert all visits on twofold terminal when making it non terminal.
@@ -335,7 +335,7 @@ void Node::MakeNotTerminal() {
       LOGFILE << "Successfully reverted " << terminal_visits << " visits at depth " << depth;
       depth++;
       // If wl != 0, we would have to switch signs at each depth.
-    } */
+    }
     n_ = 0;
   } else {
     // Any other case, just setting n_ = 0 is sufficient, as parent is root.

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -327,7 +327,7 @@ void Node::MakeNotTerminal() {
     const auto terminal_visits = n_;
     // Logging stuff for debugging purposes
     LOGFILE << "Attempting to revert terminal visits";
-    for (Node* node = *this; node != nullptr; node = node->GetParent()) {
+/*    for (Node* node = this; node != nullptr; node = node->GetParent()) {
       // Logging stuff for debugging purposes
       LOGFILE << "Attempting to revert " << terminal_visits << " visits at depth " << depth;
       // Revert all visits on twofold terminal when making it non terminal.
@@ -335,7 +335,7 @@ void Node::MakeNotTerminal() {
       LOGFILE << "Successfully reverted " << terminal_visits << " visits at depth " << depth;
       depth++;
       // If wl != 0, we would have to switch signs at each depth.
-    }
+    } */
   } else {
     // Any other case, just setting n_ = 0 is sufficient, as parent is root.
     n_ = 0;

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -325,6 +325,8 @@ void Node::MakeNotTerminal() {
     const auto d = d_;
     const auto m = m_;
     const auto terminal_visits = n_;
+    // Logging stuff for debugging purposes
+    LOGFILE << "Attempting to revert terminal visits";
     for (Node* node = this; node != nullptr; node = node->GetParent()) {
       // Logging stuff for debugging purposes
       LOGFILE << "Attempting to revert " << terminal_visits << " visits at depth " << depth;

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -327,7 +327,7 @@ void Node::MakeNotTerminal() {
     const auto terminal_visits = n_;
     // Logging stuff for debugging purposes
     LOGFILE << "Attempting to revert terminal visits";
-    for (Node* node = this; node != nullptr; node = node->GetParent()) {
+    for (Node* node = *this; node != nullptr; node = node->GetParent()) {
       // Logging stuff for debugging purposes
       LOGFILE << "Attempting to revert " << terminal_visits << " visits at depth " << depth;
       // Revert all visits on twofold terminal when making it non terminal.
@@ -430,8 +430,7 @@ void Node::RevertTerminalVisits(float v, float d, float m, int multivisit) {
     n_ -= multivisit;
   }
   // Best child is potentially no longer valid.
-  // Deactivating temporarily
-  // best_child_cached_ = nullptr;
+  best_child_cached_ = nullptr;
 }
 
 void Node::UpdateBestChild(const Iterator& best_edge, int visits_allowed) {

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -401,9 +401,9 @@ void Node::RevertTerminalVisits(float v, float d, float m, int multivisit) {
     m_ -= multivisit * (m - m_) / n_new;
     // Decrement N.
     n_ -= multivisit;
-    // Best child is potentially no longer valid.
-    best_child_cached_ = nullptr;
   }
+  // Best child is potentially no longer valid.
+  best_child_cached_ = nullptr;
 }
 
 void Node::UpdateBestChild(const Iterator& best_edge, int visits_allowed) {

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -429,9 +429,9 @@ void Node::RevertTerminalVisits(float v, float d, float m, int multivisit) {
     m_ -= multivisit * (m - m_) / n_new;
     // Decrement N.
     n_ -= multivisit;
+    // Best child is potentially no longer valid.
+    best_child_cached_ = nullptr;
   }
-  // Best child is potentially no longer valid.
-  best_child_cached_ = nullptr;
 }
 
 void Node::UpdateBestChild(const Iterator& best_edge, int visits_allowed) {

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -313,29 +313,7 @@ void Node::MakeTerminal(GameResult result, float plies_left, Terminal type) {
 
 void Node::MakeNotTerminal() {
   if (terminal_type_ == Terminal::TwoFold) {
-    // When reverting a terminal twofold repetition draw, this can happen
-    // in the tree. To keep consistency, we revert the effect of the visits
-    // to that terminal on all parent nodes and let PUCT revisit the nodes
-    // and fetch the evals without the twofold draw.
-    int depth = 0;
-    // Cache node's values as we reset them in the process. We could manually
-    // set wl and d, but if we want to reuse this for reverting other terminal
-    // nodes this is the way to go.
-    const auto wl = wl_;
-    const auto d = d_;
-    const auto m = m_;
-    const auto terminal_visits = n_;
-    // Logging stuff for debugging purposes
-    LOGFILE << "Attempting to revert terminal visits";
-    for (Node* node = this; node != nullptr; node = node->GetParent()) {
-      // Logging stuff for debugging purposes
-      LOGFILE << "Attempting to revert " << terminal_visits << " visits at depth " << depth;
-      // Revert all visits on twofold terminal when making it non terminal.
-      node->RevertTerminalVisits(wl, d, m + (float)depth, terminal_visits);
-      LOGFILE << "Successfully reverted " << terminal_visits << " visits at depth " << depth;
-      depth++;
-      // If wl != 0, we would have to switch signs at each depth.
-    }
+    // Special handling of reverting terminal nodes happens in search.cc now.
     n_ = 0;
   } else {
     // Any other case, just setting n_ = 0 is sufficient, as parent is root.

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -336,6 +336,7 @@ void Node::MakeNotTerminal() {
       depth++;
       // If wl != 0, we would have to switch signs at each depth.
     } */
+    n_ = 0;
   } else {
     // Any other case, just setting n_ = 0 is sufficient, as parent is root.
     n_ = 0;

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -428,7 +428,8 @@ void Node::RevertTerminalVisits(float v, float d, float m, int multivisit) {
     n_ -= multivisit;
   }
   // Best child is potentially no longer valid.
-  best_child_cached_ = nullptr;
+  // Deactivating temporarily
+  // best_child_cached_ = nullptr;
 }
 
 void Node::UpdateBestChild(const Iterator& best_edge, int visits_allowed) {

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -312,14 +312,8 @@ void Node::MakeTerminal(GameResult result, float plies_left, Terminal type) {
 }
 
 void Node::MakeNotTerminal() {
-  if (terminal_type_ == Terminal::TwoFold) {
-    // Special handling of reverting terminal nodes happens in search.cc now.
-    n_ = 0;
-  } else {
-    // Any other case, just setting n_ = 0 is sufficient, as parent is root.
-    n_ = 0;
-  }
   terminal_type_ = Terminal::NonTerminal;
+  n_ = 0;
 
   // If we have edges, we've been extended (1 visit), so include children too.
   if (edges_) {

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -326,7 +326,7 @@ void Node::MakeNotTerminal() {
     const auto m = m_;
     const auto terminal_visits = n_;
     // Logging stuff for debugging purposes
-    LOGFILE << "Attempting to revert terminal visits";
+    // LOGFILE << "Attempting to revert terminal visits";
 /*    for (Node* node = this; node != nullptr; node = node->GetParent()) {
       // Logging stuff for debugging purposes
       LOGFILE << "Attempting to revert " << terminal_visits << " visits at depth " << depth;

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -327,7 +327,7 @@ void Node::MakeNotTerminal() {
     const auto terminal_visits = n_;
     // Logging stuff for debugging purposes
     LOGFILE << "Attempting to revert terminal visits";
-/*    for (Node* node = this; node != nullptr; node = node->GetParent()) {
+    for (Node* node = this; node != nullptr; node = node->GetParent()) {
       // Logging stuff for debugging purposes
       LOGFILE << "Attempting to revert " << terminal_visits << " visits at depth " << depth;
       // Revert all visits on twofold terminal when making it non terminal.
@@ -335,8 +335,8 @@ void Node::MakeNotTerminal() {
       LOGFILE << "Successfully reverted " << terminal_visits << " visits at depth " << depth;
       depth++;
       // If wl != 0, we would have to switch signs at each depth.
-    } */
-    n_ = 0;
+    }
+    // n_ = 0;
   } else {
     // Any other case, just setting n_ = 0 is sufficient, as parent is root.
     n_ = 0;

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -327,9 +327,10 @@ void Node::MakeNotTerminal() {
     const auto terminal_visits = n_;
     for (Node* node = this; node != nullptr; node = node->GetParent()) {
       // Logging stuff for debugging purposes
+      LOGFILE << "Attempting to revert " << terminal_visits << " visits at depth " << depth;
       // Revert all visits on twofold terminal when making it non terminal.
       node->RevertTerminalVisits(wl, d, m + (float)depth, terminal_visits);
-      LOGFILE << "Successfully everted " << terminal_visits << " visits at depth " << depth;
+      LOGFILE << "Successfully reverted " << terminal_visits << " visits at depth " << depth;
       depth++;
       // If wl != 0, we would have to switch signs at each depth.
     }

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -165,7 +165,7 @@ class Node {
   // Returns whether the node is known to be draw/lose/win.
   bool IsTerminal() const { return terminal_type_ != Terminal::NonTerminal; }
   bool IsTbTerminal() const { return terminal_type_ == Terminal::Tablebase; }
-  bool IsTwofoldTerminal() const { return terminal_type_ == Terminal::TwoFold; }
+  bool IsTwoFoldTerminal() const { return terminal_type_ == Terminal::TwoFold; }
   typedef std::pair<GameResult, GameResult> Bounds;
   Bounds GetBounds() const { return {lower_bound_, upper_bound_}; }
   uint8_t GetNumEdges() const { return num_edges_; }

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -165,7 +165,7 @@ class Node {
   // Returns whether the node is known to be draw/lose/win.
   bool IsTerminal() const { return terminal_type_ != Terminal::NonTerminal; }
   bool IsTbTerminal() const { return terminal_type_ == Terminal::Tablebase; }
-  bool IsTwofoldTerminal() const { return terminal_type_ == Node::Terminal::TwoFold; }
+  bool IsTwofoldTerminal() const { return terminal_type_ == Terminal::TwoFold; }
   typedef std::pair<GameResult, GameResult> Bounds;
   Bounds GetBounds() const { return {lower_bound_, upper_bound_}; }
   uint8_t GetNumEdges() const { return num_edges_; }

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -192,6 +192,8 @@ class Node {
   void FinalizeScoreUpdate(float v, float d, float m, int multivisit);
   // Like FinalizeScoreUpdate, but it updates n existing visits by delta amount.
   void AdjustForTerminal(float v, float d, float m, int multivisit);
+  // Revert visits to a node which ended in a now reverted terminal.
+  void RevertTerminalVisits(float v, float d, float m, int multivisit);
   // When search decides to treat one visit as several (in case of collisions
   // or visiting terminal nodes several times), it amplifies the visit by
   // incrementing n_in_flight.

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -165,6 +165,7 @@ class Node {
   // Returns whether the node is known to be draw/lose/win.
   bool IsTerminal() const { return terminal_type_ != Terminal::NonTerminal; }
   bool IsTbTerminal() const { return terminal_type_ == Terminal::Tablebase; }
+  bool IsTwofoldTerminal() const { return terminal_type_ == Node::Terminal::TwoFold; }
   typedef std::pair<GameResult, GameResult> Bounds;
   Bounds GetBounds() const { return {lower_bound_, upper_bound_}; }
   uint8_t GetNumEdges() const { return num_edges_; }

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -39,6 +39,7 @@
 #include "neural/encoder.h"
 #include "neural/writer.h"
 #include "proto/net.pb.h"
+#include "utils/logging.h"
 #include "utils/mutex.h"
 
 namespace lczero {

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -39,7 +39,6 @@
 #include "neural/encoder.h"
 #include "neural/writer.h"
 #include "proto/net.pb.h"
-#include "utils/logging.h"
 #include "utils/mutex.h"
 
 namespace lczero {

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -91,10 +91,11 @@ const OptionId SearchParams::kRootHasOwnCpuctParamsId{
     "If enabled, cpuct parameters for root node are taken from *AtRoot "
     "parameters. Otherwise, they are the same as for the rest of nodes. "
     "Temporary flag for transition to a new version."};
-const OptionId SearchParams::kTwoFoldDrawLevelId{
-    "two-fold-draw-level", "TwoFoldDrawLevel",
-    "Liberality level of evaluating two-fold repetitions as draws. "
-    "0: never, 1: theoretically correct, 2: optimized version, 3: always."};
+const OptionId SearchParams::kTwoFoldDrawsId{
+    "two-fold-draws", "TwoFoldDraws",
+    "Evaluates twofold repetitions in the search tree as draws. Visits to "
+    "these positions are reverted when the first occurrence is played "
+    "and not in the search tree anymore."};
 const OptionId SearchParams::kTemperatureId{
     "temperature", "Temperature",
     "Tau value from softmax formula for the first move. If equal to 0, the "
@@ -287,7 +288,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctFactorId, 0.0f, 1000.0f) = 2.815f;
   options->Add<FloatOption>(kCpuctFactorAtRootId, 0.0f, 1000.0f) = 2.815f;
   options->Add<BoolOption>(kRootHasOwnCpuctParamsId) = true;
-  options->Add<IntOption>(kTwoFoldDrawLevelId, 0, 3) = 0;
+  options->Add<BoolOption>(kTwoFoldDrawsId) = true;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 100) = 0;
   options->Add<IntOption>(kTempDecayDelayMovesId, 0, 100) = 0;

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -53,7 +53,7 @@ class SearchParams {
   float GetCpuctFactor(bool at_root) const {
     return at_root ? kCpuctFactorAtRoot : kCpuctFactor;
   }
-  int GetTwoFoldDrawLevel() const {return options_.Get<int>(kTwoFoldDrawLevelId); }
+  bool GetTwoFoldDraws() const { return options_.Get<bool>(kTwoFoldDrawsId); }
   float GetTemperature() const { return options_.Get<float>(kTemperatureId); }
   float GetTemperatureVisitOffset() const {
     return options_.Get<float>(kTemperatureVisitOffsetId);
@@ -122,7 +122,7 @@ class SearchParams {
   static const OptionId kCpuctFactorId;
   static const OptionId kCpuctFactorAtRootId;
   static const OptionId kRootHasOwnCpuctParamsId;
-  static const OptionId kTwoFoldDrawLevelId;
+  static const OptionId kTwoFoldDrawsId;
   static const OptionId kTemperatureId;
   static const OptionId kTempDecayMovesId;
   static const OptionId kTempDecayDelayMovesId;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1311,9 +1311,9 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
     } else if (repetitions == 1 && params_.GetTwoFoldDraws() &&
                depth - 1 >= 4 &&
                depth - 1 >= history_.Last().GetPliesSincePrevRepetition()) {
-      const auto cyclelength = history_.Last().GetPliesSincePrevRepetition();
+      const auto cycle_length = history_.Last().GetPliesSincePrevRepetition();
       // use plies since first repetition as moves left; exact if forced draw.
-      node->MakeTerminal(GameResult::DRAW, (float)cyclelength,
+      node->MakeTerminal(GameResult::DRAW, (float)cycle_length,
                          Node::Terminal::TwoFold);
       return;
     }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1317,16 +1317,19 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
         // always mark as draw
         LOGFILE << "== marked level 3 twofold draw == depth: " << depth;
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
+        return;
       } else if (twofolddrawlevel == 2 && depth >= 3) {
         // only mark as draw if depth of extended node is >= 4
         LOGFILE << "== marked level 2 twofold draw == depth: " << depth;
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
+        return;
       } else if (twofolddrawlevel == 1 && depth >= 3 && depth >=
                  history_.ComputePliesSinceFirstRepetition()) {
         // check whether first repetition happened at root or in the tree
         // don't mark as draw if repetition happened in the game history
         LOGFILE << "== marked level 1 twofold draw == depth: " << depth;
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
+        return;
       }
     }
 

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1315,7 +1315,7 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
     } else if (repetitions == 1 && twofolddrawlevel > 0) {
       if (twofolddrawlevel == 3) {
         // always mark as draw
-        LOGFILE << "== marked level 3 twofold draw ==";
+        LOGFILE << "== marked level 3 twofold draw == depth: " << depth;
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
       } else if (twofolddrawlevel == 2 && depth >= 3) {
         // only mark as draw if depth of extended node is >= 4

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1312,7 +1312,7 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
       if (twofolddrawlevel == 3) {
         // always mark as draw
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
-      } else if (twofolddrawlevel == 2 && depth >= 3) {
+      } else if (twofolddrawlevel == 2 && depth >= 1) {
         // only mark as draw if depth of extended node is >= 4
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
       } else if (twofolddrawlevel == 1 && depth >= 3 && depth >=

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1147,12 +1147,15 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     }
     // probably best place to check for two-fold draws consistently
     if (node->IsTwofoldTerminal() && ( params_.GetTwoFoldDrawLevel() > 0 ) ) {
+      LOGFILE << "== encountered twofold draw ==";
       if (params_.GetTwoFoldDrawLevel() == 2 && depth <= 3) {
         // Level 2: no two-fold draw at depth 3 or lower
+        LOGFILE << "== level 2 twofold draw reset ==";
         node->MakeNotTerminal();
       } else if (params_.GetTwoFoldDrawLevel() == 1 && depth <= 3) {
         // Level 1: check whether first repetition was before root
         // temporary approximation: MakeNotTerminal() when depth <= 3
+        LOGFILE << "== level 1 twofold draw reset ==";
         node->MakeNotTerminal();
       }
 
@@ -1312,14 +1315,17 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
     } else if (repetitions == 1 && twofolddrawlevel > 0) {
       if (twofolddrawlevel == 3) {
         // always mark as draw
+        LOGFILE << "== marked level 3 twofold draw ==";
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
       } else if (twofolddrawlevel == 2 && depth >= 3) {
         // only mark as draw if depth of extended node is >= 4
+        LOGFILE << "== marked level 2 twofold draw ==";
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
       } else if (twofolddrawlevel == 1 && depth >= 3 && depth >=
                  history_.ComputePliesSinceFirstRepetition()) {
         // check whether first repetition happened at root or in the tree
         // don't mark as draw if repetition happened in the game history
+        LOGFILE << "== marked level 1 twofold draw ==";
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
       }
     }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1315,22 +1315,15 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
     if (repetitions >= 2) {
       node->MakeTerminal(GameResult::DRAW);
       return;
-    } else if (repetitions == 1 && twofolddrawlevel > 0) {
-      if (twofolddrawlevel == 3) {
-        // always mark as draw
-        validtwofold = true;
-      } else if (twofolddrawlevel == 2 && depth - 1 >= 4) {
-        // only mark as draw if depth of extended node is >= 4
-        validtwofold = true;
-      } else if (twofolddrawlevel == 1 && depth - 1 >= 4 && depth - 1 >=
-                 history_.ComputePliesSinceFirstRepetition()) {
-        // check whether first repetition happened at root or in the tree
-        // don't mark as draw if repetition happened in the game history
-        validtwofold = true;
-      }
-    }
-    // if node turned out to be a valid twofold, mark it as Terminal::Twofold
-    if (validtwofold) {
+    } else if (repetitions == 1 && twofolddrawlevel > 0) &&
+    // Level 3: always mark as draw
+              ( (twofolddrawlevel == 3) ||
+    // Level 2: only mark as draw if depth of extended node is >= 4
+                (twofolddrawlevel == 2 && depth - 1 >= 4) ||
+    // Level 1: check whether first repetition happened at root or in the tree
+    // don't mark as draw if repetition happened in the game history
+                (twofolddrawlevel == 1 && depth - 1 >= 4 && depth - 1 >=
+                 history_.ComputePliesSinceFirstRepetition()) ) {
       const auto cyclelength = history_.ComputePliesSinceFirstRepetition();
       // logging for debugging purpose
       LOGFILE << "== marked twofold draw == depth: " << depth - 1;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1044,7 +1044,7 @@ void SearchWorker::GatherMinibatch() {
     // of the game), it means that we already visited this node before.
     if (picked_node.IsExtendable()) {
       // Node was never visited, extend it.
-      ExtendNode(node,picked_node.depth);
+      ExtendNode(node, picked_node.depth);
 
       // Only send non-terminal nodes to a neural network.
       if (!node->IsTerminal()) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1304,7 +1304,7 @@ void SearchWorker::ExtendNode(Node* node) {
 
     // Mark two-fold repetitions as draws according to settings
     const auto repetitions = history_.Last().GetRepetitions();
-    const auto twofolddrawlevel = history_.Last().GetTwoFoldDrawLevel();
+    const auto twofolddrawlevel = params_.GetTwoFoldDrawLevel();
     if (repetitions >= 2) {
       node->MakeTerminal(GameResult::DRAW);
       return;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1145,20 +1145,18 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
       }
       return NodeToProcess::Collision(node, depth, collision_limit);
     }
-    // Probably best place to check for two-fold draws consistently.
-    // Depth starts with 1 at root, so real depth is depth - 1.
-    if (node->IsTwoFoldTerminal() && params_.GetTwoFoldDraws()) {
-      if (depth - 1 < node->GetM()) {
+    // Either terminal or unexamined leaf node -- the end of this playout.
+    if (node->IsTerminal() || !node->HasChildren()) {
+      // Probably best place to check for two-fold draws consistently.
+      // Depth starts with 1 at root, so real depth is depth - 1.
+      if (node->IsTwoFoldTerminal() && depth - 1 < node->GetM()) {
         // Check whether first repetition was before root. If yes, remove
         // terminal status of node.
         // Length of repetition was stored in m_.
-        // TODO: Cleaner alternative to call position history?
         node->MakeNotTerminal();
+      } else {
+        return NodeToProcess::Visit(node, depth);
       }
-    }
-    // Either terminal or unexamined leaf node -- the end of this playout.
-    if (node->IsTerminal() || !node->HasChildren()) {
-      return NodeToProcess::Visit(node, depth);
     }
     Node* possible_shortcut_child = node->GetCachedBestChild();
     if (possible_shortcut_child) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1316,7 +1316,7 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
         // only mark as draw if depth of extended node is >= 4
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
       } else if (twofolddrawlevel == 1 && depth >= 3 && depth >=
-                 history_.Last().ComputePliesSinceFirstRepetition()) {
+                 history_.ComputePliesSinceFirstRepetition()) {
         // check whether first repetition happened at root or in the tree
         // don't mark as draw if repetition happened in the game history
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1147,7 +1147,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     }
     // Probably best place to check for two-fold draws consistently.
     // Depth starts with 1 at root, so real depth is depth - 1
-    if (node->IsTwofoldTerminal() && ( params_.GetTwoFoldDrawLevel() > 0 ) ) {
+    if (node->IsTwoFoldTerminal() && ( params_.GetTwoFoldDrawLevel() > 0 ) ) {
       LOGFILE << "== encountered twofold draw == depth: " << depth - 1;
       if (params_.GetTwoFoldDrawLevel() == 2 && depth - 1 <= 3) {
         // Level 2: no two-fold draw at depth 3 or lower
@@ -1309,7 +1309,6 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
 
     const auto repetitions = history_.Last().GetRepetitions();
     const auto twofolddrawlevel = params_.GetTwoFoldDrawLevel();
-    bool validtwofold = false;
     // Mark two-fold repetitions as draws according to settings
     // Depth starts with 1 at root, so number of plies in PV is depth - 1
     if (repetitions >= 2) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1303,15 +1303,15 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
     }
 
     const auto repetitions = history_.Last().GetRepetitions();
-    const auto twofolddraws = params_.GetTwoFoldDraws();
-    // Mark two-fold repetitions as draws according to settings
-    // Depth starts with 1 at root, so number of plies in PV is depth - 1
+    // Mark two-fold repetitions as draws according to settings.
+    // Depth starts with 1 at root, so number of plies in PV is depth - 1.
     if (repetitions >= 2) {
       node->MakeTerminal(GameResult::DRAW);
       return;
-    } else if (repetitions == 1 && twofolddraws && depth - 1 >= 4 &&
-               depth - 1 >= history_.Last().GetPliesSinceFirstRepetition()) {
-      const auto cyclelength = history_.Last().GetPliesSinceFirstRepetition();
+    } else if (repetitions == 1 && params_.GetTwoFoldDraws() &&
+               depth - 1 >= 4 &&
+               depth - 1 >= history_.Last().GetPliesSincePrevRepetition()) {
+      const auto cyclelength = history_.Last().GetPliesSincePrevRepetition();
       // use plies since first repetition as moves left; exact if forced draw.
       node->MakeTerminal(GameResult::DRAW, (float)cyclelength,
                          Node::Terminal::TwoFold);

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1146,20 +1146,18 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
       return NodeToProcess::Collision(node, depth, collision_limit);
     }
     // Probably best place to check for two-fold draws consistently.
-    // Depth starts with 1 at root, so real depth is depth - 1
-    if (node->IsTwoFoldTerminal() && ( params_.GetTwoFoldDrawLevel() > 0 ) ) {
+    // Depth starts with 1 at root, so real depth is depth - 1.
+    if (node->IsTwoFoldTerminal() && params_.GetTwoFoldDrawLevel() > 0) {
       LOGFILE << "== encountered twofold draw == depth: " << depth - 1;
-      if (params_.GetTwoFoldDrawLevel() == 2 && depth - 1 <= 3) {
+      if ((params_.GetTwoFoldDrawLevel() == 2 && depth - 1 <= 3) ||
         // Level 2: no two-fold draw at depth 3 or lower
-        LOGFILE << "== level 2 twofold draw reset ==";
-        node->MakeNotTerminal();
-      } else if (params_.GetTwoFoldDrawLevel() == 1 && depth - 1 < node->GetM()) {
+          (params_.GetTwoFoldDrawLevel() == 1 && depth - 1 < node->GetM())) {
         // Level 1: check whether first repetition was before root
-        // Length of repetition was stored in m_, so we don't need to calculate
-        LOGFILE << "== level 1 twofold draw reset ==";
+        // Length of repetition was stored in m_.
+        // TODO: Cleaner alternative to call position history?
+        LOGFILE << "== twofold draw reset ==";
         node->MakeNotTerminal();
       }
-
     }
     // Either terminal or unexamined leaf node -- the end of this playout.
     if (node->IsTerminal() || !node->HasChildren()) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1150,9 +1150,10 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
       if (params_.GetTwoFoldDrawLevel() == 2 && depth <= 3) {
         // Level 2: no two-fold draw at depth 3 or lower
         node->MakeNotTerminal();
-      } else if (params_.GetTwoFoldDrawLevel() == 1) {
+      } else if (params_.GetTwoFoldDrawLevel() == 1 && depth <= 3) {
         // Level 1: check whether first repetition was before root
-
+        // temporary approximation: MakeNotTerminal() when depth <= 3
+        node->MakeNotTerminal();
       }
 
     }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1147,7 +1147,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     }
     // probably best place to check for two-fold draws consistently
     if (node->IsTwofoldTerminal() && ( params_.GetTwoFoldDrawLevel() > 0 ) ) {
-      LOGFILE << "== encountered twofold draw == depth: " << to_string(depth);
+      LOGFILE << "== encountered twofold draw == depth: " << depth;
       if (params_.GetTwoFoldDrawLevel() == 2 && depth <= 3) {
         // Level 2: no two-fold draw at depth 3 or lower
         LOGFILE << "== level 2 twofold draw reset ==";
@@ -1319,13 +1319,13 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
       } else if (twofolddrawlevel == 2 && depth >= 3) {
         // only mark as draw if depth of extended node is >= 4
-        LOGFILE << "== marked level 2 twofold draw == depth: " << to_string(depth);
+        LOGFILE << "== marked level 2 twofold draw == depth: " << depth;
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
       } else if (twofolddrawlevel == 1 && depth >= 3 && depth >=
                  history_.ComputePliesSinceFirstRepetition()) {
         // check whether first repetition happened at root or in the tree
         // don't mark as draw if repetition happened in the game history
-        LOGFILE << "== marked level 1 twofold draw == depth: " << to_string(depth);
+        LOGFILE << "== marked level 1 twofold draw == depth: " << depth;
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
       }
     }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1313,7 +1313,7 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
       if (twofolddrawlevel == 3) {
         // always mark as draw
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
-      } else if (twofolddrawlevel == 2 && depth >= 1) {
+      } else if (twofolddrawlevel == 2 && depth >= 3) {
         // only mark as draw if depth of extended node is >= 4
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
       } else if (twofolddrawlevel == 1 && depth >= 3 && depth >=

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1044,7 +1044,7 @@ void SearchWorker::GatherMinibatch() {
     // of the game), it means that we already visited this node before.
     if (picked_node.IsExtendable()) {
       // Node was never visited, extend it.
-      ExtendNode(node);
+      ExtendNode(node,picked_node.depth);
 
       // Only send non-terminal nodes to a neural network.
       if (!node->IsTerminal()) {
@@ -1250,7 +1250,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
   }
 }
 
-void SearchWorker::ExtendNode(Node* node) {
+void SearchWorker::ExtendNode(Node* node, int depth) {
   // Initialize position sequence with pre-move position.
   history_.Trim(search_->played_history_.GetLength());
   std::vector<Move> to_add;
@@ -1312,10 +1312,11 @@ void SearchWorker::ExtendNode(Node* node) {
       if (twofolddrawlevel == 3) {
         // always mark as draw
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
-      } else if (twofolddrawlevel == 2) {
-        // only mark as draw if depth >= 4
+      } else if (twofolddrawlevel == 2 && depth >= 3) {
+        // only mark as draw if depth of extended node is >= 4
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
-      } else if (twofolddrawlevel == 1) {
+      } else if (twofolddrawlevel == 1 && depth >= 3 && depth >=
+                 history_.Last().ComputePliesSinceFirstRepetition()) {
         // check whether first repetition happened at root or in the tree
         // don't mark as draw if repetition happened in the game history
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1326,6 +1326,8 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
       } else if (twofolddrawlevel == 2 && depth - 1 >= 4) {
         // only mark as draw if depth of extended node is >= 4
         LOGFILE << "== marked level 2 twofold draw == depth: " << depth - 1;
+        LOGFILE << "== plies since first repetition: "
+                << history_.ComputePliesSinceFirstRepetition();
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
         return;
       } else if (twofolddrawlevel == 1 && depth - 1 >= 4 && depth - 1 >=
@@ -1333,6 +1335,8 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
         // check whether first repetition happened at root or in the tree
         // don't mark as draw if repetition happened in the game history
         LOGFILE << "== marked level 1 twofold draw == depth: " << depth - 1;
+        LOGFILE << "== plies since first repetition: "
+                << history_.ComputePliesSinceFirstRepetition();
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
         return;
       }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1147,7 +1147,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     }
     // probably best place to check for two-fold draws consistently
     if (node->IsTwofoldTerminal() && ( params_.GetTwoFoldDrawLevel() > 0 ) ) {
-      LOGFILE << std::format("== found twofold draw at depth {}==", depth);
+      LOGFILE << "== encountered twofold draw == depth: " << to_string(depth);
       if (params_.GetTwoFoldDrawLevel() == 2 && depth <= 3) {
         // Level 2: no two-fold draw at depth 3 or lower
         LOGFILE << "== level 2 twofold draw reset ==";
@@ -1319,13 +1319,13 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
       } else if (twofolddrawlevel == 2 && depth >= 3) {
         // only mark as draw if depth of extended node is >= 4
-        LOGFILE << std::format("== marked level 2 twofold draw at depth {}==", depth);
+        LOGFILE << "== marked level 2 twofold draw == depth: " << to_string(depth);
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
       } else if (twofolddrawlevel == 1 && depth >= 3 && depth >=
                  history_.ComputePliesSinceFirstRepetition()) {
         // check whether first repetition happened at root or in the tree
         // don't mark as draw if repetition happened in the game history
-        LOGFILE << std::format("== marked level 1 twofold draw at depth {}==", depth);
+        LOGFILE << "== marked level 1 twofold draw == depth: " << to_string(depth);
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
       }
     }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1146,8 +1146,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
       return NodeToProcess::Collision(node, depth, collision_limit);
     }
     // probably best place to check for two-fold draws consistently
-    if (node->terminal_type_ == Node::Terminal::TwoFold &&
-                    ( params_.GetTwoFoldDrawLevel() > 0 ) ) {
+    if (node->IsTwofoldTerminal() && ( params_.GetTwoFoldDrawLevel() > 0 ) ) {
       if (params_.GetTwoFoldDrawLevel() == 2 && depth <= 3) {
         // Level 2: no two-fold draw at depth 3 or lower
         node->MakeNotTerminal();

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1146,15 +1146,14 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
       return NodeToProcess::Collision(node, depth, collision_limit);
     }
     // Probably best place to check for two-fold draws consistently.
-    // Depth starts with 1 at root, and is incremented before checking
-    // for twofold draws here, so real depth is depth - 2
+    // Depth starts with 1 at root, so real depth is depth - 1
     if (node->IsTwofoldTerminal() && ( params_.GetTwoFoldDrawLevel() > 0 ) ) {
-      LOGFILE << "== encountered twofold draw == depth: " << depth - 2;
-      if (params_.GetTwoFoldDrawLevel() == 2 && depth - 2 <= 3) {
+      LOGFILE << "== encountered twofold draw == depth: " << depth - 1;
+      if (params_.GetTwoFoldDrawLevel() == 2 && depth - 1 <= 3) {
         // Level 2: no two-fold draw at depth 3 or lower
         LOGFILE << "== level 2 twofold draw reset ==";
         node->MakeNotTerminal();
-      } else if (params_.GetTwoFoldDrawLevel() == 1 && depth - 2 <= 3) {
+      } else if (params_.GetTwoFoldDrawLevel() == 1 && depth - 1 <= 3) {
         // Level 1: check whether first repetition was before root
         // temporary approximation: MakeNotTerminal() when depth <= 3
         LOGFILE << "== level 1 twofold draw reset ==";

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1331,7 +1331,7 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
     }
     // if node turned out to be a valid twofold, mark it as Terminal::Twofold
     if (validtwofold) {
-      auto cyclelength = history_.ComputePliesSinceFirstRepetition();
+      const auto cyclelength = history_.ComputePliesSinceFirstRepetition();
       // logging for debugging purpose
       LOGFILE << "== marked twofold draw == depth: " << depth - 1;
       LOGFILE << "== plies since first repetition: " << cyclelength;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1147,7 +1147,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     }
     // probably best place to check for two-fold draws consistently
     if (node->IsTwofoldTerminal() && ( params_.GetTwoFoldDrawLevel() > 0 ) ) {
-      LOGFILE << "== encountered twofold draw ==";
+      LOGFILE << std::format("== found twofold draw at depth {}==", depth);
       if (params_.GetTwoFoldDrawLevel() == 2 && depth <= 3) {
         // Level 2: no two-fold draw at depth 3 or lower
         LOGFILE << "== level 2 twofold draw reset ==";
@@ -1319,13 +1319,13 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
       } else if (twofolddrawlevel == 2 && depth >= 3) {
         // only mark as draw if depth of extended node is >= 4
-        LOGFILE << "== marked level 2 twofold draw ==";
+        LOGFILE << std::format("== marked level 2 twofold draw at depth {}==", depth);
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
       } else if (twofolddrawlevel == 1 && depth >= 3 && depth >=
                  history_.ComputePliesSinceFirstRepetition()) {
         // check whether first repetition happened at root or in the tree
         // don't mark as draw if repetition happened in the game history
-        LOGFILE << "== marked level 1 twofold draw ==";
+        LOGFILE << std::format("== marked level 1 twofold draw at depth {}==", depth);
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
       }
     }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1315,15 +1315,15 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
     if (repetitions >= 2) {
       node->MakeTerminal(GameResult::DRAW);
       return;
-    } else if (repetitions == 1 && twofolddrawlevel > 0) &&
+    } else if ( (repetitions == 1 && twofolddrawlevel > 0) &&
     // Level 3: always mark as draw
-              ( (twofolddrawlevel == 3) ||
+                ( (twofolddrawlevel == 3) ||
     // Level 2: only mark as draw if depth of extended node is >= 4
-                (twofolddrawlevel == 2 && depth - 1 >= 4) ||
+                  (twofolddrawlevel == 2 && depth - 1 >= 4) ||
     // Level 1: check whether first repetition happened at root or in the tree
     // don't mark as draw if repetition happened in the game history
-                (twofolddrawlevel == 1 && depth - 1 >= 4 && depth - 1 >=
-                 history_.ComputePliesSinceFirstRepetition()) ) {
+                  (twofolddrawlevel == 1 && depth - 1 >= 4 && depth - 1 >=
+                   history_.ComputePliesSinceFirstRepetition()) ) ) {
       const auto cyclelength = history_.ComputePliesSinceFirstRepetition();
       // logging for debugging purpose
       LOGFILE << "== marked twofold draw == depth: " << depth - 1;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1323,8 +1323,8 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
     // Level 1: check whether first repetition happened at root or in the tree
     // don't mark as draw if repetition happened in the game history
                   (twofolddrawlevel == 1 && depth - 1 >= 4 && depth - 1 >=
-                   history_.ComputePliesSinceFirstRepetition()) ) ) {
-      const auto cyclelength = history_.ComputePliesSinceFirstRepetition();
+                   history_.Last().GetPliesSinceFirstRepetition()) ) ) {
+      const auto cyclelength = history_.Last().GetPliesSinceFirstRepetition();
       // logging for debugging purpose
       LOGFILE << "== marked twofold draw == depth: " << depth - 1;
       LOGFILE << "== plies since first repetition: " << cyclelength;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1319,6 +1319,8 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
       if (twofolddrawlevel == 3) {
         // always mark as draw
         LOGFILE << "== marked level 3 twofold draw == depth: " << depth - 1;
+        LOGFILE << "== plies since first repetition: "
+                << history_.ComputePliesSinceFirstRepetition();
         node->MakeTerminal(GameResult::DRAW, 0.0f, Node::Terminal::TwoFold);
         return;
       } else if (twofolddrawlevel == 2 && depth - 1 >= 4) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1167,21 +1167,21 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
       for (Node* node_to_revert = node; node_to_revert != nullptr;
                         node_to_revert = node_to_revert->GetParent()) {
         // Revert all visits on twofold terminal when making it non terminal.
-        node_to_revert->RevertTerminalVisits(wl, d, m + (float)depth_revert, terminal_visits);
-        // Logging stuff for debugging purposes
-        LOGFILE << "Successfully reverted " << terminal_visits << " visits at depth " << depth_revert;
+        node_to_revert->RevertTerminalVisits(wl, d,
+                          m + (float)depth_revert, terminal_visits);
         depth_revert++;
         // Even if original tree still exists, we don't want to revert more
         // than until new root.
         if (depth_revert > depth - 1) break;
         // If wl != 0, we would have to switch signs at each depth.
       }
-      // When reverting the visits, we also need to revert the total playouts.
-      search_->total_playouts_ -= terminal_visits;
-      search_->cum_depth_ -= (depth - 1) * terminal_visits;
-      // Max depth doesn't change when reverting the visits.
-
+      // Mark the prior twofold repetition as non terminal to extend it again.
       node->MakeNotTerminal();
+      // When reverting the visits, we also need to revert the initial visits,
+      // as we reused fewer nodes than anticipated.
+      search_->initial_visits_ -= terminal_visits;
+      // Max depth doesn't change when reverting the visits, and cum_depth_
+      // only counts the average depth of new nodes, not reused ones.
     }
     // Either terminal or unexamined leaf node -- the end of this playout.
     if (node->IsTerminal() || !node->HasChildren()) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1145,43 +1145,49 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
       }
       return NodeToProcess::Collision(node, depth, collision_limit);
     }
-    // Probably best place to check for two-fold draws consistently.
-    // Depth starts with 1 at root, so real depth is depth - 1.
-    if (node->IsTwoFoldTerminal() && depth - 1 < node->GetM()) {
-      // Check whether first repetition was before root. If yes, remove
-      // terminal status of node and revert all visits in the tree.
-      // Length of repetition was stored in m_.
-      int depth_counter = 0;
-      // Cache node's values as we reset them in the process. We could manually
-      // set wl and d, but if we want to reuse this for reverting other
-      // terminal nodes this is the way to go.
-      const auto wl = node->GetWL();
-      const auto d = node->GetD();
-      const auto m = node->GetM();
-      const auto terminal_visits = node->GetN();
-      LOGFILE << "== reverting " << terminal_visits << " visits to " <<
-            "a twofold terminal at depth " << depth - 1 << " ==";
-      for (Node* node_to_revert = node; node_to_revert != nullptr;
+    // If terminal, we either found a twofold draw to be reverted, or
+    // reached the end of this playout.
+    if (node->IsTerminal()) {
+      // Probably best place to check for two-fold draws consistently.
+      // Depth starts with 1 at root, so real depth is depth - 1.
+      if (node->IsTwoFoldTerminal() && depth - 1 < node->GetM()) {
+        // Check whether first repetition was before root. If yes, remove
+        // terminal status of node and revert all visits in the tree.
+        // Length of repetition was stored in m_.
+        int depth_counter = 0;
+        // Cache node's values as we reset them in the process. We could
+        // manually set wl and d, but if we want to reuse this for reverting
+        // other terminal nodes this is the way to go.
+        const auto wl = node->GetWL();
+        const auto d = node->GetD();
+        const auto m = node->GetM();
+        const auto terminal_visits = node->GetN();
+        LOGFILE << "== reverting " << terminal_visits << " visits to " <<
+              "a twofold terminal at depth " << depth - 1 << " ==";
+        for (Node* node_to_revert = node; node_to_revert != nullptr;
                         node_to_revert = node_to_revert->GetParent()) {
-        // Revert all visits on twofold terminal when making it non terminal.
-        node_to_revert->RevertTerminalVisits(wl, d,
+          // Revert all visits on twofold draw when making it non terminal.
+          node_to_revert->RevertTerminalVisits(wl, d,
                           m + (float)depth_counter, terminal_visits);
-        depth_counter++;
-        // Even if original tree still exists, we don't want to revert more
-        // than until new root.
-        if (depth_counter > depth - 1) break;
-        // If wl != 0, we would have to switch signs at each depth.
+          depth_counter++;
+          // Even if original tree still exists, we don't want to revert more
+          // than until new root.
+          if (depth_counter > depth - 1) break;
+          // If wl != 0, we would have to switch signs at each depth.
+        }
+        // Mark the prior twofold draw as non terminal to extend it again.
+        node->MakeNotTerminal();
+        // When reverting the visits, we also need to revert the initial
+        // visits, as we reused fewer nodes than anticipated.
+        search_->initial_visits_ -= terminal_visits;
+        // Max depth doesn't change when reverting the visits, and cum_depth_
+        // only counts the average depth of new nodes, not reused ones.
+      } else {
+        return NodeToProcess::Visit(node, depth);
       }
-      // Mark the prior twofold repetition as non terminal to extend it again.
-      node->MakeNotTerminal();
-      // When reverting the visits, we also need to revert the initial visits,
-      // as we reused fewer nodes than anticipated.
-      search_->initial_visits_ -= terminal_visits;
-      // Max depth doesn't change when reverting the visits, and cum_depth_
-      // only counts the average depth of new nodes, not reused ones.
     }
-    // Either terminal or unexamined leaf node -- the end of this playout.
-    if (node->IsTerminal() || !node->HasChildren()) {
+    // If unexamined leaf node -- the end of this playout.
+    if (!node->HasChildren()) {
       return NodeToProcess::Visit(node, depth);
     }
     Node* possible_shortcut_child = node->GetCachedBestChild();

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1176,6 +1176,11 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         if (depth_revert > depth - 1) break;
         // If wl != 0, we would have to switch signs at each depth.
       }
+      // When reverting the visits, we also need to revert the total playouts.
+      search_->total_playouts_ -= terminal_visits;
+      search_->cum_depth_ -= (depth - 1) * terminal_visits;
+      // Max depth doesn't change when reverting the visits.
+
       node->MakeNotTerminal();
     }
     // Either terminal or unexamined leaf node -- the end of this playout.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1164,10 +1164,10 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         const auto m = node->GetM();
         const auto terminal_visits = node->GetN();
         for (Node* node_to_revert = node; node_to_revert != nullptr;
-                        node_to_revert = node_to_revert->GetParent()) {
+             node_to_revert = node_to_revert->GetParent()) {
           // Revert all visits on twofold draw when making it non terminal.
           node_to_revert->RevertTerminalVisits(wl, d, m + (float)depth_counter,
-                                                terminal_visits);
+                                               terminal_visits);
           depth_counter++;
           // Even if original tree still exists, we don't want to revert more
           // than until new root.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1145,18 +1145,17 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
       }
       return NodeToProcess::Collision(node, depth, collision_limit);
     }
+    // Probably best place to check for two-fold draws consistently.
+    // Depth starts with 1 at root, so real depth is depth - 1.
+    if (node->IsTwoFoldTerminal() && depth - 1 < node->GetM()) {
+      // Check whether first repetition was before root. If yes, remove
+      // terminal status of node.
+      // Length of repetition was stored in m_.
+      node->MakeNotTerminal();
+    }
     // Either terminal or unexamined leaf node -- the end of this playout.
     if (node->IsTerminal() || !node->HasChildren()) {
-      // Probably best place to check for two-fold draws consistently.
-      // Depth starts with 1 at root, so real depth is depth - 1.
-      if (node->IsTwoFoldTerminal() && depth - 1 < node->GetM()) {
-        // Check whether first repetition was before root. If yes, remove
-        // terminal status of node.
-        // Length of repetition was stored in m_.
-        node->MakeNotTerminal();
-      } else {
-        return NodeToProcess::Visit(node, depth);
-      }
+      return NodeToProcess::Visit(node, depth);
     }
     Node* possible_shortcut_child = node->GetCachedBestChild();
     if (possible_shortcut_child) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1151,6 +1151,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
       // Check whether first repetition was before root. If yes, remove
       // terminal status of node.
       // Length of repetition was stored in m_.
+      LOGFILE << "== resetting twofold terminal at depth " << depth - 1;
       node->MakeNotTerminal();
     }
     // Either terminal or unexamined leaf node -- the end of this playout.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1149,14 +1149,9 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
     // Depth starts with 1 at root, so real depth is depth - 1.
     if (node->IsTwoFoldTerminal() && depth - 1 < node->GetM()) {
       // Check whether first repetition was before root. If yes, remove
-      // terminal status of node.
+      // terminal status of node and revert all visits in the tree.
       // Length of repetition was stored in m_.
-      LOGFILE << "== resetting twofold terminal at depth " << depth - 1;
-      // When reverting a terminal twofold repetition draw, this can happen
-      // in the tree. To keep consistency, we revert the effect of the visits
-      // to that terminal on all parent nodes and let PUCT revisit the nodes
-      // and fetch the evals without the twofold draw.
-      int depth_revert = 0;
+      int depth_counter = 0;
       // Cache node's values as we reset them in the process. We could manually
       // set wl and d, but if we want to reuse this for reverting other
       // terminal nodes this is the way to go.
@@ -1164,15 +1159,17 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
       const auto d = node->GetD();
       const auto m = node->GetM();
       const auto terminal_visits = node->GetN();
+      LOGFILE << "== reverting " << terminal_visits << " visits to " <<
+            "a twofold terminal at depth " << depth - 1 << " ==";
       for (Node* node_to_revert = node; node_to_revert != nullptr;
                         node_to_revert = node_to_revert->GetParent()) {
         // Revert all visits on twofold terminal when making it non terminal.
         node_to_revert->RevertTerminalVisits(wl, d,
-                          m + (float)depth_revert, terminal_visits);
-        depth_revert++;
+                          m + (float)depth_counter, terminal_visits);
+        depth_counter++;
         // Even if original tree still exists, we don't want to revert more
         // than until new root.
-        if (depth_revert > depth - 1) break;
+        if (depth_counter > depth - 1) break;
         // If wl != 0, we would have to switch signs at each depth.
       }
       // Mark the prior twofold repetition as non terminal to extend it again.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1338,8 +1338,8 @@ void SearchWorker::ExtendNode(Node* node, int depth) {
     if (repetitions >= 2) {
       node->MakeTerminal(GameResult::DRAW);
       return;
-    } else if (repetitions == 1 && params_.GetTwoFoldDraws() &&
-               depth - 1 >= 4 &&
+    } else if (repetitions == 1 && depth - 1 >= 4 &&
+               params_.GetTwoFoldDraws() &&
                depth - 1 >= history_.Last().GetPliesSincePrevRepetition()) {
       const auto cycle_length = history_.Last().GetPliesSincePrevRepetition();
       // use plies since first repetition as moves left; exact if forced draw.

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -303,7 +303,7 @@ class SearchWorker {
   };
 
   NodeToProcess PickNodeToExtend(int collision_limit);
-  void ExtendNode(Node* node, int depth = 0);
+  void ExtendNode(Node* node, int depth);
   bool AddNodeToComputation(Node* node, bool add_if_cached, int* transform_out);
   int PrefetchIntoCache(Node* node, int budget, bool is_odd_depth);
   void FetchSingleNodeResult(NodeToProcess* node_to_process,

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -303,7 +303,7 @@ class SearchWorker {
   };
 
   NodeToProcess PickNodeToExtend(int collision_limit);
-  void ExtendNode(Node* node);
+  void ExtendNode(Node* node, int depth = 0);
   bool AddNodeToComputation(Node* node, bool add_if_cached, int* transform_out);
   int PrefetchIntoCache(Node* node, int budget, bool is_odd_depth);
   void FetchSingleNodeResult(NodeToProcess* node_to_process,

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -172,7 +172,7 @@ class Search {
   const SearchParams params_;
   const MoveList searchmoves_;
   const std::chrono::steady_clock::time_point start_time_;
-  const int64_t initial_visits_;
+  int64_t initial_visits_;
   // tb_hits_ must be initialized before root_move_filter_.
   std::atomic<int> tb_hits_{0};
   const MoveList root_move_filter_;

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -131,6 +131,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   defaults->Set<std::string>(SearchParams::kHistoryFillId, "no");
   defaults->Set<std::string>(NetworkFactory::kBackendId, "multiplexing");
   defaults->Set<bool>(SearchParams::kStickyEndgamesId, false);
+  defaults->Set<bool>(SearchParams::kTwoFoldDrawsId, false);
 }
 
 SelfPlayTournament::SelfPlayTournament(


### PR DESCRIPTION
EDIT: It is fully functional now, tests are welcome! Also, the tree reuse problem with level 1 being complicated has been solved successfully, so the heuristic of level 2 probably isn't needed anymore.

Original post:
This is a draft for a twofold draw scoring patch. For development + testing purposes, this PR introduces an `int TwoFoldDrawLevel = 0...3` where the levels are:

- `0`: never score twofold repetions as draws. This is current behavior.
- `1`: score twofold repetitions when their first repetition is at root or in the tree, but not when it happened in history. This is the theoretically sound implementation, avoiding delusional evals, making this the preferred implementation.
- `2`: score twofold repetions as draws when they happen at depth 4 or deeper in the tree. This is equivalent to `level 1` in the most common 3-fold repetitions moving 1 piece each forward and backward, and much easier to implement
- `3`: score all twofold repetitions as draws. This isn't intended to be used for playing or analysis, only for testing purposes.

This PR isn't functional yet, and only identifies the positions in the code so far. The main problem with `level 1` is marking two-fold draws as non terminal when a move is played and therefore a tree node loses its property of being a two-fold with its first repetition at root or later.

I also want to thank @Mardak for his prior efforts on making a functional two-fold PR, his implementation was somewhere between `level 2` and `level 3` by making two-fold draws non-terminal only at depth 1.