### PR TITLE
Add a WLD transform to apply contempt.

### DIFF
--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -131,6 +131,10 @@ class SearchParams {
   int GetIdlingMinimumWork() const { return kIdlingMinimumWork; }
   int GetThreadIdlingThreshold() const { return kThreadIdlingThreshold; }
 
+  const std::vector<float>& GetWLDTransformMatrix() const {
+    return kWLDTransformMatrix;
+  }
+
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
   static const OptionId kMaxPrefetchBatchId;
@@ -191,6 +195,7 @@ class SearchParams {
   static const OptionId kMinimumWorkPerTaskForProcessingId;
   static const OptionId kIdlingMinimumWorkId;
   static const OptionId kThreadIdlingThresholdId;
+  static const OptionId kContemptId;
 
  private:
   const OptionsDict& options_;
@@ -245,6 +250,7 @@ class SearchParams {
   const int kMinimumWorkPerTaskForProcessing;
   const int kIdlingMinimumWork;
   const int kThreadIdlingThreshold;
+  std::vector<float> kWLDTransformMatrix;
 };
 
 }  // namespace lczero

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -2343,6 +2343,50 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
   node_to_process->v = -computation.GetQVal(idx_in_computation);
   node_to_process->d = computation.GetDVal(idx_in_computation);
   node_to_process->m = computation.GetMVal(idx_in_computation);
+  const auto& transform = params_.GetWLDTransformMatrix();
+
+  float d = node_to_process->d;
+  float w = (node_to_process->v + 1.0f - d) / 2.0f;
+  float l = w - node_to_process->v;
+  if (node_to_process->depth % 2 == 1) {
+    std::swap(w, l);
+  }
+  float w_p[9];
+  float d_p[9];
+  float l_p[9];
+  w_p[0] = d_p[0] = l_p[0] = 1.0;
+  for (int i = 1; i < 9; i++) {
+    w_p[i] = w_p[i - 1] * w;
+    d_p[i] = d_p[i - 1] * d;
+    l_p[i] = l_p[i - 1] * l;
+  }
+  float new_d = 0.0f;
+  float new_w = 0.0f;
+  float new_l = 0.0f;
+  for (int i=0; i < 25; i++) {
+    int row = i % 25;
+    float other =
+        row < 9 ? w_p[row] : (row < 17 ? d_p[row - 9+1] : l_p[row - 17+1]);
+    new_w += transform[i] * other;
+    new_d += transform[i + 25] * other;
+    new_l += transform[i + 50] * other;
+  }
+
+  new_d = std::max(0.0f, new_d);
+  new_w = std::max(0.0f, new_w);
+  new_l = std::max(0.0f, new_l);
+  float sum = new_d + new_w + new_l;
+  d = new_d / sum;
+  w = new_w / sum;
+  l = new_l / sum;
+
+  if (node_to_process->depth % 2 == 1) {
+    std::swap(w, l);
+  }
+
+  node_to_process->v = w - l;
+  node_to_process->d = d;
+
   // ...and secondly, the policy data.
   // Calculate maximum first.
   float max_p = -std::numeric_limits<float>::infinity();


### PR DESCRIPTION
Tuned specifically for T70 vs self at 800 nodes vs 1200.

20k games played with both sides contempt set to 0 - elo measured by self play was 75. (Note: this also formed my training data for the tuning of the 75 constants lots of systemic bias to be had here...)

Giving contempt=1.0 to the 1200 node player match is still under way, but very early result after 250 games is 115 elo.
Knowing my luck that will converge back down, but for now its promising.