### PR TITLE
Residual block fusion winograd optimization

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -447,7 +447,7 @@ if get_option('build_backends')
       )
 	 files += cuda_files
     files += cuda_gen.process(cuda_files_nvcc_common)
-    files += cuda_gen.process(cuda_files_nvcc_fp16, extra_args: ['-arch=compute_70', '-code=sm_70'])
+    files += cuda_gen.process(cuda_files_nvcc_fp16, extra_args: ['-arch=compute_75', '-code=sm_80', '-code=sm_75', '-code=sm_86'])
     has_backends = true
   endif
   

--- a/meson.build
+++ b/meson.build
@@ -447,7 +447,7 @@ if get_option('build_backends')
       )
 	 files += cuda_files
     files += cuda_gen.process(cuda_files_nvcc_common)
-    files += cuda_gen.process(cuda_files_nvcc_fp16, extra_args: ['-arch=compute_75', '-code=sm_80', '-code=sm_75', '-code=sm_86'])
+    files += cuda_gen.process(cuda_files_nvcc_fp16, extra_args: ['-arch=compute_53'])
     has_backends = true
   endif
   

--- a/src/neural/cuda/common_kernels.cu
+++ b/src/neural/cuda/common_kernels.cu
@@ -613,5 +613,16 @@ template void OutputTransform<float, false, true, true, true>(
     const float* w2, const float* b2);
 
 
+template void OutputInputTransform<float, true, true, true, true>(
+    int N, int C, int se_K, float* output, const float* input,
+    const float* skip, const float* bias, const float* w1, const float* b1,
+    const float* w2, const float* b2);
+
+template void OutputInputTransform<float, false, true, true, false>(
+    int N, int C, int se_K, float* output, const float* input,
+    const float* skip, const float* bias, const float* w1, const float* b1,
+    const float* w2, const float* b2);
+
+
 }  // namespace cudnn_backend
 }  // namespace lczero

--- a/src/neural/cuda/common_kernels.cu
+++ b/src/neural/cuda/common_kernels.cu
@@ -618,6 +618,11 @@ template void OutputInputTransform<float, true, true, true, true>(
     const float* skip, const float* bias, const float* w1, const float* b1,
     const float* w2, const float* b2);
 
+template void OutputInputTransform<float, false, true, true, true>(
+    int N, int C, int se_K, float* output, const float* input,
+    const float* skip, const float* bias, const float* w1, const float* b1,
+    const float* w2, const float* b2);
+
 template void OutputInputTransform<float, false, true, true, false>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,

--- a/src/neural/cuda/fp16_kernels.cu
+++ b/src/neural/cuda/fp16_kernels.cu
@@ -217,5 +217,16 @@ template void OutputTransform<half, false, true, true, true>(
     const half* bias, const half* w1, const half* b1, const half* w2,
     const half* b2);
 
+template void OutputInputTransform<half, true, true, true, true>(
+    int N, int C, int se_K, half* output, const half* input, const half* skip,
+    const half* bias, const half* w1, const half* b1, const half* w2,
+    const half* b2);
+
+template void OutputInputTransform<half, false, true, true, false>(
+    int N, int C, int se_K, half* output, const half* input, const half* skip,
+    const half* bias, const half* w1, const half* b1, const half* w2,
+    const half* b2);
+
+
 }   // namespace cudnn_backend
 }   // namespace lczero

--- a/src/neural/cuda/fp16_kernels.cu
+++ b/src/neural/cuda/fp16_kernels.cu
@@ -222,6 +222,11 @@ template void OutputInputTransform<half, true, true, true, true>(
     const half* bias, const half* w1, const half* b1, const half* w2,
     const half* b2);
 
+template void OutputInputTransform<half, false, true, true, true>(
+    int N, int C, int se_K, half* output, const half* input, const half* skip,
+    const half* bias, const half* w1, const half* b1, const half* w2,
+    const half* b2);
+
 template void OutputInputTransform<half, false, true, true, false>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,

--- a/src/neural/cuda/kernels.h
+++ b/src/neural/cuda/kernels.h
@@ -95,6 +95,10 @@ void OutputTransform(int N, int C, int se_K, T* output, const T* input,
                      const T* skip, const T* bias, const T* w1, const T* b1,
                      const T* w2, const T* b2);
 
+template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
+void OutputInputTransform(int N, int C, int se_K, T* output, const T* input,
+                     const T* skip, const T* bias, const T* w1, const T* b1,
+                     const T* w2, const T* b2);
 
 }  // namespace cudnn_backend
 }  // namespace lczero

