### PR TITLE
Use NHCW layout for fused winograd residual block

### DIFF
--- a/src/neural/cuda/common_kernels.cu
+++ b/src/neural/cuda/common_kernels.cu
@@ -597,25 +597,45 @@ template void PolicyMap<half>(int N, half* output, const half* input,
 template void FilterTransform<float>(int N, int C, float* transformedFilter,
                                      const float* filter);
 
-template void InputTransform<float>(int N, int C, float* transformed_input,
-                                    const float* input);
+template void InputTransform<float, true>(int N, int C,
+                                          float* transformed_input,
+                                          const float* input);
 
-template void OutputTransform<float, true, true, true, true>(
+template void InputTransform<float, false>(int N, int C,
+                                           float* transformed_input,
+                                           const float* input);
+
+template void OutputTransform<float, true, true, true, true, false, false>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
     const float* w2, const float* b2);
 
-template void OutputTransform<float, false, true, true, false>(
+template void OutputTransform<float, false, true, true, true, false, false>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
     const float* w2, const float* b2);
 
-template void OutputTransform<float, false, true, true, true>(
+template void OutputTransform<float, true, true, true, true, true, false>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
     const float* w2, const float* b2);
 
-template void OutputTransform<float, false, false, true, false>(
+template void OutputTransform<float, false, true, true, true, true, false>(
+    int N, int C, int se_K, float* output, const float* input,
+    const float* skip, const float* bias, const float* w1, const float* b1,
+    const float* w2, const float* b2);
+
+template void OutputTransform<float, false, true, true, false, false, false>(
+    int N, int C, int se_K, float* output, const float* input,
+    const float* skip, const float* bias, const float* w1, const float* b1,
+    const float* w2, const float* b2);
+
+template void OutputTransform<float, false, true, true, false, false, true>(
+    int N, int C, int se_K, float* output, const float* input,
+    const float* skip, const float* bias, const float* w1, const float* b1,
+    const float* w2, const float* b2);
+
+template void OutputTransform<float, false, false, true, false, false, false>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
     const float* w2, const float* b2);

--- a/src/neural/cuda/fp16_kernels.cu
+++ b/src/neural/cuda/fp16_kernels.cu
@@ -199,32 +199,49 @@ template void FilterTransform<half>(int N, int C, half* transformedFilter,
                                     const half* filter);
 
 
-template void InputTransform<half>(int N, int C, half* transformed_input,
-                                    const half* input);
+template void InputTransform<half, true>(int N, int C, half* transformed_input,
+                                         const half* input);
+template void InputTransform<half, false>(int N, int C, half* transformed_input,
+                                          const half* input);
 
-template void OutputTransform<half, true, true, true, true>(
+template void OutputTransform<half, true, true, true, true, false, false>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
     const half* b2);
 
-template void OutputTransform<half, false, true, true, false>(
+template void OutputTransform<half, false, true, true, true, false, false>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
     const half* b2);
 
-template void OutputTransform<half, false, true, true, true>(
+template void OutputTransform<half, true, true, true, true, true, false>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
     const half* b2);
 
-template void OutputTransform<half, false, false, true, false>(
+template void OutputTransform<half, false, true, true, true, true, false>(
+    int N, int C, int se_K, half* output, const half* input, const half* skip,
+    const half* bias, const half* w1, const half* b1, const half* w2,
+    const half* b2);
+
+template void OutputTransform<half, false, true, true, false, false, false>(
+    int N, int C, int se_K, half* output, const half* input, const half* skip,
+    const half* bias, const half* w1, const half* b1, const half* w2,
+    const half* b2);
+
+template void OutputTransform<half, false, true, true, false, false, true>(
+    int N, int C, int se_K, half* output, const half* input, const half* skip,
+    const half* bias, const half* w1, const half* b1, const half* w2,
+    const half* b2);
+
+template void OutputTransform<half, false, false, true, false, false, false>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
     const half* b2);
 
 template void OutputInputTransform<half, true, true, true, true>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
-    const half* bias, const half* w1, const half* b1, const half* w2,
+    const half* bias, const half* w1, const half* b1, const half* w2, 
     const half* b2);
 
 template void OutputInputTransform<half, false, true, true, true>(

--- a/src/neural/cuda/kernels.h
+++ b/src/neural/cuda/kernels.h
@@ -87,10 +87,11 @@ void PolicyMap(int N, T* output, const T* input, const short* indices,
 template <typename T>
 void FilterTransform(int N, int C, T* transformedFilter, const T* filter);
 
-template <typename T>
+template <typename T, bool nhcw>
 void InputTransform(int N, int C, T* transformedInput, const T* input);
 
-template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
+template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip,
+          bool skipInput_nhcw, bool output_nhcw>
 void OutputTransform(int N, int C, int se_K, T* output, const T* input,
                      const T* skip, const T* bias, const T* w1, const T* b1,
                      const T* w2, const T* b2);

--- a/src/neural/cuda/layers.h
+++ b/src/neural/cuda/layers.h
@@ -204,8 +204,8 @@ class FusedWinogradConvSELayer : public BaseLayer<DataType> {
 
  public:
   FusedWinogradConvSELayer(BaseLayer<DataType>* ip, int C, int H, int W,
-                         int Cin, bool relu, bool bias, bool skipAdd, bool se,
-                           int se_k, bool use_gemm_ex);
+                           int Cin, bool relu, bool bias, bool skipAdd, bool se,
+                           int se_k, bool use_gemm_ex, bool op_nhcw = false);
 
   ~FusedWinogradConvSELayer();
   void LoadWeights(float* pfilter, float* pBias, void* scratch);
@@ -223,6 +223,7 @@ class FusedWinogradConvSELayer : public BaseLayer<DataType> {
   const bool has_se_;
   const int se_k_;
   const bool use_gemm_ex_;
+  const bool op_nhcw_;
 
   DataType* biases_ = nullptr;
   DataType* transformed_weights_ = nullptr;  // After winograd transform.

--- a/src/neural/cuda/network_cuda.cc
+++ b/src/neural/cuda/network_cuda.cc
@@ -239,8 +239,8 @@ class CudaNetwork : public Network {
     // Input.
     {
       auto inputConv = std::make_unique<FusedWinogradConvSELayer<DataType>>(
-          nullptr, kNumFilters, 8, 8, kNumInputPlanes, true, true, false,
-          false, 0, use_gemm_ex);
+          nullptr, kNumFilters, 8, 8, kNumInputPlanes, true, true, false, false,
+          0, use_gemm_ex, use_res_block_winograd_fuse_opt_);
       inputConv->LoadWeights(&weights.input.weights[0],
                              &weights.input.biases[0], scratch_mem_);
       network_.emplace_back(std::move(inputConv));

--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -43,7 +43,6 @@
 
 //#define DEBUG_RAW_NPS
 
-
 namespace lczero {
 using namespace cudnn_backend;
 
@@ -261,7 +260,8 @@ class CudnnNetwork : public Network {
               "consider using a smaller network.";
     }
 
-    const bool custom_winograd_override = !options.IsDefault<bool>("custom_winograd");
+    const bool custom_winograd_override =
+        !options.IsDefault<bool>("custom_winograd");
 
     if (!custom_winograd_override && use_custom_winograd_ &&
         transformed_residual_weight_size > 0.5 * deviceProp.totalGlobalMem) {
@@ -270,11 +270,11 @@ class CudnnNetwork : public Network {
               "Please consider using a smaller network.";
       use_custom_winograd_ = false;
     }
-    
+
     // Override if set in backend-opts.
     if (custom_winograd_override)
       use_custom_winograd_ = options.Get<bool>("custom_winograd");
-    
+
     if (use_custom_winograd_ &&
         transformed_residual_weight_size > 0.4 * deviceProp.totalGlobalMem) {
       CERR << "WARNING: Low GPU video memory. You may still run into OOM "
@@ -284,6 +284,20 @@ class CudnnNetwork : public Network {
 
     // Winograd needs nchw tensor layout.
     if (use_custom_winograd_) nhwc_ = false;
+
+    use_res_block_winograd_fuse_opt_ = false;
+    if (use_custom_winograd_) {
+      // Disable res block fusing for > 384 filters (the fused output input
+      // transform kernel runs out of register space) and for fp32 for now.
+      if (kNumFilters <= 384 && fp16) {
+        use_res_block_winograd_fuse_opt_ = true;
+      }
+      // Override if set in backend-opts.
+      if (!options.IsDefault<bool>("res_block_fusing")) {
+        use_res_block_winograd_fuse_opt_ =
+            options.Get<bool>("res_block_fusing");
+      }
+    }
 
     const bool use_gemm_ex = deviceProp.major >= 5;
 
@@ -348,8 +362,8 @@ class CudnnNetwork : public Network {
     if (use_custom_winograd_) {
       // Need additional space for transformed input/outputs which are 36/16
       // times size (4x4 block transformed into 6x6).
-      transformed_tensor_size =
-          (size_t)(max_batch_size_ * kNumFilters * 64 * (36.0 / 16.0) * sizeof(DataType));
+      transformed_tensor_size = (size_t)(max_batch_size_ * kNumFilters * 64 *
+                                         (36.0 / 16.0) * sizeof(DataType));
       scratch_size_ = std::max(scratch_size_, 2 * transformed_tensor_size);
     }
 
@@ -361,7 +375,14 @@ class CudnnNetwork : public Network {
     // 2. Build the network, and copy the weights to GPU memory.
 
     // Input.
-    {
+    if (use_custom_winograd_) {
+      auto inputConv = std::make_unique<FusedWinogradConvSELayer<DataType>>(
+          nullptr, kNumFilters, 8, 8, kNumInputPlanes, true, true, false, false,
+          0, use_gemm_ex, use_res_block_winograd_fuse_opt_);
+      inputConv->LoadWeights(&weights.input.weights[0],
+                             &weights.input.biases[0], scratch_mem_);
+      network_.emplace_back(std::move(inputConv));
+    } else {
       auto inputConv = std::make_unique<ConvLayer<DataType>>(
           nhwc_, kNumFilters, 8, 8, 3, kNumInputPlanes, true, true);
       inputConv->LoadWeights(&weights.input.weights[0],
@@ -372,30 +393,49 @@ class CudnnNetwork : public Network {
     // Residual block.
     for (int block = 0; block < numBlocks_; block++) {
       if (use_custom_winograd_) {
-
         bool has_se = weights.residual[block].has_se;
         int se_k = (int)weights.residual[block].se.b1.size();
 
-        auto conv1 = std::make_unique<FusedWinogradConvSELayer<DataType>>(
-            getLastLayer(), kNumFilters, 8, 8, kNumFilters, true, true, false,
-            false, 0, use_gemm_ex);
-        conv1->LoadWeights(&weights.residual[block].conv1.weights[0],
-                           &weights.residual[block].conv1.biases[0],
-                           scratch_mem_);
-        network_.emplace_back(std::move(conv1));
+        if (use_res_block_winograd_fuse_opt_) {
+          auto layer = std::make_unique<ResidualBlock<DataType>>(
+              getLastLayer(), kNumFilters, has_se, se_k, use_gemm_ex,
+              block == 0, block == (numBlocks_ - 1));
+          layer->LoadWeights0(&weights.residual[block].conv1.weights[0],
+                              &weights.residual[block].conv1.biases[0],
+                              scratch_mem_);
+          layer->LoadWeights1(&weights.residual[block].conv2.weights[0],
+                              &weights.residual[block].conv2.biases[0],
+                              scratch_mem_);
+          if (has_se)
+            layer->LoadSEWeights(&weights.residual[block].se.w1[0],
+                                 &weights.residual[block].se.b1[0],
+                                 &weights.residual[block].se.w2[0],
+                                 &weights.residual[block].se.b2[0],
+                                 scratch_mem_);
+          network_.emplace_back(std::move(layer));
+        } else {
+          auto conv1 = std::make_unique<FusedWinogradConvSELayer<DataType>>(
+              getLastLayer(), kNumFilters, 8, 8, kNumFilters, true, true, false,
+              false, 0, use_gemm_ex);
+          conv1->LoadWeights(&weights.residual[block].conv1.weights[0],
+                             &weights.residual[block].conv1.biases[0],
+                             scratch_mem_);
+          network_.emplace_back(std::move(conv1));
 
-        auto conv2 = std::make_unique<FusedWinogradConvSELayer<DataType>>(
-            getLastLayer(), kNumFilters, 8, 8, kNumFilters, true, true, true,
-            has_se, se_k, use_gemm_ex);
-        conv2->LoadWeights(&weights.residual[block].conv2.weights[0],
-                           &weights.residual[block].conv2.biases[0],
-                           scratch_mem_);
-        if (has_se)
-          conv2->LoadSEWeights(&weights.residual[block].se.w1[0],
-                               &weights.residual[block].se.b1[0],
-                               &weights.residual[block].se.w2[0],
-                               &weights.residual[block].se.b2[0], scratch_mem_);
-        network_.emplace_back(std::move(conv2));
+          auto conv2 = std::make_unique<FusedWinogradConvSELayer<DataType>>(
+              getLastLayer(), kNumFilters, 8, 8, kNumFilters, true, true, true,
+              has_se, se_k, use_gemm_ex);
+          conv2->LoadWeights(&weights.residual[block].conv2.weights[0],
+                             &weights.residual[block].conv2.biases[0],
+                             scratch_mem_);
+          if (has_se)
+            conv2->LoadSEWeights(&weights.residual[block].se.w1[0],
+                                 &weights.residual[block].se.b1[0],
+                                 &weights.residual[block].se.w2[0],
+                                 &weights.residual[block].se.b2[0],
+                                 scratch_mem_);
+          network_.emplace_back(std::move(conv2));
+        }
 
       } else {
         auto conv1 = std::make_unique<ConvLayer<DataType>>(
@@ -538,6 +578,11 @@ class CudnnNetwork : public Network {
       maxSize = std::max(maxSize, layer->GetOutputSize(max_batch_size_));
     }
 
+    // when this optimization is enabled, we write transformed outputs to
+    // intermediate tensor memory
+    if (use_res_block_winograd_fuse_opt_ && transformed_tensor_size > maxSize)
+      maxSize = transformed_tensor_size;
+
     for (auto& mem : tensor_mem_) {
       ReportCUDAErrors(cudaMalloc(&mem, maxSize));
       ReportCUDAErrors(cudaMemset(mem, 0, maxSize));
@@ -587,39 +632,47 @@ class CudnnNetwork : public Network {
     int l = 0;
     // Input.
     network_[l++]->Eval(
-        batchSize, tensor_mem_[2],
+        batchSize,
+        use_res_block_winograd_fuse_opt_ ? tensor_mem_[1] : tensor_mem_[2],
         tensor_mem_[0], nullptr, scratch_mem_, scratch_size_, cudnn_,
         cublas_);  // input conv
 
     // Residual block.
     for (int block = 0; block < numBlocks_; block++) {
-      network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2], nullptr,
-                          scratch_mem_, scratch_size_, cudnn_,
-                          cublas_);  // conv1
-
-      if (use_custom_winograd_) {
-        network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[0],
-                            tensor_mem_[2], scratch_mem_, scratch_size_, cudnn_,
-                            cublas_);  // conv2
+      if (use_res_block_winograd_fuse_opt_) {
+        network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[1], nullptr,
+                            scratch_mem_, scratch_size_, cudnn_,
+                            cublas_);  // block
       } else {
-        // For SE Resnet, skip connection is added after SE (and bias is added
-        // as part of SE).
-        if (has_se_) {
-          network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0],
-                              nullptr, scratch_mem_, scratch_size_, cudnn_,
-                              cublas_);  // conv2
-        } else {
+        network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2], nullptr,
+                            scratch_mem_, scratch_size_, cudnn_,
+                            cublas_);  // conv1
+
+        if (use_custom_winograd_) {
           network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[0],
                               tensor_mem_[2], scratch_mem_, scratch_size_,
                               cudnn_,
                               cublas_);  // conv2
-        }
+        } else {
+          // For SE Resnet, skip connection is added after SE (and bias is added
+          // as part of SE).
+          if (has_se_) {
+            network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0],
+                                nullptr, scratch_mem_, scratch_size_, cudnn_,
+                                cublas_);  // conv2
+          } else {
+            network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[0],
+                                tensor_mem_[2], scratch_mem_, scratch_size_,
+                                cudnn_,
+                                cublas_);  // conv2
+          }
 
-        if (has_se_) {
-          network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[1],
-                              tensor_mem_[2], scratch_mem_, scratch_size_,
-                              cudnn_,
-                              cublas_);  // SE layer
+          if (has_se_) {
+            network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[1],
+                                tensor_mem_[2], scratch_mem_, scratch_size_,
+                                cudnn_,
+                                cublas_);  // SE layer
+          }
         }
       }
     }
@@ -678,7 +731,6 @@ class CudnnNetwork : public Network {
                         scratch_mem_, scratch_size_, cudnn_,
                         cublas_);  // value FC1
 
-
     if (fp16) {
       // TODO: consider fusing the bias-add of FC2 with format conversion.
       network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[1], nullptr,
@@ -687,8 +739,8 @@ class CudnnNetwork : public Network {
       copyTypeConverted(opVal, (half*)(tensor_mem_[0]),
                         wdl_ ? 3 * batchSize : batchSize);  // VALUE
     } else {
-      network_[l++]->Eval(batchSize, (DataType*)opVal, tensor_mem_[1],
-                          nullptr, scratch_mem_, scratch_size_, cudnn_,
+      network_[l++]->Eval(batchSize, (DataType*)opVal, tensor_mem_[1], nullptr,
+                          scratch_mem_, scratch_size_, cudnn_,
                           cublas_);  // value FC2    // VALUE
     }
 
@@ -819,6 +871,9 @@ class CudnnNetwork : public Network {
 
   bool use_custom_winograd_;  // Custom winograd convolution implementation for
                               // convolutions of the residual tower.
+
+  bool use_res_block_winograd_fuse_opt_;  // Fuse operations inside the residual
+                                          // tower.
 
   // Currently only one NN Eval can happen a time (we can fix this if needed
   // by allocating more memory).

--- a/src/neural/cuda/winograd_helper.inc
+++ b/src/neural/cuda/winograd_helper.inc
@@ -126,11 +126,13 @@ __global__ void filterTransform_kernel(int K, int C, int elements,
 }
 
 
+#define INDEX_NCHW(n, c, h, w) ((n)*C * 8 * 8 + (c)*8 * 8 + (h)*8 + w)
+#define INDEX_NHCW(n, c, h, w) ((n)*C * 8 * 8 + (h)*C * 8 + (c)*8 + w)
+
 // index in intermediate/temp tensor
 // W, H == 6 here! (6x6 transformed blocks)
 // N also includes part of dimension (2x2)
 #define GemmN (N * 4)
-#define INDEX_NCHW(n, c, h, w) ((n)*C * 8 * 8 + (c)*8 * 8 + (h)*8 + w)
 #define TEMP_INDEX_HWNC(h, w, n, c) \
   ((h)*6 * GemmN * C + (w)*GemmN * C + (n)*C + c)
 
@@ -138,7 +140,7 @@ __global__ void filterTransform_kernel(int K, int C, int elements,
 // 'N' blocks
 // every thread transforms an entire board/plane (8x8 elements)
 // - producing 4 x 6x6 elements
-template <typename T>
+template <typename T, bool nhcw>
 __global__ void InputTransform_kernel(int N, int C, const T* input, T* output) {
   int c = threadIdx.x;
   int n = blockIdx.x;
@@ -150,9 +152,15 @@ __global__ void InputTransform_kernel(int N, int C, const T* input, T* output) {
 // read the board (a row at a time for fp16)
 #pragma unroll
   for (int y = 0; y < 8; y++) {
-    *((uint4*)(&board[y][0])) = *((uint4*)(&input[INDEX_NCHW(n, c, y, 0)]));
-    if (!fp16)
-      *((uint4*)(&board[y][4])) = *((uint4*)(&input[INDEX_NCHW(n, c, y, 4)]));
+    if (nhcw) {
+      *((uint4*)(&board[y][0])) = *((uint4*)(&input[INDEX_NHCW(n, c, y, 0)]));
+      if (!fp16)
+        *((uint4*)(&board[y][4])) = *((uint4*)(&input[INDEX_NHCW(n, c, y, 4)]));
+    } else {
+      *((uint4*)(&board[y][0])) = *((uint4*)(&input[INDEX_NCHW(n, c, y, 0)]));
+      if (!fp16)
+        *((uint4*)(&board[y][4])) = *((uint4*)(&input[INDEX_NCHW(n, c, y, 4)]));
+    }
   }
 
   // top-left
@@ -240,7 +248,8 @@ __global__ void InputTransform_kernel(int N, int C, const T* input, T* output) {
 // 'C' threads per block
 // 'N' blocks
 // every thread generates an entire board/plane (8x8 elements)
-template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
+template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip, 
+          bool skipInput_nhcw, bool output_nhcw>
 __global__ void OutputTransform_kernel(int N, int C, int se_K, T* output,
                                        const T* input, const T* skip,
                                        const T* bias, const T* w1, const T* b1,
@@ -329,9 +338,15 @@ __global__ void OutputTransform_kernel(int N, int C, int se_K, T* output,
     // residual add
     if (use_skip) {
       T skipInp[8];
-      *((uint4*)(&skipInp[0])) = *((uint4*)(&skip[INDEX_NCHW(n, k, h, 0)]));
-      if (!fp16)
-        *((uint4*)(&skipInp[4])) = *((uint4*)(&skip[INDEX_NCHW(n, k, h, 4)]));
+      if (skipInput_nhcw) {
+        *((uint4*)(&skipInp[0])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 0)]));
+        if (!fp16)
+          *((uint4*)(&skipInp[4])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 4)]));
+      } else {
+        *((uint4*)(&skipInp[0])) = *((uint4*)(&skip[INDEX_NCHW(n, k, h, 0)]));
+        if (!fp16)
+          *((uint4*)(&skipInp[4])) = *((uint4*)(&skip[INDEX_NCHW(n, k, h, 4)]));
+      }
 #pragma unroll
       for (int w = 0; w < 8; w++) board[h][w] += skipInp[w];
     }
@@ -344,9 +359,15 @@ __global__ void OutputTransform_kernel(int N, int C, int se_K, T* output,
     }
 
     // Write to output (use 128 bit writes to store one row a time)
-    *((uint4*)(&output[INDEX_NCHW(n, k, h, 0)])) = *((uint4*)&board[h][0]);
-    if (!fp16)
-      *((uint4*)(&output[INDEX_NCHW(n, k, h, 4)])) = *((uint4*)&board[h][4]);
+    if (output_nhcw) {
+      *((uint4*)(&output[INDEX_NHCW(n, k, h, 0)])) = *((uint4*)&board[h][0]);
+      if (!fp16)
+        *((uint4*)(&output[INDEX_NHCW(n, k, h, 4)])) = *((uint4*)&board[h][4]);
+    } else {
+      *((uint4*)(&output[INDEX_NCHW(n, k, h, 0)])) = *((uint4*)&board[h][0]);
+      if (!fp16)
+        *((uint4*)(&output[INDEX_NCHW(n, k, h, 4)])) = *((uint4*)&board[h][4]);
+    }
   }
 }
 
@@ -357,7 +378,7 @@ __global__ void OutputTransform_kernel(int N, int C, int se_K, T* output,
 // 'N' blocks
 // every thread generates an entire board/plane (8x8 elements)
 template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
-__global__ 
+__global__ __launch_bounds__(384, 1)
 void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* output,
                                                               const T* input, const T* skip,
                                                               const T* bias, const T* w1, const T* b1,
@@ -446,9 +467,9 @@ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* ou
     // residual add
     if (use_skip) {
       T skipInp[8];
-      *((uint4*)(&skipInp[0])) = *((uint4*)(&skip[INDEX_NCHW(n, k, h, 0)]));
+      *((uint4*)(&skipInp[0])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 0)]));
       if (!fp16)
-        *((uint4*)(&skipInp[4])) = *((uint4*)(&skip[INDEX_NCHW(n, k, h, 4)]));
+        *((uint4*)(&skipInp[4])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 4)]));
 #pragma unroll
       for (int w = 0; w < 8; w++) board[h][w] += skipInp[w];
     }
@@ -464,9 +485,9 @@ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* ou
     if (use_skip)
     {
       // Write to skip (use 128 bit writes to store one row a time)
-      *((uint4*)(&skip[INDEX_NCHW(n, k, h, 0)])) = *((uint4*)&board[h][0]);
+      *((uint4*)(&skip[INDEX_NHCW(n, k, h, 0)])) = *((uint4*)&board[h][0]);
       if (!fp16)
-        *((uint4*)(&skip[INDEX_NCHW(n, k, h, 4)])) = *((uint4*)&board[h][4]);
+        *((uint4*)(&skip[INDEX_NHCW(n, k, h, 4)])) = *((uint4*)&board[h][4]);
     }
   }
 
@@ -563,20 +584,21 @@ void FilterTransform(int N, int C, T* transformedFilter, const T* filter) {
   ReportCUDAErrors(cudaGetLastError());
 }
 
-template <typename T>
+template <typename T, bool nhcw>
 void InputTransform(int N, int C, T* transformed_input, const T* input) {
   // Each thread processes entire chess board (input 8x8 elements -> outputs
   // 2x2, 6x6 elements)
-  InputTransform_kernel<<<N, C>>>(N, C, input, transformed_input);
+  InputTransform_kernel<T, nhcw><<<N, C>>>(N, C, input, transformed_input);
   ReportCUDAErrors(cudaGetLastError());
 }
 
-template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
+template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip, 
+          bool skipInput_nhcw, bool output_nhcw>
 void OutputTransform(int N, int C, int se_K, T* output, const T* input,
                      const T* skip, const T* bias, const T* w1, const T* b1,
                      const T* w2, const T* b2) {
   // Each thread processes entire chess board
-  OutputTransform_kernel<T, use_se, relu, use_bias, use_skip>
+  OutputTransform_kernel<T, use_se, relu, use_bias, use_skip, skipInput_nhcw, output_nhcw>
       <<<N, C>>>(N, C, se_K, output, input, skip, bias, w1, b1, w2, b2);
   ReportCUDAErrors(cudaGetLastError());
 }

--- a/src/neural/cuda/winograd_helper.inc
+++ b/src/neural/cuda/winograd_helper.inc
@@ -381,13 +381,18 @@ __device__ __forceinline__ float warpReduce(float x)
     return x;
 }
 
+// max supported filter count for this fast path
+// TODO: extend it to cover bigger networks!
+// (We are limited by no of registers per thread)
+#define MAX_SUPPORTED_C 384
+
 // input is in transformed space (HWNC layout) --- output of GEMM
 // output is also in transformed space (HWNC layout) --- input to GEMM (for next layer)
 // 'C' threads per block
 // 'N' blocks
 // every thread generates an entire board/plane (8x8 elements)
 template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
-__global__ __launch_bounds__(384, 1)
+__global__ __launch_bounds__(MAX_SUPPORTED_C, 1)
 void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* output,
                                                               const T* input, const T* skip,
                                                               const T* bias, const T* w1, const T* b1,
@@ -444,7 +449,7 @@ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* ou
     }
 
   if (use_se) {
-    __shared__ float shared_data[384];
+    __shared__ float shared_data[MAX_SUPPORTED_C];
     float avg = S / 64;
     shared_data[k] = avg;
 
@@ -457,7 +462,7 @@ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* ou
     // As se_K << C, we want to loop over se_K instead of C
     // even if it means taking the sum across threads
 
-    __shared__ float shared_sums[384/32][384];  // per-warp sums
+    __shared__ float shared_sums[MAX_SUPPORTED_C/32][MAX_SUPPORTED_C];  // per-warp sums
 
     for (int i = 0; i < se_K; i++) {
       float val = shared_data[k] * float(readw1(k, i));
@@ -501,12 +506,6 @@ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* ou
 
     // residual add
     if (use_skip) {
-#if 0
-      T skipInp[8];
-      *((uint4*)(&skipInp[0])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 0)]));
-      if (!fp16)
-        *((uint4*)(&skipInp[4])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 4)]));
-#endif
 #pragma unroll
       for (int w = 0; w < 8; w++) board[h][w] += skipInp[h][w];
     }

