### PR TITLE
simple backend

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -487,7 +487,40 @@ if get_option('build_backends')
     subdir('src/neural/dx/shaders')
 
     has_backends = true
-  endif  
+  endif
+
+  build_simple = false
+  if get_option('simple')
+    if get_option('dnnl') and dnnl_lib.found()
+      add_project_arguments(['-DUSE_DNNL'], language : 'cpp')
+      includes += include_directories(get_option('dnnl_dir') + '/include')
+      deps += [ dnnl_lib, dependency('openmp', required:true) ]
+      build_simple = true
+    elif get_option('accelerate') and accelerate_lib.found()
+      deps += [ accelerate_lib ]
+      build_simple = true
+    elif get_option('openblas') and openblas_lib.found()
+      add_project_arguments(['-DUSE_OPENBLAS'], language : 'cpp')
+      build_simple = true
+    endif
+  endif
+
+  if build_simple
+    files += [
+      'src/neural/simple/network_simple.cc',
+      'src/neural/simple/layers.cc',
+    ]
+# Temporary files to be removed later.
+    files += [
+      'src/neural/simple/convolution1.cc',
+      'src/neural/simple/winograd_convolution3.cc',
+      'src/neural/simple/fully_connected_layer.cc',
+      'src/neural/simple/se_unit.cc',
+      'src/neural/simple/activation.cc',
+      'src/neural/simple/winograd_filter.cc',
+    ]
+    has_backends = true
+  endif
  
 
 endif # if get_option('build_backends')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -83,6 +83,11 @@ option('dx',
        value: true,
        description: 'Enable DirectX12 backend')
 
+option('simple',
+       type: 'boolean',
+       value: false,
+       description: 'Enable simple backend')
+
 option('tensorflow',
        type: 'boolean',
        value: false,

--- a/src/neural/simple/activation.cc
+++ b/src/neural/simple/activation.cc
@@ -1,0 +1,66 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2018 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "neural/shared/activation.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace lczero {
+namespace simple_backend {
+namespace {
+constexpr int kWidth = 8;
+constexpr int kHeight = 8;
+constexpr int kSquares = kWidth * kHeight;
+}  // namespace
+
+void BiasResidualRelu(const size_t batch_size, const size_t channels,
+                 float* data, const float* biases,
+                 const float* eltwise,
+                 const bool relu) {
+  for (size_t i = 0; i < batch_size; i++) {
+    for (size_t c = 0; c < channels; ++c) {
+      auto bias = (biases != nullptr) ? biases[c] : 0.0f;
+
+      if (eltwise == nullptr) {
+        auto arr = &data[c * kSquares];
+        for (size_t b = 0; b < kSquares; b++) {
+          float val = arr[b] + bias;
+          if (relu) {
+            val = val > 0 ? val : 0;
+          }
+          arr[b] = val;
+        }
+      } else {
+        auto arr = &data[c * kSquares];
+        auto res = &eltwise[c * kSquares];
+        for (size_t b = 0; b < kSquares; b++) {
+          float val = res[b] + arr[b] + bias;
+          if (relu) {
+            val = val > 0 ? val : 0;
+          }
+          arr[b] = val;
+        }
+      }
+    }
+    data += channels * kSquares;
+    if (eltwise != nullptr) eltwise += channels * kSquares;
+  }
+}
+}  // namespace simple_backend
+}  // namespace lczero

--- a/src/neural/simple/activation.h
+++ b/src/neural/simple/activation.h
@@ -1,0 +1,32 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2018 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace lczero {
+namespace simple_backend {
+
+void BiasResidualRelu(const size_t batch_size, const size_t channels,
+                 float* data, const float* biases,
+                 const float* eltwise = nullptr,
+                 const bool relu = true);
+}  // namespace simple_backend
+}  // namespace lczero

--- a/src/neural/simple/convolution1.cc
+++ b/src/neural/simple/convolution1.cc
@@ -1,0 +1,69 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2018 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "convolution1.h"
+#include "simple_common.h"
+
+
+namespace lczero {
+namespace simple_backend {
+
+void Convolution1::Forward(const size_t batch_size,
+                                  const size_t input_channels,
+                                  const size_t output_channels,
+                                  const float* input, const float* weights,
+                                  float* output) {
+  for (size_t i = 0; i < batch_size; i++) {
+    // C←αAB + βC
+    // M Number of rows in matrices A and C.
+    // N Number of columns in matrices B and C.
+    // K Number of columns in matrix A; number of rows in matrix B.
+    // lda The size of the first dimension of matrix A; if you are
+    // passing a matrix A[m][n], the value should be m.
+    //    cblas_sgemm(CblasRowMajor, TransA, TransB, M, N, K, alpha, A, lda, B,
+    //                ldb, beta, C, N);
+
+    //             C                          A                     B
+    //
+    //           outputs       :=          weights        x      input
+    //
+    //   cols:  kSquares (N)         input_channels (K)        kSquares(N)
+    //
+    //   rows:  output_channels (M)   output_channels (M)  input_channels (K)
+
+    const float* batch_input = input + i * kSquares * input_channels;
+    float* batch_output = output + i * kSquares * output_channels;
+    cblas_sgemm(CblasRowMajor,         // Row major formar
+                CblasNoTrans,          // A not transposed
+                CblasNoTrans,          // B not transposed
+                (int)output_channels,  // M
+                kSquares,              // N
+                (int)input_channels,   // K
+                1.0f,                  // Alpha
+                weights,               // A
+                (int)input_channels,   // lda, leading rank of A
+                batch_input,           // B
+                kSquares,              // ldb, leading rank of B
+                0.0f,                  // beta
+                batch_output,          // C
+                kSquares);             // ldc, leading rank of B
+  }
+}
+
+}  // namespace simple_backend
+}  // namespace lczero

--- a/src/neural/simple/convolution1.h
+++ b/src/neural/simple/convolution1.h
@@ -1,0 +1,42 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2018 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace lczero {
+namespace simple_backend {
+// Convolution 1x1
+class Convolution1 {
+ public:
+  Convolution1() = delete;
+
+  // Batched forward inference.
+  static void Forward(const size_t batch_size, const size_t input_channels,
+                      const size_t output_channels, const float* input,
+                      const float* weights, float* output);
+
+ private:
+  static constexpr auto kWidth = 8;
+  static constexpr auto kHeight = 8;
+  static constexpr auto kSquares = kWidth * kHeight;
+};
+}  // namespace simple_backend
+}  // namespace lczero