--- a/src/neural/cuda/layers.cc
+++ b/src/neural/cuda/layers.cc
@@ -1089,7 +1089,7 @@ void ResidualBlock<DataType>::Eval(
       transformed_input + scratch_size / (2 * sizeof(DataType));
 
   if (first_block_) {
-    InputTransform<DataType>(N, C, transformed_input, input);
+    InputTransform<DataType>(N, c_input_, transformed_input, input);
 
     cublasRowMajorMatrixMul(transformed_input, transformed_weights0_,
                             transformed_output, N * 4, C, c_input_, 36, cublas);

--- a/src/neural/cuda/layers.cc
+++ b/src/neural/cuda/layers.cc
@@ -1109,13 +1109,23 @@ void ResidualBlock<DataType>::Eval(
                           transformed_output, N * 4, C, C, 36, cublas);
 
   if (last_block_) {
-    OutputTransform<DataType, true, true, true, true>(
-        N, C, se_k_, output, transformed_output, input, biases1_, w1_, b1_, w2_,
-        b2_);
+    if (has_se_)
+      OutputTransform<DataType, true, true, true, true>(
+          N, C, se_k_, output, transformed_output, input, biases1_, w1_, b1_,
+          w2_, b2_);
+    else
+      OutputTransform<DataType, false, true, true, true>(
+          N, C, se_k_, output, transformed_output, input, biases1_, w1_, b1_,
+          w2_, b2_);
   } else {
-    OutputInputTransform<DataType, true, true, true, true>(
-        N, C, se_k_, output, transformed_output, input, biases1_, w1_, b1_, w2_,
-        b2_);
+    if (has_se_)
+      OutputInputTransform<DataType, true, true, true, true>(
+          N, C, se_k_, output, transformed_output, input, biases1_, w1_, b1_,
+          w2_, b2_);
+    else
+      OutputInputTransform<DataType, false, true, true, true>(
+          N, C, se_k_, output, transformed_output, input, biases1_, w1_, b1_,
+          w2_, b2_);
     // "output" tensor now contains transformed input for the next
     // convolution
   }

--- a/src/neural/cuda/layers.cc
+++ b/src/neural/cuda/layers.cc
@@ -886,6 +886,7 @@ void FusedWinogradConvSELayer<DataType>::Eval(
         nullptr, nullptr);
   else
     throw Exception("unsupported network type!");
+
 }
 
 template <typename DataType>
@@ -899,6 +900,218 @@ FusedWinogradConvSELayer<DataType>::~FusedWinogradConvSELayer() {
     ReportCUDAErrors(cudaFree(b2_));
   }
 }