--- a/src/neural/cuda/winograd_helper.inc
+++ b/src/neural/cuda/winograd_helper.inc
@@ -371,6 +371,15 @@ __global__ void OutputTransform_kernel(int N, int C, int se_K, T* output,
   }
 }
 
+// fast reduction for the warp
+__device__ __forceinline__ float warpReduce(float x)
+{
+    #pragma unroll
+    for(int mask = 16; mask > 0 ; mask >>= 1)
+        x += __shfl_xor_sync(0xFFFFFFFF, x, mask);
+
+    return x;
+}
 
 // input is in transformed space (HWNC layout) --- output of GEMM
 // output is also in transformed space (HWNC layout) --- input to GEMM (for next layer)
@@ -390,6 +399,14 @@ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* ou
 
   T board[8][8];
   T b = bias[k];
+
+  T skipInp[8][8];
+  #pragma unroll
+  for (int h = 0; h < 8; h++) {
+      *((uint4*)(&skipInp[h][0])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 0)]));
+      if (!fp16)
+        *((uint4*)(&skipInp[h][4])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 4)]));
+  }
 
 #pragma unroll
   for (int hStart = 0; hStart < 8; hStart += 4)
@@ -427,21 +444,39 @@ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* ou
     }
 
   if (use_se) {
-    __shared__ float shared_data[1024];
+    __shared__ float shared_data[384];
     float avg = S / 64;
     shared_data[k] = avg;
+
+    int lane = k & 0x1F;
+    int warp = k >> 5;
     __syncthreads();
 
     // First fully-connected layer for SE
-    if (k < se_K) {
+
+    // As se_K << C, we want to loop over se_K instead of C
+    // even if it means taking the sum across threads
+
+    __shared__ float shared_sums[384/32][384];  // per-warp sums
+
+    for (int i = 0; i < se_K; i++) {
+      float val = shared_data[k] * float(readw1(k, i));
+      val = warpReduce(val);
+      if (lane == 0)
+        shared_sums[warp][i] = val;
+    }
+    __syncthreads();
+    if (k < se_K) 
+    {
       S = 0;
-      for (int i = 0; i < C; i++) {
-        S += shared_data[i] * float(readw1(i, k));
-      }
+      for (int i=0;i<C/32;i++)
+        S += shared_sums[i][k];
+
       S += (float)b1[k];
       if (S < 0) S = 0;  // relu
       shared_data[k] = S;
     }
+
     __syncthreads();
 
     // Second fully-connected layer for SE
@@ -466,12 +501,14 @@ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* ou
 
     // residual add
     if (use_skip) {
+#if 0
       T skipInp[8];
       *((uint4*)(&skipInp[0])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 0)]));
       if (!fp16)
         *((uint4*)(&skipInp[4])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 4)]));
+#endif
 #pragma unroll
-      for (int w = 0; w < 8; w++) board[h][w] += skipInp[w];
+      for (int w = 0; w < 8; w++) board[h][w] += skipInp[h][w];
     }
 
     // relu


### PR DESCRIPTION
 - Allows better memory access pattern.
 - As the optimization is currently limited to networks with filter size <= 384, add __launch_bounds__ compiler hint to allow it use max possible no of registers to support upto 384 channels.
 - Get rid of residual block path from cudnn backend (people who are able to use that with cudnn backend should be already running the new cuda backend).

With lc0 benchmark running on A100, recent T60 network, minibatch-size=96:
Baseline: 54152
Optimized: 55320