--- a/src/neural/simple/fully_connected_layer.cc
+++ b/src/neural/simple/fully_connected_layer.cc
@@ -1,0 +1,100 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2018 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "fully_connected_layer.h"
+#include "simple_common.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+
+namespace lczero {
+namespace simple_backend {
+namespace {
+void ApplyBias(size_t batch_size, const size_t output_size, const float* biases,
+               bool apply_relu, bool apply_tanh, float* outputs) {
+  if (apply_relu) {
+    for (size_t i = 0; i < batch_size; i++) {
+      float* batch_outputs = outputs + i * output_size;
+      for (size_t o = 0; o < output_size; o++) {
+        float val = biases[o] + batch_outputs[o];
+        batch_outputs[o] = val >= 0 ? val : 0;
+      }
+    }
+  } else if (apply_tanh) {
+    for (size_t i = 0; i < batch_size; i++) {
+      float* batch_outputs = outputs + i * output_size;
+      for (size_t o = 0; o < output_size; o++) {
+        float val = biases[o] + batch_outputs[o];
+        batch_outputs[o] = tanh(val);
+      }
+    }
+  } else {
+    for (size_t i = 0; i < batch_size; i++) {
+      float* batch_outputs = outputs + i * output_size;
+      for (size_t o = 0; o < output_size; o++) {
+        batch_outputs[o] += biases[o];
+      }
+    }
+  }
+}
+} // namespace
+
+
+void FullyConnectedLayer::Forward1D(
+    size_t batch_size, const size_t input_size, const size_t output_size,
+    const float* inputs, const float* weights, const float* biases,
+    bool apply_relu, bool apply_tanh, float* outputs) {
+
+    // more columns, matrix-matrix multiplication
+    //
+    //             C                     A                         B
+    //
+    //            outputs      :=       weights        x         inputs
+    //
+    //   cols:   batch_size (N)       input_size  (K)          batch_size (N)
+    //
+    //   rows  output_size (M)        output_size (M)         input_size (K)
+    //
+
+    // C←αAB + βC
+    // M Number of rows in matrices A and C.
+    // N Number of columns in matrices B and C.
+    // K Number of columns in matrix A; number of rows in matrix B.
+    // lda The size of the first dimension of matrix A; if you are
+    // passing a matrix A[m][n], the value should be m.
+    //    cblas_sgemm(CblasRowMajor, TransA, TransB, M, N, K, alpha, A, lda, B,
+    //                ldb, beta, C, N);
+    cblas_sgemm(CblasColMajor, CblasTrans, CblasNoTrans,
+                (int)output_size,   // M
+                (int)batch_size,    // N
+                (int)input_size,    // K
+                1.0f,               // alpha
+                weights,            // A
+                (int)input_size,    // lda, leading rank of A
+                inputs,             // B
+                (int)input_size,    // ldb, leading rank of B
+                0.0f,               // beta
+                outputs,            // C
+                (int)output_size);  // ldc, leading rank of C
+
+    ApplyBias(batch_size, output_size, biases, apply_relu, apply_tanh, outputs);
+}
+
+}  // namespace simple_backend
+}  // namespace lczero

--- a/src/neural/simple/fully_connected_layer.h
+++ b/src/neural/simple/fully_connected_layer.h
@@ -1,0 +1,37 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2018 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace lczero {
+namespace simple_backend {
+class FullyConnectedLayer {
+ public:
+  FullyConnectedLayer() = delete;
+
+  // Forward inference, batched, from input_size to output_size
+  static void Forward1D(const size_t batch_size, const size_t input_size,
+                        const size_t output_size, const float* input,
+                        const float* weights, const float* biases,
+                        bool apply_relu, bool apply_tanh, float* output);
+};
+}  // namespace simple_backend
+}  // namespace lczero

--- a/src/neural/simple/layers.cc
+++ b/src/neural/simple/layers.cc
@@ -1,0 +1,227 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2020 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#include "winograd_filter.h"
+#include "winograd_convolution3.h"
+#include "activation.h"
+#include "convolution1.h"
+#include "fully_connected_layer.h"
+#include "se_unit.h"
+#include "simple_common.h"
+
+#include "layers.h"
+
+#include "utils/exception.h"
+
+#include <cstddef>
+#include <cassert>
+#include <cstring>
+#include <vector>
+
+namespace lczero {
+namespace simple_backend {
+
+BaseLayer::BaseLayer(int c, int h, int w, BaseLayer* ip)
+    : input_(ip), C(c), H(h), W(w) {}
+
+ConvLayer::ConvLayer(BaseLayer* ip, int C, int H, int W, int filter, int Cin,
+                     bool relu, bool skip)
+    : BaseLayer(C, H, W, ip),
+      c_input_(Cin),
+      filter_size_(filter),
+      use_relu_(relu),
+      use_skip_(skip) {
+  biases = (float*)malloc(sizeof(float) * C);
+
+  if (filter_size_ == 1) {
+    weights = (float*)malloc(C * c_input_ * sizeof(float));
+    return;
+  }
+  if (filter_size_ == 3) {
+    constexpr auto kWinogradAlpha = 4;
+    constexpr auto kWinogradTile = kWinogradAlpha * kWinogradAlpha;
+
+    weights = (float*)malloc(kWinogradTile * C * c_input_ * sizeof(float));
+    return;
+  }
+
+  throw Exception("Unsupported filter_size.");
+}
+
+void ConvLayer::LoadWeights(float* pfilter, float* pBias, void* /*scratch*/) {
+  memcpy(biases, pBias, sizeof(float) * C);
+
+  if (filter_size_ == 1) {
+    memcpy(weights, pfilter, sizeof(float) * C * c_input_);
+    return;
+  }
+  if (filter_size_ == 3) {
+    WinogradFilterTransformF(weights, pfilter, C, c_input_);
+    return;
+  }
+}
+
+void ConvLayer::Eval(int N, float* output, const float* input, void* scratch,
+                     size_t /*scratch_size*/) {
+  if (filter_size_ == 1) {
+    Convolution1::Forward(N, c_input_, C, input, weights,
+                          use_skip_ ? (float*)scratch : output);
+  } else if (filter_size_ == 3) {
+    WinogradConvolution3 convolve3(N, c_input_, C);
+    convolve3.Forward(N, c_input_, C, input, weights,
+                      use_skip_ ? (float*)scratch : output);
+  }
+  BiasResidualRelu(N, C, output, biases, use_skip_ ? (float*)scratch : nullptr,
+                   use_relu_);
+}
+
+ConvLayer::~ConvLayer() {
+  free(biases);
+  free(weights);
+}
+
+SELayer::SELayer(BaseLayer* ip, int fc1Outputs)
+    : BaseLayer(ip->GetC(), ip->GetH(), ip->GetW(), ip),
+      numFc1Out_(fc1Outputs) {
+  w1_ = (float*)malloc(C * numFc1Out_ * sizeof(float));
+  w2_ = (float*)malloc(2 * C * numFc1Out_ * sizeof(float));
+
+  b1_ = (float*)malloc(numFc1Out_ * sizeof(float));
+  b2_ = (float*)malloc(2 * C * sizeof(float));
+}
+
+SELayer::~SELayer() {
+  free(w1_);
+  free(w2_);
+  free(b1_);
+  free(b2_);
+}
+
+void SELayer::LoadWeights(float* w1, float* b1, float* w2, float* b2,
+                          void* /*scratch*/) {
+  const size_t num_weights1 = C * numFc1Out_;
+  const size_t weight_size1 = sizeof(float) * num_weights1;
+
+  const size_t weight_size2 = 2 * weight_size1;
+
+  // Weight for the first FC layer.
+  memcpy(w1_, w1, weight_size1);
+
+  // Weight for the second FC layer.
+  memcpy(w2_, w2, weight_size2);
+
+  // Bias for the first FC layer.
+  memcpy(b1_, b1, numFc1Out_ * sizeof(float));
+
+  // Bias for the second FC layer.
+  memcpy(b2_, b2, 2 * C * sizeof(float));
+}
+
+void SELayer::Eval(int N, float* output, const float* input, void* /*scratch*/,
+                   size_t /*scratch_size*/) {
+  ApplySEUnit(N, C, numFc1Out_, input, output, w1_, b1_, w2_, b2_, output);
+}
+
+FCLayer::FCLayer(BaseLayer* ip, int C, int H, int W, bool relu, bool bias,
+                 bool tanh)
+    : BaseLayer(C, H, W, ip),
+      use_bias_(bias),
+      use_relu_(relu),
+      use_tanh_(tanh) {
+  const size_t weight_size =
+      sizeof(float) * C * H * W * ip->GetC() * ip->GetH() * ip->GetW();
+  const size_t bias_size = sizeof(float) * C * H * W;
+
+  weights_ = (float*)malloc(weight_size);
+  if (use_bias_) {
+    biases_ = (float*)malloc(bias_size);
+  } else {
+    biases_ = nullptr;
+  }
+}
+
+void FCLayer::LoadWeights(float* cpuWeight, float* cpuBias, void* /*scratch*/) {
+  const size_t num_weights =
+      C * H * W * input_->GetC() * input_->GetH() * input_->GetW();
+  const size_t weight_size = sizeof(float) * num_weights;
+  const size_t num_biases = C * H * W;
+  const size_t bias_size = sizeof(float) * num_biases;
+
+  memcpy(weights_, cpuWeight, weight_size);
+  if (use_bias_) {
+    memcpy(biases_, cpuBias, bias_size);
+  }
+}
+
+void FCLayer::Eval(int N, float* output_tensor, const float* input_tensor,
+                   void* /*scratch*/, size_t /*scratch_size*/) {
+  const int num_outputs = C * H * W;
+  const int num_inputs = input_->GetC() * input_->GetH() * input_->GetW();
+  FullyConnectedLayer::Forward1D(N, num_inputs, num_outputs, input_tensor,
+                                 weights_, biases_, use_relu_, use_tanh_,
+                                 output_tensor);
+}
+
+FCLayer::~FCLayer() {
+  free(weights_);
+  free(biases_);
+}
+
+PolicyMapLayer::PolicyMapLayer(BaseLayer* ip, int C, int H, int W, int usedSize)
+    : BaseLayer(C, H, W, ip), used_size_(usedSize) {
+  size_t weight_size = sizeof(short) * used_size_ * 64;
+
+  weights_ = (short*)malloc(weight_size);
+}
+
+void PolicyMapLayer::LoadWeights(const short* cpuWeight, void* /*scratch*/) {
+  size_t weight_size = sizeof(short) * used_size_;
+  memcpy(weights_, cpuWeight, weight_size);
+}
+
+void PolicyMapLayer::Eval(int N, float* output_tensor,
+                          const float* input_tensor, void* /*scratch*/,
+                          size_t /*scratch_size*/) {
+  int inputSize =
+      this->input_->GetC() * this->input_->GetH() * this->input_->GetW();
+  int outputSize = this->C * this->H * this->W;
+
+  for (int batch = 0; batch < N; batch++) {
+    for (int i = 0; i < used_size_; i++) {
+      auto j = weights_[i];
+      if (j >= 0) {
+        output_tensor[batch * outputSize + j] =
+            input_tensor[batch * inputSize + i];
+      }
+    }
+  }
+}
+
+PolicyMapLayer::~PolicyMapLayer() { free(weights_); }
+
+}  // namespace simple_backend
+}  // namespace lczero

