### PR TITLE
Fix log spam during infinite analysis

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -531,7 +531,7 @@ void Search::MaybeTriggerStop(const IterationStats& stats,
   // Don't stop when the root node is not yet expanded.
   if (total_playouts_ + initial_visits_ == 0) return;
 
-  if (!stop_.load(std::memory_order_acquire) || !ok_to_respond_bestmove_) {
+  if (!stop_.load(std::memory_order_acquire)) {
     if (stopper_->ShouldStop(stats, hints)) FireStopInternal();
   }
 


### PR DESCRIPTION
Fixes "Stopped search: Reached visits limit" log file spam when the visits limit is reached in analysis mode.

In infinite analysis mode, once stop_ is true but "stop" hasn't yet been received from the GUI, there is no need to spam FireStopInternal() (since the watchdog thread wait_for is non-blocking at that point anyway), and none of the ShouldStop methods for stoppers that can be present at such times appear to have important side effects. This fix should therefore be safe.

Fixes #1507