### PR TITLE
Don't divide by zero after the instamove.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 .clang_complete
 .DS_Store
+.cache/
 .clangd/
 build/
 __pycache__/

--- a/src/mcts/stoppers/smooth.cc
+++ b/src/mcts/stoppers/smooth.cc
@@ -204,7 +204,7 @@ class SmoothTimeManager : public TimeManager {
     // Update time_use estimation.
     const float this_move_time_use =
         move_allocated_time_ms_ <= 0.0f
-            ? 1
+            ? 1.0f
             : total_move_time / move_allocated_time_ms_;
     // Recompute expected move time for logging.
     const float expected_move_time = move_allocated_time_ms_ * timeuse_;

--- a/src/mcts/stoppers/smooth.cc
+++ b/src/mcts/stoppers/smooth.cc
@@ -202,7 +202,10 @@ class SmoothTimeManager : public TimeManager {
     const float this_move_time_fraction =
         avg_ms_per_move_ <= 0.0f ? 0.0f : total_move_time / avg_ms_per_move_;
     // Update time_use estimation.
-    const float this_move_time_use = total_move_time / move_allocated_time_ms_;
+    const float this_move_time_use =
+        move_allocated_time_ms_ <= 0.0f
+            ? 1
+            : total_move_time / move_allocated_time_ms_;
     // Recompute expected move time for logging.
     const float expected_move_time = move_allocated_time_ms_ * timeuse_;
     // If piggybank was used, cannot update timeuse_.


### PR DESCRIPTION
(which makes all remaining moves instamoves)

Fixes #1454