### PR TITLE
Add n_in_flight limiting for small trees.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -396,7 +396,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kBatchLimitStartId, 1, 10000) = 50;
   options->Add<IntOption>(kBatchLimitEndId, 1, 10000) = 1893;
   options->Add<IntOption>(kBatchLimitMaxId, 1, 10000) = 2622;
-  options->Add<FloatOption>(kBatchLimitPowerId, 0.01, 100) = 1.0;
+  options->Add<FloatOption>(kBatchLimitPowerId, 0.01, 100) = 2.5;
 
   options->HideOption(kNoiseEpsilonId);
   options->HideOption(kNoiseAlphaId);

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -315,6 +315,9 @@ const OptionId SearchParams::kBatchLimitEndId{
 const OptionId SearchParams::kBatchLimitMaxId{
     "batch-limit-max", "BatchLimitMax",
     "Maximum allowed n_in_flight limit regardless of tree size."};
+const OptionId SearchParams::kBatchLimitPowerId{
+    "batch-limit-power", "BatchLimitPower",
+    "Power to apply to the interpolation between 0 and max to make it curved."};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -393,6 +396,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kBatchLimitStartId, 1, 10000) = 50;
   options->Add<IntOption>(kBatchLimitEndId, 1, 10000) = 1893;
   options->Add<IntOption>(kBatchLimitMaxId, 1, 10000) = 2622;
+  options->Add<FloatOption>(kBatchLimitPowerId, 0.01, 100) = 1.0;
 
   options->HideOption(kNoiseEpsilonId);
   options->HideOption(kNoiseAlphaId);
@@ -483,7 +487,8 @@ SearchParams::SearchParams(const OptionsDict& options)
       kThreadIdlingThreshold(options.Get<int>(kThreadIdlingThresholdId)),
       kBatchLimitStart(options.Get<int>(kBatchLimitStartId)),
       kBatchLimitEnd(options.Get<int>(kBatchLimitEndId)),
-      kBatchLimitMax(options.Get<int>(kBatchLimitMaxId)) {
+      kBatchLimitMax(options.Get<int>(kBatchLimitMaxId)),
+      kBatchLimitPower(options.Get<float>(kBatchLimitPowerId)) {
   if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +
           std::max(std::abs(kDrawScoreWhite), std::abs(kDrawScoreBlack)) >
       1.0f) {

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -130,6 +130,9 @@ class SearchParams {
   }
   int GetIdlingMinimumWork() const { return kIdlingMinimumWork; }
   int GetThreadIdlingThreshold() const { return kThreadIdlingThreshold; }
+  int GetBatchLimitStart() const { return kBatchLimitStart; }
+  int GetBatchLimitEnd() const { return kBatchLimitEnd; }
+  int GetBatchLimitMax() const { return kBatchLimitMax; }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -191,6 +194,9 @@ class SearchParams {
   static const OptionId kMinimumWorkPerTaskForProcessingId;
   static const OptionId kIdlingMinimumWorkId;
   static const OptionId kThreadIdlingThresholdId;
+  static const OptionId kBatchLimitStartId;
+  static const OptionId kBatchLimitEndId;
+  static const OptionId kBatchLimitMaxId;
 
  private:
   const OptionsDict& options_;
@@ -245,6 +251,9 @@ class SearchParams {
   const int kMinimumWorkPerTaskForProcessing;
   const int kIdlingMinimumWork;
   const int kThreadIdlingThreshold;
+  const int kBatchLimitStart;
+  const int kBatchLimitEnd;
+  const int kBatchLimitMax;
 };
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -133,6 +133,7 @@ class SearchParams {
   int GetBatchLimitStart() const { return kBatchLimitStart; }
   int GetBatchLimitEnd() const { return kBatchLimitEnd; }
   int GetBatchLimitMax() const { return kBatchLimitMax; }
+  float GetBatchLimitPower() const { return kBatchLimitPower; }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -197,6 +198,7 @@ class SearchParams {
   static const OptionId kBatchLimitStartId;
   static const OptionId kBatchLimitEndId;
   static const OptionId kBatchLimitMaxId;
+  static const OptionId kBatchLimitPowerId;
 
  private:
   const OptionsDict& options_;
@@ -254,6 +256,7 @@ class SearchParams {
   const int kBatchLimitStart;
   const int kBatchLimitEnd;
   const int kBatchLimitMax;
+  const float kBatchLimitPower;
 };
 
 }  // namespace lczero

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1252,8 +1252,8 @@ void SearchWorker::GatherMinibatch2() {
     if (cur_n > params_.GetBatchLimitStart() && cur_n < params_.GetBatchLimitEnd()) {
       in_flight_threshold =
           mix(params_.GetBatchLimitMax(), 0,
-              (static_cast<float>(cur_n) - params_.GetBatchLimitStart()) /
-                  (params_.GetBatchLimitEnd() - params_.GetBatchLimitStart()));
+              std::powf((static_cast<float>(cur_n) - params_.GetBatchLimitStart()) /
+                  (params_.GetBatchLimitEnd() - params_.GetBatchLimitStart()), params_.GetBatchLimitPower()));
     } else if (cur_n >= params_.GetBatchLimitEnd()) {
       in_flight_threshold = params_.GetBatchLimitMax();
     }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1252,7 +1252,7 @@ void SearchWorker::GatherMinibatch2() {
     if (cur_n > params_.GetBatchLimitStart() && cur_n < params_.GetBatchLimitEnd()) {
       in_flight_threshold =
           mix(params_.GetBatchLimitMax(), 0,
-              std::powf((static_cast<float>(cur_n) - params_.GetBatchLimitStart()) /
+              std::pow((static_cast<float>(cur_n) - params_.GetBatchLimitStart()) /
                   (params_.GetBatchLimitEnd() - params_.GetBatchLimitStart()), params_.GetBatchLimitPower()));
     } else if (cur_n >= params_.GetBatchLimitEnd()) {
       in_flight_threshold = params_.GetBatchLimitMax();


### PR DESCRIPTION
Used in combination with increasing default out of order limit and max collision limits aims to improve elo at match play without poor consequences at small fixed nodes.

Only implemented for multigather=true here, I kind of expect that we'll complete the multigather landing before this is ready.

Values for the new parameters come from a tune at fairly short TC (1"+0.1") with 2080TI using 703810. There are probably fairly broad options available that are similar. The 'max' is actually a no-op in the tuning scenario since its > threads*(minibatch_size+max_collision_visits).  The tune pretty much equally preferred all values in the deadspace above that limit, but value is selected for its pairing with the end parameter to create the slope.

Haven't started validation tests yet.