### PR TITLE
replace cudnn softmax with cpu version

### DIFF
--- a/src/neural/cuda/layers.cc
+++ b/src/neural/cuda/layers.cc
@@ -49,40 +49,6 @@ BaseLayer<DataType>::BaseLayer(int c, int h, int w, BaseLayer* ip)
     : input_(ip), C(c), H(h), W(w), nhwc_(ip->nhwc_) {}
 
 template <typename DataType>
-SoftMaxLayer<DataType>::SoftMaxLayer(BaseLayer<DataType>* ip)
-    : BaseLayer<DataType>(ip->GetC(), ip->GetH(), ip->GetW(), ip) {
-  cudnnCreateTensorDescriptor(&out_tensor_desc_);
-}
-
-template <typename DataType>
-SoftMaxLayer<DataType>::~SoftMaxLayer() {
-  cudnnDestroyTensorDescriptor(out_tensor_desc_);
-}
-
-template <typename DataType>
-void SoftMaxLayer<DataType>::Eval(int N, DataType* output,
-                                  const DataType* input,
-                                  const DataType* /*input2*/, void* /*scratch*/,
-                                  size_t /*scratch_size*/, cudnnHandle_t cudnn,
-                                  cublasHandle_t /*cublas*/) {
-  float alpha = 1.0f, beta = 0.0f;
-
-  const cudnnDataType_t dataType =
-      std::is_same<half, DataType>::value ? CUDNN_DATA_HALF : CUDNN_DATA_FLOAT;
-
-  const cudnnTensorFormat_t layout =
-      nhwc_ ? CUDNN_TENSOR_NHWC : CUDNN_TENSOR_NCHW;
-
-  // Need to call this at Eval as 'N' changes :-/
-  cudnnSetTensor4dDescriptor(out_tensor_desc_, layout, dataType, N, GetC(),
-                             GetH(), GetW());
-
-  cudnnSoftmaxForward(cudnn, CUDNN_SOFTMAX_ACCURATE,
-                      CUDNN_SOFTMAX_MODE_INSTANCE, &alpha, out_tensor_desc_,
-                      input, &beta, out_tensor_desc_, output);
-}
-
-template <typename DataType>
 void ConvLayer<DataType>::init() {
   // Allocate memory for weights (filter tensor) and biases.
   const size_t weight_size =
@@ -906,9 +872,6 @@ template class ConvLayer<float>;
 
 template class FCLayer<half>;
 template class FCLayer<float>;
-
-template class SoftMaxLayer<half>;
-template class SoftMaxLayer<float>;
 
 template class SELayer<half>;
 template class SELayer<float>;

--- a/src/neural/cuda/layers.h
+++ b/src/neural/cuda/layers.h
@@ -108,24 +108,6 @@ class ConvLayer : public BaseLayer<DataType> {
 };
 
 template <typename DataType>
-class SoftMaxLayer : public BaseLayer<DataType> {
-  using BaseLayer<DataType>::GetC;
-  using BaseLayer<DataType>::GetH;
-  using BaseLayer<DataType>::GetW;
-  using BaseLayer<DataType>::nhwc_;
-
- public:
-  SoftMaxLayer(BaseLayer<DataType>* ip);
-  ~SoftMaxLayer();
-  void Eval(int N, DataType* output, const DataType* input,
-            const DataType* input2, void* scratch, size_t scratch_size,
-            cudnnHandle_t cudnn, cublasHandle_t cublas) override;
-
- private:
-  cudnnTensorDescriptor_t out_tensor_desc_;
-};
-
-template <typename DataType>
 class FCLayer : public BaseLayer<DataType> {
  using BaseLayer<DataType>::nhwc_;
 

--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -609,7 +609,7 @@ class CudnnNetwork : public Network {
   }
 
   void forwardEval(InputsOutputs* io, int batchSize) {
-    std::lock_guard<std::mutex> lock(lock_);
+    std::unique_lock<std::mutex> lock(lock_);
 
 #ifdef DEBUG_RAW_NPS
     auto t_start = std::chrono::high_resolution_clock::now();
@@ -770,6 +770,8 @@ class CudnnNetwork : public Network {
     }
 
     ReportCUDAErrors(cudaDeviceSynchronize());
+    // The next thread can start using the GPU now.
+    lock.unlock();
 
     if (wdl_) {
       // Value softmax done cpu side.

--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -552,12 +552,6 @@ class CudnnNetwork : public Network {
       FCVal2->LoadWeights(&weights.ip2_val_w[0], &weights.ip2_val_b[0],
                           scratch_mem_);
       network_.emplace_back(std::move(FCVal2));
-
-      if (wdl_) {
-        auto softmaxVal =
-            std::make_unique<SoftMaxLayer<DataType>>(getLastLayer());
-        network_.emplace_back(std::move(softmaxVal));
-      }
     }
     value_out_ = getLastLayer();
 
@@ -738,36 +732,18 @@ class CudnnNetwork : public Network {
                         scratch_mem_, scratch_size_, cudnn_,
                         cublas_);  // value FC1
 
-    if (wdl_) {
+
+    if (fp16) {
+      // TODO: consider fusing the bias-add of FC2 with format conversion.
       network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[1], nullptr,
                           scratch_mem_, scratch_size_, cudnn_,
-                          cublas_);  // value FC2    // VALUE
-
-      // Value softmax
-      if (fp16) {
-        // TODO: consider fusing the bias-add of FC2 with format conversion.
-        network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0], nullptr,
-                            scratch_mem_, scratch_size_, cudnn_,
-                            cublas_);  // value FC2
-        copyTypeConverted(opVal, (half*)(tensor_mem_[1]),
-                          3 * batchSize);  // VALUE
-      } else {
-        network_[l++]->Eval(batchSize, (DataType*)opVal, tensor_mem_[0],
-                            nullptr, scratch_mem_, scratch_size_, cudnn_,
-                            cublas_);  // value FC2    // VALUE
-      }
+                          cublas_);  // value FC2
+      copyTypeConverted(opVal, (half*)(tensor_mem_[0]),
+                        wdl_ ? 3 * batchSize : batchSize);  // VALUE
     } else {
-      if (fp16) {
-        // TODO: consider fusing the bias-add of FC2 with format conversion.
-        network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[1], nullptr,
-                            scratch_mem_, scratch_size_, cudnn_,
-                            cublas_);  // value FC2
-        copyTypeConverted(opVal, (half*)(tensor_mem_[0]), batchSize);  // VALUE
-      } else {
-        network_[l++]->Eval(batchSize, (DataType*)opVal, tensor_mem_[1],
-                            nullptr, scratch_mem_, scratch_size_, cudnn_,
-                            cublas_);  // value FC2    // VALUE
-      }
+      network_[l++]->Eval(batchSize, (DataType*)opVal, tensor_mem_[1],
+                          nullptr, scratch_mem_, scratch_size_, cudnn_,
+                          cublas_);  // value FC2    // VALUE
     }
 
     if (moves_left_) {
@@ -794,6 +770,22 @@ class CudnnNetwork : public Network {
     }
 
     ReportCUDAErrors(cudaDeviceSynchronize());
+
+    if (wdl_) {
+      // Value softmax done cpu side.
+      for (int i = 0; i < batchSize; i++) {
+        float w = std::exp(io->op_value_mem_[3 * i + 0]);
+        float d = std::exp(io->op_value_mem_[3 * i + 1]);
+        float l = std::exp(io->op_value_mem_[3 * i + 2]);
+        float sum = w + d + l;
+        w /= sum;
+        l /= sum;
+        d = 1.0f - w - l;
+        io->op_value_mem_[3 * i + 0] = w;
+        io->op_value_mem_[3 * i + 1] = d;
+        io->op_value_mem_[3 * i + 2] = l;
+      }
+    }
 
 #ifdef DEBUG_RAW_NPS
     const int reportingCalls = 100;


### PR DESCRIPTION
This is a follow-up to #1422. Needs performance testing whether it brings a small nps improvement.
1. The softmax of WDL values is probably not very well suited to a gpu implementation. 
2. @ankan-ban suggested doing the softmax after freeing the lock.