### PR TITLE
Increase default moooef

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -343,7 +343,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kMaxCollisionEventsId, 1, 65536) = 32;
   options->Add<IntOption>(kMaxCollisionVisitsId, 1, 1000000) = 9999;
   options->Add<BoolOption>(kOutOfOrderEvalId) = true;
-  options->Add<FloatOption>(kMaxOutOfOrderEvalsId, 0.0f, 100.0f) = 1.0f;
+  options->Add<FloatOption>(kMaxOutOfOrderEvalsId, 0.0f, 100.0f) = 2.4f;
   options->Add<BoolOption>(kStickyEndgamesId) = true;
   options->Add<BoolOption>(kSyzygyFastPlayId) = false;
   options->Add<IntOption>(kMultiPvId, 1, 500) = 1;


### PR DESCRIPTION
This value we use at competition. It has clear nps improvement properties.
Fixed node 1k test non-regression:
Score of lc0 more-ooo vs lc0: 354 - 336 - 1310 [0.504]
...      lc0 more-ooo playing White: 231 - 131 - 638  [0.550] 1000
...      lc0 more-ooo playing Black: 123 - 205 - 672  [0.459] 1000
...      White vs Black: 436 - 254 - 1310  [0.545] 2000
Elo difference: 3.1 +/- 8.9, LOS: 75.3 %, DrawRatio: 65.5 %
2000 of 2000 games finished.