### PR TITLE
Let lc0 switch to another NN during the game (PR 573 rebased to current master)

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -81,6 +81,18 @@ MoveList StringsToMovelist(const std::vector<std::string>& moves,
   return result;
 }
 
+  // Stuff required for switching NN during play START
+  bool second_nn_already_loaded_ = false;
+  int k_pieces_left = 32;
+  std::string CPuct_for_primary_NN = "";
+  std::string FPU_for_primary_NN = "";
+  std::string PolicyTemperature_for_primary_NN = "";
+
+  // Purely informational vars, writing to them do not affect behaviour, they
+  // are just convenient to have when we want to tell about the current state.
+  std::string weights_currently_in_use;
+  // Stuff required for switching NN during play STOP
+
 }  // namespace
 
 EngineController::EngineController(std::unique_ptr<UciResponder> uci_responder,
@@ -108,6 +120,18 @@ void EngineController::PopulateOptions(OptionsParser* options) {
 
   options->Add<BoolOption>(kStrictUciTiming) = false;
   options->HideOption(kStrictUciTiming);
+}
+
+void EngineController::SetSearchParamsforSecondNN(OptionsParser* options) {
+  options->GetMutableOptions()->Set<float>(SearchParams::kCpuctId, options->GetOptionsDict().Get<float>(NetworkFactory::kSecondWeightsCpuctId));
+  options->GetMutableOptions()->Set<float>(SearchParams::kFpuValueId, options->GetOptionsDict().Get<float>(NetworkFactory::kSecondWeightsFpuValueId));
+  options->GetMutableOptions()->Set<float>(SearchParams::kPolicySoftmaxTempId, options->GetOptionsDict().Get<float>(NetworkFactory::kSecondWeightsPolicySoftmaxTempId));
+}
+
+void EngineController::ResetSearchParamsforPrimaryNN(OptionsParser* options) {
+  options->GetMutableOptions()->Set<float>(SearchParams::kCpuctId, stof(CPuct_for_primary_NN));
+  options->GetMutableOptions()->Set<float>(SearchParams::kFpuValueId, stof(FPU_for_primary_NN));
+  options->GetMutableOptions()->Set<float>(SearchParams::kPolicySoftmaxTempId, stof(PolicyTemperature_for_primary_NN));
 }
 
 void EngineController::ResetMoveTimer() {
@@ -150,6 +174,7 @@ void EngineController::EnsureReady() {
   std::unique_lock<RpSharedMutex> lock(busy_mutex_);
   // If a UCI host is waiting for our ready response, we can consider the move
   // not started until we're done ensuring ready.
+  EngineController::SwitchToSecondaryNN();
   ResetMoveTimer();
 }
 
@@ -163,6 +188,16 @@ void EngineController::NewGame() {
   tree_.reset();
   CreateFreshTimeManager();
   current_position_.reset();
+  // reload the main NN every new game in a tournament
+  if(second_nn_already_loaded_){
+    auto network_configuration = NetworkFactory::BackendConfiguration(options_);
+    network_ = NetworkFactory::LoadNetwork(options_);
+    network_configuration_ = network_configuration;
+    second_nn_already_loaded_ = false;
+    k_pieces_left = 32;
+    weights_currently_in_use = options_.Get<std::string>(NetworkFactory::kWeightsId);
+    LOGFILE << "Reloaded Leela NN: " << weights_currently_in_use;
+  }
   UpdateFromUciOptions();
 }
 
@@ -285,6 +320,9 @@ void EngineController::Go(const GoParams& params) {
   LOGFILE << "Timer started at "
           << FormatTime(SteadyClockToSystemClock(*move_start_time_));
   search_->StartThreads(options_.Get<int>(kThreadsOptionId));
+  // Count the remaining pieces on the board
+  auto board = search_->PublicHistory().Last().GetBoard();
+  k_pieces_left = board.ours().count() + board.theirs().count();
 }
 
 void EngineController::PonderHit() {
@@ -295,6 +333,24 @@ void EngineController::PonderHit() {
 
 void EngineController::Stop() {
   if (search_) search_->Stop();
+}
+
+void EngineController::SwitchToSecondaryNN() {
+  if(!second_nn_already_loaded_ &&
+   options_.Get<std::string>(NetworkFactory::kSecondWeightsId) != "" &&
+   k_pieces_left <= options_.Get<int>(NetworkFactory::kSecondWeightsSwitchAtId)){
+    std::string net_path = options_.Get<std::string>(NetworkFactory::kSecondWeightsId);
+    std::string backend = options_.Get<std::string>(NetworkFactory::kBackendId);
+    std::string backend_options = options_.Get<std::string>(NetworkFactory::kBackendOptionsId);
+    LOGFILE << "Will switch to second NN on backend " << backend << " with options " << backend_options;
+    CERR << "Loading weights file from: " << net_path;
+    WeightsFile weights = LoadWeightsFromFile(net_path);
+    OptionsDict network_options(&options_);
+    network_options.AddSubdictFromString(backend_options);
+    network_ = NetworkFactory::Get()->Create(backend, weights, network_options);
+    second_nn_already_loaded_ = true;
+    weights_currently_in_use = net_path;
+  }
 }
 
 EngineLoop::EngineLoop()
@@ -323,7 +379,13 @@ void EngineLoop::CmdUci() {
 }
 
 void EngineLoop::CmdIsReady() {
+  bool nn_changed = second_nn_already_loaded_;
   engine_.EnsureReady();
+  // If EnsureReady() actually switched NN, then also set cpuct etc to
+  // fit the new NN, if these are defined.
+  if(nn_changed != second_nn_already_loaded_){
+    engine_.SetSearchParamsforSecondNN(&options_);
+  }
   SendResponse("readyok");
 }
 
@@ -335,7 +397,14 @@ void EngineLoop::CmdSetOption(const std::string& name, const std::string& value,
       options_.GetOptionsDict().Get<std::string>(kLogFileId));
 }
 
-void EngineLoop::CmdUciNewGame() { engine_.NewGame(); }
+void EngineLoop::CmdUciNewGame() {
+  bool nn_changed = second_nn_already_loaded_;
+  engine_.NewGame();
+  if(nn_changed != second_nn_already_loaded_){
+    // Reset Search parameters too (cpuct et al)
+    engine_.ResetSearchParamsforPrimaryNN(&options_);
+  }
+}
 
 void EngineLoop::CmdPosition(const std::string& position,
                              const std::vector<std::string>& moves) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -58,6 +58,10 @@ class EngineController {
 
   void PopulateOptions(OptionsParser* options);
 
+  void SwitchToSecondaryNN();
+  void SetSearchParamsforSecondNN(OptionsParser* options);
+  void ResetSearchParamsforPrimaryNN(OptionsParser* options);
+
   // Blocks.
   void EnsureReady();
 

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -279,6 +279,8 @@ const OptionId SearchParams::kSolidTreeThresholdId{
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
   // Many of them are overridden with training specific values in tournament.cc.
+  // For defaults on cpuct, fpur and policy softmax temp for the second NN,
+  // see neural/factory.cc
   options->Add<IntOption>(kMiniBatchSizeId, 1, 1024) = DEFAULT_MINIBATCH_SIZE;
   options->Add<IntOption>(kMaxPrefetchBatchId, 0, 1024) = DEFAULT_MAX_PREFETCH;
   options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 2.147f;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -842,7 +842,7 @@ void Search::PopulateCommonIterationStats(IterationStats* stats) {
 }
 
 void Search::WatchdogThread() {
-  LOGFILE << "Start a watchdog thread.";
+  LOGFILE << "Start a watchdog thread." << " Cpuct: " << params_.GetCpuct(false) << " FPU: " << params_.GetFpuValue(false) << " PolicySoftMaxTemp: " << params_.GetPolicySoftmaxTemp();
   StoppersHints hints;
   IterationStats stats;
   while (true) {

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -93,6 +93,9 @@ class Search {
   // Returns the search parameters.
   const SearchParams& GetParams() const { return params_; }
 
+  // A public version of history, needed to get piece count in engine.cc
+  const PositionHistory& PublicHistory() { return played_history_; }
+
   // If called after GetBestMove, another call to GetBestMove will have results
   // from temperature having been applied again.
   void ResetBestMove();

--- a/src/neural/factory.cc
+++ b/src/neural/factory.cc
@@ -48,6 +48,31 @@ const OptionId NetworkFactory::kBackendOptionsId{
     "Parameters of neural network backend. "
     "Exact parameters differ per backend.",
     'o'};
+const OptionId NetworkFactory::kSecondWeightsId{
+    "secondweights", "SecondWeightsFile",
+    "Path from which to load network weights for the second NN.",
+    's'};
+const OptionId NetworkFactory::kSecondWeightsSwitchAtId{
+    "switchat", "SwitchAt",
+    "Switch to the second NN when this number of pieces are left on the board. "
+    "Switch will take place _after_ lc0 has made a move, when it is the "
+    "opponents time to think."};
+const OptionId NetworkFactory::kSecondWeightsCpuctId{
+    "SWcpuct", "SWCPuct",
+    "cpuct_init constant from \"UCT search\" algorithm. Higher values promote "
+    "more exploration/wider search, lower values promote more "
+    "confidence/deeper search. "
+    "This value is used for the Secondary NN."};
+const OptionId NetworkFactory::kSecondWeightsFpuValueId{
+    "SWfpu-value", "SWFpuValue",
+    "\"First Play Urgency\" value used to adjust unvisited node eval based on "
+    "--fpu-strategy."
+    "This value is used for the Secondary NN."};
+const OptionId NetworkFactory::kSecondWeightsPolicySoftmaxTempId{
+    "SWpolicy-softmax-temp", "SWPolicyTemperature",
+    "Policy softmax temperature. Higher values make priors of move candidates "
+    "closer to each other, widening the search. "
+    "This value is used for the Secondary NN."};
 const char* kAutoDiscover = "<autodiscover>";
 const char* kEmbed = "<built in>";
 
@@ -71,6 +96,11 @@ void NetworkFactory::PopulateOptions(OptionsParser* options) {
   options->Add<ChoiceOption>(NetworkFactory::kBackendId, backends) =
       backends.empty() ? "<none>" : backends[0];
   options->Add<StringOption>(NetworkFactory::kBackendOptionsId);
+  options->Add<StringOption>(NetworkFactory::kSecondWeightsId);
+  options->Add<IntOption>(NetworkFactory::kSecondWeightsSwitchAtId, 5, 16) = 12;
+  options->Add<FloatOption>(kSecondWeightsCpuctId, 0.0f, 100.0f) = 1.32f;
+  options->Add<FloatOption>(kSecondWeightsFpuValueId, -100.0f, 100.0f) = 0.23f;
+  options->Add<FloatOption>(kSecondWeightsPolicySoftmaxTempId, 0.1f, 10.0f) = 1.4f;
 }
 
 void NetworkFactory::RegisterNetwork(const std::string& name,

--- a/src/neural/factory.h
+++ b/src/neural/factory.h
@@ -74,6 +74,11 @@ class NetworkFactory {
   static const OptionId kWeightsId;
   static const OptionId kBackendId;
   static const OptionId kBackendOptionsId;
+  static const OptionId kSecondWeightsId;
+  static const OptionId kSecondWeightsSwitchAtId;
+  static const OptionId kSecondWeightsCpuctId;
+  static const OptionId kSecondWeightsFpuValueId;
+  static const OptionId kSecondWeightsPolicySoftmaxTempId;
 
   struct BackendConfiguration {
     BackendConfiguration() = default;


### PR DESCRIPTION
This a a rewrite of [PR 573](https://github.com/LeelaChessZero/lc0/pull/573) against the current master.

Let `lc0` switch to another NN during the game. The intended use case is to combine a stronger general NN with and an NN which is better at endgames.

This patch exports five new UCI-options `SecondWeightsFile`, `SwitchAt`, `SWCpuct`, `SWFpuValue`, `SWPolicyTemperature`

`SecondWeightsFile` defines a path to secondary weights file which substitute the primary weights file when `SwitchAt`pieces remain on the board. `SWCpuct`, `SWFpuValue`, `SWPolicyTemperature` defines Cpuct, Fpu and PolicySoftmaxTemp to be used with the secondary NN.

This PR has been tested with Sergio Vieri's [128x10 net](https://www.comp.nus.edu.sg/~sergio-v/new/128x10-t60-2/128x10-t60-2-5300.pb.gz) against itself + [Medium Ender](https://github.com/dkappe/leela-chess-weights/releases/download/MediumEnder/me.pb.gz), but the PR itself is NN neutral.

To verify that the NN is switched, use the `LogFile` UCI directive and look for the string `Will switch to second NN`. For transparency, CPuct, FPU and PolicyTemperature is logged at each move, to clarify when the settings for the second NN is in effect.