### PR TITLE
Turn syzygy fast play off by default.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -314,7 +314,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<BoolOption>(kOutOfOrderEvalId) = true;
   options->Add<FloatOption>(kMaxOutOfOrderEvalsId, 0.0f, 100.0f) = 1.0f;
   options->Add<BoolOption>(kStickyEndgamesId) = true;
-  options->Add<BoolOption>(kSyzygyFastPlayId) = true;
+  options->Add<BoolOption>(kSyzygyFastPlayId) = false;
   options->Add<IntOption>(kMultiPvId, 1, 500) = 1;
   options->Add<BoolOption>(kPerPvCountersId) = false;
   std::vector<std::string> score_type = {"centipawn",


### PR DESCRIPTION
Assuming #1470 and #1471 are committed, I think its worth turning this off by default for a release.

If we don't get complaints, maybe we can even remove the setting later on.