+
+
+template <typename DataType>
+ResidualBlock<DataType>::ResidualBlock(
+    BaseLayer<DataType>* ip, int C, bool se, int se_k, bool use_gemm_ex)
+    : BaseLayer<DataType>(C, 8, 8, ip),
+      c_input_(C),
+      has_se_(se),
+      se_k_(se_k),
+      use_gemm_ex_(use_gemm_ex) {
+  // Allocate memory for weights (filter tensor) and biases.
+  const size_t weight_size = sizeof(DataType) * C * C * 3 * 3;
+
+  const size_t blas_size = sizeof(DataType) * C;
+  ReportCUDAErrors(cudaMalloc(&biases0_, blas_size));
+  ReportCUDAErrors(cudaMalloc(&biases1_, blas_size));
+
+  // 6x6 transformed filter size, for 3x3 convolution
+  ReportCUDAErrors(cudaMalloc(&transformed_weights0_, weight_size * 4));
+  ReportCUDAErrors(cudaMalloc(&transformed_weights1_, weight_size * 4));
+
+  if (has_se_) {
+    const size_t num_weights1 = C * se_k_;
+    const size_t num_weights2 = num_weights1 * 2;
+    const size_t num_biases1 = se_k_;
+    const size_t num_biases2 = 2 * C;
+
+    const size_t weight_size1 = sizeof(DataType) * num_weights1;
+    const size_t weight_size2 = sizeof(DataType) * num_weights2;
+    const size_t biases_size1 = sizeof(DataType) * num_biases1;
+    const size_t biases_size2 = sizeof(DataType) * num_biases2;
+
+    ReportCUDAErrors(cudaMalloc(&w1_, weight_size1));
+    ReportCUDAErrors(cudaMalloc(&w2_, weight_size2));
+    ReportCUDAErrors(cudaMalloc(&b1_, biases_size1));
+    ReportCUDAErrors(cudaMalloc(&b2_, biases_size2));
+  }
+}
+
+template <typename DataType>
+void ResidualBlock<DataType>::LoadWeights0(float* pfilter,
+                                           float* pBias,
+                                           void* scratch) {
+
+  const size_t weight_size = sizeof(float) * c_input_ * C * 3 * 3;
+  const size_t blas_size = sizeof(float) * C;
+
+  // Store untransformed weights in scratch.
+  const DataType* weights = (DataType*)scratch + weight_size + blas_size;
+
+  // first copy from CPU memory to scratch space in GPU memory
+  // and then do the type conversion using a kernel
+  assert(scratch);
+  ReportCUDAErrors(
+      cudaMemcpy(scratch, pfilter, weight_size, cudaMemcpyHostToDevice));
+  copyTypeConverted((DataType*)weights, (float*)scratch, C * c_input_ * 3 * 3);
+
+  if (pBias) {
+    ReportCUDAErrors(
+        cudaMemcpy(scratch, pBias, blas_size, cudaMemcpyHostToDevice));
+    copyTypeConverted((DataType*)biases0_, (float*)scratch, C);
+  }
+
+  // run winograd transform kernel for the filter
+  FilterTransform(C, c_input_, transformed_weights0_, weights);
+}
+
+template <typename DataType>
+void ResidualBlock<DataType>::LoadWeights1(float* pfilter, float* pBias,
+                                           void* scratch) {
+  const size_t weight_size = sizeof(float) * C * C * 3 * 3;
+  const size_t blas_size = sizeof(float) * C;
+
+  // Store untransformed weights in scratch.
+  const DataType* weights = (DataType*)scratch + weight_size + blas_size;
+
+  // first copy from CPU memory to scratch space in GPU memory
+  // and then do the type conversion using a kernel
+  assert(scratch);
+  ReportCUDAErrors(
+      cudaMemcpy(scratch, pfilter, weight_size, cudaMemcpyHostToDevice));
+  copyTypeConverted((DataType*)weights, (float*)scratch, C * C * 3 * 3);
+
+  if (pBias) {
+    ReportCUDAErrors(
+        cudaMemcpy(scratch, pBias, blas_size, cudaMemcpyHostToDevice));
+    copyTypeConverted((DataType*)biases1_, (float*)scratch, C);
+  }
+
+  // run winograd transform kernel for the filter
+  FilterTransform(C, C, transformed_weights1_, weights);
+}
+
+template <typename DataType>
+void ResidualBlock<DataType>::LoadSEWeights(float* w1, float* b1,
+                                            float* w2, float* b2,
+                                            void* scratch) {
+  const size_t num_weights1 = C * se_k_;
+  const size_t num_weights2 = num_weights1 * 2;
+  const size_t num_biases1 = se_k_;
+  const size_t num_biases2 = 2 * C;
+
+  // The shader uses transposed weight matrices.
+  std::vector<float> temp_transposed(num_weights2);
+
+  CpuTranspose(temp_transposed.data(), w1, se_k_, C);
+  ReportCUDAErrors(cudaMemcpy(scratch, temp_transposed.data(),
+                              num_weights1 * sizeof(float),
+                              cudaMemcpyHostToDevice));
+  copyTypeConverted((DataType*)w1_, (float*)scratch, (int)num_weights1);
+
+  CpuTranspose(temp_transposed.data(), w2, 2 * C, se_k_);
+  ReportCUDAErrors(cudaMemcpy(scratch, temp_transposed.data(),
+                              num_weights2 * sizeof(float),
+                              cudaMemcpyHostToDevice));
+  copyTypeConverted((DataType*)w2_, (float*)scratch, (int)num_weights2);
+
+  ReportCUDAErrors(cudaMemcpy(scratch, b1, num_biases1 * sizeof(float),
+                              cudaMemcpyHostToDevice));
+  copyTypeConverted((DataType*)b1_, (float*)scratch, (int)num_biases1);
+
+  ReportCUDAErrors(cudaMemcpy(scratch, b2, num_biases2 * sizeof(float),
+                              cudaMemcpyHostToDevice));
+  copyTypeConverted((DataType*)b2_, (float*)scratch, (int)num_biases2);
+}
+
+template <>
+void ResidualBlock<half>::cublasRowMajorMatrixMul(
+    const half* A, const half* B, half* Out, int M, int N, int K, int batchSize,
+    cublasHandle_t cublas) {
+  // Need to initialize 1.0 and 0.0 as hexadecimal for fp16 because typecasting
+  // float to half type doesn't work before CUDA 10.0
+  __half_raw one_h{0x3C00};
+  __half_raw zero_h{0};
+  half halfOne = one_h;
+  half halfZero = zero_h;
+
+  // dimensions of matrix A = M x K
+  // dimensions of matrix B = K x N
+  // dimensions of output   = M x N
+
+  // cublas supports only col major output
+  // to multiply row major matrices, use the trick below
+  ReportCUBLASErrors(cublasGemmStridedBatchedEx(
+      cublas, CUBLAS_OP_N, CUBLAS_OP_N, N, M, K, &halfOne, B, CUDA_R_16F, N,
+      N * K, A, CUDA_R_16F, K, K * M, &halfZero, Out, CUDA_R_16F, N, N * M,
+      batchSize, CUDA_R_16F, CUBLAS_GEMM_DEFAULT));
+}
+
+template <>
+void ResidualBlock<float>::cublasRowMajorMatrixMul(
+    const float* A, const float* B, float* Out, int M, int N, int K,
+    int batchSize, cublasHandle_t cublas) {
+  float floatOne = 1.0f;
+  float floatZero = 0.0f;
+  if (use_gemm_ex_)
+    ReportCUBLASErrors(cublasGemmStridedBatchedEx(
+        cublas, CUBLAS_OP_N, CUBLAS_OP_N, N, M, K, &floatOne, B, CUDA_R_32F, N,
+        N * K, A, CUDA_R_32F, K, K * M, &floatZero, Out, CUDA_R_32F, N, N * M,
+        batchSize, CUDA_R_32F, CUBLAS_GEMM_DEFAULT));
+  else
+    ReportCUBLASErrors(cublasSgemmStridedBatched(
+        cublas, CUBLAS_OP_N, CUBLAS_OP_N, N, M, K, &floatOne, B, N, N * K, A, K,
+        K * M, &floatZero, Out, N, N * M, batchSize));
+}
+
+template <typename DataType>
+void ResidualBlock<DataType>::Eval(
+    int N, DataType* output, const DataType* input, const DataType* input2,
+    void* scratch, size_t scratch_size, cudnnHandle_t /*cudnn*/,
+    cublasHandle_t cublas) {
+
+  // Split the scratch space into two parts - use first part for holding
+  // transformed input and second part for transformed output.
+  DataType* transformed_input = (DataType*)scratch;
+  DataType* transformed_output =
+      transformed_input + scratch_size / (2 * sizeof(DataType));
+
+  // this shouldn't be needed, as previous block would handle it!
+  InputTransform<DataType>(N, C, transformed_input, input);
+
+  cublasRowMajorMatrixMul(transformed_input, transformed_weights0_,
+                          transformed_output, N * 4, C, c_input_, 36, cublas);
+
+  // "transformed_input" tensor now contains transformed input for the next convolution
+  OutputInputTransform<DataType, false, true, true, false>(
+      N, C, 0, transformed_input, transformed_output, nullptr, biases0_,
+      nullptr, nullptr, nullptr, nullptr);
+
+  cublasRowMajorMatrixMul(transformed_input, transformed_weights1_,
+                          transformed_output, N * 4, C, C, 36, cublas);
+
+  OutputTransform<DataType, true, true, true, true>(
+    N, C, se_k_, output, transformed_output, input2, biases1_, w1_, b1_, w2_,
+    b2_);
+
+}
+
+template <typename DataType>
+ResidualBlock<DataType>::~ResidualBlock() {
+  ReportCUDAErrors(cudaFree(transformed_weights0_));
+  ReportCUDAErrors(cudaFree(biases0_));
+  ReportCUDAErrors(cudaFree(transformed_weights1_));
+  ReportCUDAErrors(cudaFree(biases1_));
+  if (has_se_) {
+    ReportCUDAErrors(cudaFree(w1_));
+    ReportCUDAErrors(cudaFree(w2_));
+    ReportCUDAErrors(cudaFree(b1_));
+    ReportCUDAErrors(cudaFree(b2_));
+  }
+}
+
 
 // Template instantiation.
 template class ConvLayer<half>;
