### PR TITLE
Sort edges to reduce cpu load by allowing an early out in the inner pick loop.

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -283,6 +283,15 @@ bool Node::MakeSolid() {
   return true;
 }
 
+void Node::SortEdges() {
+  assert(edges_);
+  assert(!child_);
+  // Sorting on raw p_ is the same as sorting on GetP() as a side effect of
+  // the encoding, and its noticeably faster.
+  std::sort(edges_.get(), (edges_.get() + num_edges_),
+            [](const Edge& a, const Edge& b) { return a.p_ > b.p_; });
+}
+
 void Node::MakeTerminal(GameResult result, float plies_left, Terminal type) {
   SetBounds(result, result);
   terminal_type_ = type;

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -107,6 +107,7 @@ class Edge {
   // Probability that this move will be made, from the policy head of the neural
   // network; compressed to a 16 bit format (5 bits exp, 11 bits significand).
   uint16_t p_ = 0;
+  friend class Node;
 };
 
 class EdgeAndNode;
@@ -249,6 +250,8 @@ class Node {
   // Reallocates this nodes children to be in a solid block, if possible and not
   // already done. Returns true if the transformation was performed.
   bool MakeSolid();
+
+  void SortEdges();
 
   ~Node() {
     if (solid_children_ && child_) {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1098,6 +1098,7 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
         moves_left_support_ &&
         (std::abs(node_q) > params_.GetMovesLeftThreshold());
 
+    bool can_exit = false;
     for (auto child : node->Edges()) {
       if (is_root_node) {
         // If there's no chance to catch up to the current best node with
@@ -1151,6 +1152,13 @@ SearchWorker::NodeToProcess SearchWorker::PickNodeToExtend(
       } else if (score > second_best) {
         second_best = score;
         second_best_edge = child;
+      }
+      if (can_exit) break;
+      if (child.GetNStarted() == 0) {
+        // One more loop will get 2 unvisited nodes, which is sufficient to
+        // ensure second best is correct. This relies upon the fact that edges
+        // are sorted in policy decreasing order.
+        can_exit = true;
       }
     }
 
@@ -1506,6 +1514,7 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
     ApplyDirichletNoise(node, params_.GetNoiseEpsilon(),
                         params_.GetNoiseAlpha());
   }
+  node->SortEdges();
 }
 
 // 6. Propagate the new nodes' information to all their parents in the tree.


### PR DESCRIPTION
This has 'obvious' improvements in cpu profiling - and small but measurable improvements (2-3%) with a 8 million node search of startpos T70 running on 2080TI on a fast intel cpu using windows PGO build.  8 million node search appears more gpu bound than cpu bound for most of the time.

FetchSingleNodeResult is definitely slower (maybe 30%), but the gains in PickNode are much better and clearly offset it in the profile traces I've gathered.  Maybe the sort could be optimized a bit more for small arrays - but it already seems a win.

NOTE:
This is not purely an nps gain. By changing the sort order of the edges it changes the order of tiebreaks in the pick inner loop.
I think the new mode is 'logically' better - but I'll try to run a before/after elo test just in case.
For reference - tie breaks are less about movegen order now.  They are more often based on policy, and in the case that policy is equal it is 'undefined' what order the tiebreak is since it depends on the implementation of std::sort.