--- a/src/neural/simple/layers.h
+++ b/src/neural/simple/layers.h
@@ -1,0 +1,142 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2020 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+#pragma once
+
+namespace lczero {
+namespace simple_backend {
+
+// The Layer objects only hold memory for weights, biases, etc
+// memory for input and output tensors is provided by caller of Eval.
+
+class BaseLayer {
+ public:
+  int GetC() const { return C; }
+  int GetH() const { return H; }
+  int GetW() const { return W; }
+
+  BaseLayer(int c, int h, int w, BaseLayer* ip);
+  virtual ~BaseLayer() = default;
+  size_t GetOutputSize(int N) const { return sizeof(float) * N * C * H * W; }
+
+  virtual void Eval(int N, float* output, const float* input, void* scratch,
+                    size_t scratch_size) = 0;
+
+ protected:
+  BaseLayer* input_;
+
+  int C;  // Output tensor dimensions.
+  int H;
+  int W;
+};
+
+class ConvLayer : public BaseLayer {
+  using BaseLayer::C;
+  using BaseLayer::H;
+  using BaseLayer::W;
+  using BaseLayer::GetC;
+  using BaseLayer::GetH;
+  using BaseLayer::GetW;
+
+ public:
+  ConvLayer(BaseLayer* ip, int C, int H, int W, int size, int Cin,
+            bool relu = false, bool skip = false);
+
+  ConvLayer(int C, int H, int W, int size, int Cin, bool relu = false,
+            bool bias = false);
+
+  ~ConvLayer();
+  void LoadWeights(float* pfilter, float* pBias, void* scratch);
+  void Eval(int N, float* output, const float* input, void* scratch,
+            size_t scratch_size) override;
+
+ private:
+  const int c_input_;
+  const int filter_size_;
+  const bool use_relu_;
+  const bool use_skip_;
+
+  float* biases = nullptr;
+  float* weights = nullptr;
+};
+
+class FCLayer : public BaseLayer {
+ public:
+  FCLayer(BaseLayer* ip, int C, int H, int W, bool relu, bool bias,
+          bool tanh = false);
+  ~FCLayer();
+
+  void LoadWeights(float* cpuWeight, float* cpuBias, void* scratch);
+  void Eval(int N, float* output, const float* input, void* scratch,
+            size_t scratch_size) override;
+
+ private:
+  const bool use_bias_;
+  const bool use_relu_;
+  const bool use_tanh_;
+  float* weights_ = nullptr;
+  float* biases_ = nullptr;
+};
+
+class PolicyMapLayer : public BaseLayer {
+ public:
+  PolicyMapLayer(BaseLayer* ip, int C, int H, int W, int usedSize);
+  ~PolicyMapLayer();
+
+  void LoadWeights(const short* cpuWeight, void* scratch);
+  void Eval(int N, float* output, const float* input, void* scratch,
+            size_t scratch_size) override;
+
+ private:
+  int used_size_;
+  short* weights_ = nullptr;
+};
+
+// Fused SE layer:
+// (optional bias add +) global avg -> FC1 -> FC2 -> global scale -> add skip
+// connection -> RELU.
+class SELayer : public BaseLayer {
+  using BaseLayer::C;
+
+ public:
+  SELayer(BaseLayer* ip, int numFc1Out);
+  ~SELayer();
+
+  void LoadWeights(float* w1, float* b1, float* w2, float* b2, void* scratch);
+
+  void Eval(int N, float* output, const float* input, void* scratch,
+            size_t scratch_size) override;
+
+ private:
+  float* w1_ = nullptr;
+  float* b1_ = nullptr;
+  float* w2_ = nullptr;
+  float* b2_ = nullptr;
+  int numFc1Out_;
+};
+
+}  // namespace simple_backend
+}  // namespace lczero

