### PR TITLE
Limited mcv

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -396,7 +396,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kBatchLimitStartId, 1, 10000) = 50;
   options->Add<IntOption>(kBatchLimitEndId, 1, 10000) = 1893;
   options->Add<IntOption>(kBatchLimitMaxId, 1, 10000) = 2622;
-  options->Add<FloatOption>(kBatchLimitPowerId, 0.01, 100) = 1.0;
+  options->Add<FloatOption>(kBatchLimitPowerId, 0.01, 100) = 2.5;
 
   options->HideOption(kNoiseEpsilonId);
   options->HideOption(kNoiseAlphaId);

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -306,18 +306,16 @@ const OptionId SearchParams::kThreadIdlingThresholdId{
     "If there are more than this number of search threads that are not "
     "actively in the process of either sending data to the backend or waiting "
     "for data from the backend, assume that the backend is idle."};
-const OptionId SearchParams::kBatchLimitStartId{
-    "batch-limit-start", "BatchLimitStart",
-    "Tree size where max n_in_flight allowed limit starts scaling up from 0."};
-const OptionId SearchParams::kBatchLimitEndId{
-    "batch-limit-end", "BatchLimitEnd",
-    "Tree size where n_in_flight allowed limit reaches max."};
-const OptionId SearchParams::kBatchLimitMaxId{
-    "batch-limit-max", "BatchLimitMax",
-    "Maximum allowed n_in_flight limit regardless of tree size."};
-const OptionId SearchParams::kBatchLimitPowerId{
-    "batch-limit-power", "BatchLimitPower",
-    "Power to apply to the interpolation between 0 and max to make it curved."};
+const OptionId SearchParams::kMaxCollisionVisitsScalingStartId{
+    "max-collision-visits-scaling-start", "MaxCollisionVisitsScalingStart",
+    "Tree size where max collision visits starts scaling up from 1."};
+const OptionId SearchParams::kMaxCollisionVisitsScalingEndId{
+    "max-collision-visits-scaling-end", "MaxCollisionVisitsScalingEnd",
+    "Tree size where max collision visits reaches max. Set to 0 to disable "
+    "scaling entirely."};
+const OptionId SearchParams::kMaxCollisionVisitsScalingPowerId{
+    "max-collision-visits-scaling-power", "MaxCollisionVisitsScalingPower",
+    "Power to apply to the interpolation between 1 and max to make it curved."};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -353,7 +351,11 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kCacheHistoryLengthId, 0, 7) = 0;
   options->Add<FloatOption>(kPolicySoftmaxTempId, 0.1f, 10.0f) = 1.359f;
   options->Add<IntOption>(kMaxCollisionEventsId, 1, 65536) = 917;
-  options->Add<IntOption>(kMaxCollisionVisitsId, 1, 1000000) = 1000;
+  options->Add<IntOption>(kMaxCollisionVisitsId, 1, 100000000) = 2631;
+  options->Add<IntOption>(kMaxCollisionVisitsScalingStartId, 1, 100000) = 28;
+  options->Add<IntOption>(kMaxCollisionVisitsScalingEndId, 0, 100000000) = 9520;
+  options->Add<FloatOption>(kMaxCollisionVisitsScalingPowerId, 0.01, 100) =
+      1.25;
   options->Add<BoolOption>(kOutOfOrderEvalId) = true;
   options->Add<FloatOption>(kMaxOutOfOrderEvalsId, 0.0f, 100.0f) = 2.4f;
   options->Add<BoolOption>(kStickyEndgamesId) = true;
@@ -393,10 +395,6 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kMinimumWorkPerTaskForProcessingId, 1, 100000) = 8;
   options->Add<IntOption>(kIdlingMinimumWorkId, 0, 10000) = 0;
   options->Add<IntOption>(kThreadIdlingThresholdId, 0, 128) = 1;
-  options->Add<IntOption>(kBatchLimitStartId, 1, 10000) = 28;
-  options->Add<IntOption>(kBatchLimitEndId, 1, 10000) = 9207;
-  options->Add<IntOption>(kBatchLimitMaxId, 1, 10000) = 2650;
-  options->Add<FloatOption>(kBatchLimitPowerId, 0.01, 100) = 1.3;
 
   options->HideOption(kNoiseEpsilonId);
   options->HideOption(kNoiseAlphaId);
