### PR TITLE
Reduce computation cost of first collision after a visit.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1086,6 +1086,7 @@ void SearchWorker::GatherMinibatch() {
       --minibatch_size;
       ++number_out_of_order_;
     } else if (picked_node.multivisit > 1) {
+      SharedMutex::Lock lock(search_->nodes_mutex_);
       if (picked_node.node != search_->root_node_) {
         IncrementNInFlight(picked_node.node->GetParent(), search_->root_node_,
                            picked_node.multivisit - 1);

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -293,8 +293,8 @@ class SearchWorker {
                                    int collision_count) {
       return NodeToProcess(node, depth, true, collision_count);
     }
-    static NodeToProcess Visit(Node* node, uint16_t depth) {
-      return NodeToProcess(node, depth, false, 1);
+    static NodeToProcess Visit(Node* node, uint16_t depth, int count_to_next) {
+      return NodeToProcess(node, depth, false, count_to_next);
     }
 
    private:


### PR DESCRIPTION
Will clean it up if it works.

Note that this transform is technically not safe if concurrent searchers is not the default value of 1. But otherwise, it should 'theoretically' be identical to previous behavior, just potentially less computation. (Assuming I didn't mess anything up :P)