### PR TITLE
Improvements for backendbench

### DIFF
--- a/src/benchmark/backendbench.cc
+++ b/src/benchmark/backendbench.cc
@@ -1,6 +1,6 @@
 /*
   This file is part of Leela Chess Zero.
-  Copyright (C) 2020 The LCZero Authors
+  Copyright (C) 2020-2021 The LCZero Authors
 
   Leela Chess is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -44,6 +44,8 @@ const OptionId kStartBatchSizeId{"start-batch-size", "",
                                  "Start benchmark from this batch size."};
 const OptionId kMaxBatchSizeId{"max-batch-size", "",
                                "Maximum batch size to benchmark."};
+const OptionId kBatchStepId{"batch-step", "",
+                            "Step of batch size in benchmark."};
 const OptionId kFenId{"fen", "", "Benchmark initial position FEN."};
 
 const OptionId kClippyId{"clippy", "", "Enable helpful assistant."};
@@ -77,6 +79,7 @@ void BackendBenchmark::Run() {
   options.Add<IntOption>(kBatchesId, 1, 999999999) = 100;
   options.Add<IntOption>(kStartBatchSizeId, 1, 1024) = 1;
   options.Add<IntOption>(kMaxBatchSizeId, 1, 1024) = 256;
+  options.Add<IntOption>(kBatchStepId, 1, 256) = 1;
   options.Add<StringOption>(kFenId) = ChessBoard::kStartposFen;
   options.Add<BoolOption>(kClippyId) = false;
   options.Add<FloatOption>(kClippyThresholdId, 0.0f, 1.0f) = 0.15f;
@@ -97,7 +100,8 @@ void BackendBenchmark::Run() {
     std::optional<std::chrono::time_point<std::chrono::steady_clock>> pending;
 
     for (int i = option_dict.Get<int>(kStartBatchSizeId);
-         i <= option_dict.Get<int>(kMaxBatchSizeId); i++) {
+         i <= option_dict.Get<int>(kMaxBatchSizeId);
+         i += option_dict.Get<int>(kBatchStepId)) {
       const auto start = std::chrono::steady_clock::now();
       // TODO: support threads not equal to 1 to be able to more sensibly test
       // multiplexing backend.

--- a/src/benchmark/backendbench.cc
+++ b/src/benchmark/backendbench.cc
@@ -93,6 +93,14 @@ void BackendBenchmark::Run() {
 
     NodeTree tree;
     tree.ResetToPosition(option_dict.Get<std::string>(kFenId), {});
+
+    // Do any backend initialization outside the loop.
+    auto warmup = network->NewComputation();
+    warmup->AddInput(EncodePositionForNN(
+        network->GetCapabilities().input_format, tree.GetPositionHistory(), 8,
+        FillEmptyHistory::ALWAYS, nullptr));
+    warmup->ComputeBlocking();
+
     const int batches = option_dict.Get<int>(kBatchesId);
 
     int best = 1;

--- a/src/benchmark/backendbench.cc
+++ b/src/benchmark/backendbench.cc
@@ -40,6 +40,8 @@ const OptionId kThreadsOptionId{"threads", "Threads",
                                 "Number of (CPU) worker threads to use.", 't'};
 const OptionId kBatchesId{"batches", "",
                           "Number of batches to run as a benchmark."};
+const OptionId kStartBatchSizeId{"start-batch-size", "",
+                                 "Start benchmark from this batch size."};
 const OptionId kMaxBatchSizeId{"max-batch-size", "",
                                "Maximum batch size to benchmark."};
 const OptionId kFenId{"fen", "", "Benchmark initial position FEN."};
@@ -47,8 +49,9 @@ const OptionId kFenId{"fen", "", "Benchmark initial position FEN."};
 const OptionId kClippyId{"clippy", "", "Enable helpful assistant."};
 
 const OptionId kClippyThresholdId{"clippy-threshold", "",
-                                "Ratio of nps improvement necessary for each "
-                                "doubling of batchsize to be considered best."};
+                                  "Ratio of nps improvement necessary for each "
+                                  "doubling of batchsize to be considered "
+                                  "best."};
 
 void Clippy(std::string msg) {
   std::cout << "  __" << std::endl;
@@ -72,6 +75,7 @@ void BackendBenchmark::Run() {
   options.Add<IntOption>(kThreadsOptionId, 1, 128) = kDefaultThreads;
 
   options.Add<IntOption>(kBatchesId, 1, 999999999) = 100;
+  options.Add<IntOption>(kStartBatchSizeId, 1, 1024) = 1;
   options.Add<IntOption>(kMaxBatchSizeId, 1, 1024) = 256;
   options.Add<StringOption>(kFenId) = ChessBoard::kStartposFen;
   options.Add<BoolOption>(kClippyId) = false;
@@ -92,7 +96,8 @@ void BackendBenchmark::Run() {
     float best_nps = 0.0f;
     std::optional<std::chrono::time_point<std::chrono::steady_clock>> pending;
 
-    for (int i = 1; i <= option_dict.Get<int>(kMaxBatchSizeId); i++) {
+    for (int i = option_dict.Get<int>(kStartBatchSizeId);
+         i <= option_dict.Get<int>(kMaxBatchSizeId); i++) {
       const auto start = std::chrono::steady_clock::now();
       // TODO: support threads not equal to 1 to be able to more sensibly test
       // multiplexing backend.


### PR DESCRIPTION
Adds two new options, `--start-batch-size` and `--batch-step` and runs one minimal computation outside the loop to warm-up the backend.