### PR TITLE
Updated description of score-type Q

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -214,7 +214,7 @@ const OptionId SearchParams::kPerPvCountersId{
 const OptionId SearchParams::kScoreTypeId{
     "score-type", "ScoreType",
     "What to display as score. Either centipawns (the UCI default), win "
-    "percentage or Q (the actual internal score) multiplied by 100."};
+    "percentage or Q (the actual internal score) multiplied by 10000."};
 const OptionId SearchParams::kHistoryFillId{
     "history-fill", "HistoryFill",
     "Neural network uses 7 previous board positions in addition to the current "


### PR DESCRIPTION
The manual says that if you request score-type Q, then you will get the internal value of Q multiplied by 100. 

```
--score-type=CHOICE
               What to display as score. Either centipawns (the UCI default), win percentage or
               Q (the actual internal score) multiplied by 100.
               [UCI: ScoreType  DEFAULT: centipawn  VALUES: centipawn,centipawn_with_drawscore,centipawn_2019,centipawn_2018,win_percentage,Q,W-L]
```

This is not correct, what you will get is the internal value of Q multiplied by 10000.

```
$ ./lc0 --backend=random --score-type=Q 
       _
|   _ | |
|_ |_ |_| v0.27.0-dev+git.34f4107 built Nov 25 2020
go nodes 1
Creating backend [random]...
info depth 1 seldepth 1 time 4 nodes 1 score cp -5752 tbhits 0 pv h2h4
bestmove h2h4
```


This patch updates the documentation to reflect the actual behaviour.