--- a/src/neural/simple/network_simple.cc
+++ b/src/neural/simple/network_simple.cc
@@ -1,0 +1,563 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2020 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <functional>
+#include <list>
+#include <memory>
+#include <mutex>
+
+#include "simple_common.h"
+#include "layers.h"
+#include "neural/factory.h"
+#include "neural/network_legacy.h"
+#include "neural/shared/policy_map.h"
+#include "utils/bititer.h"
+#include "utils/exception.h"
+
+//#define DEBUG_RAW_NPS
+
+namespace lczero {
+using namespace simple_backend;
+
+static constexpr int kNumOutputPolicy = 1858;
+
+struct InputsOutputs {
+  InputsOutputs(int maxBatchSize, bool wdl, bool moves_left) {
+    input_masks_mem_ =
+        (uint64_t*)malloc(maxBatchSize * kInputPlanes * sizeof(uint64_t));
+
+    input_val_mem_ =
+        (float*)malloc(maxBatchSize * kInputPlanes * sizeof(float));
+
+    op_policy_mem_ =
+        (float*)malloc(maxBatchSize * kNumOutputPolicy * sizeof(float));
+
+    op_value_mem_ =
+        (float*)malloc(maxBatchSize * (wdl ? 3 : 1) * sizeof(float));
+
+    if (moves_left) {
+      op_moves_left_mem_ = (float*)malloc(maxBatchSize * sizeof(float));
+    } else
+      op_moves_left_mem_ = nullptr;
+  }
+  ~InputsOutputs() {
+    free(input_masks_mem_);
+    free(input_val_mem_);
+    free(op_policy_mem_);
+    free(op_value_mem_);
+    if (op_moves_left_mem_) {
+      free(op_moves_left_mem_);
+    }
+  }
+  uint64_t* input_masks_mem_;
+  float* input_val_mem_;
+  float* op_policy_mem_;
+  float* op_value_mem_;
+  float* op_moves_left_mem_;
+};
+
+class SimpleNetwork;
+
+class SimpleNetworkComputation : public NetworkComputation {
+ public:
+  SimpleNetworkComputation(SimpleNetwork* network, bool wdl, bool moves_left);
+  ~SimpleNetworkComputation();
+
+  void AddInput(InputPlanes&& input) override {
+    const auto iter_mask =
+        &inputs_outputs_->input_masks_mem_[batch_size_ * kInputPlanes];
+    const auto iter_val =
+        &inputs_outputs_->input_val_mem_[batch_size_ * kInputPlanes];
+
+    int i = 0;
+    for (const auto& plane : input) {
+      iter_mask[i] = plane.mask;
+      iter_val[i] = plane.value;
+      i++;
+    }
+
+    batch_size_++;
+  }
+
+  void ComputeBlocking() override;
+
+  int GetBatchSize() const override { return batch_size_; }
+
+  float GetQVal(int sample) const override {
+    if (wdl_) {
+      auto w = inputs_outputs_->op_value_mem_[3 * sample + 0];
+      auto l = inputs_outputs_->op_value_mem_[3 * sample + 2];
+      return w - l;
+    } else {
+      return inputs_outputs_->op_value_mem_[sample];
+    }
+  }
+
+  float GetDVal(int sample) const override {
+    if (wdl_) {
+      auto d = inputs_outputs_->op_value_mem_[3 * sample + 1];
+      return d;
+    } else {
+      return 0.0f;
+    }
+  }
+
+  float GetPVal(int sample, int move_id) const override {
+    return inputs_outputs_->op_policy_mem_[sample * kNumOutputPolicy + move_id];
+  }
+
+  float GetMVal(int sample) const override {
+    if (moves_left_) {
+      return inputs_outputs_->op_moves_left_mem_[sample];
+    }
+    return 0.0f;
+  }
+
+ private:
+  // Memory holding inputs, outputs.
+  std::unique_ptr<InputsOutputs> inputs_outputs_;
+  int batch_size_;
+  bool wdl_;
+  bool moves_left_;
+
+  SimpleNetwork* network_;
+};
+
+class SimpleNetwork : public Network {
+ public:
+  SimpleNetwork(const WeightsFile& file, const OptionsDict& options)
+      : capabilities_{file.format().network_format().input(),
+                      file.format().network_format().moves_left()} {
+    LegacyWeights weights(file.weights());
+
+    conv_policy_ = file.format().network_format().policy() ==
+                   pblczero::NetworkFormat::POLICY_CONVOLUTION;
+
+    max_batch_size_ = options.GetOrDefault<int>("max_batch", 1024);
+
+    // Default layout is nchw.
+
+    const int kNumInputPlanes = kInputPlanes;
+    const int kNumFilters = (int)weights.input.biases.size();
+    numBlocks_ = (int)weights.residual.size();
+    size_t residual_single_layer_weight_size =
+        3 * 3 * kNumFilters * kNumFilters * sizeof(float);
+
+    // 0. Check for SE.
+
+    has_se_ = false;
+    if (weights.residual[0].has_se) {
+      has_se_ = true;
+    }
+
+    // 1. Allocate scratch space.
+
+    // Have some minumum as we also use this for transforming weights.
+    size_t max_weight_size = 128 * 1024 * 1024;
+
+    // Parts from scratch allocation are suballocated to hold various weights
+    // and biases when transforming winograd weights (one layer at a time), 128
+    // MB is way more than that what we need but make sure it's at least 3x of
+    // single layer's weight size to be safe.
+    if (max_weight_size < 3 * residual_single_layer_weight_size)
+      max_weight_size = 3 * residual_single_layer_weight_size;
+
+    scratch_size_ = max_weight_size;
+
+    scratch_mem_ = malloc(scratch_size_);
+
+    // 2. Build the network, and copy the weights to GPU memory.
+
+    // Input.
+    {
+      auto inputConv = std::make_unique<ConvLayer>(nullptr, kNumFilters, 8, 8,
+                                                   3, kNumInputPlanes, true);
+      inputConv->LoadWeights(&weights.input.weights[0],
+                             &weights.input.biases[0], scratch_mem_);
+      network_.emplace_back(std::move(inputConv));
+    }
+
+    // Residual block.
+    for (size_t block = 0; block < weights.residual.size(); block++) {
+      auto conv1 = std::make_unique<ConvLayer>(getLastLayer(), kNumFilters, 8,
+                                               8, 3, kNumFilters, true);
+      conv1->LoadWeights(&weights.residual[block].conv1.weights[0],
+                         &weights.residual[block].conv1.biases[0],
+                         scratch_mem_);
+      network_.emplace_back(std::move(conv1));
+
+      // Relu of second convolution and skip connection is handled by SELayer.
+      bool has_se = weights.residual[block].has_se;
+
+      auto conv2 = std::make_unique<ConvLayer>(
+          getLastLayer(), kNumFilters, 8, 8, 3, kNumFilters, !has_se, !has_se);
+      conv2->LoadWeights(&weights.residual[block].conv2.weights[0],
+                         &weights.residual[block].conv2.biases[0],
+                         scratch_mem_);
+      network_.emplace_back(std::move(conv2));
+
+      if (has_se) {
+        int numFCOut = (int)weights.residual[block].se.b1.size();
+        auto se = std::make_unique<SELayer>(getLastLayer(), numFCOut);
+        se->LoadWeights(&weights.residual[block].se.w1[0],
+                        &weights.residual[block].se.b1[0],
+                        &weights.residual[block].se.w2[0],
+                        &weights.residual[block].se.b2[0], scratch_mem_);
+        network_.emplace_back(std::move(se));
+      }
+    }
+
+    BaseLayer* resi_last_ = getLastLayer();
+
+    // Policy head.
+    if (conv_policy_) {
+      auto conv1 = std::make_unique<ConvLayer>(resi_last_, kNumFilters, 8, 8, 3,
+                                               kNumFilters, true);
+      conv1->LoadWeights(&weights.policy1.weights[0],
+                         &weights.policy1.biases[0], scratch_mem_);
+      network_.emplace_back(std::move(conv1));
+
+      auto pol_channels = weights.policy.biases.size();
+
+      // No relu
+      auto conv2 = std::make_unique<ConvLayer>(getLastLayer(), pol_channels, 8,
+                                               8, 3, kNumFilters, false);
+      conv2->LoadWeights(&weights.policy.weights[0], &weights.policy.biases[0],
+                         scratch_mem_);
+      network_.emplace_back(std::move(conv2));
+
+      auto policymap = std::make_unique<PolicyMapLayer>(
+          getLastLayer(), kNumOutputPolicy, 1, 1, 73 * 8 * 8);
+      policymap->LoadWeights(kConvPolicyMap, scratch_mem_);
+
+      network_.emplace_back(std::move(policymap));
+    } else {
+      auto convPol = std::make_unique<ConvLayer>(
+          resi_last_, weights.policy.biases.size(), 8, 8, 1, kNumFilters, true);
+      convPol->LoadWeights(&weights.policy.weights[0],
+                           &weights.policy.biases[0], scratch_mem_);
+      network_.emplace_back(std::move(convPol));
+
+      auto FCPol = std::make_unique<FCLayer>(
+          getLastLayer(), weights.ip_pol_b.size(), 1, 1, false, true);
+      FCPol->LoadWeights(&weights.ip_pol_w[0], &weights.ip_pol_b[0],
+                         scratch_mem_);
+      network_.emplace_back(std::move(FCPol));
+    }
+
+    // Value head.
+    {
+      auto convVal = std::make_unique<ConvLayer>(
+          resi_last_, weights.value.biases.size(), 8, 8, 1, kNumFilters, true);
+      convVal->LoadWeights(&weights.value.weights[0], &weights.value.biases[0],
+                           scratch_mem_);
+      network_.emplace_back(std::move(convVal));
+
+      auto FCVal1 = std::make_unique<FCLayer>(
+          getLastLayer(), weights.ip1_val_b.size(), 1, 1, true, true);
+      FCVal1->LoadWeights(&weights.ip1_val_w[0], &weights.ip1_val_b[0],
+                          scratch_mem_);
+      network_.emplace_back(std::move(FCVal1));
+
+      wdl_ = file.format().network_format().value() ==
+             pblczero::NetworkFormat::VALUE_WDL;
+      auto fc2_tanh = !wdl_;
+
+      auto FCVal2 =
+          std::make_unique<FCLayer>(getLastLayer(), weights.ip2_val_b.size(), 1,
+                                    1, false, true, fc2_tanh);
+      FCVal2->LoadWeights(&weights.ip2_val_w[0], &weights.ip2_val_b[0],
+                          scratch_mem_);
+      network_.emplace_back(std::move(FCVal2));
+    }
+
+    // Moves left head
+    moves_left_ = (file.format().network_format().moves_left() ==
+                   pblczero::NetworkFormat::MOVES_LEFT_V1) &&
+                  options.GetOrDefault<bool>("mlh", true);
+    if (moves_left_) {
+      auto convMov = std::make_unique<ConvLayer>(
+          resi_last_, weights.moves_left.biases.size(), 8, 8, 1, kNumFilters,
+          true);
+      convMov->LoadWeights(&weights.moves_left.weights[0],
+                           &weights.moves_left.biases[0], scratch_mem_);
+      network_.emplace_back(std::move(convMov));
+
+      auto FCMov1 = std::make_unique<FCLayer>(
+          getLastLayer(), weights.ip1_mov_b.size(), 1, 1, true, true);
+      FCMov1->LoadWeights(&weights.ip1_mov_w[0], &weights.ip1_mov_b[0],
+                          scratch_mem_);
+      network_.emplace_back(std::move(FCMov1));
+
+      auto FCMov2 =
+          std::make_unique<FCLayer>(getLastLayer(), 1, 1, 1, true, true);
+      FCMov2->LoadWeights(&weights.ip2_mov_w[0], &weights.ip2_mov_b[0],
+                          scratch_mem_);
+      network_.emplace_back(std::move(FCMov2));
+    }
+
+    // 3. Allocate memory for running the network:
+    //    - three buffers of max size are enough (one to hold input, second to
+    //      hold output and third to hold skip connection's input).
+
+    // size of input to the network
+    size_t maxSize = max_batch_size_ * kNumInputPlanes * 64 * sizeof(float);
+
+    // take max size of all layers
+    for (auto& layer : network_) {
+      maxSize = std::max(maxSize, layer->GetOutputSize(max_batch_size_));
+    }
+
+    for (auto& mem : tensor_mem_) {
+      mem = (float*)malloc(maxSize);
+      memset(mem, 0, maxSize);
+    }
+  }
+
+  void forwardEval(InputsOutputs* io, int batchSize) {
+    std::lock_guard<std::mutex> lock(lock_);
+
+    // Expand packed planes to full planes.
+    uint64_t* ipDataMasks = io->input_masks_mem_;
+    float* ipDataValues = io->input_val_mem_;
+    float* buffer = tensor_mem_[0];
+    for (int j = 0; j < batchSize * kInputPlanes; j++) {
+      const float value = ipDataValues[j];
+      const uint64_t mask = ipDataMasks[j];
+      for (auto i = 0; i < 64; i++)
+        *(buffer++) = (mask & (((uint64_t)1) << i)) != 0 ? value : 0;
+    }
+
+    float* opPol = io->op_policy_mem_;
+    float* opVal = io->op_value_mem_;
+    float* opMov = io->op_moves_left_mem_;
+
+    int l = 0;
+    // Input.
+    network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[0], scratch_mem_,
+                        scratch_size_);  // input conv
+
+    // Residual block.
+    for (int block = 0; block < numBlocks_; block++) {
+      network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2],
+                          scratch_mem_, scratch_size_);  // conv1
+
+      // For SE Resnet, skip connection is added after SE (and bias is added
+      // as part of SE).
+      if (has_se_) {
+        network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0],
+                            scratch_mem_, scratch_size_);  // conv2
+      } else {
+        network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[0],
+                            scratch_mem_, scratch_size_);  // conv2
+      }
+
+      if (has_se_) {
+        network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[1],
+                            scratch_mem_, scratch_size_);  // SE layer
+      }
+    }
+
+    // Policy head.
+    if (conv_policy_) {
+      network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2],
+                          scratch_mem_, scratch_size_);  // policy conv1
+
+      network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0],
+                          scratch_mem_, scratch_size_);  // policy conv2
+
+      network_[l++]->Eval(batchSize, (float*)opPol, tensor_mem_[1],
+                          scratch_mem_,
+                          scratch_size_);  // policy map layer  // POLICY output
+    } else {
+      network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2],
+                          scratch_mem_, scratch_size_);  // pol conv
+
+      network_[l++]->Eval(batchSize, (float*)opPol, tensor_mem_[0],
+                          scratch_mem_, scratch_size_);  // pol FC  // POLICY
+    }
+
+    // value head
+    network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2], scratch_mem_,
+                        scratch_size_);  // value conv
+
+    network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0], scratch_mem_,
+                        scratch_size_);  // value FC1
+
+    network_[l++]->Eval(batchSize, (float*)opVal, tensor_mem_[1], scratch_mem_,
+                        scratch_size_);  // value FC2    // VALUE
+
+    if (moves_left_) {
+      // Moves left head
+      network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2],
+                          scratch_mem_, scratch_size_);  // moves conv
+
+      network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0],
+                          scratch_mem_, scratch_size_);  // moves FC1
+
+      // Moves left FC2
+      network_[l++]->Eval(batchSize, (float*)opMov, tensor_mem_[1],
+                          scratch_mem_, scratch_size_);
+    }
+
+    if (wdl_) {
+      // Value softmax done cpu side.
+      for (int i = 0; i < batchSize; i++) {
+        float w = std::exp(io->op_value_mem_[3 * i + 0]);
+        float d = std::exp(io->op_value_mem_[3 * i + 1]);
+        float l = std::exp(io->op_value_mem_[3 * i + 2]);
+        float sum = w + d + l;
+        w /= sum;
+        l /= sum;
+        d = 1.0f - w - l;
+        io->op_value_mem_[3 * i + 0] = w;
+        io->op_value_mem_[3 * i + 1] = d;
+        io->op_value_mem_[3 * i + 2] = l;
+      }
+    }
+  }
+
+  ~SimpleNetwork() {
+    for (auto mem : tensor_mem_) {
+      if (mem) free(mem);
+    }
+  }
+
+  const NetworkCapabilities& GetCapabilities() const override {
+    return capabilities_;
+  }
+
+  std::unique_ptr<NetworkComputation> NewComputation() override {
+    // Set correct gpu id for this computation (as it might have been called
+    // from a different thread).
+    return std::make_unique<SimpleNetworkComputation>(this, wdl_, moves_left_);
+  }
+
+  std::unique_ptr<InputsOutputs> GetInputsOutputs() {
+    std::lock_guard<std::mutex> lock(inputs_outputs_lock_);
+    if (free_inputs_outputs_.empty()) {
+      return std::make_unique<InputsOutputs>(max_batch_size_, wdl_,
+                                             moves_left_);
+    } else {
+      std::unique_ptr<InputsOutputs> resource =
+          std::move(free_inputs_outputs_.front());
+      free_inputs_outputs_.pop_front();
+      return resource;
+    }
+  }
+
+  void ReleaseInputsOutputs(std::unique_ptr<InputsOutputs> resource) {
+    std::lock_guard<std::mutex> lock(inputs_outputs_lock_);
+    free_inputs_outputs_.push_back(std::move(resource));
+  }
+
+ private:
+  const NetworkCapabilities capabilities_;
+  int max_batch_size_;
+  bool wdl_;
+  bool moves_left_;
+
+  std::mutex lock_;
+
+  int numBlocks_;
+  bool has_se_;
+  bool conv_policy_;
+  std::vector<std::unique_ptr<BaseLayer>> network_;
+  BaseLayer* getLastLayer() { return network_.back().get(); }
+
+  float* tensor_mem_[3];
+  void* scratch_mem_;
+  size_t scratch_size_;
+
+  std::mutex inputs_outputs_lock_;
+
+  std::list<std::unique_ptr<InputsOutputs>> free_inputs_outputs_;
+};
+
+SimpleNetworkComputation::SimpleNetworkComputation(SimpleNetwork* network,
+                                                   bool wdl, bool moves_left)
+    : wdl_(wdl), moves_left_(moves_left), network_(network) {
+  batch_size_ = 0;
+  inputs_outputs_ = network_->GetInputsOutputs();
+}
+
+SimpleNetworkComputation::~SimpleNetworkComputation() {
+  network_->ReleaseInputsOutputs(std::move(inputs_outputs_));
+}
+
+void SimpleNetworkComputation::ComputeBlocking() {
+  network_->forwardEval(inputs_outputs_.get(), GetBatchSize());
+}
+
+std::unique_ptr<Network> MakeSimpleNetwork(const std::optional<WeightsFile>& w,
+                                           const OptionsDict& options) {
+  if (!w) {
+    throw Exception("The simple backend requires a network file.");
+  }
+  const WeightsFile& weights = *w;
+  if (weights.format().network_format().network() !=
+          pblczero::NetworkFormat::NETWORK_CLASSICAL_WITH_HEADFORMAT &&
+      weights.format().network_format().network() !=
+          pblczero::NetworkFormat::NETWORK_SE_WITH_HEADFORMAT) {
+    throw Exception(
+        "Network format " +
+        std::to_string(weights.format().network_format().network()) +
+        " is not supported by the simple backend.");
+  }
+  if (weights.format().network_format().policy() !=
+          pblczero::NetworkFormat::POLICY_CLASSICAL &&
+      weights.format().network_format().policy() !=
+          pblczero::NetworkFormat::POLICY_CONVOLUTION) {
+    throw Exception("Policy format " +
+                    std::to_string(weights.format().network_format().policy()) +
+                    " is not supported by the simple backend.");
+  }
+  if (weights.format().network_format().value() !=
+          pblczero::NetworkFormat::VALUE_CLASSICAL &&
+      weights.format().network_format().value() !=
+          pblczero::NetworkFormat::VALUE_WDL) {
+    throw Exception("Value format " +
+                    std::to_string(weights.format().network_format().value()) +
+                    " is not supported by the simple backend.");
+  }
+  if (weights.format().network_format().moves_left() !=
+          pblczero::NetworkFormat::MOVES_LEFT_NONE &&
+      weights.format().network_format().moves_left() !=
+          pblczero::NetworkFormat::MOVES_LEFT_V1) {
+    throw Exception(
+        "Movest left head format " +
+        std::to_string(weights.format().network_format().moves_left()) +
+        " is not supported by the simple backend.");
+  }
+  return std::make_unique<SimpleNetwork>(weights, options);
+}
+
+REGISTER_NETWORK("simple", MakeSimpleNetwork, 10)
+
+}  // namespace lczero

