### PR TITLE
SF-like centipawn formula as distinct option.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -321,6 +321,7 @@ void SearchParams::Populate(OptionsParser* options) {
                                          "centipawn_with_drawscore",
                                          "centipawn_2019",
                                          "centipawn_2018",
+                                         "centipawn_SF",
                                          "win_percentage",
                                          "Q",
                                          "W-L"};

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -243,6 +243,8 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
       uci_info.score = 295 * wl / (1 - 0.976953126 * std::pow(wl, 14));
     } else if (score_type == "centipawn_2018") {
       uci_info.score = 290.680623072 * tan(1.548090806 * wl);
+    } else if (score_type == "centipawn_SF") {
+      uci_info.score = 295 * wl / (1 - 0.976953126 * std::pow(wl, 8));
     } else if (score_type == "win_percentage") {
       uci_info.score = wl * 5000 + 5000;
     } else if (score_type == "Q") {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -244,7 +244,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
     } else if (score_type == "centipawn_2018") {
       uci_info.score = 290.680623072 * tan(1.548090806 * wl);
     } else if (score_type == "centipawn_SF") {
-      uci_info.score = 295 * wl / (1 - 0.976953126 * std::pow(wl, 8));
+      uci_info.score = 317.6 * wl / (1 - 0.9751875 * std::pow(wl, 10));
     } else if (score_type == "win_percentage") {
       uci_info.score = wl * 5000 + 5000;
     } else if (score_type == "Q") {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -244,7 +244,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
     } else if (score_type == "centipawn_2018") {
       uci_info.score = 290.680623072 * tan(1.548090806 * wl);
     } else if (score_type == "centipawn_SF") {
-      uci_info.score = 317.6 * wl / (1 - 0.9751875 * std::pow(wl, 10));
+      uci_info.score = 357.2 * wl / (1 - 0.9720941 * std::pow(wl, 22));
     } else if (score_type == "win_percentage") {
       uci_info.score = wl * 5000 + 5000;
     } else if (score_type == "Q") {


### PR DESCRIPTION
Centipawn formula has been changed to a simpler one in April 2020 and doesn't correlate well to SF's CP evals especially in the lower evals. Discussion with correlation plots from TransInfinitum and eval data from Chad and me here:
https://github.com/LeelaChessZero/lc0/pull/1193#issuecomment-612854515
https://discord.com/channels/425419482568196106/539960268982059008/733434482128060516
Added formula in this PR is an updated version of `centipawn_2019` and has an even better fit in higher evals for T40 and later networks (helpful for correct TCEC adjudication), which is the reason why it was replaced (besides a more complicated inversion).
I don't understand the motivation behind the change to the currently used formula, for me correlation to most commonly used CPU-engine SF would be 1st priority and current formula is much worse here, but I'd like users to have the option of using one that correlates best. It would retain it's name `centipawn_SF` in the future, in case a better fit was found.