### PR TITLE
Clippy Threshold update.

### DIFF
--- a/src/benchmark/backendbench.cc
+++ b/src/benchmark/backendbench.cc
@@ -75,7 +75,7 @@ void BackendBenchmark::Run() {
   options.Add<IntOption>(kMaxBatchSizeId, 1, 1024) = 256;
   options.Add<StringOption>(kFenId) = ChessBoard::kStartposFen;
   options.Add<BoolOption>(kClippyId) = false;
-  options.Add<FloatOption>(kClippyThresholdId, 0.0f, 1.0f) = 0.2f;
+  options.Add<FloatOption>(kClippyThresholdId, 0.0f, 1.0f) = 0.15f;
 
   if (!options.ProcessAllFlags()) return;
 


### PR DESCRIPTION
Updating Clippy threshold to a parameter value that favors higher batch sizes (closer in functionality to old algorithm).
Snapshot of a running test before release deadline: mb32 is batch size 32 (1st peak), mb68 is 2nd peak:
```
   # ENGINE                          :  RATING  ERROR  CFS(%)   GAMES  DRAWS(%)
   1 lc0.net.256x20-t40-1541_mb68    :     4.3   11.1    69.6    1462      61.0
   2 lc0.net.256x20-t40-1541_mb32    :     0.2   10.9    51.7    1463      61.9
   3 stockfish-dev                   :     0.0   ----     ---    2925      61.5
```
Although MB=68 is the one with 21% higher NPS in backendbench and 32% higher NPS in match logfile, the result is very close but indicating that current threshold prefers smaller batch sizes too much (batch size 32 would be picked as best).
![plot_256x20-t40-1541_RTX3080](https://user-images.githubusercontent.com/11909324/108605635-a9348b80-73b5-11eb-87b4-d123a3410b9e.png)
Lines in graph show when the current best NPS is replaced by the clippy backendbench.
General consensus by other users seems to be something that comes close to 1.10, but I haven't see test data on this other than mine and the negative impact of higher batch sizes seems to be rather high. So I'm suggesting 1.15 (actually 0.15 in the code).