--- a/src/neural/simple/se_unit.cc
+++ b/src/neural/simple/se_unit.cc
@@ -1,0 +1,93 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2018 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "se_unit.h"
+#include "fully_connected_layer.h"
+
+#include <cmath>
+
+namespace lczero {
+namespace simple_backend {
+namespace {
+constexpr int kWidth = 8;
+constexpr int kHeight = 8;
+constexpr int kSquares = kWidth * kHeight;
+}  // namespace
+
+static void global_avg_pooling(const size_t channels, const float* input,
+                               float* output) {
+  for (auto c = size_t{0}; c < channels; c++) {
+    auto acc = 0.0f;
+    for (auto i = size_t{0}; i < kSquares; i++) {
+      acc += input[c * kSquares + i];
+    }
+    output[c] = acc / kSquares;
+  }
+}
+
+static void apply_se(const size_t channels, const size_t batch_size,
+                     const float* input, const float* res, const float* scale,
+                     float* output) {
+  const auto lambda_ReLU = [](const auto val) {
+    return (val > 0.0f) ? val : 0;
+  };
+
+  const auto lambda_sigmoid = [](const auto val) {
+    return 1.0f / (1.0f + std::exp(-val));
+  };
+
+  for (auto c = size_t{0}; c < channels * batch_size; c++) {
+    auto batch = c / channels;
+    auto gamma = lambda_sigmoid(scale[c + batch * channels]);
+    auto beta = scale[c + batch * channels + channels];
+    for (auto i = size_t{0}; i < kSquares; i++) {
+      output[c * kSquares + i] = lambda_ReLU(gamma * input[c * kSquares + i] +
+                                             beta + res[c * kSquares + i]);
+    }
+  }
+}
+
+void ApplySEUnit(const size_t batch_size, const size_t channels,
+                 const size_t se_fc_outputs, const float* input,
+                 const float* residual, const float* weights_w1,
+                 const float* weights_b1, const float* weights_w2,
+                 const float* weights_b2, float* output) {
+  std::vector<float> pool(2 * channels * batch_size);
+  std::vector<float> fc_out1(batch_size * se_fc_outputs);
+
+  global_avg_pooling(channels * batch_size, input, pool.data());
+
+  FullyConnectedLayer::Forward1D(batch_size, channels, se_fc_outputs,
+                                            pool.data(), weights_w1, weights_b1,
+                                            true,  // Relu On
+                                            false, // tanh
+                                            fc_out1.data());
+
+  FullyConnectedLayer::Forward1D(batch_size, se_fc_outputs,
+                                            2 * channels, fc_out1.data(),
+                                            weights_w2, weights_b2,
+                                            false,  // Relu Off
+                                            false, //tanh
+                                            pool.data());
+
+  // Sigmoid, scale and add residual
+  apply_se(channels, batch_size, input, residual, pool.data(), output);
+}
+
+}  // namespace simple_backend
+}  // namespace lczero

