### PR TITLE
TB adjudication in training

### DIFF
--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -79,7 +79,8 @@ class SelfPlayGame {
   
   // Starts the game and blocks until the game is finished.
   void Play(int white_threads, int black_threads, bool training,
-	  SyzygyTablebase* syzygy_tb, bool enable_resign = true);
+	    SyzygyTablebase* syzygy_tb, bool adjudicate,
+	    bool enable_resign = true);
   // Aborts the game currently played, doesn't matter if it's synchronous or
   // not.
   void Abort();

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -37,6 +37,9 @@
 
 namespace lczero {
 namespace {
+const OptionId kAdjudicateId{"adjudicate", "Adjudicate",
+  "When the game reaches a position covered by the endgame table database, "
+  "adjudicate the game according to the result given by the database."};
 const OptionId kShareTreesId{"share-trees", "ShareTrees",
                              "When on, game tree is shared for two players; "
                              "when off, each side has a separate tree."};
@@ -104,6 +107,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   SearchParams::Populate(options);
 
   options->Add<BoolOption>(kShareTreesId) = true;
+  options->Add<BoolOption>(kAdjudicateId) = false;
   options->Add<IntOption>(kTotalGamesId, -2, 999999) = -1;
   options->Add<IntOption>(kParallelGamesId, 1, 256) = 8;
   options->Add<IntOption>(kPlayoutsId, -1, 999999999) = -1;
@@ -156,6 +160,7 @@ SelfPlayTournament::SelfPlayTournament(
       tournament_callback_(tournament_info),
       kTotalGames(options.Get<int>(kTotalGamesId)),
       kShareTree(options.Get<bool>(kShareTreesId)),
+      kAdjudicate(options.Get<bool>(kAdjudicateId)),
       kParallelism(options.Get<int>(kParallelGamesId)),
       kTraining(options.Get<bool>(kTrainingId)),
       kResignPlaythrough(options.Get<float>(kResignPlaythroughId)),
@@ -350,7 +355,7 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
   auto player1_threads = player_options_[0][color_idx[0]].Get<int>(kThreadsId);
   auto player2_threads = player_options_[1][color_idx[1]].Get<int>(kThreadsId);
   game.Play(player1_threads, player2_threads, kTraining, syzygy_tb_.get(),
-            enable_resign);
+	    kAdjudicate, enable_resign);
   
   // If game was aborted, it's still undecided.
   if (game.GetGameResult() != GameResult::UNDECIDED) {

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -104,6 +104,7 @@ class SelfPlayTournament {
   TournamentInfo::Callback tournament_callback_;
   const int kTotalGames;
   const bool kShareTree;
+  const bool kAdjudicate;
   const size_t kParallelism;
   const bool kTraining;
   const float kResignPlaythrough;


### PR DESCRIPTION
This PR builds on [Syzygy tablebase for use with selfplay](https://github.com/LeelaChessZero/lc0/pull/1241), and adds adjudication in `selfplay` mode. A new parameter `--adjudicate` (and `--no-adjudicate`) actives (and de-activates) adjudication which defaults to off.

To verify the behaviour of this patch, consider the following position, where Black can choose to enter a 5-men TB position with Kxg6.

![foo](https://user-images.githubusercontent.com/551014/102270702-9a95a800-3f1e-11eb-9707-6f8cdf2d76c1.png)

A binary compiled with this patch was given an opening pgn (named `endgame.pgn`) which ended in the above position using three different settings:

A. No `--syzygy-path` given
B. `--sygyzy-path` given, no `--adjudicate` given
C. Both `--sygyzy-path` given, and `--adjudicate` given.

The full command for A was

```
./lc0 selfplay --visits=800 --backend=random --games=1 --parallelism=1 --training --openings-pgn=endgame.pgn --logfile=bar.log
```
and for B
```
./lc0 selfplay --visits=800 --backend=random --games=1 --parallelism=1 --training --openings-pgn=endgame.pgn --syzygy-paths=syzygy --logfile=bar.log
```
and for C
```
./lc0 selfplay --visits=800 --backend=random --games=1 --parallelism=1 --training --openings-pgn=endgame.pgn --syzygy-paths=syzygy --adjudicate --logfile=bar.log
```
A resulted in a draw in 71 moves:

```
id name Lc0 v0.27.0-dev+git.34f4107
id author The LCZero Authors.
Creating backend [random]...
gameready trainingfile /home/hans/.cache/lc0/data-mjfvthklmsyf/game_000000.gz gameid 0 play_start_ply 75 player1 white result draw moves d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 g1f3 e8g8 e2e3 c7c6 f1e2 d5c4 e2c4 b8d7 e1g1 b7b6 a1c1 c8b7 d1e2 c6c5 d4c5 d7c5 h2h3 c5e4 c3e4 f6e4 g5e7 d8e7 c4d3 f8c8 d3e4 b7e4 c1c8 a8c8 f1d1 c8d8 d1d8 e7d8 f3d2 d8d5 d2e4 d5e4 e2f3 e4b4 f3a8 b4f8 a8f8 g8f8 f2f4 f7f6 e3e4 f6f5 e4f5 e6f5 g2g4 f5g4 h3g4 h7h6 b2b4 a7a5 b4a5 b6a5 g4g5 h6g5 f4g5 f8f7 g1f2 f7g6 f2g3 a5a4 g3f4 g6f7 g5g6 f7e8 f4g4 e8f8 g4h3 f8g8 h3g4 g8h8 g4h4 a4a3 h4g4 h8g8 g4f4 g8h8 f4e3 h8g8 e3e2 g8f8 e2d1 f8e7 d1e1 e7f6 e1f1 f6g5 f1g1 g5h6 g1h2 h6h5 h2g1 h5g6 g1g2 g6f7 g2f1 f7g8 f1f2 g8h8 f2f3 g7g6 f3g2 h8g7 g2g3 g7f6 g3h2 f6f5 h2g2 f5e6 g2f2 e6e5 f2e3 e5f5 e3d2 f5f6 d2d3 f6e7 d3e3 e7e8 e3e2 e8d7 e2f1 d7e6 f1g2 g6g5 g2f1 e6d7 f1g2 d7e6 g2f2 e6d7 f2g3 d7e7 g3g2 e7e6
tournamentstatus P1: +0 -0 =1 Win: 50.00% Elo: -0.00 P1-W: +0 -0 =1 P1-B: +0 -0 =0 npm 802.098592 nodes 56949 moves 71
tournamentstatus final P1: +0 -0 =1 Win: 50.00% Elo: -0.00 P1-W: +0 -0 =1 P1-B: +0 -0 =0 npm 802.098592 nodes 56949 moves 71
```
B ended in a black win in 57 moves

```
id name Lc0 v0.27.0-dev+git.34f4107
id author The LCZero Authors.
Creating backend [random]...
Loading Syzygy tablebases from /home/hans/syzygy
Found 145 WDL, 0 DTM and 145 DTZ tablebase files.
gameready trainingfile /home/hans/.cache/lc0/data-qpzbtkwikmyx/game_000000.gz gameid 0 play_start_ply 75 player1 white result blackwon moves d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 g1f3 e8g8 e2e3 c7c6 f1e2 d5c4 e2c4 b8d7 e1g1 b7b6 a1c1 c8b7 d1e2 c6c5 d4c5 d7c5 h2h3 c5e4 c3e4 f6e4 g5e7 d8e7 c4d3 f8c8 d3e4 b7e4 c1c8 a8c8 f1d1 c8d8 d1d8 e7d8 f3d2 d8d5 d2e4 d5e4 e2f3 e4b4 f3a8 b4f8 a8f8 g8f8 f2f4 f7f6 e3e4 f6f5 e4f5 e6f5 g2g4 f5g4 h3g4 h7h6 b2b4 a7a5 b4a5 b6a5 g4g5 h6g5 f4g5 f8f7 g1f2 f7g6 f2g3 a5a4 g3f4 g6f7 g5g6 f7g6 f4g4 a4a3 g4h3 g6f6 h3h4 g7g6 h4g4 g6g5 g4f3 f6f5 f3e3 g5g4 e3f2 f5f4 f2e2 g4g3 e2d1 g3g2 d1e2 g2g1q e2d3 g1a1 d3c4 a1a2 c4d3 a2g2 d3d4 a3a2 d4c5 a2a1r c5c4 a1a4 c4c5 g2c6 c5c6 f4f5 c6d6 a4a5 d6d7 a5e5 d7d6 f5f6 d6d7 e5e6 d7c7 f6e7 c7b8 e7d6 b8b7 d6d7 b7a8 d7c7 a8a7 e6c6 a7a8 c6a6
tournamentstatus P1: +0 -1 =0 LOS: 15.87% P1-W: +0 -1 =0 P1-B: +0 -0 =0 npm 802.508772 nodes 45743 moves 57
tournamentstatus final P1: +0 -1 =0 LOS: 15.87% P1-W: +0 -1 =0 P1-B: +0 -0 =0 npm 802.508772 nodes 45743 moves 57
 ```
 and C ended, as expected in a black win in 1 move
 ```
 id name Lc0 v0.27.0-dev+git.34f4107
id author The LCZero Authors.
Creating backend [random]...
Loading Syzygy tablebases from /home/hans/syzygy
Found 145 WDL, 0 DTM and 145 DTZ tablebase files.
gameready trainingfile /home/hans/.cache/lc0/data-vpgdjggaebcd/game_000000.gz gameid 0 play_start_ply 75 player1 white result blackwon moves d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1g5 f8e7 g1f3 e8g8 e2e3 c7c6 f1e2 d5c4 e2c4 b8d7 e1g1 b7b6 a1c1 c8b7 d1e2 c6c5 d4c5 d7c5 h2h3 c5e4 c3e4 f6e4 g5e7 d8e7 c4d3 f8c8 d3e4 b7e4 c1c8 a8c8 f1d1 c8d8 d1d8 e7d8 f3d2 d8d5 d2e4 d5e4 e2f3 e4b4 f3a8 b4f8 a8f8 g8f8 f2f4 f7f6 e3e4 f6f5 e4f5 e6f5 g2g4 f5g4 h3g4 h7h6 b2b4 a7a5 b4a5 b6a5 g4g5 h6g5 f4g5 f8f7 g1f2 f7g6 f2g3 a5a4 g3f4 g6f7 g5g6 f7g6
tournamentstatus P1: +0 -1 =0 LOS: 15.87% P1-W: +0 -1 =0 P1-B: +0 -0 =0 npm 800.000000 nodes 800 moves 1
tournamentstatus final P1: +0 -1 =0 LOS: 15.87% P1-W: +0 -1 =0 P1-B: +0 -0 =0 npm 800.000000 nodes 800 moves 1
```
 
It is difficult to demonstrate any positive effect on playing strength by this patch because of the amount of calculations needed, but the theory as for why it would help in training is that the network does no longer need to remember how to win the final phase of endgames.

The patch has a more material advantage in that it avoids unnecessary computations, a goal set out in [PR 1241](https://github.com/LeelaChessZero/lc0/pull/1241), but not achieved by it, as pointed out [here](https://github.com/LeelaChessZero/lc0/pull/1241#issuecomment-620008244).

In addition to providing support for adjudication, this patch also removes some redundant documentation bits added in the wrong place by PR 1241.