### PR TITLE
Early exit if backend is idle and there is work to do.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -297,6 +297,16 @@ const OptionId SearchParams::kMinimumWorkPerTaskForProcessingId{
     "minimum-per-task-processing", "MinimumPerTaskProcessing",
     "Processing work won't be split into chunks smaller than this (unless its "
     "more than half of MinimumProcessingWork)."};
+const OptionId SearchParams::kIdlingMinimumWorkId{
+    "idling-minimum-work", "IdlingMinimumWork",
+    "Only early exit gathering due to 'idle' backend if more than this many "
+    "nodes will be sent to the backend."};
+const OptionId SearchParams::kThreadIdlingThresholdId{
+    "thread-idling-threshold", "ThreadIdlingThreshold",
+    "If there are more than this number of search threads that are not "
+    "actively in the process of either sending data to the backend or waiting "
+    "for data from the backend, assume that the backend is idle."};
+
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
   // Many of them are overridden with training specific values in tournament.cc.
@@ -369,6 +379,8 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kMinimumRemainingWorkSizeForPickingId, 0, 100000) =
       20;
   options->Add<IntOption>(kMinimumWorkPerTaskForProcessingId, 1, 100000) = 8;
+  options->Add<IntOption>(kIdlingMinimumWorkId, 0, 10000) = 0;
+  options->Add<IntOption>(kThreadIdlingThresholdId, 0, 128) = 1;
 
   options->HideOption(kNoiseEpsilonId);
   options->HideOption(kNoiseAlphaId);
@@ -449,7 +461,9 @@ SearchParams::SearchParams(const OptionsDict& options)
       kMinimumRemainingWorkSizeForPicking(
           options.Get<int>(kMinimumRemainingWorkSizeForPickingId)),
       kMinimumWorkPerTaskForProcessing(
-          options.Get<int>(kMinimumWorkPerTaskForProcessingId)) {
+          options.Get<int>(kMinimumWorkPerTaskForProcessingId)),
+      kIdlingMinimumWork(options.Get<int>(kIdlingMinimumWorkId)),
+      kThreadIdlingThreshold(options.Get<int>(kThreadIdlingThresholdId)) {
   if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +
           std::max(std::abs(kDrawScoreWhite), std::abs(kDrawScoreBlack)) >
       1.0f) {

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -128,6 +128,8 @@ class SearchParams {
   int GetMinimumWorkPerTaskForProcessing() const {
     return kMinimumWorkPerTaskForProcessing;
   }
+  int GetIdlingMinimumWork() const { return kIdlingMinimumWork; }
+  int GetThreadIdlingThreshold() const { return kThreadIdlingThreshold; }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -187,6 +189,8 @@ class SearchParams {
   static const OptionId kMinimumWorkSizeForPickingId;
   static const OptionId kMinimumRemainingWorkSizeForPickingId;
   static const OptionId kMinimumWorkPerTaskForProcessingId;
+  static const OptionId kIdlingMinimumWorkId;
+  static const OptionId kThreadIdlingThresholdId;
 
  private:
   const OptionsDict& options_;
@@ -239,6 +243,8 @@ class SearchParams {
   const int kMinimumWorkSizeForPicking;
   const int kMinimumRemainingWorkSizeForPicking;
   const int kMinimumWorkPerTaskForProcessing;
+  const int kIdlingMinimumWork;
+  const int kThreadIdlingThreshold;
 };
 
 }  // namespace lczero

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1073,7 +1073,7 @@ void SearchWorker::ExecuteOneIteration() {
   } else {
     GatherMinibatch();
   }
-  backend_waiting_counter_.fetch_add(1, std::memory_order_relaxed);
+  search_->backend_waiting_counter_.fetch_add(1, std::memory_order_relaxed);
 
   // 2b. Collect collisions.
   CollectCollisions();
@@ -1087,7 +1087,7 @@ void SearchWorker::ExecuteOneIteration() {
 
   // 4. Run NN computation.
   RunNNComputation();
-  backend_waiting_counter_.fetch_add(-1, std::memory_order_relaxed);
+  search_->backend_waiting_counter_.fetch_add(-1, std::memory_order_relaxed);
 
   // 5. Retrieve NN computations (and terminal values) into nodes.
   FetchMinibatchResults();
@@ -1346,7 +1346,7 @@ void SearchWorker::GatherMinibatch2() {
     // If only collisions and there is backend work to be done, and the backend is idle - exit immediately.
     if (non_collisions == 0 && minibatch_size > 0 &&
         computation_->GetCacheMisses() > 0 && 
-        backend_waiting_counter_.load(std::memory_order_relaxed) == 0) {
+        search_->backend_waiting_counter_.load(std::memory_order_relaxed) == 0) {
       return;
     }
   }

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -193,6 +193,7 @@ class Search {
       GUARDED_BY(counters_mutex_);
 
   std::atomic<int> pending_searchers_{0};
+  std::atomic<int> backend_waiting_counter_{0};
 
   std::vector<std::pair<Node*, int>> shared_collisions_
       GUARDED_BY(nodes_mutex_);
@@ -449,7 +450,6 @@ class SearchWorker {
   const bool moves_left_support_;
   IterationStats iteration_stats_;
   StoppersHints latest_time_manager_hints_;
-  std::atomic<int> backend_waiting_counter_{0};
 
   // Multigather task related fields.
 

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -194,6 +194,7 @@ class Search {
 
   std::atomic<int> pending_searchers_{0};
   std::atomic<int> backend_waiting_counter_{0};
+  std::atomic<int> thread_count_{0};
 
   std::vector<std::pair<Node*, int>> shared_collisions_
       GUARDED_BY(nodes_mutex_);

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -449,6 +449,7 @@ class SearchWorker {
   const bool moves_left_support_;
   IterationStats iteration_stats_;
   StoppersHints latest_time_manager_hints_;
+  std::atomic<int> backend_waiting_counter_{0};
 
   // Multigather task related fields.
 


### PR DESCRIPTION
Inspired by investigations into `position fen 1r1qr1k1/6bp/1n4p1/2pPpp2/1n3P2/1QN5/1P1N2PP/R4RBK w - - 0 24`

In that position on my machine this change almost doubles NPS at one point during the search (a few million nodes in).
In my 'standard benchmark run' it may be worth a couple of percent.

I think this heuristic can probably be improved upon, but it seems a pretty good start.

Since its an early exit - so long as the nps stays high I think its a clear win (the early exit itself is potentially worth elo at fixed nodes - untested).

I am unclear if there are any scenarios where this will be a net loss of nps - but I haven't thought of any of signifiance so far.