### PR TITLE
support for windows mimalloc

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -124,6 +124,17 @@ if short_rev != ''
   message('Using build identifier "' + build_identifier + '".')
 endif
 
+# Some malloc libraries require to be linked first.
+if get_option('malloc') == 'mimalloc' and cc.get_id() == 'msvc'
+  if get_option('b_vscrt') != 'md' and get_option('b_vscrt') != 'mdd'
+    error('You need -Db_vscrt=md (or mdd)')
+  endif
+  add_project_link_arguments('/INCLUDE:mi_version', language : 'cpp')
+  deps += cc.find_library('mimalloc-override', dirs: get_option('mimalloc_libdir'), required: true)
+elif get_option('malloc') != ''
+  deps += cc.find_library(get_option('malloc'), required: true)
+endif
+
 #############################################################################
 ## Main files
 #############################################################################
@@ -554,10 +565,6 @@ endif
   endif
 
   deps += cc.find_library('libatomic', required: false)
-
-  if get_option('malloc') != ''
-    deps += cc.find_library(get_option('malloc'), required: true)
-  endif
 
 #############################################################################
 ## Main Executable

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -116,7 +116,7 @@ option('malloc',
 option('mimalloc_libdir',
        type : 'string',
        value: '',
-       description: 'Library directory for malloc=mimallloc')
+       description: 'Library directory for malloc=mimalloc')
 
 option('popcnt',
        type: 'boolean',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -113,6 +113,11 @@ option('malloc',
        value: '',
        description: 'Use alternative memory allocator, e.g. tcmalloc/jemalloc')
 
+option('mimalloc_libdir',
+       type : 'string',
+       value: '',
+       description: 'Library directory for malloc=mimallloc')
+
 option('popcnt',
        type: 'boolean',
        value: true,


### PR DESCRIPTION
For windows, mimalloc seems to be a good replacement for the default allocator. Huge trees are destructed many times faster and I also see a measurable nps increase with the random backend.

To build you need to pass `-Dmalloc=mimalloc -Dmimalloc_libdir=c:\path\to\mimalloc\libraries` to meson, and to run you will need to copy `mimalloc-redirect.dll` and `mimalloc-override.dll`.

Thanks to @cn4750 for the suggestion. 