### PR TITLE
[WIP] Implement the RENTS algorithm for tree exploration

### DIFF
--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -578,6 +578,11 @@ std::string EdgeAndNode::DebugString() const {
          (node_ ? node_->DebugString() : "(no node)");
 }
 
+float EdgeAndNode::GetQ(float default_q, float draw_score, bool use_rents) const {
+  if (use_rents && !node_) return edge_->GetInitialQ();
+  return (node_ && node_->GetN() > 0) ? node_->GetQ(draw_score) : default_q;
+}
+
 /////////////////////////////////////////////////////////////////////////
 // NodeTree
 /////////////////////////////////////////////////////////////////////////

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -95,6 +95,11 @@ class Edge {
   float GetP() const;
   void SetP(float val);
 
+  // Returns the initial Q value assigned to dangling edges, before the node is
+  // expanded. Must be in [-1, 1]
+  float GetInitialQ() const { return initial_q_; }
+  void SetInitialQ(float val) { initial_q_ = val; };
+
   // Debug information about the edge.
   std::string DebugString() const;
 
@@ -107,6 +112,8 @@ class Edge {
   // Probability that this move will be made, from the policy head of the neural
   // network; compressed to a 16 bit format (5 bits exp, 11 bits significand).
   uint16_t p_ = 0;
+
+  float initial_q_ = 0;
   friend class Node;
 };
 
@@ -382,9 +389,7 @@ class EdgeAndNode {
   Node* node() const { return node_; }
 
   // Proxy functions for easier access to node/edge.
-  float GetQ(float default_q, float draw_score) const {
-    return (node_ && node_->GetN() > 0) ? node_->GetQ(draw_score) : default_q;
-  }
+  float GetQ(float default_q, float draw_score, bool use_rents) const;
   float GetWL(float default_wl) const {
     return (node_ && node_->GetN() > 0) ? node_->GetWL() : default_wl;
   }

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -275,6 +275,9 @@ const OptionId SearchParams::kSolidTreeThresholdId{
     "solid-tree-threshold", "SolidTreeThreshold",
     "Only nodes with at least this number of visits will be considered for "
     "solidification for improved cache locality."};
+const OptionId SearchParams::kUseRENTSId{
+    "use-rents", "UseRENTS",
+    "Use the RENTS algorithm instead of the PUCT algorithm to search."};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -341,6 +344,8 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kDrawScoreBlackId, -100, 100) = 0;
   options->Add<FloatOption>(kNpsLimitId, 0.0f, 1e6f) = 0.0f;
   options->Add<IntOption>(kSolidTreeThresholdId, 1, 2000000000) = 100;
+  options->Add<BoolOption>(kUseRENTSId) = false;
+
 
   options->HideOption(kNoiseEpsilonId);
   options->HideOption(kNoiseAlphaId);
@@ -407,7 +412,8 @@ SearchParams::SearchParams(const OptionsDict& options)
           1, static_cast<int>(options.Get<float>(kMaxOutOfOrderEvalsId) *
                               options.Get<int>(kMiniBatchSizeId)))),
       kNpsLimit(options.Get<float>(kNpsLimitId)),
-      kSolidTreeThreshold(options.Get<int>(kSolidTreeThresholdId)) {
+      kSolidTreeThreshold(options.Get<int>(kSolidTreeThresholdId)),
+      kUseRENTS(options.Get<bool>(kUseRENTSId)) {
   if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +
           std::max(std::abs(kDrawScoreWhite), std::abs(kDrawScoreBlack)) >
       1.0f) {

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -111,6 +111,7 @@ class SearchParams {
   int GetMaxOutOfOrderEvals() const { return kMaxOutOfOrderEvals; }
   float GetNpsLimit() const { return kNpsLimit; }
   int GetSolidTreeThreshold() const { return kSolidTreeThreshold; }
+  bool GetUseRENTS() const { return kUseRENTS; }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -164,6 +165,7 @@ class SearchParams {
   static const OptionId kMaxOutOfOrderEvalsId;
   static const OptionId kNpsLimitId;
   static const OptionId kSolidTreeThresholdId;
+  static const OptionId kUseRENTSId;
 
  private:
   const OptionsDict& options_;
@@ -209,6 +211,7 @@ class SearchParams {
   const int kMaxOutOfOrderEvals;
   const float kNpsLimit;
   const int kSolidTreeThreshold;
+  const bool kUseRENTS;
 };
 
 }  // namespace lczero

--- a/src/utils/softmax.h
+++ b/src/utils/softmax.h
@@ -1,0 +1,51 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018-2019 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#pragma once
+
+#include <cmath>
+#include <tuple>
+
+#include "utils/fastmath.h"
+
+namespace lczero {
+
+inline std::tuple<float, std::array<float, 256>> RelativeEntropySoftmax(
+    std::array<float, 256>& q, std::array<float, 256>& p, int length,
+    float temperature = 1.0) {
+  float sum = 0.0;
+  std::array<float, 256> new_policy;
+  for (int i = 0; i < length; i++) {
+    new_policy[i] = p[i] * FastExp(q[i] / temperature);
+    sum += new_policy[i];
+  }
+  for (int i = 0; i < length; i++) {
+    new_policy[i] /= sum;
+  }
+  return {FastLog(sum), new_policy};
+  }
+}  // namespace lczero


### PR DESCRIPTION
## Description 
This is a WIP branch where I will implement the RENTS algorithm as proposed by Tuan et al. 2020 [[1]](https://arxiv.org/abs/2007.00391).

Policies are continually recomputed using the following weighted softmax:
![max_relent](https://user-images.githubusercontent.com/564473/92719659-c9badd00-f363-11ea-8b4d-e17d3d01e0dc.PNG)

To ensure enough exploration, the uniform distribution is mixed in:
![e3w](https://user-images.githubusercontent.com/564473/92719770-f40c9a80-f363-11ea-8bc3-766d9da59f7e.PNG)
with the following exploration term:
![lambda_s](https://user-images.githubusercontent.com/564473/92719795-fd960280-f363-11ea-811f-3b1ed950b9f2.PNG)

The initialization of the Q values is crucial. It is possible to use the existing policy head to come up with a semi-decent initialization, but preliminary experiments in a0lite have shown that initializing using the value head is much better. For that we would need a value head which outputs Q values for every move.

## Pros and Cons
Pros:

- Faster convergence than PUCT
- Potentially better scaling behaviour
- Potentially easier collection of batches

Cons:
- More computational overhead during backpropagation (may need to come up with a clever updating scheme, or update only rarely)
- Unclear yet, if it is better for chess (the variant TENTS could work better)

## To do
Implementation:
- [x] Implement weighted softmax function
- [ ] Initialize Q values
- [ ] Update Q values and policies during backpropagation
- [ ] Select moves based on policies
- [ ] Additional parameters to control exploration, softmax temperature etc

Test:
- [ ] Performance using fixed nodes
- [ ] ...


## References
[1] Dam, T., D'Eramo, C., Peters, J., and Pajarinen, J., “[Convex Regularization in Monte-Carlo Tree Search](https://arxiv.org/abs/2007.00391)”, <i>arXiv e-prints</i>, 2020.