--- a/src/neural/simple/se_unit.h
+++ b/src/neural/simple/se_unit.h
@@ -1,0 +1,33 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2018 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+namespace lczero {
+namespace simple_backend {
+
+void ApplySEUnit(const size_t batch_size, const size_t channels,
+                 const size_t se_fc_outputs, const float* input,
+                 const float* residual, const float* weights_w1,
+                 const float* weights_b1, const float* weights_w2,
+                 const float* weights_b2, float* output);
+
+}  // namespace simple_backend
+}  // namespace lczero

--- a/src/neural/simple/simple_common.h
+++ b/src/neural/simple/simple_common.h
@@ -1,0 +1,59 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+#pragma once
+
+#if defined(USE_OPENBLAS)
+#include <cblas.h>
+
+#elif defined(USE_DNNL)
+#include <dnnl.h>
+
+// Implement the cblas subset needed using dnnl_sgemm().
+extern "C" {
+#define CblasRowMajor 0
+#define CblasColMajor 1
+#define CblasNoTrans 'N'
+#define CblasTrans 'T'
+static inline void cblas_sgemm(char order, char transa, char transb,
+                               dnnl_dim_t M, dnnl_dim_t N, dnnl_dim_t K,
+                               float alpha, const float *A, dnnl_dim_t lda,
+                               const float *B, dnnl_dim_t ldb, float beta,
+                               float *C, dnnl_dim_t ldc) {
+  // DNNL only has row major sgemm.
+  if (order == CblasRowMajor) {
+    dnnl_sgemm(transa, transb, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc);
+  } else {
+    dnnl_sgemm(transb, transa, N, M, K, alpha, B, ldb, A, lda, beta, C, ldc);
+  }
+}
+
+}
+
+#elif defined(__APPLE__)
+#include <Accelerate/Accelerate.h>
+
+#endif

