### PR TITLE
Better default value for minimum picking work and clean up some old comments

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -287,8 +287,8 @@ const OptionId SearchParams::kMinimumWorkSizeForProcessingId{
     "accelerate processing."};
 const OptionId SearchParams::kMinimumWorkSizeForPickingId{
     "minimum-picking-work", "MinimumPickingWork",
-    "Search branches with this many collisions may be split off to task "
-    "workers."};
+    "Search branches with more than this many collisions/visits may be split "
+    "off to task workers."};
 const OptionId SearchParams::kMinimumRemainingWorkSizeForPickingId{
     "minimum-remaining-picking-work", "MinimumRemainingPickingWork",
     "Search branches won't be split off to task workers unless there is at "
@@ -375,7 +375,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<BoolOption>(kMultiGatherEnabledId) = false;
   options->Add<IntOption>(kTaskWorkersPerSearchWorkerId, 0, 128) = 4;
   options->Add<IntOption>(kMinimumWorkSizeForProcessingId, 2, 100000) = 20;
-  options->Add<IntOption>(kMinimumWorkSizeForPickingId, 1, 100000) = 10;
+  options->Add<IntOption>(kMinimumWorkSizeForPickingId, 1, 100000) = 1;
   options->Add<IntOption>(kMinimumRemainingWorkSizeForPickingId, 0, 100000) =
       20;
   options->Add<IntOption>(kMinimumWorkPerTaskForProcessingId, 1, 100000) = 8;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1366,11 +1366,8 @@ void SearchWorker::GatherMinibatch2() {
 void SearchWorker::ProcessPickedTask(int start_idx, int end_idx,
                                      TaskWorkspace* workspace) {
   auto& history = workspace->history;
-  // This code runs multiple passes of work across the same input in order to
-  // reduce taking/dropping mutexes in quick succession.
   history = search_->played_history_;
 
-  // First pass - Extend nodes.
   for (int i = start_idx; i < end_idx; i++) {
     auto& picked_node = minibatch_[i];
     if (picked_node.IsCollision()) continue;


### PR DESCRIPTION
Both zz and I have found a speed up in benchmarking reducing this parameter to its minimum value.
Also clean up some comments that were wrong/obsolete that were bothering me.