### PR TITLE
Precache nodes per search worker.

### DIFF
--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -275,7 +275,7 @@ class Node {
 
   // Reallocates this nodes children to be in a solid block, if possible and not
   // already done. Returns true if the transformation was performed.
-  bool MakeSolid();
+  bool MakeSolid(std::vector<std::unique_ptr<Node>>* cache);
 
   void SortEdges();
 
@@ -300,6 +300,22 @@ class Node {
   void Reinit(Node* parent, uint16_t index) {
     parent_ = parent;
     index_ = index;
+  }
+
+  // Clear out fields that aren't reset by std::move or Reinit - so a moved from node is safe to reinit and reuse.
+  void PrepareForReinit() {
+    wl_ = 0.0;
+    d_ = 0.0f;
+    m_ = 0.0f;
+    visited_policy_ = 0.0f;
+    n_ = 0;
+    n_in_flight_ = 0;
+    best_child_cache_in_flight_limit_ = 0;
+    num_edges_ = 0;
+    terminal_type_ = Terminal::NonTerminal;
+    lower_bound_ = GameResult::BLACK_WON;
+    upper_bound_ = GameResult::WHITE_WON;
+    solid_children_ = false;
   }
 
   // For each child, ensures that its parent pointer is pointing to this.

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1142,6 +1142,15 @@ void SearchWorker::InitializeIteration(
       if (!any_changes) break;
     }
   }
+  while (static_cast<int>(main_workspace_.node_source.size()) < params_.GetMiniBatchSize() * 3) {
+    main_workspace_.node_source.push_back(std::make_unique<Node>(nullptr, 0));
+  }
+  for (int i = 0; i < static_cast<int>(task_workspaces_.size()); i++) {
+    while (static_cast<int>(task_workspaces_[i].node_source.size()) < params_.GetMiniBatchSize() * 3) {
+      task_workspaces_[i].node_source.push_back(
+          std::make_unique<Node>(nullptr, 0));
+    }
+  }
 }
 
 // 2. Gather minibatch.
@@ -1503,8 +1512,6 @@ void SearchWorker::PickNodesToExtendTask(Node* node, int base_depth,
                                          const std::vector<Move>& moves_to_base,
                                          std::vector<NodeToProcess>* receiver,
                                          TaskWorkspace* workspace) {
-  // TODO: Bring back pre-cached nodes created outside locks in a way that works
-  // with tasks.
   // TODO: pre-reserve visits_to_perform for expected depth and likely maximum
   // width. Maybe even do so outside of lock scope.
   std::vector<std::unique_ptr<std::array<int, 256>>> visits_to_perform;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1142,11 +1142,14 @@ void SearchWorker::InitializeIteration(
       if (!any_changes) break;
     }
   }
-  while (static_cast<int>(main_workspace_.node_source.size()) < params_.GetMiniBatchSize() * 3) {
+  main_workspace_.node_source.reserve(params_.GetMiniBatchSize() * 4);
+  while (static_cast<int>(main_workspace_.node_source.size()) <
+         params_.GetMiniBatchSize() * 4) {
     main_workspace_.node_source.push_back(std::make_unique<Node>(nullptr, 0));
   }
   for (int i = 0; i < static_cast<int>(task_workspaces_.size()); i++) {
-    while (static_cast<int>(task_workspaces_[i].node_source.size()) < params_.GetMiniBatchSize() * 3) {
+    task_workspaces_[i].node_source.reserve(params_.GetMiniBatchSize() * 4);
+    while (static_cast<int>(task_workspaces_[i].node_source.size()) < params_.GetMiniBatchSize() * 4) {
       task_workspaces_[i].node_source.push_back(
           std::make_unique<Node>(nullptr, 0));
     }
@@ -1774,7 +1777,7 @@ void SearchWorker::PickNodesToExtendTask(Node* node, int base_depth,
           node_source = &(workspace->node_source.back());
         }
         Node* child_node = best_edge.GetOrSpawnNode(/* parent */ node, node_source);
-        if (!workspace->node_source.empty()) {
+        if (!workspace->node_source.empty() && !workspace->node_source.back()) {
           workspace->node_source.pop_back();
         }
 

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1126,6 +1126,22 @@ void SearchWorker::InitializeIteration(
   computation_->Reserve(params_.GetMiniBatchSize());
   minibatch_.clear();
   minibatch_.reserve(2 * params_.GetMiniBatchSize());
+  // Re-balance workspaces.
+  if (!task_workspaces_.empty()) {
+    while (true) {
+      bool any_changes = false;
+      for (int i = 0; i < static_cast<int>(task_workspaces_.size()); i++) {
+        if (task_workspaces_[i].node_source.size() + 2 <
+            main_workspace_.node_source.size()) {
+          task_workspaces_[i].node_source.push_back(
+              std::move(main_workspace_.node_source.back()));
+          main_workspace_.node_source.pop_back();
+          any_changes = true;
+        }
+      }
+      if (!any_changes) break;
+    }
+  }
 }
 
 // 2. Gather minibatch.
@@ -1746,7 +1762,14 @@ void SearchWorker::PickNodesToExtendTask(Node* node, int base_depth,
         }
         (*visits_to_perform.back())[best_idx] += new_visits;
         cur_limit -= new_visits;
-        Node* child_node = best_edge.GetOrSpawnNode(/* parent */ node, nullptr);
+        std::unique_ptr<Node>* node_source = nullptr;
+        if (!workspace->node_source.empty()) {
+          node_source = &(workspace->node_source.back());
+        }
+        Node* child_node = best_edge.GetOrSpawnNode(/* parent */ node, node_source);
+        if (!workspace->node_source.empty()) {
+          workspace->node_source.pop_back();
+        }
 
         // Probably best place to check for two-fold draws consistently.
         // Depth starts with 1 at root, so real depth is depth - 1.
@@ -2575,7 +2598,7 @@ void SearchWorker::DoBackupUpdateSingleNode(
       n->AdjustForTerminal(v_delta, d_delta, m_delta, n_to_fix);
     }
     if (n->GetN() >= solid_threshold) {
-      if (n->MakeSolid() && n == search_->root_node_) {
+      if (n->MakeSolid(&(main_workspace_.node_source)) && n == search_->root_node_) {
         // If we make the root solid, the current_best_edge_ becomes invalid and
         // we should repopulate it.
         search_->current_best_edge_ =

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -379,6 +379,7 @@ class SearchWorker {
   struct TaskWorkspace {
     std::array<Node::Iterator, 256> cur_iters;
     std::vector<std::unique_ptr<std::array<int, 256>>> vtp_buffer;
+    std::vector<std::unique_ptr<Node>> node_source;
   };
 
   struct PickTask {


### PR DESCRIPTION
Still in draft because:
1) Performance improvement seems small. (<1% on benchmark)
2) I'm precaching regardless of whether multigather is enabled.
3) The precaching size is hard coded at 4* minibatch - when it should probably be (1+moooef)*minibatch.  Possibly with a downscaling ratio of some kind when there is a non-zero number of task workers.  This detail only matters at super short time control where a search is likely to get less than 4*threads*minibatch total nodes - as otherwise it should always be worth it.

It also adds recycling of left over nodes from solid tree - but this seems a super tiny fraction in practice so it doesn't make much of a difference.