### PR TITLE
New parameter to try and increase gpu batch fullness without incurring as much out of order risk.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -177,6 +177,10 @@ const OptionId SearchParams::kMaxOutOfOrderEvalsId{
     "max-out-of-order-evals-factor", "MaxOutOfOrderEvalsFactor",
     "Maximum number of out of order evals during gathering of a batch is "
     "calculated by multiplying the maximum batch size by this number."};
+const OptionId SearchParams::kMaxNotOutOfOrderId{
+    "max-not-out-of-order-factor", "MaxNotOutOfOrderFactor",
+    "Maximum number of not out of order entries during gathering of a batch is "
+    "calculated by multiplying the maximum batch size by this number."};
 const OptionId SearchParams::kStickyEndgamesId{
     "sticky-endgames", "StickyEndgames",
     "When an end of game position is found during search, allow the eval of "
@@ -296,6 +300,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kMaxCollisionVisitsId, 1, 1000000) = 9999;
   options->Add<BoolOption>(kOutOfOrderEvalId) = true;
   options->Add<FloatOption>(kMaxOutOfOrderEvalsId, 0.0f, 100.0f) = 1.0f;
+  options->Add<FloatOption>(kMaxNotOutOfOrderId, 0.0f, 100.0f) = 1.0f;
   options->Add<BoolOption>(kStickyEndgamesId) = true;
   options->Add<BoolOption>(kSyzygyFastPlayId) = true;
   options->Add<IntOption>(kMultiPvId, 1, 500) = 1;
@@ -388,6 +393,9 @@ SearchParams::SearchParams(const OptionsDict& options)
       kDrawScoreBlack{options.Get<int>(kDrawScoreBlackId) / 100.0f},
       kMaxOutOfOrderEvals(std::max(
           1, static_cast<int>(options.Get<float>(kMaxOutOfOrderEvalsId) *
+                              options.Get<int>(kMiniBatchSizeId)))),
+      kMaxNotOutOfOrder(std::max(
+          1, static_cast<int>(options.Get<float>(kMaxNotOutOfOrderId) *
                               options.Get<int>(kMiniBatchSizeId)))),
       kNpsLimit(options.Get<float>(kNpsLimitId)),
       kSolidTreeThreshold(options.Get<int>(kSolidTreeThresholdId)) {

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -108,6 +108,7 @@ class SearchParams {
   float GetWhiteDrawDelta() const { return kDrawScoreWhite; }
   float GetBlackDrawDelta() const { return kDrawScoreBlack; }
   int GetMaxOutOfOrderEvals() const { return kMaxOutOfOrderEvals; }
+  int GetMaxNotOutOfOrder() const { return kMaxNotOutOfOrder; }
   float GetNpsLimit() const { return kNpsLimit; }
   int GetSolidTreeThreshold() const { return kSolidTreeThreshold; }
 
@@ -160,6 +161,7 @@ class SearchParams {
   static const OptionId kDrawScoreWhiteId;
   static const OptionId kDrawScoreBlackId;
   static const OptionId kMaxOutOfOrderEvalsId;
+  static const OptionId kMaxNotOutOfOrderId;
   static const OptionId kNpsLimitId;
   static const OptionId kSolidTreeThresholdId;
 
@@ -205,6 +207,7 @@ class SearchParams {
   const float kDrawScoreWhite;
   const float kDrawScoreBlack;
   const int kMaxOutOfOrderEvals;
+  const int kMaxNotOutOfOrder;
   const float kNpsLimit;
   const int kSolidTreeThreshold;
 };


### PR DESCRIPTION
This will need tuning at time control and a fully time control based elo check. Probably should tune in conjunction with MOOOEF and collision events.
I have no idea when 'I' will be able to give that a go. Maybe someone else will be able to help me out ;)

Note that setting it to 1 is not the same as the previous behavior! Previously collection would abort when out of order ran out even if the batch itself was tiny!  There is no preserving of previous behavior in any scenario that out of order was enabled before.
Setting to 1 is a no-op if out of order is disabled, like it is for training. So this should be 'safe' for training.

I do think the idea has merit though, hopefully testing agrees...