### PR TITLE
res block fusing changes

### DIFF
--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -346,17 +346,19 @@ class CudnnNetwork : public Network {
     if (use_custom_winograd_) nhwc_ = false;
 
     if (use_custom_winograd_) {
-      use_res_block_winograd_fuse_opt_ =
-          options.GetOrDefault<bool>("res_block_fusing", true);
-    } else {
-      use_res_block_winograd_fuse_opt_ = false;
+      // Disable res block fusing for > 384 filters (the fused output input
+      // transform kernel runs out of register space) and for fp32 for now.
+      if (kNumFilters <= 384 && fp16) {
+        use_res_block_winograd_fuse_opt_ = true;
+      } else {
+        use_res_block_winograd_fuse_opt_ = false;
+      }
+      // Override if set in backend-opts.
+      if (!options.IsDefault<bool>("res_block_fusing")) {
+        use_res_block_winograd_fuse_opt_ =
+            options.Get<bool>("res_block_fusing");
+      }
     }
-
-    // Disable res block fusing for > 384 filters
-    // (the fused output input transform kernel runs 
-    // out of register space)
-    if (kNumFilters > 384) use_res_block_winograd_fuse_opt_ = false;
-
 
     const bool use_gemm_ex = deviceProp.major >= 5;
 

--- a/src/neural/cuda/winograd_helper.inc
+++ b/src/neural/cuda/winograd_helper.inc
@@ -358,7 +358,6 @@ __global__ void OutputTransform_kernel(int N, int C, int se_K, T* output,
 // every thread generates an entire board/plane (8x8 elements)
 template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
 __global__ 
-__launch_bounds__(384)
 void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* output,
                                                               const T* input, const T* skip,
                                                               const T* bias, const T* w1, const T* b1,


### PR DESCRIPTION
Removes `__launch_bounds__(384)`
Disables optimization for fp32 but allows override from options