### PR TITLE
Better recycling to do with nodes to process.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1096,6 +1096,15 @@ void SearchWorker::ExecuteOneIteration() {
   // 7. Update the Search's status and progress information.
   UpdateCounters();
 
+  for (NodeToProcess& node_to_process : minibatch_) {
+    if (!node_to_process.IsCollision()) {
+      main_workspace_.move_list_cache.push_back(
+          std::move(node_to_process.moves_to_visit));
+      break;
+    }
+  }
+
+
   // If required, waste time to limit nps.
   if (params_.GetNpsLimit() > 0) {
     while (search_->IsSearchActive()) {
@@ -1126,6 +1135,22 @@ void SearchWorker::InitializeIteration(
   computation_->Reserve(params_.GetMiniBatchSize());
   minibatch_.clear();
   minibatch_.reserve(2 * params_.GetMiniBatchSize());
+  // Re-balance workspaces.
+  if (!task_workspaces_.empty()) {
+    while (true) {
+      bool any_changes = false;
+      for (int i = 0; i < static_cast<int>(task_workspaces_.size()); i++) {
+        if (task_workspaces_[i].move_list_cache.size() + 2 <
+            main_workspace_.move_list_cache.size()) {
+          task_workspaces_[i].move_list_cache.push_back(
+              std::move(main_workspace_.move_list_cache.back()));
+          main_workspace_.move_list_cache.pop_back();
+          any_changes = true;
+        }
+      }
+      if (!any_changes) break;
+    }
+  }
 }
 
 // 2. Gather minibatch.
@@ -1294,6 +1319,8 @@ void SearchWorker::GatherMinibatch2() {
           minibatch_.erase(minibatch_.begin() + i);
         } else if (minibatch_[i].ooo_completed) {
           DoBackupUpdateSingleNode(minibatch_[i]);
+          main_workspace_.move_list_cache.push_back(
+              std::move(minibatch_[i].moves_to_visit));
           minibatch_.erase(minibatch_.begin() + i);
           --minibatch_size;
           ++number_out_of_order_;
@@ -1390,6 +1417,8 @@ void SearchWorker::ProcessPickedTask(int start_idx, int end_idx,
     if (params_.GetOutOfOrderEval() && picked_node.CanEvalOutOfOrder()) {
       // Perform out of order eval for the last entry in minibatch_.
       FetchSingleNodeResult2(&picked_node, picked_node, 0);
+      // Release the cache lock now rather than waiting until later under mutex lock.
+      picked_node.lock = NNCacheLock();
       picked_node.ooo_completed = true;
     }
   }
@@ -1500,10 +1529,8 @@ void SearchWorker::PickNodesToExtendTask(Node* node, int base_depth,
   current_path.reserve(30);
   std::vector<Move> moves_to_path = moves_to_base;
   moves_to_path.reserve(30);
-  // Sometimes receiver is reused, othertimes not, so only jump start if small.
-  if (receiver->capacity() < 30) {
-    receiver->reserve(receiver->size() + 30);
-  }
+  auto& picking_results = workspace->picking_results;
+  picking_results.reserve(30);
 
   // These 2 are 'filled pre-emptively'.
   std::array<float, 256> current_pol;
@@ -1550,7 +1577,7 @@ void SearchWorker::PickNodesToExtendTask(Node* node, int base_depth,
           // ensure the outer gather loop gives up.
           if (node->TryStartScoreUpdate()) {
             cur_limit -= 1;
-            minibatch_.push_back(NodeToProcess::Visit(
+            picking_results.push_back(NodeToProcess::Visit(
                 node, static_cast<uint16_t>(current_path.size() + base_depth)));
             completed_visits++;
           }
@@ -1562,7 +1589,7 @@ void SearchWorker::PickNodesToExtendTask(Node* node, int base_depth,
               max_limit > cur_limit) {
             max_count = max_limit;
           }
-          receiver->push_back(NodeToProcess::Collision(
+          picking_results.push_back(NodeToProcess::Collision(
               node, static_cast<uint16_t>(current_path.size() + base_depth),
               cur_limit, max_count));
           completed_visits += cur_limit;
@@ -1771,13 +1798,20 @@ void SearchWorker::PickNodesToExtendTask(Node* node, int base_depth,
           // Reduce 1 for the visits_to_perform to ensure the collision created
           // doesn't include this visit.
           (*visits_to_perform.back())[best_idx] -= 1;
-          receiver->push_back(NodeToProcess::Visit(
+          picking_results.push_back(NodeToProcess::Visit(
               child_node,
               static_cast<uint16_t>(current_path.size() + 1 + base_depth)));
           completed_visits++;
-          receiver->back().moves_to_visit.reserve(moves_to_path.size() + 1);
-          receiver->back().moves_to_visit = moves_to_path;
-          receiver->back().moves_to_visit.push_back(best_edge.GetMove());
+          if (workspace->move_list_cache.empty()) {
+            picking_results.back().moves_to_visit.reserve(moves_to_path.size() +
+                                                          1);
+          } else {
+            picking_results.back().moves_to_visit =
+                std::move(workspace->move_list_cache.back());
+            workspace->move_list_cache.pop_back();
+          }
+          picking_results.back().moves_to_visit = moves_to_path;
+          picking_results.back().moves_to_visit.push_back(best_edge.GetMove());
         }
         if (best_idx > vtp_last_filled.back() &&
             (*visits_to_perform.back())[best_idx] > 0) {
@@ -1817,6 +1851,11 @@ void SearchWorker::PickNodesToExtendTask(Node* node, int base_depth,
       vtp_last_filled.pop_back();
     }
   }
+  receiver->reserve(picking_results.size());
+  for (int i = 0; i < picking_results.size(); i++) {
+    receiver->push_back(std::move(picking_results[i]));
+  }
+  picking_results.clear();
 }
 
 void SearchWorker::ExtendNode2(Node* node, int depth,

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -379,6 +379,8 @@ class SearchWorker {
   struct TaskWorkspace {
     std::array<Node::Iterator, 256> cur_iters;
     std::vector<std::unique_ptr<std::array<int, 256>>> vtp_buffer;
+    std::vector<NodeToProcess> picking_results;
+    std::vector<std::vector<Move>> move_list_cache;
   };
 
   struct PickTask {


### PR DESCRIPTION
Basic benchmark shows maybe 1-2% improvement.

There is a one liner in here which is potentially worth its own PR since its not really related. (Releasing the cache lock for ooo cache hit as soon as its processed inside processing task rather than waiting until later while the nodes lock is held.

Draft because:
1) moves_to_visit recycling in ExecuteOneIteration should be conditional on multi-gather (since otherwise we're just collecting empty arrays and never using them).
2) I'm still not really happy with the picking_results recycling.  Picking should recycle the instances used to communicate between task and main, rather than having to move the individual elements, potentially another small speed up over this, and maybe cleaner code.