@@ -919,6 +1132,8 @@ template class PolicyMapLayer<float>;
 template class FusedWinogradConvSELayer<half>;
 template class FusedWinogradConvSELayer<float>;
 
+template class ResidualBlock<half>;
+template class ResidualBlock<float>;
 
 // Misc error handling stuff.
 void CudnnError(cudnnStatus_t status, const char* file, const int& line) {

--- a/src/neural/cuda/layers.h
+++ b/src/neural/cuda/layers.h
@@ -248,5 +248,49 @@ class FusedWinogradConvSELayer : public BaseLayer<DataType> {
                                int batchSize, cublasHandle_t cublas);
 };
 
+// Multi-pass Winograd Conv fused with (optional) SE
+template <typename DataType>
+class ResidualBlock : public BaseLayer<DataType> {
+  using BaseLayer<DataType>::C;
+  using BaseLayer<DataType>::H;
+  using BaseLayer<DataType>::W;
+  using BaseLayer<DataType>::GetC;
+  using BaseLayer<DataType>::GetH;
+  using BaseLayer<DataType>::GetW;
+
+ public:
+  ResidualBlock(BaseLayer<DataType>* ip, int C, bool se, int se_k, bool use_gemm_ex);
+
+  ~ResidualBlock();
+  void LoadWeights0(float* pfilter, float* pBias, void* scratch);
+  void LoadWeights1(float* pfilter, float* pBias, void* scratch);
+  void LoadSEWeights(float* w1, float* b1, float* w2, float* b2, void* scratch);
+
+  void Eval(int N, DataType* output, const DataType* input,
+            const DataType* input2, void* scratch, size_t scratch_size,
+            cudnnHandle_t cudnn, cublasHandle_t cublas) override;
+
+ private:
+  const bool has_se_;
+  const int se_k_;
+  const bool use_gemm_ex_;
+  const int c_input_;
+
+  DataType* biases0_ = nullptr;
+  DataType* biases1_ = nullptr;
+  DataType* transformed_weights0_ = nullptr;  // After winograd transform.
+  DataType* transformed_weights1_ = nullptr;  // After winograd transform.
+
+  // Weights and Biases for (optional) SE.
+  DataType* w1_;
+  DataType* w2_;
+  DataType* b1_;
+  DataType* b2_;
+
+  void cublasRowMajorMatrixMul(const DataType* A, const DataType* B,
+                               DataType* Out, int M, int N, int K,
+                               int batchSize, cublasHandle_t cublas);
+};
+
 }  // namespace cudnn_backend
 }  // namespace lczero

