### PR TITLE
Make multi-gather default.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -341,7 +341,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kCacheHistoryLengthId, 0, 7) = 0;
   options->Add<FloatOption>(kPolicySoftmaxTempId, 0.1f, 10.0f) = 1.359f;
   options->Add<IntOption>(kMaxCollisionEventsId, 1, 65536) = 32;
-  options->Add<IntOption>(kMaxCollisionVisitsId, 1, 1000000) = 9999;
+  options->Add<IntOption>(kMaxCollisionVisitsId, 1, 1000000) = 32;
   options->Add<BoolOption>(kOutOfOrderEvalId) = true;
   options->Add<FloatOption>(kMaxOutOfOrderEvalsId, 0.0f, 100.0f) = 2.4f;
   options->Add<BoolOption>(kStickyEndgamesId) = true;
@@ -372,7 +372,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kDrawScoreBlackId, -100, 100) = 0;
   options->Add<FloatOption>(kNpsLimitId, 0.0f, 1e6f) = 0.0f;
   options->Add<IntOption>(kSolidTreeThresholdId, 1, 2000000000) = 100;
-  options->Add<BoolOption>(kMultiGatherEnabledId) = false;
+  options->Add<BoolOption>(kMultiGatherEnabledId) = true;
   options->Add<IntOption>(kTaskWorkersPerSearchWorkerId, 0, 128) = 4;
   options->Add<IntOption>(kMinimumWorkSizeForProcessingId, 2, 100000) = 20;
   options->Add<IntOption>(kMinimumWorkSizeForPickingId, 1, 100000) = 1;

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -139,6 +139,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   defaults->Set<std::string>(NetworkFactory::kBackendId, "multiplexing");
   defaults->Set<bool>(SearchParams::kStickyEndgamesId, false);
   defaults->Set<bool>(SearchParams::kTwoFoldDrawsId, false);
+  defaults->Set<int>(SearchParams::kTaskWorkersPerSearchWorkerId, 0);
 }
 
 SelfPlayTournament::SelfPlayTournament(


### PR DESCRIPTION
Testing in training looks 'fine' - so I think its time to make it the default.

Forcing the task workers default to 0 for selfplay since we already have parallelism to chew up cpus.