--- a/src/neural/simple/winograd_convolution3.cc
+++ b/src/neural/simple/winograd_convolution3.cc
@@ -1,0 +1,234 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2018 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "winograd_convolution3.h"
+#include "simple_common.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+
+#include <array>
+
+
+namespace lczero {
+namespace simple_backend {
+
+WinogradConvolution3::WinogradConvolution3(
+    const size_t max_batch_size, const size_t max_input_layers,
+    const size_t max_output_layers)
+    : V_(max_batch_size * kWinogradTile * max_input_layers * kTiles),
+      M_(max_batch_size * kWinogradTile * max_output_layers * kTiles) {}
+
+void WinogradConvolution3::Forward(const size_t batch_size,
+                                              const size_t input_channels,
+                                              const size_t output_channels,
+                                              const float* input,
+                                              const float* weights,
+                                              float* output) {
+  TransformIn(batch_size, input, input_channels);
+  Sgemm(batch_size, weights, input_channels, output_channels);
+  TransformOut(batch_size, output, output_channels);
+}
+
+void WinogradConvolution3::TransformIn(const size_t batch_size,
+                                                  const float* input,
+                                                  const size_t channels) {
+  static const size_t kCacheSize = 128;
+  float x[kWinogradAlpha][kWinogradAlpha];
+  float T1[kWinogradAlpha][kWinogradAlpha];
+  float R[16][kCacheSize];
+  for (size_t batch_index = 0; batch_index < batch_size; batch_index++) {
+    size_t channels_rem = channels;
+    const float* input_batch =
+        input + batch_index * kWidth * kHeight * channels;
+    float* V_batch = &V_[channels * kTiles * batch_index];
+    for (size_t channel_long = 0; channel_long < channels;
+         channel_long += kCacheSize) {
+      const size_t channel_step = std::min<size_t>(kCacheSize, channels_rem);
+      channels_rem -= channel_step;
+      for (int block_y = 0; block_y < kWtiles; block_y++) {
+        for (int block_x = 0; block_x < kWtiles; block_x++) {
+          // Tiles overlap by 2
+          const int yin = 2 * block_y - 1;
+          const int xin = 2 * block_x - 1;
+
+          for (size_t ch = 0; ch < channel_step; ++ch) {
+            const size_t channel = channel_long + ch;
+
+            const float* input_channel =
+                input_batch + channel * (kWidth * kHeight);
+            for (int i = 0; i < kWinogradAlpha; i++) {
+              for (int j = 0; j < kWinogradAlpha; j++) {
+                if ((yin + i) >= 0 && (xin + j) >= 0 && (yin + i) < kHeight &&
+                    (xin + j) < kWidth) {
+                  x[i][j] = input_channel[(yin + i) * kWidth + (xin + j)];
+                } else {
+                  x[i][j] = 0.0f;
+                }
+              }
+            }
+
+            // Calculates transpose(B).x.B
+            // B = [[ 1.0,  0.0,  0.0,  0.0],
+            //      [ 0.0,  1.0, -1.0,  1.0],
+            //      [-1.0,  1.0,  1.0,  0.0],
+            //      [ 0.0,  0.0,  0.0, -1.0]]
+
+            T1[0][0] = x[0][0] - x[2][0];
+            T1[0][1] = x[0][1] - x[2][1];
+            T1[0][2] = x[0][2] - x[2][2];
+            T1[0][3] = x[0][3] - x[2][3];
+            T1[1][0] = x[1][0] + x[2][0];
+            T1[1][1] = x[1][1] + x[2][1];
+            T1[1][2] = x[1][2] + x[2][2];
+            T1[1][3] = x[1][3] + x[2][3];
+            T1[2][0] = x[2][0] - x[1][0];
+            T1[2][1] = x[2][1] - x[1][1];
+            T1[2][2] = x[2][2] - x[1][2];
+            T1[2][3] = x[2][3] - x[1][3];
+            T1[3][0] = x[1][0] - x[3][0];
+            T1[3][1] = x[1][1] - x[3][1];
+            T1[3][2] = x[1][2] - x[3][2];
+            T1[3][3] = x[1][3] - x[3][3];
+
+            R[0][ch] = T1[0][0] - T1[0][2];
+            R[1][ch] = T1[0][1] + T1[0][2];
+            R[2][ch] = T1[0][2] - T1[0][1];
+            R[3][ch] = T1[0][1] - T1[0][3];
+            R[4][ch] = T1[1][0] - T1[1][2];
+            R[5][ch] = T1[1][1] + T1[1][2];
+            R[6][ch] = T1[1][2] - T1[1][1];
+            R[7][ch] = T1[1][1] - T1[1][3];
+            R[8][ch] = T1[2][0] - T1[2][2];
+            R[9][ch] = T1[2][1] + T1[2][2];
+            R[10][ch] = T1[2][2] - T1[2][1];
+            R[11][ch] = T1[2][1] - T1[2][3];
+            R[12][ch] = T1[3][0] - T1[3][2];
+            R[13][ch] = T1[3][1] + T1[3][2];
+            R[14][ch] = T1[3][2] - T1[3][1];
+            R[15][ch] = T1[3][1] - T1[3][3];
+          }
+          float* V_channel = V_batch + channel_long;
+          const auto V_incr = channels * kTiles * batch_size;
+          float* wTile_V = V_channel + channels * (block_y * kWtiles + block_x);
+          for (size_t i = 0; i < 16; ++i) {
+            for (size_t ch = 0; ch < channel_step; ++ch) {
+              wTile_V[ch] = R[i][ch];
+            }
+            wTile_V += V_incr;
+          }
+        }
+      }
+    }
+  }
+}
+
+void WinogradConvolution3::Sgemm(const size_t batch_size,
+                                        const float* weights,
+                                        const size_t input_channels,
+                                        const size_t output_channels) {
+  for (size_t b = 0; b < kWinogradTile; b++) {
+    auto offset_u = b * output_channels * input_channels;
+
+    // In col major
+    //
+    //            M               =         weights(T)        x          V
+    //
+    // cols      tiles                  input_channels              tiles
+    // rows   output_channels          output_channels            input_channels
+
+    auto offset_v = b * batch_size * input_channels * kTiles;
+    auto offset_m = b * batch_size * output_channels * kTiles;
+    cblas_sgemm(CblasColMajor,               // Row major format
+                CblasNoTrans,                // A no trans
+                CblasNoTrans,                // B no trans
+                (int)output_channels,        // rows W, M
+                (int)(batch_size * kTiles),  // cols V, M
+                (int)input_channels,         // cols W, rows V
+                1.0f,                        // alpha
+                &weights[offset_u],          // W
+                (int)output_channels,        // ldW
+                &V_[offset_v],               // V
+                (int)input_channels, 0.0f,   // ldV
+                &M_[offset_m],               // M
+                (int)output_channels);       // ldM
+  }
+}
+
+void WinogradConvolution3::TransformOut(const size_t batch_size,
+                                                   float* output,
+                                                   const size_t channels) {
+  float m[kWinogradTile];
+
+  for (size_t batch_index = 0; batch_index < batch_size; batch_index++) {
+    const float* M_batch = &M_[channels * kTiles * batch_index];
+    float* output_batch = output + batch_index * kWidth * kHeight * channels;
+
+    for (size_t channel = 0; channel < channels; channel++) {
+      const float* M_channel = M_batch + channel;
+      float* output_channel = output_batch + channel * (kHeight * kWidth);
+
+      for (int block_x = 0; block_x < kWtiles; block_x++) {
+        for (int block_y = 0; block_y < kWtiles; block_y++) {
+          const auto x = 2 * block_x;
+          const auto y = 2 * block_y;
+
+          const auto b = block_y * kWtiles + block_x;
+          const float* M_wtile = M_channel + channels * b;
+          const auto M_incr = channels * kTiles * batch_size;
+
+          for (int wTile = 0; wTile < kWinogradTile; wTile++) {
+            m[wTile] = *M_wtile;
+            M_wtile += M_incr;
+          }
+
+          // Calculates transpose(A).temp_m.A
+          //    A = [1.0,  0.0],
+          //        [1.0,  1.0],
+          //        [1.0, -1.0],
+          //        [0.0, -1.0]]
+
+          auto o11 = m[0 * 4 + 0] + m[0 * 4 + 1] + m[0 * 4 + 2] + m[1 * 4 + 0] +
+                     m[1 * 4 + 1] + m[1 * 4 + 2] + m[2 * 4 + 0] + m[2 * 4 + 1] +
+                     m[2 * 4 + 2];
+
+          auto o12 = m[0 * 4 + 1] - m[0 * 4 + 2] - m[0 * 4 + 3] + m[1 * 4 + 1] -
+                     m[1 * 4 + 2] - m[1 * 4 + 3] + m[2 * 4 + 1] - m[2 * 4 + 2] -
+                     m[2 * 4 + 3];
+
+          auto o21 = m[1 * 4 + 0] + m[1 * 4 + 1] + m[1 * 4 + 2] - m[2 * 4 + 0] -
+                     m[2 * 4 + 1] - m[2 * 4 + 2] - m[3 * 4 + 0] - m[3 * 4 + 1] -
+                     m[3 * 4 + 2];
+
+          auto o22 = m[1 * 4 + 1] - m[1 * 4 + 2] - m[1 * 4 + 3] - m[2 * 4 + 1] +
+                     m[2 * 4 + 2] + m[2 * 4 + 3] - m[3 * 4 + 1] + m[3 * 4 + 2] +
+                     m[3 * 4 + 3];
+
+          output_channel[(y)*kWidth + (x)] = o11;
+          output_channel[(y)*kWidth + (x + 1)] = o12;
+          output_channel[(y + 1) * kWidth + (x)] = o21;
+          output_channel[(y + 1) * kWidth + (x + 1)] = o22;
+        }
+      }
+    }
+  }
+}
+
+}  // namespace simple_backend
+}  // namespace lczero