--- a/src/neural/cuda/layers.h
+++ b/src/neural/cuda/layers.h
@@ -259,7 +259,7 @@ class ResidualBlock : public BaseLayer<DataType> {
   using BaseLayer<DataType>::GetW;
 
  public:
-  ResidualBlock(BaseLayer<DataType>* ip, int C, bool se, int se_k, bool use_gemm_ex);
+  ResidualBlock(BaseLayer<DataType>* ip, int C, bool se, int se_k, bool use_gemm_ex, bool first, bool last);
 
   ~ResidualBlock();
   void LoadWeights0(float* pfilter, float* pBias, void* scratch);
@@ -275,6 +275,8 @@ class ResidualBlock : public BaseLayer<DataType> {
   const int se_k_;
   const bool use_gemm_ex_;
   const int c_input_;
+  const bool first_block_;
+  const bool last_block_;
 
   DataType* biases0_ = nullptr;
   DataType* biases1_ = nullptr;

--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -352,6 +352,11 @@ class CudnnNetwork : public Network {
       use_res_block_winograd_fuse_opt_ = false;
     }
 
+    // Disable res block fusing for > 512 filters
+    // (the fused output input transform kernel runs 
+    // out of register space)
+    if (kNumFilters > 512) use_res_block_winograd_fuse_opt_ = false;
+
 
     const bool use_gemm_ex = deviceProp.major >= 5;
 

--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -42,7 +42,6 @@
 
 //#define DEBUG_RAW_NPS
 
-#define RESIDUAL_BLOCK_OPT
 
 namespace lczero {
 using namespace cudnn_backend;
@@ -346,6 +345,14 @@ class CudnnNetwork : public Network {
     // Winograd needs nchw tensor layout.
     if (use_custom_winograd_) nhwc_ = false;
 
+    if (use_custom_winograd_) {
+      use_res_block_winograd_fuse_opt_ =
+          options.GetOrDefault<bool>("res_block_fusing", true);
+    } else {
+      use_res_block_winograd_fuse_opt_ = false;
+    }
+
+
     const bool use_gemm_ex = deviceProp.major >= 5;
 
     // 0. Check for SE.
@@ -437,44 +444,46 @@ class CudnnNetwork : public Network {
         bool has_se = weights.residual[block].has_se;
         int se_k = (int)weights.residual[block].se.b1.size();
 
-#ifdef RESIDUAL_BLOCK_OPT
-        auto layer = std::make_unique<ResidualBlock<DataType>>(
-            getLastLayer(), kNumFilters, true, se_k, use_gemm_ex, block == 0,
-            block == (numBlocks_-1));
-        layer->LoadWeights0(&weights.residual[block].conv1.weights[0],
-                            &weights.residual[block].conv1.biases[0],
-                            scratch_mem_);
-        layer->LoadWeights1(&weights.residual[block].conv2.weights[0],
-                            &weights.residual[block].conv2.biases[0],
-                            scratch_mem_);
+        if (use_res_block_winograd_fuse_opt_) {
+          auto layer = std::make_unique<ResidualBlock<DataType>>(
+              getLastLayer(), kNumFilters, has_se, se_k, use_gemm_ex,
+              block == 0, block == (numBlocks_ - 1));
+          layer->LoadWeights0(&weights.residual[block].conv1.weights[0],
+                              &weights.residual[block].conv1.biases[0],
+                              scratch_mem_);
+          layer->LoadWeights1(&weights.residual[block].conv2.weights[0],
+                              &weights.residual[block].conv2.biases[0],
+                              scratch_mem_);
 
-        layer->LoadSEWeights(&weights.residual[block].se.w1[0],
-                             &weights.residual[block].se.b1[0],
-                             &weights.residual[block].se.w2[0],
-                             &weights.residual[block].se.b2[0], scratch_mem_);
-        network_.emplace_back(std::move(layer));
-#else
-        auto conv1 = std::make_unique<FusedWinogradConvSELayer<DataType>>(
-            getLastLayer(), kNumFilters, 8, 8, kNumFilters, true, true, false,
-            false, 0, use_gemm_ex);
-        conv1->LoadWeights(&weights.residual[block].conv1.weights[0],
-                           &weights.residual[block].conv1.biases[0],
-                           scratch_mem_);
-        network_.emplace_back(std::move(conv1));
-
-        auto conv2 = std::make_unique<FusedWinogradConvSELayer<DataType>>(
-            getLastLayer(), kNumFilters, 8, 8, kNumFilters, true, true, true,
-            has_se, se_k, use_gemm_ex);
-        conv2->LoadWeights(&weights.residual[block].conv2.weights[0],
-                           &weights.residual[block].conv2.biases[0],
-                           scratch_mem_);
-        if (has_se)
-          conv2->LoadSEWeights(&weights.residual[block].se.w1[0],
+          layer->LoadSEWeights(&weights.residual[block].se.w1[0],
                                &weights.residual[block].se.b1[0],
                                &weights.residual[block].se.w2[0],
                                &weights.residual[block].se.b2[0], scratch_mem_);
-        network_.emplace_back(std::move(conv2));
-#endif
+          network_.emplace_back(std::move(layer));
+        } else {
+          auto conv1 = std::make_unique<FusedWinogradConvSELayer<DataType>>(
+              getLastLayer(), kNumFilters, 8, 8, kNumFilters, true, true, false,
+              false, 0, use_gemm_ex);
+          conv1->LoadWeights(&weights.residual[block].conv1.weights[0],
+                             &weights.residual[block].conv1.biases[0],
+                             scratch_mem_);
+          network_.emplace_back(std::move(conv1));
+
+          auto conv2 = std::make_unique<FusedWinogradConvSELayer<DataType>>(
+              getLastLayer(), kNumFilters, 8, 8, kNumFilters, true, true, true,
+              has_se, se_k, use_gemm_ex);
+          conv2->LoadWeights(&weights.residual[block].conv2.weights[0],
+                             &weights.residual[block].conv2.biases[0],
+                             scratch_mem_);
+          if (has_se)
+            conv2->LoadSEWeights(&weights.residual[block].se.w1[0],
+                                 &weights.residual[block].se.b1[0],
+                                 &weights.residual[block].se.w2[0],
+                                 &weights.residual[block].se.b2[0],
+                                 scratch_mem_);
+          network_.emplace_back(std::move(conv2));
+        }
+
       } else {
         auto conv1 = std::make_unique<ConvLayer<DataType>>(
             getLastLayer(), kNumFilters, 8, 8, 3, kNumFilters, true, true);
@@ -622,11 +631,10 @@ class CudnnNetwork : public Network {
       maxSize = std::max(maxSize, layer->GetOutputSize(max_batch_size_));
     }
 
-#ifdef RESIDUAL_BLOCK_OPT
-    // when this optimization is enabled, we write transformed outputs to 
+    // when this optimization is enabled, we write transformed outputs to
     // intermediate tensor memory
-    maxSize = std::max(maxSize, transformed_tensor_size);
-#endif
+    if (use_res_block_winograd_fuse_opt_ && transformed_tensor_size > maxSize)
+      maxSize = transformed_tensor_size;
 
     for (auto& mem : tensor_mem_) {
       ReportCUDAErrors(cudaMalloc(&mem, maxSize));
@@ -676,53 +684,50 @@ class CudnnNetwork : public Network {
 
     int l = 0;
     // Input.
-#ifdef RESIDUAL_BLOCK_OPT
-    network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0], nullptr,
-                        scratch_mem_, scratch_size_, cudnn_,
-                        cublas_);  // input conv
-#else
-    network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[0], nullptr,
-                        scratch_mem_, scratch_size_, cudnn_,
-                        cublas_);  // input conv
-#endif
+    network_[l++]->Eval(
+        batchSize,
+        use_res_block_winograd_fuse_opt_ ? tensor_mem_[1] : tensor_mem_[2],
+        tensor_mem_[0], nullptr, scratch_mem_, scratch_size_, cudnn_,
+        cublas_);  // input conv
 
     // Residual block.
     for (int block = 0; block < numBlocks_; block++) {
-#ifdef RESIDUAL_BLOCK_OPT
-      network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[1],
-                          nullptr, scratch_mem_, scratch_size_, cudnn_,
-                          cublas_);  // block
-#else
-      network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2], nullptr,
-                          scratch_mem_, scratch_size_, cudnn_,
-                          cublas_);  // conv1
-
-      if (use_custom_winograd_) {
-        network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[0],
-                            tensor_mem_[2], scratch_mem_, scratch_size_, cudnn_,
-                            cublas_);  // conv2
+      if (use_res_block_winograd_fuse_opt_) {
+        network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[1], nullptr,
+                            scratch_mem_, scratch_size_, cudnn_,
+                            cublas_);  // block
       } else {
-        // For SE Resnet, skip connection is added after SE (and bias is added
-        // as part of SE).
-        if (has_se_) {
-          network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0],
-                              nullptr, scratch_mem_, scratch_size_, cudnn_,
-                              cublas_);  // conv2
-        } else {
+        network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2], nullptr,
+                            scratch_mem_, scratch_size_, cudnn_,
+                            cublas_);  // conv1
+
+        if (use_custom_winograd_) {
           network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[0],
                               tensor_mem_[2], scratch_mem_, scratch_size_,
                               cudnn_,
                               cublas_);  // conv2