@@ -485,10 +483,12 @@ SearchParams::SearchParams(const OptionsDict& options)
           options.Get<int>(kMinimumWorkPerTaskForProcessingId)),
       kIdlingMinimumWork(options.Get<int>(kIdlingMinimumWorkId)),
       kThreadIdlingThreshold(options.Get<int>(kThreadIdlingThresholdId)),
-      kBatchLimitStart(options.Get<int>(kBatchLimitStartId)),
-      kBatchLimitEnd(options.Get<int>(kBatchLimitEndId)),
-      kBatchLimitMax(options.Get<int>(kBatchLimitMaxId)),
-      kBatchLimitPower(options.Get<float>(kBatchLimitPowerId)) {
+      kMaxCollisionVisitsScalingStart(
+          options.Get<int>(kMaxCollisionVisitsScalingStartId)),
+      kMaxCollisionVisitsScalingEnd(
+          options.Get<int>(kMaxCollisionVisitsScalingEndId)),
+      kMaxCollisionVisitsScalingPower(
+          options.Get<float>(kMaxCollisionVisitsScalingPowerId)) {
   if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +
           std::max(std::abs(kDrawScoreWhite), std::abs(kDrawScoreBlack)) >
       1.0f) {

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -393,10 +393,10 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kMinimumWorkPerTaskForProcessingId, 1, 100000) = 8;
   options->Add<IntOption>(kIdlingMinimumWorkId, 0, 10000) = 0;
   options->Add<IntOption>(kThreadIdlingThresholdId, 0, 128) = 1;
-  options->Add<IntOption>(kBatchLimitStartId, 1, 10000) = 50;
-  options->Add<IntOption>(kBatchLimitEndId, 1, 10000) = 1893;
-  options->Add<IntOption>(kBatchLimitMaxId, 1, 10000) = 2622;
-  options->Add<FloatOption>(kBatchLimitPowerId, 0.01, 100) = 2.5;
+  options->Add<IntOption>(kBatchLimitStartId, 1, 10000) = 28;
+  options->Add<IntOption>(kBatchLimitEndId, 1, 10000) = 9207;
+  options->Add<IntOption>(kBatchLimitMaxId, 1, 10000) = 2650;
+  options->Add<FloatOption>(kBatchLimitPowerId, 0.01, 100) = 1.3;
 
   options->HideOption(kNoiseEpsilonId);
   options->HideOption(kNoiseAlphaId);

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -315,6 +315,9 @@ const OptionId SearchParams::kBatchLimitEndId{
 const OptionId SearchParams::kBatchLimitMaxId{
     "batch-limit-max", "BatchLimitMax",
     "Maximum allowed n_in_flight limit regardless of tree size."};
+const OptionId SearchParams::kBatchLimitPowerId{
+    "batch-limit-power", "BatchLimitPower",
+    "Power to apply to the interpolation between 0 and max to make it curved."};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -393,6 +396,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kBatchLimitStartId, 1, 10000) = 50;
   options->Add<IntOption>(kBatchLimitEndId, 1, 10000) = 1893;
   options->Add<IntOption>(kBatchLimitMaxId, 1, 10000) = 2622;
+  options->Add<FloatOption>(kBatchLimitPowerId, 0.01, 100) = 1.0;
 
   options->HideOption(kNoiseEpsilonId);
   options->HideOption(kNoiseAlphaId);
@@ -483,7 +487,8 @@ SearchParams::SearchParams(const OptionsDict& options)
       kThreadIdlingThreshold(options.Get<int>(kThreadIdlingThresholdId)),
       kBatchLimitStart(options.Get<int>(kBatchLimitStartId)),
       kBatchLimitEnd(options.Get<int>(kBatchLimitEndId)),
-      kBatchLimitMax(options.Get<int>(kBatchLimitMaxId)) {
+      kBatchLimitMax(options.Get<int>(kBatchLimitMaxId)),
+      kBatchLimitPower(options.Get<float>(kBatchLimitPowerId)) {
   if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +
           std::max(std::abs(kDrawScoreWhite), std::abs(kDrawScoreBlack)) >
       1.0f) {

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -351,9 +351,9 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kCacheHistoryLengthId, 0, 7) = 0;
   options->Add<FloatOption>(kPolicySoftmaxTempId, 0.1f, 10.0f) = 1.359f;
   options->Add<IntOption>(kMaxCollisionEventsId, 1, 65536) = 917;
-  options->Add<IntOption>(kMaxCollisionVisitsId, 1, 100000000) = 2631;
+  options->Add<IntOption>(kMaxCollisionVisitsId, 1, 100000000) = 80000;
   options->Add<IntOption>(kMaxCollisionVisitsScalingStartId, 1, 100000) = 28;
-  options->Add<IntOption>(kMaxCollisionVisitsScalingEndId, 0, 100000000) = 9520;
+  options->Add<IntOption>(kMaxCollisionVisitsScalingEndId, 0, 100000000) = 145000;
   options->Add<FloatOption>(kMaxCollisionVisitsScalingPowerId, 0.01, 100) =
       1.25;
   options->Add<BoolOption>(kOutOfOrderEvalId) = true;

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -130,10 +130,15 @@ class SearchParams {
   }
   int GetIdlingMinimumWork() const { return kIdlingMinimumWork; }
   int GetThreadIdlingThreshold() const { return kThreadIdlingThreshold; }
-  int GetBatchLimitStart() const { return kBatchLimitStart; }
-  int GetBatchLimitEnd() const { return kBatchLimitEnd; }
-  int GetBatchLimitMax() const { return kBatchLimitMax; }
-  float GetBatchLimitPower() const { return kBatchLimitPower; }
+  int GetMaxCollisionVisitsScalingStart() const {
+    return kMaxCollisionVisitsScalingStart;
+  }
+  int GetMaxCollisionVisitsScalingEnd() const {
+    return kMaxCollisionVisitsScalingEnd;
+  }
+  float GetMaxCollisionVisitsScalingPower() const {
+    return kMaxCollisionVisitsScalingPower;
+  }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -195,10 +200,9 @@ class SearchParams {
   static const OptionId kMinimumWorkPerTaskForProcessingId;
   static const OptionId kIdlingMinimumWorkId;
   static const OptionId kThreadIdlingThresholdId;
-  static const OptionId kBatchLimitStartId;
-  static const OptionId kBatchLimitEndId;
-  static const OptionId kBatchLimitMaxId;
-  static const OptionId kBatchLimitPowerId;
+  static const OptionId kMaxCollisionVisitsScalingStartId;
+  static const OptionId kMaxCollisionVisitsScalingEndId;
+  static const OptionId kMaxCollisionVisitsScalingPowerId;
 
  private:
   const OptionsDict& options_;
@@ -253,10 +257,9 @@ class SearchParams {
   const int kMinimumWorkPerTaskForProcessing;
   const int kIdlingMinimumWork;
   const int kThreadIdlingThreshold;
-  const int kBatchLimitStart;
-  const int kBatchLimitEnd;
-  const int kBatchLimitMax;
-  const float kBatchLimitPower;
+  const int kMaxCollisionVisitsScalingStart;
+  const int kMaxCollisionVisitsScalingEnd;
+  const float kMaxCollisionVisitsScalingPower;
 };
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -130,6 +130,9 @@ class SearchParams {
   }
   int GetIdlingMinimumWork() const { return kIdlingMinimumWork; }
   int GetThreadIdlingThreshold() const { return kThreadIdlingThreshold; }
+  int GetBatchLimitStart() const { return kBatchLimitStart; }
+  int GetBatchLimitEnd() const { return kBatchLimitEnd; }
+  int GetBatchLimitMax() const { return kBatchLimitMax; }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -191,6 +194,9 @@ class SearchParams {
   static const OptionId kMinimumWorkPerTaskForProcessingId;
   static const OptionId kIdlingMinimumWorkId;
   static const OptionId kThreadIdlingThresholdId;
+  static const OptionId kBatchLimitStartId;
+  static const OptionId kBatchLimitEndId;
+  static const OptionId kBatchLimitMaxId;
 
  private:
   const OptionsDict& options_;
@@ -245,6 +251,9 @@ class SearchParams {
   const int kMinimumWorkPerTaskForProcessing;
   const int kIdlingMinimumWork;
   const int kThreadIdlingThreshold;
+  const int kBatchLimitStart;
+  const int kBatchLimitEnd;
+  const int kBatchLimitMax;
 };
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -133,6 +133,7 @@ class SearchParams {
   int GetBatchLimitStart() const { return kBatchLimitStart; }
   int GetBatchLimitEnd() const { return kBatchLimitEnd; }
   int GetBatchLimitMax() const { return kBatchLimitMax; }
+  float GetBatchLimitPower() const { return kBatchLimitPower; }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -197,6 +198,7 @@ class SearchParams {
   static const OptionId kBatchLimitStartId;
   static const OptionId kBatchLimitEndId;
   static const OptionId kBatchLimitMaxId;
+  static const OptionId kBatchLimitPowerId;
 
  private:
   const OptionsDict& options_;
@@ -254,6 +256,7 @@ class SearchParams {
   const int kBatchLimitStart;
   const int kBatchLimitEnd;
   const int kBatchLimitMax;
+  const float kBatchLimitPower;
 };
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -84,7 +84,7 @@ class SearchParams {
   int GetCacheHistoryLength() const { return kCacheHistoryLength; }
   float GetPolicySoftmaxTemp() const { return kPolicySoftmaxTemp; }
   int GetMaxCollisionEvents() const { return kMaxCollisionEvents; }
-  int GetMaxCollisionVisitsId() const { return kMaxCollisionVisits; }
+  int GetMaxCollisionVisits() const { return kMaxCollisionVisits; }
   bool GetOutOfOrderEval() const { return kOutOfOrderEval; }
   bool GetStickyEndgames() const { return kStickyEndgames; }
   bool GetSyzygyFastPlay() const { return kSyzygyFastPlay; }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1252,8 +1252,8 @@ void SearchWorker::GatherMinibatch2() {
     if (cur_n > params_.GetBatchLimitStart() && cur_n < params_.GetBatchLimitEnd()) {
       in_flight_threshold =
           mix(params_.GetBatchLimitMax(), 0,
-              (static_cast<float>(cur_n) - params_.GetBatchLimitStart()) /
-                  (params_.GetBatchLimitEnd() - params_.GetBatchLimitStart()));
+              std::powf((static_cast<float>(cur_n) - params_.GetBatchLimitStart()) /
+                  (params_.GetBatchLimitEnd() - params_.GetBatchLimitStart()), params_.GetBatchLimitPower()));
     } else if (cur_n >= params_.GetBatchLimitEnd()) {
       in_flight_threshold = params_.GetBatchLimitMax();
     }

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1252,7 +1252,7 @@ void SearchWorker::GatherMinibatch2() {
     if (cur_n > params_.GetBatchLimitStart() && cur_n < params_.GetBatchLimitEnd()) {
       in_flight_threshold =
           mix(params_.GetBatchLimitMax(), 0,
-              std::powf((static_cast<float>(cur_n) - params_.GetBatchLimitStart()) /
+              std::pow((static_cast<float>(cur_n) - params_.GetBatchLimitStart()) /
                   (params_.GetBatchLimitEnd() - params_.GetBatchLimitStart()), params_.GetBatchLimitPower()));
     } else if (cur_n >= params_.GetBatchLimitEnd()) {
       in_flight_threshold = params_.GetBatchLimitMax();


### PR DESCRIPTION
Similar 1k nodes regression to limiting n_in_flight - after partial tuning I got the following result.
Score of lc0 vs lc0 dev: 438 - 303 - 1259 [0.534]
...      lc0 playing White: 273 - 103 - 624  [0.585] 1000
...      lc0 playing Black: 165 - 200 - 635  [0.482] 1000
...      White vs Black: 473 - 268 - 1259  [0.551] 2000
Elo difference: 23.5 +/- 9.2, LOS: 100.0 %, DrawRatio: 62.9 %
2000 of 2000 games finished.

Bonus here is that max collision visits preferred curvature is closer to straight line which potentially implies we can scale MCV=tree_size/4 to an almost arbitrary level.  Since this increases the limit over 1000 for even moderately sized trees - this potentially has better nps characteristics than our competition version. Also since this is a collision limit and not an n_in_flight limit, earlier batches should be a tiny bit faster.
Will run some time control tests of this and the other option, see if there is an obvious preference on that side.  This option is probably the default otherwise.