### PR TITLE
A first step towards value repair

### DIFF
--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -78,7 +78,7 @@ class Search {
 
   // Returns best move, from the point of view of white player. And also ponder.
   // May or may not use temperature, according to the settings.
-  std::pair<Move, Move> GetBestMove();
+  std::pair<Move, Move> GetBestMove(const bool force_temp_to_zero);
 
   // Returns the evaluation of the best move, WITHOUT temperature. This differs
   // from the above function; with temperature enabled, these two functions may
@@ -100,7 +100,7 @@ class Search {
 
  private:
   // Computes the best move, maybe with temperature (according to the settings).
-  void EnsureBestMoveKnown();
+  void EnsureBestMoveKnown(const bool force_temp_to_zero);
 
   // Returns a child with most visits, with or without temperature.
   // NoTemperature is safe to use on non-extended nodes, while WithTemperature


### PR DESCRIPTION
Implement value repair by triggering temp=0 if a large enough discrepancy between 1 node eval and best eval after search.

Currently, this patch hardcodes a threshold for surprise. If the absolute value of `best_eval.wl - orig_eval.wl` is greater than this threshold, temp=0 will be applied for the rest of the game.

Hopefully, this behaviour will in it self be good in that it should correct bad evaluations faster than if these positions were played out with temperature and deblunder, but the mechanism can also be combined with an opening book of positions that we know a priori will trigger this behaviour, in more concerted efforts at value repair.