-        }
+        } else {
+          // For SE Resnet, skip connection is added after SE (and bias is added
+          // as part of SE).
+          if (has_se_) {
+            network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0],
+                                nullptr, scratch_mem_, scratch_size_, cudnn_,
+                                cublas_);  // conv2
+          } else {
+            network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[0],
+                                tensor_mem_[2], scratch_mem_, scratch_size_,
+                                cudnn_,
+                                cublas_);  // conv2
+          }
 
-        if (has_se_) {
-          network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[1],
-                              tensor_mem_[2], scratch_mem_, scratch_size_,
-                              cudnn_,
-                              cublas_);  // SE layer
+          if (has_se_) {
+            network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[1],
+                                tensor_mem_[2], scratch_mem_, scratch_size_,
+                                cudnn_,
+                                cublas_);  // SE layer
+          }
         }
       }
-#endif
     }
 
     // Policy head.
@@ -920,6 +925,8 @@ class CudnnNetwork : public Network {
 
   bool use_custom_winograd_;  // Custom winograd convolution implementation for
                               // convolutions of the residual tower.
+
+  bool use_res_block_winograd_fuse_opt_;    // fuse operations inside the residual tower
 
   // Currently only one NN Eval can happen a time (we can fix this if needed
   // by allocating more memory).

--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -454,11 +454,11 @@ class CudnnNetwork : public Network {
           layer->LoadWeights1(&weights.residual[block].conv2.weights[0],
                               &weights.residual[block].conv2.biases[0],
                               scratch_mem_);
-
-          layer->LoadSEWeights(&weights.residual[block].se.w1[0],
-                               &weights.residual[block].se.b1[0],
-                               &weights.residual[block].se.w2[0],
-                               &weights.residual[block].se.b2[0], scratch_mem_);
+          if (has_se)
+            layer->LoadSEWeights(&weights.residual[block].se.w1[0],
+                                 &weights.residual[block].se.b1[0],
+                                 &weights.residual[block].se.w2[0],
+                                 &weights.residual[block].se.b2[0], scratch_mem_);
           network_.emplace_back(std::move(layer));
         } else {
           auto conv1 = std::make_unique<FusedWinogradConvSELayer<DataType>>(

--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -352,10 +352,10 @@ class CudnnNetwork : public Network {
       use_res_block_winograd_fuse_opt_ = false;
     }
 
-    // Disable res block fusing for > 512 filters
+    // Disable res block fusing for > 384 filters
     // (the fused output input transform kernel runs 
     // out of register space)
-    if (kNumFilters > 512) use_res_block_winograd_fuse_opt_ = false;
+    if (kNumFilters > 384) use_res_block_winograd_fuse_opt_ = false;
 
 
     const bool use_gemm_ex = deviceProp.major >= 5;

--- a/src/neural/cuda/winograd_helper.inc
+++ b/src/neural/cuda/winograd_helper.inc
@@ -350,6 +350,205 @@ __global__ void OutputTransform_kernel(int N, int C, int se_K, T* output,
   }
 }
 
+
+// input is in transformed space (HWNC layout) --- output of GEMM
+// output is also in transformed space (HWNC layout) --- input to GEMM (for next layer)
+// 'C' threads per block
+// 'N' blocks
+// every thread generates an entire board/plane (8x8 elements)
+template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
+__global__ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* output,
+                                                              const T* input, const T* skip,
+                                                              const T* bias, const T* w1, const T* b1,
+                                                              const T* w2, const T* b2) {
+  const bool fp16 = std::is_same<half, T>::value;
+
+  int k = threadIdx.x;
+  int n = blockIdx.x;
+
+  T board[8][8];
+  T b = bias[k];
+
+#pragma unroll
+  for (int hStart = 0; hStart < 8; hStart += 4)
+#pragma unroll
+    for (int wStart = 0; wStart < 8; wStart += 4) {
+      //  i) read to per thread registers (for doing output transform)
+      int shln = n * 4 + (hStart / 4) * 2 + (wStart / 4);
+      T outElTransformed[6][6];
+#pragma unroll
+      for (int y = 0; y < 6; y++)
+#pragma unroll
+        for (int x = 0; x < 6; x++)
+          outElTransformed[y][x] = input[TEMP_INDEX_HWNC(y, x, shln, k)];
+
+      // ii) transform it
+      T outEl[4][4];
+      OutputTransform4x4(&outEl[0][0], &outElTransformed[0][0]);
+
+#pragma unroll
+      for (int y = 0; y < 4; y++)
+#pragma unroll
+        for (int x = 0; x < 4; x++) board[hStart + y][wStart + x] = outEl[y][x];
+    }
+
+  // Add bias, and compute the average for SE.
+  float S = 0;
+  float B = 0;
+
+#pragma unroll
+  for (int y = 0; y < 8; y++)
+#pragma unroll
+    for (int x = 0; x < 8; x++) {
+      if (use_bias) board[y][x] += b;
+      if (use_se) S += (float)board[y][x];
+    }
+
+  if (use_se) {
+    __shared__ float shared_data[1024];
+    float avg = S / 64;
+    shared_data[k] = avg;
+    __syncthreads();
+
+    // First fully-connected layer for SE
+    if (k < se_K) {
+      S = 0;
+      for (int i = 0; i < C; i++) {
+        S += shared_data[i] * float(readw1(i, k));
+      }
+      S += (float)b1[k];
+      if (S < 0) S = 0;  // relu
+      shared_data[k] = S;
+    }
+    __syncthreads();
+
+    // Second fully-connected layer for SE
+    S = 0;
+    for (int i = 0; i < se_K; i++) {
+      float val = shared_data[i];
+      S += val * float(readw2(i, k));
+      B += val * float(readw2(i, k + C));
+    }
+    S += (float)b2[k];
+    B += (float)b2[k + C];
+
+    // Sigmoid (only on the scale part).
+    S = 1.0f / (1.0f + exp(-S));
+  }
+
+  // Scale/bias, add skip connection, perform relu, and write to output.
+  for (int h = 0; h < 8; h++) {
+    if (use_se)
+#pragma unroll
+      for (int w = 0; w < 8; w++) board[h][w] = (T)(float(board[h][w]) * S + B);
+
+    // residual add
+    if (use_skip) {
+      T skipInp[8];
+      *((uint4*)(&skipInp[0])) = *((uint4*)(&skip[INDEX_NCHW(n, k, h, 0)]));
+      if (!fp16)
+        *((uint4*)(&skipInp[4])) = *((uint4*)(&skip[INDEX_NCHW(n, k, h, 4)]));
+#pragma unroll
+      for (int w = 0; w < 8; w++) board[h][w] += skipInp[w];
+    }
+
+    // relu
+    if (relu) {
+#pragma unroll
+      for (int w = 0; w < 8; w++)
+        if (board[h][w] < (T)0) board[h][w] = 0;
+    }
+
+    // write un-transformed output to 'skip' if required
+    if (use_skip)
+    {
+      // Write to skip (use 128 bit writes to store one row a time)
+      *((uint4*)(&skip[INDEX_NCHW(n, k, h, 0)])) = *((uint4*)&board[h][0]);
+      if (!fp16)
+        *((uint4*)(&skip[INDEX_NCHW(n, k, h, 4)])) = *((uint4*)&board[h][4]);
+    }
+  }
+
+  // perform input transform    
+
+  int c = k;
+  // top-left
+  {
+    T inEl[6][6] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+#pragma unroll
+    for (int i = 0; i < 5; i++)
+#pragma unroll
+      for (int j = 0; j < 5; j++) inEl[i + 1][j + 1] = board[i][j];
+
+    InputTransform4x4(&inEl[0][0], &inEl[0][0]);
+
+#pragma unroll
+    for (int y = 0; y < 6; y++)
+#pragma unroll
+      for (int x = 0; x < 6; x++)
+        output[TEMP_INDEX_HWNC(y, x, n * 4 + 0, c)] = inEl[y][x];
+  }
+
+  // top-right
+  {
+    T inEl[6][6] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+#pragma unroll
+    for (int i = 0; i < 5; i++)
+#pragma unroll
+      for (int j = 0; j < 5; j++) inEl[i + 1][j] = board[i][j + 3];
+
+    InputTransform4x4(&inEl[0][0], &inEl[0][0]);
+
+#pragma unroll
+    for (int y = 0; y < 6; y++)
+#pragma unroll
+      for (int x = 0; x < 6; x++)
+        output[TEMP_INDEX_HWNC(y, x, n * 4 + 1, c)] = inEl[y][x];
+  }
+
+  // bottom-left
+  {
+    T inEl[6][6] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+#pragma unroll
+    for (int i = 0; i < 5; i++)
+#pragma unroll
+      for (int j = 0; j < 5; j++) inEl[i][j + 1] = board[i + 3][j];
+
+    InputTransform4x4(&inEl[0][0], &inEl[0][0]);
+
+#pragma unroll
+    for (int y = 0; y < 6; y++)
+#pragma unroll
+      for (int x = 0; x < 6; x++)
+        output[TEMP_INDEX_HWNC(y, x, n * 4 + 2, c)] = inEl[y][x];
+  }
+
+  // bottom-right
+  {
+    T inEl[6][6] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+#pragma unroll
+    for (int i = 0; i < 5; i++)
+#pragma unroll
+      for (int j = 0; j < 5; j++) inEl[i][j] = board[i + 3][j + 3];
+
+    InputTransform4x4(&inEl[0][0], &inEl[0][0]);
+
+#pragma unroll
+    for (int y = 0; y < 6; y++)
+#pragma unroll
+      for (int x = 0; x < 6; x++)
+        output[TEMP_INDEX_HWNC(y, x, n * 4 + 3, c)] = inEl[y][x];
+  } 
+}
+
 template <typename T>
 void FilterTransform(int N, int C, T* transformedFilter, const T* filter) {
   // Each thread processes entire filter block (input 3x3 elements -> output 6x6
@@ -380,6 +579,17 @@ void OutputTransform(int N, int C, int se_K, T* output, const T* input,
       <<<N, C>>>(N, C, se_K, output, input, skip, bias, w1, b1, w2, b2);
   ReportCUDAErrors(cudaGetLastError());
 }
+
+template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
+void OutputInputTransform(int N, int C, int se_K, T* output, const T* input,
+                         const T* skip, const T* bias, const T* w1, const T* b1,
+                         const T* w2, const T* b2) {
+  // Each thread processes entire chess board
+  OutputTransform_SE_relu_InputTransform_kernel<T, use_se, relu, use_bias, use_skip>
+                    <<<N, C>>>(N, C, se_K, output, input, skip, bias, w1, b1, w2, b2);
+  ReportCUDAErrors(cudaGetLastError());
+}
+
 
 }  // namespace cudnn_backend
 }  // namespace lczero