--- a/src/neural/simple/winograd_convolution3.h
+++ b/src/neural/simple/winograd_convolution3.h
@@ -1,0 +1,75 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2018 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace lczero {
+namespace simple_backend {
+// Convolution 3x3 on a 8x8 board using the Winograd algorithm.
+//
+// Ref:
+//
+// Fast Algorithms for Convolutional Neural Networks
+// https://arxiv.org/abs/1509.09308
+//
+// https://ai.intel.com/winograd/
+// https://ai.intel.com/winograd-2/
+
+// Convolution 3x3 using the Winograd algorithm
+class WinogradConvolution3 {
+ public:
+  // The instance will allocate memory resources for the
+  // largest batch size, and the largest input and output
+  // layers.
+  WinogradConvolution3(const size_t max_batch_size,
+                       const size_t max_input_layers,
+                       const size_t max_output_layers);
+
+  // Forward inference, batched.
+  void Forward(const size_t batch_size, const size_t input_channels,
+               const size_t output_channels, const float* input,
+               const float* weights, float* output);
+
+ private:
+  void TransformIn(const size_t batch_size, const float* input,
+                   const size_t channels);
+
+  void Sgemm(const size_t batch_size, const float* weights,
+             const size_t input_channels, const size_t output_channels);
+
+  void TransformOut(const size_t batch_size, float* output,
+                    const size_t channels);
+
+  static constexpr auto kWidth = 8;
+  static constexpr auto kHeight = 8;
+  static constexpr auto kSquares = kWidth * kHeight;
+
+  static constexpr auto kWtiles = (kWidth + 1) / 2;  // 4
+  static constexpr auto kTiles = kWtiles * kWtiles;  // 16
+
+  static constexpr auto kWinogradAlpha = 4;
+  static constexpr auto kWinogradTile = kWinogradAlpha * kWinogradAlpha;
+
+  std::vector<float> V_;
+  std::vector<float> M_;
+};
+}  // namespace simple_backend
+}  // namespace lczero

--- a/src/neural/simple/winograd_filter.cc
+++ b/src/neural/simple/winograd_filter.cc
@@ -1,0 +1,70 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2018 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "winograd_filter.h"
+
+#include <array>
+
+namespace lczero {
+namespace simple_backend {
+namespace {
+
+static constexpr auto kWinogradAlpha = 4;
+static constexpr auto kWinogradTile = kWinogradAlpha * kWinogradAlpha;
+
+}  // namespace
+
+void WinogradFilterTransformF(float* U, const float* f,
+                              const size_t outputs,
+                              const size_t channels) {
+  // F(2x2, 3x3) Winograd filter transformation
+  // transpose(G.dot(f).dot(G.transpose()))
+  // U matrix is transposed for better memory layout in SGEMM
+
+  auto G = std::array<float, kWinogradTile>{1.0, 0.0,  0.0, 0.5, 0.5, 0.5,
+                                            0.5, -0.5, 0.5, 0.0, 0.0, 1.0};
+  auto temp = std::array<float, 12>{};
+
+  for (size_t o = 0; o < outputs; o++) {
+    for (size_t c = 0; c < channels; c++) {
+      for (size_t i = 0; i < 4; i++) {
+        for (size_t j = 0; j < 3; j++) {
+          auto acc = 0.0f;
+          for (size_t k = 0; k < 3; k++) {
+            acc += G[i * 3 + k] * f[o * channels * 9 + c * 9 + k * 3 + j];
+          }
+          temp[i * 3 + j] = acc;
+        }
+      }
+
+      for (size_t xi = 0; xi < 4; xi++) {
+        for (size_t nu = 0; nu < 4; nu++) {
+          auto acc = 0.0f;
+          for (size_t k = 0; k < 3; k++) {
+            acc += temp[xi * 3 + k] * G[nu * 3 + k];
+          }
+          U[xi * (4 * outputs * channels) + nu * (outputs * channels) +
+            c * outputs + o] = acc;
+        }
+      }
+    }
+  }
+}
+
+}  // namespace simple_backend
+}  // namespace lczero

--- a/src/neural/simple/winograd_filter.h
+++ b/src/neural/simple/winograd_filter.h
@@ -1,0 +1,47 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2018 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace lczero {
+namespace simple_backend {
+
+// Here are BLAS-free methods to setup the filter
+// for the 3x3 winograd convolution algorithm.
+//
+// Ref:
+//
+// Fast Algorithms for Convolutional Neural Networks
+// https://arxiv.org/abs/1509.09308
+//
+// https://ai.intel.com/winograd/
+// https://ai.intel.com/winograd-2/
+
+// Convolution filter for 3x3 Winograd algorithm
+
+
+// Create the filter transform matrix.
+void WinogradFilterTransformF(float *U, const float* f,
+                              const size_t outputs,
+                              const size_t channels);
+
+}  // namespace simple_backend
+}  // namespace lczero


### PR DESCRIPTION
This is a simple backend, based on the structure of the cudnn backend but using BLAS functions for the internals. The purpose is to make building backends for other frameworks easy in a step by step process, replacing layers one at a time. The main structure is in `network_simple.cc`, `layers.cc` and `layers.h`, the remaining files are only there to support the BLAS functions.
Starting with an earlier, more complicated, version of this, I managed to bring up a full backend in a few days of part time coding (together with some of the further simplifications now included).