### PR TITLE
Return lost check for whether root node is DTZ before doing WDL lookups in search.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1911,7 +1911,8 @@ void SearchWorker::ExtendNode(Node* node, int depth,
     }
 
     // Neither by-position or by-rule termination, but maybe it's a TB position.
-    if (search_->syzygy_tb_ && board.castlings().no_legal_castle() &&
+    if (search_->syzygy_tb_ && !search_->root_is_in_dtz_ &&
+        board.castlings().no_legal_castle() &&
         history->Last().GetRule50Ply() == 0 &&
         (board.ours() | board.theirs()).count() <=
             search_->syzygy_tb_->max_cardinality()) {


### PR DESCRIPTION
I didn't merge the original PR including this change before doing the multigather branches. Multigather branches introduced a new version of this function in parallel.  Then following cleanup brought everything to use the new version, meaning the old version with the correct code had been lost.