--- a/src/neural/cuda/winograd_helper.inc
+++ b/src/neural/cuda/winograd_helper.inc
@@ -358,7 +358,7 @@ __global__ void OutputTransform_kernel(int N, int C, int se_K, T* output,
 // every thread generates an entire board/plane (8x8 elements)
 template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
 __global__ 
-__launch_bounds__(512)
+__launch_bounds__(384)
 void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* output,
                                                               const T* input, const T* skip,
                                                               const T* bias, const T* w1, const T* b1,

--- a/src/neural/cuda/winograd_helper.inc
+++ b/src/neural/cuda/winograd_helper.inc
@@ -357,7 +357,9 @@ __global__ void OutputTransform_kernel(int N, int C, int se_K, T* output,
 // 'N' blocks
 // every thread generates an entire board/plane (8x8 elements)
 template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
-__global__ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* output,
+__global__ 
+__launch_bounds__(512)
+void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* output,
                                                               const T* input, const T* skip,
                                                               const T* bias, const T* w1, const T* b1,
                                                               const T* w2, const T* b2) {


### PR DESCRIPTION
A relatively small/easy optimization to speed the custom winograd convolution path further.

In the original implementation of custom winograd path, we had three passes for each convolution:
1. input transform.
2. GEMM
3. output transform (fused with RELU, bias addition, and optionally SE operation)

Because the residual tower is made up of many such convolutions one after other, we can fuse the output transform of the first convolution with the input transform of the next convolution - doing them in the same kernel. So, after this optimization we have each convolution do:
<input is already in winograd transformed space>
1. GEMM
2. Output Transform, followed by SE/relu/bias, followed by Input transform (for next convolution)
For the second convolution in each block, we also need to store untransformed output (to use it as skip connection)

This optimization results in 5-15% speedup with 384x30 networks:
```
lc0 benchmark (nps)

GPU           network         baseline  optimized   perf gain
-------------------------------------------------- ------------
Titan RTX   32390   (256x20)  57757     61721        6.9 %
Titan RTX   sv-3010 (384x30)  17443     20084       15.1 %
A100        32390   (256x20)  107536    120719      12.3 %
A100        sv-3010 (384x30)  41785     48815       16.8 %
````