### PR TITLE
bypass meson compiler detection in build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -24,6 +24,11 @@ rem 3. In most cases you won't need to change anything further down.
 echo Deleting build directory:
 rd /s build
 
+set CC=cl
+set CXX=cl
+set CC_LD=link
+set CXX_LD=link
+
 if exist "C:\Program Files (x86)\Microsoft Visual Studio\2019" (
   where /q cl
   if errorlevel 1 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64


### PR DESCRIPTION
In some systems gcc is detected when building on windows, which we don't currently support. This should make it easier to diagnose.