### PR TITLE
Multi-stream Optimization for CUDA backend

### DIFF
--- a/src/neural/cuda/common_kernels.cu
+++ b/src/neural/cuda/common_kernels.cu
@@ -597,25 +597,45 @@ template void PolicyMap<half>(int N, half* output, const half* input,
 template void FilterTransform<float>(int N, int C, float* transformedFilter,
                                      const float* filter);
 
-template void InputTransform<float>(int N, int C, float* transformed_input,
-                                    const float* input);
+template void InputTransform<float, true>(int N, int C,
+                                          float* transformed_input,
+                                          const float* input);
 
-template void OutputTransform<float, true, true, true, true>(
+template void InputTransform<float, false>(int N, int C,
+                                           float* transformed_input,
+                                           const float* input);
+
+template void OutputTransform<float, true, true, true, true, false, false>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
     const float* w2, const float* b2);
 
-template void OutputTransform<float, false, true, true, false>(
+template void OutputTransform<float, false, true, true, true, false, false>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
     const float* w2, const float* b2);
 
-template void OutputTransform<float, false, true, true, true>(
+template void OutputTransform<float, true, true, true, true, true, false>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
     const float* w2, const float* b2);
 
-template void OutputTransform<float, false, false, true, false>(
+template void OutputTransform<float, false, true, true, true, true, false>(
+    int N, int C, int se_K, float* output, const float* input,
+    const float* skip, const float* bias, const float* w1, const float* b1,
+    const float* w2, const float* b2);
+
+template void OutputTransform<float, false, true, true, false, false, false>(
+    int N, int C, int se_K, float* output, const float* input,
+    const float* skip, const float* bias, const float* w1, const float* b1,
+    const float* w2, const float* b2);
+
+template void OutputTransform<float, false, true, true, false, false, true>(
+    int N, int C, int se_K, float* output, const float* input,
+    const float* skip, const float* bias, const float* w1, const float* b1,
+    const float* w2, const float* b2);
+
+template void OutputTransform<float, false, false, true, false, false, false>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
     const float* w2, const float* b2);

--- a/src/neural/cuda/common_kernels.cu
+++ b/src/neural/cuda/common_kernels.cu
@@ -71,12 +71,12 @@ __global__ void addVectors_kernel(T* c, T* a, T* b, int size, int asize,
 // activation.
 template <typename T>
 void addVectors(T* c, T* a, T* b, int size, int asize, int bsize, bool relu,
-                bool use_tanh, bool use_sigmoid) {
+                bool use_tanh, bool use_sigmoid, cudaStream_t stream) {
   const int kBlockSize = 256;
   int blocks = DivUp(size, kBlockSize);
 
-  addVectors_kernel<<<blocks, kBlockSize>>>(c, a, b, size, asize, bsize, relu,
-                                            use_tanh, use_sigmoid);
+  addVectors_kernel<<<blocks, kBlockSize, 0, stream>>>(c, a, b, size, asize, bsize, relu,
+                                                       use_tanh, use_sigmoid);
   ReportCUDAErrors(cudaGetLastError());
 }
 
@@ -102,12 +102,12 @@ __global__ void addBias_NCHW_kernel(T* c, T* a, T* b, int N, int C, int H,
 
 // Add bias to convolution's output.
 template <typename T>
-void addBias_NCHW(T* c, T* a, T* b, int N, int C, int H, int W, bool relu) {
+void addBias_NCHW(T* c, T* a, T* b, int N, int C, int H, int W, bool relu, cudaStream_t stream) {
   int size = N * C * H * W;
   const int kBlockSize = 256;
   int blocks = DivUp(size, kBlockSize);
 
-  addBias_NCHW_kernel<<<blocks, kBlockSize>>>(c, a, b, N, C, H, W, relu);
+  addBias_NCHW_kernel<<<blocks, kBlockSize, 0, stream>>>(c, a, b, N, C, H, W, relu);
   ReportCUDAErrors(cudaGetLastError());
 }
 
@@ -167,10 +167,10 @@ __global__ void copyTypeConverted_kernel(DstType* op, SrcType* ip, int N) {
 }
 
 template <typename DstType, typename SrcType>
-void copyTypeConverted(DstType* op, SrcType* ip, int N) {
+void copyTypeConverted(DstType* op, SrcType* ip, int N, cudaStream_t stream) {
   const int kBlockSize = 256;
   int blocks = DivUp(N, kBlockSize);
-  copyTypeConverted_kernel<<<blocks, kBlockSize>>>(op, ip, N);
+  copyTypeConverted_kernel<<<blocks, kBlockSize, 0, stream>>>(op, ip, N);
 }
 
 template <typename T>
@@ -248,12 +248,12 @@ __global__ void expandPlanes_kernel_Fp32_NCHW(float* output,
 }
 
 void expandPlanes_Fp32_NCHW(float* output, const uint64_t* masks,
-                            const float* values, int n) {
+                            const float* values, int n, cudaStream_t stream) {
   int threads = n * 8 * 8;  // Each thread writes a single element.
   const int blockSize = 256;
   int blocks = DivUp(threads, blockSize);
-  expandPlanes_kernel_Fp32_NCHW<<<blocks, blockSize>>>(output, masks, values,
-                                                       n);
+  expandPlanes_kernel_Fp32_NCHW<<<blocks, blockSize, 0, stream>>>(output, masks,
+                                                                  values, n);
   ReportCUDAErrors(cudaGetLastError());
 }
 
@@ -280,12 +280,12 @@ __global__ void expandPlanes_kernel_Fp16_NHWC(half* output,
 }
 
 void expandPlanes_Fp16_NHWC(half* output, const uint64_t* masks,
-                            const float* values, int n) {
+                            const float* values, int n, cudaStream_t stream) {
   int threads = n * 8 * 8;  // Each thread writes a single element.
   const int kBlockSize = 256;
   int blocks = DivUp(threads, kBlockSize);
-  expandPlanes_kernel_Fp16_NHWC<<<blocks, kBlockSize>>>(output, masks, values,
-                                                        n);
+  expandPlanes_kernel_Fp16_NHWC<<<blocks, kBlockSize, 0, stream>>>(
+      output, masks, values, n);
   ReportCUDAErrors(cudaGetLastError());
 }
 
@@ -324,12 +324,12 @@ __global__ void expandPlanes_kernel_Fp16_NCHW(half* output,
 }
 
 void expandPlanes_Fp16_NCHW(half* output, const uint64_t* masks,
-                            const float* values, int n) {
+                            const float* values, int n, cudaStream_t stream = 0) {
   int threads = n * 8 * 8;  // each thread writes a single element
   const int blockSize = 256;
   int blocks = DivUp(threads, blockSize);
-  expandPlanes_kernel_Fp16_NCHW<<<blocks, blockSize>>>(output, masks, values,
-                                                       n);
+  expandPlanes_kernel_Fp16_NCHW<<<blocks, blockSize, 0, stream>>>(output, masks,
+                                                                  values, n);
   ReportCUDAErrors(cudaGetLastError());
 }
 
@@ -534,23 +534,27 @@ __global__ void policyMap_kernel(T* output, const T* input,
 
 template <typename T>
 void PolicyMap(int N, T* output, const T* input, const short* indices,
-               int inputSize, int usedSize, int outputSize) {
+               int inputSize, int usedSize, int outputSize, cudaStream_t stream) {
   // Each thread processes one input element
   // Only some of the threads (with valid mapping) write output
   const int kBlockSize = 256;
   const int kBlocks = DivUp(N * usedSize, kBlockSize);
 
-  policyMap_kernel<T><<<kBlocks, kBlockSize>>>((T*)output, (T*)input,
+  policyMap_kernel<T><<<kBlocks, kBlockSize, 0, stream>>>((T*)output, (T*)input,
                                                (short*)indices, N, inputSize,
                                                usedSize, outputSize);
   ReportCUDAErrors(cudaGetLastError());
 }
 
 // Template instantiation.
-template void copyTypeConverted<half, float>(half* op, float* ip, int N);
-template void copyTypeConverted<float, half>(float* op, half* ip, int N);
-template void copyTypeConverted<float, float>(float* op, float* ip, int N);
-template void copyTypeConverted<half, half>(half* op, half* ip, int N);
+template void copyTypeConverted<half, float>(half* op, float* ip, int N,
+                                             cudaStream_t stream);
+template void copyTypeConverted<float, half>(float* op, half* ip, int N,
+                                             cudaStream_t stream);
+template void copyTypeConverted<float, float>(float* op, float* ip, int N,
+                                              cudaStream_t stream);
+template void copyTypeConverted<half, half>(half* op, half* ip, int N,
+                                            cudaStream_t stream);
 
 template void batchNorm<float>(float* output, const float* input,
                                const float* skipInput, int N, int C, int H,
@@ -562,16 +566,16 @@ template void batchNorm<half>(half* output, const half* input,
 
 template void addVectors<float>(float* c, float* a, float* b, int size,
                                 int asize, int bsize, bool relu, bool use_tanh,
-                                bool use_sigmoid);
+                                bool use_sigmoid, cudaStream_t stream);
 template void addVectors<half>(half* c, half* a, half* b, int size, int asize,
                                int bsize, bool relu, bool use_tanh,
-                               bool use_sigmoid);
+                               bool use_sigmoid, cudaStream_t stream);
 
 template void addBias_NCHW<float>(float* c, float* a, float* b, int N, int C,
-                                  int H, int W, bool relu);
+                                  int H, int W, bool relu, cudaStream_t stream);
 
 template void addBias_NCHW<half>(half* c, half* a, half* b, int N, int C, int H,
-                                 int W, bool relu);
+                                 int W, bool relu, cudaStream_t stream);
 
 template void globalAvgPool<float>(int N, int C, float* output,
                                    const float* input,
@@ -588,72 +592,74 @@ template void globalScale<half>(int N, int C, half* output, const half* input,
 
 template void PolicyMap<float>(int N, float* output, const float* input,
                                const short* indices, int inputSize,
-                               int usedSize, int outputSize);
+                               int usedSize, int outputSize,
+                               cudaStream_t stream);
 
 template void PolicyMap<half>(int N, half* output, const half* input,
                               const short* indices, int inputSize, int usedSize,
-                              int outputSize);
+                              int outputSize, cudaStream_t stream);
 
 template void FilterTransform<float>(int N, int C, float* transformedFilter,
                                      const float* filter);
 
 template void InputTransform<float, true>(int N, int C,
                                           float* transformed_input,
-                                          const float* input);
+                                          const float* input, cudaStream_t stream);
 
 template void InputTransform<float, false>(int N, int C,
                                            float* transformed_input,
-                                           const float* input);
+                                           const float* input,
+                                           cudaStream_t stream);
 
 template void OutputTransform<float, true, true, true, true, false, false>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
-    const float* w2, const float* b2);
+    const float* w2, const float* b2, cudaStream_t stream);
 
 template void OutputTransform<float, false, true, true, true, false, false>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
-    const float* w2, const float* b2);
+    const float* w2, const float* b2, cudaStream_t stream);
 
 template void OutputTransform<float, true, true, true, true, true, false>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
-    const float* w2, const float* b2);
+    const float* w2, const float* b2, cudaStream_t stream);
 
 template void OutputTransform<float, false, true, true, true, true, false>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
-    const float* w2, const float* b2);
+    const float* w2, const float* b2, cudaStream_t stream);
 
 template void OutputTransform<float, false, true, true, false, false, false>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
-    const float* w2, const float* b2);
+    const float* w2, const float* b2, cudaStream_t stream);
 
 template void OutputTransform<float, false, true, true, false, false, true>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
-    const float* w2, const float* b2);
+    const float* w2, const float* b2, cudaStream_t stream);
 
 template void OutputTransform<float, false, false, true, false, false, false>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
-    const float* w2, const float* b2);
+    const float* w2, const float* b2, cudaStream_t stream);
 
 template void OutputInputTransform<float, true, true, true, true>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
-    const float* w2, const float* b2);
+    const float* w2, const float* b2, cudaStream_t stream);
 
 template void OutputInputTransform<float, false, true, true, true>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
-    const float* w2, const float* b2);
+    const float* w2, const float* b2, cudaStream_t stream);
 
 template void OutputInputTransform<float, false, true, true, false>(
     int N, int C, int se_K, float* output, const float* input,
     const float* skip, const float* bias, const float* w1, const float* b1,
-    const float* w2, const float* b2);
+    const float* w2, const float* b2, cudaStream_t stream);
 
 
 }  // namespace cudnn_backend

--- a/src/neural/cuda/common_kernels.cu
+++ b/src/neural/cuda/common_kernels.cu
@@ -324,7 +324,7 @@ __global__ void expandPlanes_kernel_Fp16_NCHW(half* output,
 }
 
 void expandPlanes_Fp16_NCHW(half* output, const uint64_t* masks,
-                            const float* values, int n, cudaStream_t stream = 0) {
+                            const float* values, int n, cudaStream_t stream) {
   int threads = n * 8 * 8;  // each thread writes a single element
   const int blockSize = 256;
   int blocks = DivUp(threads, blockSize);

--- a/src/neural/cuda/fp16_kernels.cu
+++ b/src/neural/cuda/fp16_kernels.cu
@@ -199,32 +199,49 @@ template void FilterTransform<half>(int N, int C, half* transformedFilter,
                                     const half* filter);
 
 
-template void InputTransform<half>(int N, int C, half* transformed_input,
-                                    const half* input);
+template void InputTransform<half, true>(int N, int C, half* transformed_input,
+                                         const half* input);
+template void InputTransform<half, false>(int N, int C, half* transformed_input,
+                                          const half* input);
 
-template void OutputTransform<half, true, true, true, true>(
+template void OutputTransform<half, true, true, true, true, false, false>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
     const half* b2);
 
-template void OutputTransform<half, false, true, true, false>(
+template void OutputTransform<half, false, true, true, true, false, false>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
     const half* b2);
 
-template void OutputTransform<half, false, true, true, true>(
+template void OutputTransform<half, true, true, true, true, true, false>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
     const half* b2);
 
-template void OutputTransform<half, false, false, true, false>(
+template void OutputTransform<half, false, true, true, true, true, false>(
+    int N, int C, int se_K, half* output, const half* input, const half* skip,
+    const half* bias, const half* w1, const half* b1, const half* w2,
+    const half* b2);
+
+template void OutputTransform<half, false, true, true, false, false, false>(
+    int N, int C, int se_K, half* output, const half* input, const half* skip,
+    const half* bias, const half* w1, const half* b1, const half* w2,
+    const half* b2);
+
+template void OutputTransform<half, false, true, true, false, false, true>(
+    int N, int C, int se_K, half* output, const half* input, const half* skip,
+    const half* bias, const half* w1, const half* b1, const half* w2,
+    const half* b2);
+
+template void OutputTransform<half, false, false, true, false, false, false>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
     const half* b2);
 
 template void OutputInputTransform<half, true, true, true, true>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
-    const half* bias, const half* w1, const half* b1, const half* w2,
+    const half* bias, const half* w1, const half* b1, const half* w2, 
     const half* b2);
 
 template void OutputInputTransform<half, false, true, true, true>(

--- a/src/neural/cuda/fp16_kernels.cu
+++ b/src/neural/cuda/fp16_kernels.cu
@@ -200,59 +200,61 @@ template void FilterTransform<half>(int N, int C, half* transformedFilter,
 
 
 template void InputTransform<half, true>(int N, int C, half* transformed_input,
-                                         const half* input);
+                                         const half* input,
+                                         cudaStream_t stream);
 template void InputTransform<half, false>(int N, int C, half* transformed_input,
-                                          const half* input);
+                                          const half* input,
+                                          cudaStream_t stream);
 
 template void OutputTransform<half, true, true, true, true, false, false>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
-    const half* b2);
+    const half* b2, cudaStream_t stream);
 
 template void OutputTransform<half, false, true, true, true, false, false>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
-    const half* b2);
+    const half* b2, cudaStream_t stream);
 
 template void OutputTransform<half, true, true, true, true, true, false>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
-    const half* b2);
+    const half* b2, cudaStream_t stream);
 
 template void OutputTransform<half, false, true, true, true, true, false>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
-    const half* b2);
+    const half* b2, cudaStream_t stream);
 
 template void OutputTransform<half, false, true, true, false, false, false>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
-    const half* b2);
+    const half* b2, cudaStream_t stream);
 
 template void OutputTransform<half, false, true, true, false, false, true>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
-    const half* b2);
+    const half* b2, cudaStream_t stream);
 
 template void OutputTransform<half, false, false, true, false, false, false>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
-    const half* b2);
+    const half* b2, cudaStream_t stream);
 
 template void OutputInputTransform<half, true, true, true, true>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2, 
-    const half* b2);
+    const half* b2, cudaStream_t stream);
 
 template void OutputInputTransform<half, false, true, true, true>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
-    const half* b2);
+    const half* b2, cudaStream_t stream);
 
 template void OutputInputTransform<half, false, true, true, false>(
     int N, int C, int se_K, half* output, const half* input, const half* skip,
     const half* bias, const half* w1, const half* b1, const half* w2,
-    const half* b2);
+    const half* b2, cudaStream_t stream);
 
 }   // namespace cudnn_backend
 }   // namespace lczero

--- a/src/neural/cuda/inputs_outputs.h
+++ b/src/neural/cuda/inputs_outputs.h
@@ -31,7 +31,8 @@ namespace lczero {
 namespace cudnn_backend {
 
 struct InputsOutputs {
-  InputsOutputs(int maxBatchSize, bool wdl, bool moves_left) {
+  InputsOutputs(int maxBatchSize, bool wdl, bool moves_left,
+                size_t tensor_mem_size = 0, size_t scratch_size = 0) {
     ReportCUDAErrors(cudaHostAlloc(
         &input_masks_mem_, maxBatchSize * kInputPlanes * sizeof(uint64_t),
         cudaHostAllocMapped));
@@ -65,6 +66,20 @@ struct InputsOutputs {
       ReportCUDAErrors(cudaHostGetDevicePointer(&op_moves_left_mem_gpu_,
                                                 op_moves_left_mem_, 0));
     }
+
+    // memory for network execution managed inside this structure
+    if (tensor_mem_size) {
+      multi_stream_ = true;
+      ReportCUDAErrors(cudaStreamCreate(&stream_));
+      ReportCUDAErrors(cudaMalloc(&scratch_mem_, scratch_size));
+      for (auto& mem : tensor_mem_) {
+        ReportCUDAErrors(cudaMalloc(&mem, tensor_mem_size));
+        ReportCUDAErrors(cudaMemsetAsync(mem, 0, tensor_mem_size, stream_));
+      }
+      ReportCUBLASErrors(cublasCreate(&cublas_));
+      ReportCUBLASErrors(cublasSetMathMode(cublas_, CUBLAS_TENSOR_OP_MATH));
+      ReportCUBLASErrors(cublasSetStream(cublas_, stream_));
+    }
   }
   ~InputsOutputs() {
     ReportCUDAErrors(cudaFreeHost(input_masks_mem_));
@@ -72,6 +87,17 @@ struct InputsOutputs {
     ReportCUDAErrors(cudaFreeHost(op_policy_mem_));
     ReportCUDAErrors(cudaFree(op_policy_mem_gpu_));
     ReportCUDAErrors(cudaFreeHost(op_value_mem_));
+
+    if (multi_stream_) {
+      for (auto mem : tensor_mem_) {
+        if (mem) ReportCUDAErrors(cudaFree(mem));
+      }
+      if (scratch_mem_) ReportCUDAErrors(cudaFree(scratch_mem_));
+
+      cudaStreamDestroy(stream_);
+      cublasDestroy(cublas_);
+    }
+  
   }
   uint64_t* input_masks_mem_;
   float* input_val_mem_;
@@ -87,6 +113,19 @@ struct InputsOutputs {
 
   // This is a seperate copy.
   float* op_policy_mem_gpu_;
+
+  // memory needed to run the network owned by InputsOutputs when multi_stream
+  // is enabled
+  bool multi_stream_;
+  void* tensor_mem_[3];
+  void* scratch_mem_;
+
+  // cuda stream used to run the network
+  cudaStream_t stream_;
+  cublasHandle_t cublas_;
+
+  // cublas handle used to run the network
+
 };
 
 }  // namespace cudnn_backend

--- a/src/neural/cuda/kernels.h
+++ b/src/neural/cuda/kernels.h
@@ -32,7 +32,7 @@ namespace cudnn_backend {
 // activation (relu, tanh or sigmoid).
 template <typename T>
 void addVectors(T* c, T* a, T* b, int size, int asize, int bsize, bool relu,
-                bool use_tanh, bool use_sigmoid, cudaStream_t stream = 0);
+                bool use_tanh, bool use_sigmoid, cudaStream_t stream);
 
 // Add bias to convolution's output.
 template <typename T>
@@ -45,7 +45,7 @@ void fp32NCHWtofp16NHWC(half* output_tensor, float* input_tensor, int Nin,
 
 // Plain data-type conversion (no layout conversion).
 template <typename DstType, typename SrcType>
-void copyTypeConverted(DstType* op, SrcType* ip, int N, cudaStream_t stream = 0);
+void copyTypeConverted(DstType* op, SrcType* ip, int N, cudaStream_t stream);
 
 // Perform batch normilization.
 template <typename T>

--- a/src/neural/cuda/kernels.h
+++ b/src/neural/cuda/kernels.h
@@ -87,10 +87,11 @@ void PolicyMap(int N, T* output, const T* input, const short* indices,
 template <typename T>
 void FilterTransform(int N, int C, T* transformedFilter, const T* filter);
 
-template <typename T>
+template <typename T, bool nhcw>
 void InputTransform(int N, int C, T* transformedInput, const T* input);
 
-template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
+template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip,
+          bool skipInput_nhcw, bool output_nhcw>
 void OutputTransform(int N, int C, int se_K, T* output, const T* input,
                      const T* skip, const T* bias, const T* w1, const T* b1,
                      const T* w2, const T* b2);

--- a/src/neural/cuda/kernels.h
+++ b/src/neural/cuda/kernels.h
@@ -32,11 +32,11 @@ namespace cudnn_backend {
 // activation (relu, tanh or sigmoid).
 template <typename T>
 void addVectors(T* c, T* a, T* b, int size, int asize, int bsize, bool relu,
-                bool use_tanh, bool use_sigmoid);
+                bool use_tanh, bool use_sigmoid, cudaStream_t stream = 0);
 
 // Add bias to convolution's output.
 template <typename T>
-void addBias_NCHW(T* c, T* a, T* b, int N, int C, int H, int W, bool relu);
+void addBias_NCHW(T* c, T* a, T* b, int N, int C, int H, int W, bool relu, cudaStream_t stream);
 
 // Conversion from: fp32 -> fp16 datatype, and NCHW -> NHWC layout.
 // Cudnn kernels work best with NCHW layout for fp32, and with NHWC for fp16.
@@ -45,7 +45,7 @@ void fp32NCHWtofp16NHWC(half* output_tensor, float* input_tensor, int Nin,
 
 // Plain data-type conversion (no layout conversion).
 template <typename DstType, typename SrcType>
-void copyTypeConverted(DstType* op, SrcType* ip, int N);
+void copyTypeConverted(DstType* op, SrcType* ip, int N, cudaStream_t stream = 0);
 
 // Perform batch normilization.
 template <typename T>
@@ -54,13 +54,13 @@ void batchNorm(T* output, const T* input, const T* skipInput, int N, int C,
 
 // Unpack planes (input to network).
 void expandPlanes_Fp32_NCHW(float* output, const uint64_t* masks,
-                            const float* values, int n);
+                            const float* values, int n, cudaStream_t stream);
 
 void expandPlanes_Fp16_NHWC(half* output, const uint64_t* masks,
-                            const float* values, int n);
+                            const float* values, int n, cudaStream_t stream);
 
 void expandPlanes_Fp16_NCHW(half* output, const uint64_t* masks,
-                            const float* values, int n);
+                            const float* values, int n, cudaStream_t stream);
 
 // Perform global avg pool.
 template <typename T>
@@ -80,7 +80,8 @@ bool Se_Fp16_NHWC(int N, int C, int numFc1Out, half* output, const half* skip,
 
 template <typename T>
 void PolicyMap(int N, T* output, const T* input, const short* indices,
-               int inputSize, int usedSize, int outputSize);
+               int inputSize, int usedSize, int outputSize,
+               cudaStream_t stream);
 
 
 // Custom winograd helper functions
@@ -88,18 +89,18 @@ template <typename T>
 void FilterTransform(int N, int C, T* transformedFilter, const T* filter);
 
 template <typename T, bool nhcw>
-void InputTransform(int N, int C, T* transformedInput, const T* input);
+void InputTransform(int N, int C, T* transformedInput, const T* input, cudaStream_t stream);
 
 template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip,
           bool skipInput_nhcw, bool output_nhcw>
 void OutputTransform(int N, int C, int se_K, T* output, const T* input,
                      const T* skip, const T* bias, const T* w1, const T* b1,
-                     const T* w2, const T* b2);
+                     const T* w2, const T* b2, cudaStream_t stream);
 
 template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
 void OutputInputTransform(int N, int C, int se_K, T* output, const T* input,
                      const T* skip, const T* bias, const T* w1, const T* b1,
-                     const T* w2, const T* b2);
+                     const T* w2, const T* b2, cudaStream_t stream);
 
 }  // namespace cudnn_backend
 }  // namespace lczero

--- a/src/neural/cuda/layers.h
+++ b/src/neural/cuda/layers.h
@@ -56,7 +56,7 @@ class BaseLayer {
   // Input2 is optional (skip connection).
   virtual void Eval(int N, DataType* output, const DataType* input,
                     const DataType* input2, void* scratch, size_t scratch_size,
-                    cudnnHandle_t cudnn, cublasHandle_t cublas) = 0;
+                    cudnnHandle_t cudnn, cublasHandle_t cublas, cudaStream_t stream) = 0;
 
  protected:
   BaseLayer* input_;
@@ -90,7 +90,8 @@ class ConvLayer : public BaseLayer<DataType> {
   void LoadWeights(float* pfilter, float* pBias, void* scratch);
   void Eval(int N, DataType* output, const DataType* input,
             const DataType* input2, void* scratch, size_t scratch_size,
-            cudnnHandle_t cudnn, cublasHandle_t cublas) override;
+            cudnnHandle_t cudnn, cublasHandle_t cublas,
+            cudaStream_t stream) override;
 
  private:
   const int c_input_;
@@ -127,7 +128,8 @@ class FCLayer : public BaseLayer<DataType> {
   void LoadWeights(float* cpuWeight, float* cpuBias, void* scratch);
   void Eval(int N, DataType* output, const DataType* input,
             const DataType* input2, void* scratch, size_t scratch_size,
-            cudnnHandle_t cudnn, cublasHandle_t cublas) override;
+            cudnnHandle_t cudnn, cublasHandle_t cublas,
+            cudaStream_t stream) override;
 
  private:
   const bool use_bias_;
@@ -149,7 +151,8 @@ class PolicyMapLayer: public BaseLayer<DataType> {
   void LoadWeights(const short* cpuWeight, void* scratch);
   void Eval(int N, DataType* output, const DataType* input,
             const DataType* input2, void* scratch, size_t scratch_size,
-            cudnnHandle_t cudnn, cublasHandle_t cublas) override;
+            cudnnHandle_t cudnn, cublasHandle_t cublas,
+            cudaStream_t stream) override;
 
  private:
   int used_size_; // Size of the input without padding (typically 73x64).
@@ -176,7 +179,8 @@ class SELayer : public BaseLayer<DataType> {
 
   void Eval(int N, DataType* output, const DataType* input,
             const DataType* input2, void* scratch, size_t scratch_size,
-            cudnnHandle_t cudnn, cublasHandle_t cublas) override;
+            cudnnHandle_t cudnn, cublasHandle_t cublas,
+            cudaStream_t stream) override;
 
  private:
   DataType* w1_ = nullptr;
@@ -213,7 +217,8 @@ class FusedWinogradConvSELayer : public BaseLayer<DataType> {
   void Eval(int N, DataType* output, const DataType* input,
             const DataType* input2,
             void* scratch, size_t scratch_size,
-            cudnnHandle_t cudnn, cublasHandle_t cublas) override;
+            cudnnHandle_t cudnn, cublasHandle_t cublas,
+            cudaStream_t stream) override;
 
  private:
   const int c_input_;
@@ -258,7 +263,8 @@ class Conv1Layer : public BaseLayer<DataType> {
   void Eval(int N, DataType* output, const DataType* input,
             const DataType* input2,
             void* scratch, size_t scratch_size,
-            cudnnHandle_t cudnn, cublasHandle_t cublas) override;
+            cudnnHandle_t cudnn, cublasHandle_t cublas,
+            cudaStream_t stream) override;
 
  private:
   const int c_input_;
@@ -294,7 +300,8 @@ class ResidualBlock : public BaseLayer<DataType> {
 
   void Eval(int N, DataType* output, const DataType* input,
             const DataType* input2, void* scratch, size_t scratch_size,
-            cudnnHandle_t cudnn, cublasHandle_t cublas) override;
+            cudnnHandle_t cudnn, cublasHandle_t cublas,
+            cudaStream_t stream) override;
 
  private:
   const bool has_se_;

--- a/src/neural/cuda/layers.h
+++ b/src/neural/cuda/layers.h
@@ -204,8 +204,8 @@ class FusedWinogradConvSELayer : public BaseLayer<DataType> {
 
  public:
   FusedWinogradConvSELayer(BaseLayer<DataType>* ip, int C, int H, int W,
-                         int Cin, bool relu, bool bias, bool skipAdd, bool se,
-                           int se_k, bool use_gemm_ex);
+                           int Cin, bool relu, bool bias, bool skipAdd, bool se,
+                           int se_k, bool use_gemm_ex, bool op_nhcw = false);
 
   ~FusedWinogradConvSELayer();
   void LoadWeights(float* pfilter, float* pBias, void* scratch);
@@ -223,6 +223,7 @@ class FusedWinogradConvSELayer : public BaseLayer<DataType> {
   const bool has_se_;
   const int se_k_;
   const bool use_gemm_ex_;
+  const bool op_nhcw_;
 
   DataType* biases_ = nullptr;
   DataType* transformed_weights_ = nullptr;  // After winograd transform.

--- a/src/neural/cuda/network_cuda.cc
+++ b/src/neural/cuda/network_cuda.cc
@@ -239,8 +239,8 @@ class CudaNetwork : public Network {
     // Input.
     {
       auto inputConv = std::make_unique<FusedWinogradConvSELayer<DataType>>(
-          nullptr, kNumFilters, 8, 8, kNumInputPlanes, true, true, false,
-          false, 0, use_gemm_ex);
+          nullptr, kNumFilters, 8, 8, kNumInputPlanes, true, true, false, false,
+          0, use_gemm_ex, use_res_block_winograd_fuse_opt_);
       inputConv->LoadWeights(&weights.input.weights[0],
                              &weights.input.biases[0], scratch_mem_);
       network_.emplace_back(std::move(inputConv));

--- a/src/neural/cuda/network_cuda.cc
+++ b/src/neural/cuda/network_cuda.cc
@@ -41,8 +41,6 @@
 #include "utils/bititer.h"
 #include "utils/exception.h"
 
-//#define DEBUG_RAW_NPS
-
 namespace lczero {
 using namespace cudnn_backend;
 
@@ -145,7 +143,7 @@ class CudaNetwork : public Network {
     // Select GPU to run on (for *the current* thread).
     ReportCUDAErrors(cudaSetDevice(gpu_id_));
 
-    ReportCUBLASErrors(cublasCreate(&cublas_));
+    multi_stream_ = options.GetOrDefault<bool>("multi_stream", true);
 
     // Default layout is nchw.
     bool hasTensorCores = false;
@@ -170,8 +168,11 @@ class CudaNetwork : public Network {
       }
     }
 
-    if (hasTensorCores)
-      ReportCUBLASErrors(cublasSetMathMode(cublas_, CUBLAS_TENSOR_OP_MATH));
+    if (!multi_stream_) {
+      ReportCUBLASErrors(cublasCreate(&cublas_));
+      if (hasTensorCores)
+        ReportCUBLASErrors(cublasSetMathMode(cublas_, CUBLAS_TENSOR_OP_MATH));
+    }
 
     const int kNumInputPlanes = kInputPlanes;
     const int kNumFilters = (int)weights.input.biases.size();
@@ -230,9 +231,6 @@ class CudaNetwork : public Network {
     scratch_size_ = std::max(scratch_size_, 2 * transformed_tensor_size);
 
     ReportCUDAErrors(cudaMalloc(&scratch_mem_, scratch_size_));
-#ifdef DEBUG_RAW_NPS
-    CERR << "allocated " << scratch_size_ << " bytes for scratch memory";
-#endif
 
     // 2. Build the network, and copy the weights to GPU memory.
 
@@ -403,19 +401,19 @@ class CudaNetwork : public Network {
     if (use_res_block_winograd_fuse_opt_ && scratch_size_ > maxSize)
       maxSize = scratch_size_;
 
-    for (auto& mem : tensor_mem_) {
-      ReportCUDAErrors(cudaMalloc(&mem, maxSize));
-      ReportCUDAErrors(cudaMemset(mem, 0, maxSize));
+    if (!multi_stream_) {
+      for (auto& mem : tensor_mem_) {
+        ReportCUDAErrors(cudaMalloc(&mem, maxSize));
+        ReportCUDAErrors(cudaMemset(mem, 0, maxSize));
+      }
     }
 
-#ifdef DEBUG_RAW_NPS
-    CERR << "allocated " << 3 * maxSize
-         << " bytes of GPU memory to run the network";
-#endif
+    tensor_mem_size_ = maxSize;
   }
 
   void forwardEval(InputsOutputs* io, int batchSize) {
-    std::unique_lock<std::mutex> lock(lock_);
+    if (!multi_stream_)
+      lock_.lock();
 
 #ifdef DEBUG_RAW_NPS
     auto t_start = std::chrono::high_resolution_clock::now();
@@ -425,13 +423,31 @@ class CudaNetwork : public Network {
     uint64_t* ipDataMasks = io->input_masks_mem_gpu_;
     float* ipDataValues = io->input_val_mem_gpu_;
 
+    DataType* tensor_mem[3];
+    void* scratch_mem;
+    cudaStream_t stream;
+    cublasHandle_t cublas;
+    if (multi_stream_) {
+      // We use tensor and scratch memory from InputOutputs (so that multiple
+      // requests can run in parallel)
+      for (int i = 0; i < 3; i++) tensor_mem[i] = (DataType*)io->tensor_mem_[i];
+      scratch_mem = io->scratch_mem_;
+      stream = io->stream_;
+      cublas = io->cublas_;
+    } else {
+      for (int i = 0; i < 3; i++) tensor_mem[i] = tensor_mem_[i];
+      scratch_mem = io->scratch_mem_;
+      stream = 0;           // default stream
+      cublas = cublas_;
+    }
+
     bool fp16 = std::is_same<half, DataType>::value;
     if (fp16) {
-      expandPlanes_Fp16_NCHW((half*)(tensor_mem_[0]), ipDataMasks,
-                               ipDataValues, batchSize * kInputPlanes);
+      expandPlanes_Fp16_NCHW((half*)(tensor_mem[0]), ipDataMasks,
+                               ipDataValues, batchSize * kInputPlanes, stream);
     } else {
-      expandPlanes_Fp32_NCHW((float*)(tensor_mem_[0]), ipDataMasks,
-                             ipDataValues, batchSize * kInputPlanes);
+      expandPlanes_Fp32_NCHW((float*)(tensor_mem[0]), ipDataMasks, ipDataValues,
+                             batchSize * kInputPlanes, stream);
     }
 
     float* opPol = io->op_policy_mem_gpu_;
@@ -442,133 +458,141 @@ class CudaNetwork : public Network {
     // Input.
     network_[l++]->Eval(
         batchSize,
-        use_res_block_winograd_fuse_opt_ ? tensor_mem_[1] : tensor_mem_[2],
-        tensor_mem_[0], nullptr, scratch_mem_, scratch_size_, nullptr,
-        cublas_);  // input conv
+        use_res_block_winograd_fuse_opt_ ? tensor_mem[1] : tensor_mem[2],
+        tensor_mem[0], nullptr, scratch_mem, scratch_size_, nullptr, cublas,
+        stream);  // input conv
 
     // Residual block.
     for (int block = 0; block < numBlocks_; block++) {
       if (use_res_block_winograd_fuse_opt_) {
-        network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[1], nullptr,
-                            scratch_mem_, scratch_size_, nullptr,
-                            cublas_);  // block
+        network_[l++]->Eval(batchSize, tensor_mem[2], tensor_mem[1], nullptr,
+                            scratch_mem, scratch_size_, nullptr, cublas,
+                            stream);  // block
       } else {
-        network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2], nullptr,
-                            scratch_mem_, scratch_size_, nullptr,
-                            cublas_);  // conv1
+        network_[l++]->Eval(batchSize, tensor_mem[0], tensor_mem[2], nullptr,
+                            scratch_mem, scratch_size_, nullptr, cublas,
+                            stream);  // conv1
 
-        network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[0],
-                          tensor_mem_[2], scratch_mem_, scratch_size_, nullptr,
-                          cublas_);  // conv2
+        network_[l++]->Eval(batchSize, tensor_mem[2], tensor_mem[0],
+                            tensor_mem[2], scratch_mem, scratch_size_, nullptr,
+                            cublas, stream);  // conv2
         }
     }
 
     // Policy head.
     if (conv_policy_) {
-      network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2], nullptr,
-                          scratch_mem_, scratch_size_, nullptr,
-                          cublas_);  // policy conv1
+      network_[l++]->Eval(batchSize, tensor_mem[0], tensor_mem[2], nullptr,
+                          scratch_mem, scratch_size_, nullptr, cublas,
+                          stream);  // policy conv1
 
-      network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0], nullptr,
-                          scratch_mem_, scratch_size_, nullptr,
-                          cublas_);  // policy conv2
+      network_[l++]->Eval(batchSize, tensor_mem[1], tensor_mem[0], nullptr,
+                          scratch_mem, scratch_size_, nullptr, cublas,
+                          stream);  // policy conv2
 
       if (fp16) {
-        network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[1], nullptr,
-                            scratch_mem_, scratch_size_, nullptr,
-                            cublas_);  // policy map layer
-        copyTypeConverted(opPol, (half*)(tensor_mem_[0]),
-                          batchSize * kNumOutputPolicy);  // POLICY output
+        network_[l++]->Eval(batchSize, tensor_mem[0], tensor_mem[1], nullptr,
+                            scratch_mem, scratch_size_, nullptr, cublas,
+                            stream);  // policy map layer
+        copyTypeConverted(opPol, (half*)(tensor_mem[0]),
+                          batchSize * kNumOutputPolicy,
+                          stream);  // POLICY output
       } else {
-        network_[l++]->Eval(batchSize, (DataType*)opPol, tensor_mem_[1],
-                            nullptr, scratch_mem_, scratch_size_, nullptr,
-                            cublas_);  // policy map layer  // POLICY output
+        network_[l++]->Eval(batchSize, (DataType*)opPol, tensor_mem[1], nullptr,
+                            scratch_mem, scratch_size_, nullptr, cublas,
+                            stream);  // policy map layer  // POLICY output
       }
     } else {
-      network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2], nullptr,
-                          scratch_mem_, scratch_size_, nullptr,
-                          cublas_);  // pol conv
+      network_[l++]->Eval(batchSize, tensor_mem[0], tensor_mem[2], nullptr,
+                          scratch_mem, scratch_size_, nullptr, cublas,
+                          stream);  // pol conv
 
       if (fp16) {
-        network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0], nullptr,
-                            scratch_mem_, scratch_size_, nullptr,
-                            cublas_);  // pol FC
+        network_[l++]->Eval(batchSize, tensor_mem[1], tensor_mem[0], nullptr,
+                            scratch_mem, scratch_size_, nullptr, cublas,
+                            stream);  // pol FC
 
-        copyTypeConverted(opPol, (half*)(tensor_mem_[1]),
-                          batchSize * kNumOutputPolicy);  // POLICY
+        copyTypeConverted(opPol, (half*)(tensor_mem[1]),
+                          batchSize * kNumOutputPolicy, stream);  // POLICY
       } else {
-        network_[l++]->Eval(batchSize, (DataType*)opPol, tensor_mem_[0],
-                            nullptr, scratch_mem_, scratch_size_, nullptr,
-                            cublas_);  // pol FC  // POLICY
+        network_[l++]->Eval(batchSize, (DataType*)opPol, tensor_mem[0], nullptr,
+                            scratch_mem, scratch_size_, nullptr, cublas,
+                            stream);  // pol FC  // POLICY
       }
     }
 
     // Copy policy output from device memory to host memory.
     ReportCUDAErrors(cudaMemcpyAsync(
         io->op_policy_mem_, io->op_policy_mem_gpu_,
-        sizeof(float) * kNumOutputPolicy * batchSize, cudaMemcpyDeviceToHost));
+                        sizeof(float) * kNumOutputPolicy * batchSize,
+                        cudaMemcpyDeviceToHost, stream));
 
     // value head
-    network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2], nullptr,
-                        scratch_mem_, scratch_size_, nullptr,
-                        cublas_);  // value conv
+    network_[l++]->Eval(batchSize, tensor_mem[0], tensor_mem[2], nullptr,
+                        scratch_mem, scratch_size_, nullptr, cublas,
+                        stream);  // value conv
 
-    network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0], nullptr,
-                        scratch_mem_, scratch_size_, nullptr,
-                        cublas_);  // value FC1
+    network_[l++]->Eval(batchSize, tensor_mem[1], tensor_mem[0], nullptr,
+                        scratch_mem, scratch_size_, nullptr, cublas,
+                        stream);  // value FC1
 
     if (wdl_) {
       if (fp16) {
-        network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[1], nullptr,
-                            scratch_mem_, scratch_size_, nullptr,
-                            cublas_);  // value FC2    // VALUE
-        copyTypeConverted(opVal, (half*)(tensor_mem_[0]),
-                          3 * batchSize);  // VALUE
+        network_[l++]->Eval(batchSize, tensor_mem[0], tensor_mem[1], nullptr,
+                            scratch_mem, scratch_size_, nullptr, cublas,
+                            stream);  // value FC2    // VALUE
+        copyTypeConverted(opVal, (half*)(tensor_mem[0]), 3 * batchSize,
+                          stream);  // VALUE
       } else {
-        network_[l++]->Eval(batchSize, (DataType*)opVal, tensor_mem_[1],
-                            nullptr, scratch_mem_, scratch_size_, nullptr,
-                            cublas_);  // value FC2    // VALUE
+        network_[l++]->Eval(batchSize, (DataType*)opVal, tensor_mem[1], nullptr,
+                            scratch_mem, scratch_size_, nullptr, cublas,
+                            stream);  // value FC2    // VALUE
       }
     } else {
       if (fp16) {
         // TODO: consider fusing the bias-add of FC2 with format conversion.
-        network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[1], nullptr,
-                            scratch_mem_, scratch_size_, nullptr,
-                            cublas_);  // value FC2
-        copyTypeConverted(opVal, (half*)(tensor_mem_[0]), batchSize);  // VALUE
+        network_[l++]->Eval(batchSize, tensor_mem[0], tensor_mem[1], nullptr,
+                            scratch_mem, scratch_size_, nullptr, cublas,
+                            stream);  // value FC2
+        copyTypeConverted(opVal, (half*)(tensor_mem[0]), batchSize,
+                          stream);  // VALUE
       } else {
-        network_[l++]->Eval(batchSize, (DataType*)opVal, tensor_mem_[1],
-                            nullptr, scratch_mem_, scratch_size_, nullptr,
-                            cublas_);  // value FC2    // VALUE
+        network_[l++]->Eval(batchSize, (DataType*)opVal, tensor_mem[1], nullptr,
+                            scratch_mem, scratch_size_, nullptr, cublas,
+                            stream);  // value FC2    // VALUE
       }
     }
 
     if (moves_left_) {
       // Moves left head
-      network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2], nullptr,
-                          scratch_mem_, scratch_size_, nullptr,
-                          cublas_);  // moves conv
+      network_[l++]->Eval(batchSize, tensor_mem[0], tensor_mem[2], nullptr,
+                          scratch_mem, scratch_size_, nullptr, cublas,
+                          stream);  // moves conv
 
-      network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0], nullptr,
-                          scratch_mem_, scratch_size_, nullptr,
-                          cublas_);  // moves FC1
+      network_[l++]->Eval(batchSize, tensor_mem[1], tensor_mem[0], nullptr,
+                          scratch_mem, scratch_size_, nullptr, cublas,
+                          stream);  // moves FC1
 
       // Moves left FC2
       if (fp16) {
         // TODO: consider fusing the bias-add of FC2 with format conversion.
-        network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[1], nullptr,
-                            scratch_mem_, scratch_size_, nullptr, cublas_);
-        copyTypeConverted(opMov, (half*)(tensor_mem_[0]), batchSize);
+        network_[l++]->Eval(batchSize, tensor_mem[0], tensor_mem[1], nullptr,
+                            scratch_mem, scratch_size_, nullptr, cublas,
+                            stream);
+        copyTypeConverted(opMov, (half*)(tensor_mem[0]), batchSize, stream);
       } else {
-        network_[l++]->Eval(batchSize, (DataType*)opMov, tensor_mem_[1],
-                            nullptr, scratch_mem_, scratch_size_, nullptr,
-                            cublas_);
+        network_[l++]->Eval(batchSize, (DataType*)opMov, tensor_mem[1], nullptr,
+                            scratch_mem, scratch_size_, nullptr, cublas,
+                            stream);
       }
     }
 
-    ReportCUDAErrors(cudaDeviceSynchronize());
-    // The next thread can start using the GPU now.
-    lock.unlock();
+    if (multi_stream_) {
+      ReportCUDAErrors(cudaStreamSynchronize(stream));
+    } else {
+      ReportCUDAErrors(cudaDeviceSynchronize());
+      // The next thread can start using the GPU now.
+      lock_.unlock();
+    }
 
     if (wdl_) {
       // Value softmax done cpu side.
@@ -585,39 +609,16 @@ class CudaNetwork : public Network {
         io->op_value_mem_[3 * i + 2] = l;
       }
     }
-
-#ifdef DEBUG_RAW_NPS
-    const int reportingCalls = 100;
-    static int numCalls = 0;
-    static int sumBatchSize = 0;
-    static double totalTime = 0;
-
-    sumBatchSize += batchSize;
-    numCalls++;
-
-    auto t_end = std::chrono::high_resolution_clock::now();
-
-    double dt = std::chrono::duration<double>(t_end - t_start).count();
-    totalTime += dt;
-    if (numCalls == reportingCalls) {
-      double avgBatchSize = ((double)sumBatchSize) / numCalls;
-      double nps = sumBatchSize / totalTime;
-      CERR << "Avg batch size: " << avgBatchSize
-           << ", NN eval time: " << totalTime << " seconds per " << sumBatchSize
-           << " evals. NPS: " << nps;
-      sumBatchSize = 0;
-      totalTime = 0;
-      numCalls = 0;
-    }
-#endif
   }
 
   ~CudaNetwork() {
-    for (auto mem : tensor_mem_) {
-      if (mem) ReportCUDAErrors(cudaFree(mem));
-    }
     if (scratch_mem_) ReportCUDAErrors(cudaFree(scratch_mem_));
-    cublasDestroy(cublas_);
+    if (!multi_stream_) {
+      for (auto mem : tensor_mem_) {
+        if (mem) ReportCUDAErrors(cudaFree(mem));
+      }
+      cublasDestroy(cublas_);
+    }
   }
 
   const NetworkCapabilities& GetCapabilities() const override {
@@ -636,7 +637,7 @@ class CudaNetwork : public Network {
     std::lock_guard<std::mutex> lock(inputs_outputs_lock_);
     if (free_inputs_outputs_.empty()) {
       return std::make_unique<InputsOutputs>(max_batch_size_, wdl_,
-                                             moves_left_);
+                                             moves_left_, tensor_mem_size_, scratch_size_);
     } else {
       std::unique_ptr<InputsOutputs> resource =
           std::move(free_inputs_outputs_.front());
@@ -657,12 +658,12 @@ class CudaNetwork : public Network {
 
  private:
   const NetworkCapabilities capabilities_;
-  cublasHandle_t cublas_;
   int gpu_id_;
   int max_batch_size_;
   bool wdl_;
   bool moves_left_;
   bool use_res_block_winograd_fuse_opt_;    // fuse operations inside the residual tower
+  bool multi_stream_;                       // run multiple parallel network evals
 
   // Currently only one NN Eval can happen a time (we can fix this if needed
   // by allocating more memory).
@@ -679,9 +680,15 @@ class CudaNetwork : public Network {
   BaseLayer<DataType>* value_out_;
   BaseLayer<DataType>* moves_left_out_;
 
-  DataType* tensor_mem_[3];
-  void* scratch_mem_;
+  size_t tensor_mem_size_;
   size_t scratch_size_;
+
+  // this copy is used only for initialization when multi-stream is enabled
+  void* scratch_mem_;
+
+  // not used when multi-steam is enabled
+  cublasHandle_t cublas_;
+  DataType* tensor_mem_[3];
 
   mutable std::mutex inputs_outputs_lock_;
   std::list<std::unique_ptr<InputsOutputs>> free_inputs_outputs_;

--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -560,6 +560,9 @@ class CudnnNetwork : public Network {
     auto t_start = std::chrono::high_resolution_clock::now();
 #endif
 
+    // TODO: consider supporting multi-stream path for cudnn backend too.
+    cudaStream_t stream = 0;    // default stream
+
     // Expand packed planes to full planes.
     uint64_t* ipDataMasks = io->input_masks_mem_gpu_;
     float* ipDataValues = io->input_val_mem_gpu_;
@@ -568,13 +571,13 @@ class CudnnNetwork : public Network {
     if (fp16) {
       if (nhwc_)
         expandPlanes_Fp16_NHWC((half*)(tensor_mem_[0]), ipDataMasks,
-                               ipDataValues, batchSize * kInputPlanes);
+                               ipDataValues, batchSize * kInputPlanes, stream);
       else
         expandPlanes_Fp16_NCHW((half*)(tensor_mem_[0]), ipDataMasks,
-                               ipDataValues, batchSize * kInputPlanes);
+                               ipDataValues, batchSize * kInputPlanes, stream);
     } else {
       expandPlanes_Fp32_NCHW((float*)(tensor_mem_[0]), ipDataMasks,
-                             ipDataValues, batchSize * kInputPlanes);
+                             ipDataValues, batchSize * kInputPlanes, stream);
     }
 
     // debug code example
@@ -588,38 +591,36 @@ class CudnnNetwork : public Network {
     // Input.
     network_[l++]->Eval(
         batchSize, tensor_mem_[2],
-        tensor_mem_[0], nullptr, scratch_mem_, scratch_size_, cudnn_,
-        cublas_);  // input conv
+        tensor_mem_[0], nullptr, scratch_mem_, scratch_size_, cudnn_, cublas_,
+                        stream);  // input conv
 
     // Residual block.
     for (int block = 0; block < numBlocks_; block++) {
       network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2], nullptr,
-                          scratch_mem_, scratch_size_, cudnn_,
-                          cublas_);  // conv1
+                          scratch_mem_, scratch_size_, cudnn_, cublas_,
+                          stream);  // conv1
 
       if (use_custom_winograd_) {
         network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[0],
                             tensor_mem_[2], scratch_mem_, scratch_size_, cudnn_,
-                            cublas_);  // conv2
+                            cublas_, stream);  // conv2
       } else {
         // For SE Resnet, skip connection is added after SE (and bias is added
         // as part of SE).
         if (has_se_) {
           network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0],
                               nullptr, scratch_mem_, scratch_size_, cudnn_,
-                              cublas_);  // conv2
+                              cublas_, stream);  // conv2
         } else {
           network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[0],
                               tensor_mem_[2], scratch_mem_, scratch_size_,
-                              cudnn_,
-                              cublas_);  // conv2
+                              cudnn_, cublas_, stream);  // conv2
         }
 
         if (has_se_) {
           network_[l++]->Eval(batchSize, tensor_mem_[2], tensor_mem_[1],
                               tensor_mem_[2], scratch_mem_, scratch_size_,
-                              cudnn_,
-                              cublas_);  // SE layer
+                              cudnn_, cublas_, stream);  // SE layer
         }
       }
     }
@@ -627,40 +628,42 @@ class CudnnNetwork : public Network {
     // Policy head.
     if (conv_policy_) {
       network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2], nullptr,
-                          scratch_mem_, scratch_size_, cudnn_,
-                          cublas_);  // policy conv1
+                          scratch_mem_, scratch_size_, cudnn_, cublas_,
+                          stream);  // policy conv1
 
       network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0], nullptr,
-                          scratch_mem_, scratch_size_, cudnn_,
-                          cublas_);  // policy conv2
+                          scratch_mem_, scratch_size_, cudnn_, cublas_,
+                          stream);  // policy conv2
 
       if (fp16) {
         network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[1], nullptr,
-                            scratch_mem_, scratch_size_, cudnn_,
-                            cublas_);  // policy map layer
+                            scratch_mem_, scratch_size_, cudnn_, cublas_,
+                            stream);  // policy map layer
         copyTypeConverted(opPol, (half*)(tensor_mem_[0]),
-                          batchSize * kNumOutputPolicy);  // POLICY output
+                          batchSize * kNumOutputPolicy,
+                          stream);  // POLICY output
       } else {
         network_[l++]->Eval(batchSize, (DataType*)opPol, tensor_mem_[1],
                             nullptr, scratch_mem_, scratch_size_, cudnn_,
-                            cublas_);  // policy map layer  // POLICY output
+                            cublas_,
+                            stream);  // policy map layer  // POLICY output
       }
     } else {
       network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2], nullptr,
-                          scratch_mem_, scratch_size_, cudnn_,
-                          cublas_);  // pol conv
+                          scratch_mem_, scratch_size_, cudnn_, cublas_,
+                          stream);  // pol conv
 
       if (fp16) {
         network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0], nullptr,
-                            scratch_mem_, scratch_size_, cudnn_,
-                            cublas_);  // pol FC
+                            scratch_mem_, scratch_size_, cudnn_, cublas_,
+                            stream);  // pol FC
 
         copyTypeConverted(opPol, (half*)(tensor_mem_[1]),
-                          batchSize * kNumOutputPolicy);  // POLICY
+                          batchSize * kNumOutputPolicy, stream);  // POLICY
       } else {
         network_[l++]->Eval(batchSize, (DataType*)opPol, tensor_mem_[0],
                             nullptr, scratch_mem_, scratch_size_, cudnn_,
-                            cublas_);  // pol FC  // POLICY
+                            cublas_, stream);  // pol FC  // POLICY
       }
     }
 
@@ -671,47 +674,48 @@ class CudnnNetwork : public Network {
 
     // value head
     network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2], nullptr,
-                        scratch_mem_, scratch_size_, cudnn_,
-                        cublas_);  // value conv
+                        scratch_mem_, scratch_size_, cudnn_, cublas_,
+                        stream);  // value conv
 
     network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0], nullptr,
-                        scratch_mem_, scratch_size_, cudnn_,
-                        cublas_);  // value FC1
+                        scratch_mem_, scratch_size_, cudnn_, cublas_,
+                        stream);  // value FC1
 
 
     if (fp16) {
       // TODO: consider fusing the bias-add of FC2 with format conversion.
       network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[1], nullptr,
-                          scratch_mem_, scratch_size_, cudnn_,
-                          cublas_);  // value FC2
+                          scratch_mem_, scratch_size_, cudnn_, cublas_,
+                          stream);  // value FC2
       copyTypeConverted(opVal, (half*)(tensor_mem_[0]),
-                        wdl_ ? 3 * batchSize : batchSize);  // VALUE
+                        wdl_ ? 3 * batchSize : batchSize, stream);  // VALUE
     } else {
       network_[l++]->Eval(batchSize, (DataType*)opVal, tensor_mem_[1],
-                          nullptr, scratch_mem_, scratch_size_, cudnn_,
-                          cublas_);  // value FC2    // VALUE
+                          nullptr, scratch_mem_, scratch_size_, cudnn_, cublas_,
+                          stream);  // value FC2    // VALUE
     }
 
     if (moves_left_) {
       // Moves left head
       network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[2], nullptr,
-                          scratch_mem_, scratch_size_, cudnn_,
-                          cublas_);  // moves conv
+                          scratch_mem_, scratch_size_, cudnn_, cublas_,
+                          stream);  // moves conv
 
       network_[l++]->Eval(batchSize, tensor_mem_[1], tensor_mem_[0], nullptr,
-                          scratch_mem_, scratch_size_, cudnn_,
-                          cublas_);  // moves FC1
+                          scratch_mem_, scratch_size_, cudnn_, cublas_,
+                          stream);  // moves FC1
 
       // Moves left FC2
       if (fp16) {
         // TODO: consider fusing the bias-add of FC2 with format conversion.
         network_[l++]->Eval(batchSize, tensor_mem_[0], tensor_mem_[1], nullptr,
-                            scratch_mem_, scratch_size_, cudnn_, cublas_);
-        copyTypeConverted(opMov, (half*)(tensor_mem_[0]), batchSize);
+                            scratch_mem_, scratch_size_, cudnn_, cublas_,
+                            stream);
+        copyTypeConverted(opMov, (half*)(tensor_mem_[0]), batchSize, stream);
       } else {
         network_[l++]->Eval(batchSize, (DataType*)opMov, tensor_mem_[1],
                             nullptr, scratch_mem_, scratch_size_, cudnn_,
-                            cublas_);
+                            cublas_, stream);
       }
     }
 

--- a/src/neural/cuda/winograd_helper.inc
+++ b/src/neural/cuda/winograd_helper.inc
@@ -126,11 +126,13 @@ __global__ void filterTransform_kernel(int K, int C, int elements,
 }
 
 
+#define INDEX_NCHW(n, c, h, w) ((n)*C * 8 * 8 + (c)*8 * 8 + (h)*8 + w)
+#define INDEX_NHCW(n, c, h, w) ((n)*C * 8 * 8 + (h)*C * 8 + (c)*8 + w)
+
 // index in intermediate/temp tensor
 // W, H == 6 here! (6x6 transformed blocks)
 // N also includes part of dimension (2x2)
 #define GemmN (N * 4)
-#define INDEX_NCHW(n, c, h, w) ((n)*C * 8 * 8 + (c)*8 * 8 + (h)*8 + w)
 #define TEMP_INDEX_HWNC(h, w, n, c) \
   ((h)*6 * GemmN * C + (w)*GemmN * C + (n)*C + c)
 
@@ -138,7 +140,7 @@ __global__ void filterTransform_kernel(int K, int C, int elements,
 // 'N' blocks
 // every thread transforms an entire board/plane (8x8 elements)
 // - producing 4 x 6x6 elements
-template <typename T>
+template <typename T, bool nhcw>
 __global__ void InputTransform_kernel(int N, int C, const T* input, T* output) {
   int c = threadIdx.x;
   int n = blockIdx.x;
@@ -150,9 +152,15 @@ __global__ void InputTransform_kernel(int N, int C, const T* input, T* output) {
 // read the board (a row at a time for fp16)
 #pragma unroll
   for (int y = 0; y < 8; y++) {
-    *((uint4*)(&board[y][0])) = *((uint4*)(&input[INDEX_NCHW(n, c, y, 0)]));
-    if (!fp16)
-      *((uint4*)(&board[y][4])) = *((uint4*)(&input[INDEX_NCHW(n, c, y, 4)]));
+    if (nhcw) {
+      *((uint4*)(&board[y][0])) = *((uint4*)(&input[INDEX_NHCW(n, c, y, 0)]));
+      if (!fp16)
+        *((uint4*)(&board[y][4])) = *((uint4*)(&input[INDEX_NHCW(n, c, y, 4)]));
+    } else {
+      *((uint4*)(&board[y][0])) = *((uint4*)(&input[INDEX_NCHW(n, c, y, 0)]));
+      if (!fp16)
+        *((uint4*)(&board[y][4])) = *((uint4*)(&input[INDEX_NCHW(n, c, y, 4)]));
+    }
   }
 
   // top-left
@@ -240,7 +248,8 @@ __global__ void InputTransform_kernel(int N, int C, const T* input, T* output) {
 // 'C' threads per block
 // 'N' blocks
 // every thread generates an entire board/plane (8x8 elements)
-template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
+template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip, 
+          bool skipInput_nhcw, bool output_nhcw>
 __global__ void OutputTransform_kernel(int N, int C, int se_K, T* output,
                                        const T* input, const T* skip,
                                        const T* bias, const T* w1, const T* b1,
@@ -329,9 +338,15 @@ __global__ void OutputTransform_kernel(int N, int C, int se_K, T* output,
     // residual add
     if (use_skip) {
       T skipInp[8];
-      *((uint4*)(&skipInp[0])) = *((uint4*)(&skip[INDEX_NCHW(n, k, h, 0)]));
-      if (!fp16)
-        *((uint4*)(&skipInp[4])) = *((uint4*)(&skip[INDEX_NCHW(n, k, h, 4)]));
+      if (skipInput_nhcw) {
+        *((uint4*)(&skipInp[0])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 0)]));
+        if (!fp16)
+          *((uint4*)(&skipInp[4])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 4)]));
+      } else {
+        *((uint4*)(&skipInp[0])) = *((uint4*)(&skip[INDEX_NCHW(n, k, h, 0)]));
+        if (!fp16)
+          *((uint4*)(&skipInp[4])) = *((uint4*)(&skip[INDEX_NCHW(n, k, h, 4)]));
+      }
 #pragma unroll
       for (int w = 0; w < 8; w++) board[h][w] += skipInp[w];
     }
@@ -344,9 +359,15 @@ __global__ void OutputTransform_kernel(int N, int C, int se_K, T* output,
     }
 
     // Write to output (use 128 bit writes to store one row a time)
-    *((uint4*)(&output[INDEX_NCHW(n, k, h, 0)])) = *((uint4*)&board[h][0]);
-    if (!fp16)
-      *((uint4*)(&output[INDEX_NCHW(n, k, h, 4)])) = *((uint4*)&board[h][4]);
+    if (output_nhcw) {
+      *((uint4*)(&output[INDEX_NHCW(n, k, h, 0)])) = *((uint4*)&board[h][0]);
+      if (!fp16)
+        *((uint4*)(&output[INDEX_NHCW(n, k, h, 4)])) = *((uint4*)&board[h][4]);
+    } else {
+      *((uint4*)(&output[INDEX_NCHW(n, k, h, 0)])) = *((uint4*)&board[h][0]);
+      if (!fp16)
+        *((uint4*)(&output[INDEX_NCHW(n, k, h, 4)])) = *((uint4*)&board[h][4]);
+    }
   }
 }
 
@@ -357,7 +378,7 @@ __global__ void OutputTransform_kernel(int N, int C, int se_K, T* output,
 // 'N' blocks
 // every thread generates an entire board/plane (8x8 elements)
 template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
-__global__ 
+__global__ __launch_bounds__(384, 1)
 void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* output,
                                                               const T* input, const T* skip,
                                                               const T* bias, const T* w1, const T* b1,
@@ -446,9 +467,9 @@ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* ou
     // residual add
     if (use_skip) {
       T skipInp[8];
-      *((uint4*)(&skipInp[0])) = *((uint4*)(&skip[INDEX_NCHW(n, k, h, 0)]));
+      *((uint4*)(&skipInp[0])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 0)]));
       if (!fp16)
-        *((uint4*)(&skipInp[4])) = *((uint4*)(&skip[INDEX_NCHW(n, k, h, 4)]));
+        *((uint4*)(&skipInp[4])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 4)]));
 #pragma unroll
       for (int w = 0; w < 8; w++) board[h][w] += skipInp[w];
     }
@@ -464,9 +485,9 @@ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* ou
     if (use_skip)
     {
       // Write to skip (use 128 bit writes to store one row a time)
-      *((uint4*)(&skip[INDEX_NCHW(n, k, h, 0)])) = *((uint4*)&board[h][0]);
+      *((uint4*)(&skip[INDEX_NHCW(n, k, h, 0)])) = *((uint4*)&board[h][0]);
       if (!fp16)
-        *((uint4*)(&skip[INDEX_NCHW(n, k, h, 4)])) = *((uint4*)&board[h][4]);
+        *((uint4*)(&skip[INDEX_NHCW(n, k, h, 4)])) = *((uint4*)&board[h][4]);
     }
   }
 
@@ -563,20 +584,21 @@ void FilterTransform(int N, int C, T* transformedFilter, const T* filter) {
   ReportCUDAErrors(cudaGetLastError());
 }
 
-template <typename T>
+template <typename T, bool nhcw>
 void InputTransform(int N, int C, T* transformed_input, const T* input) {
   // Each thread processes entire chess board (input 8x8 elements -> outputs
   // 2x2, 6x6 elements)
-  InputTransform_kernel<<<N, C>>>(N, C, input, transformed_input);
+  InputTransform_kernel<T, nhcw><<<N, C>>>(N, C, input, transformed_input);
   ReportCUDAErrors(cudaGetLastError());
 }
 
-template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
+template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip, 
+          bool skipInput_nhcw, bool output_nhcw>
 void OutputTransform(int N, int C, int se_K, T* output, const T* input,
                      const T* skip, const T* bias, const T* w1, const T* b1,
                      const T* w2, const T* b2) {
   // Each thread processes entire chess board
-  OutputTransform_kernel<T, use_se, relu, use_bias, use_skip>
+  OutputTransform_kernel<T, use_se, relu, use_bias, use_skip, skipInput_nhcw, output_nhcw>
       <<<N, C>>>(N, C, se_K, output, input, skip, bias, w1, b1, w2, b2);
   ReportCUDAErrors(cudaGetLastError());
 }

--- a/src/neural/cuda/winograd_helper.inc
+++ b/src/neural/cuda/winograd_helper.inc
@@ -621,10 +621,10 @@ void FilterTransform(int N, int C, T* transformedFilter, const T* filter) {
 }
 
 template <typename T, bool nhcw>
-void InputTransform(int N, int C, T* transformed_input, const T* input) {
+void InputTransform(int N, int C, T* transformed_input, const T* input, cudaStream_t stream) {
   // Each thread processes entire chess board (input 8x8 elements -> outputs
   // 2x2, 6x6 elements)
-  InputTransform_kernel<T, nhcw><<<N, C>>>(N, C, input, transformed_input);
+  InputTransform_kernel<T, nhcw><<<N, C, 0, stream>>>(N, C, input, transformed_input);
   ReportCUDAErrors(cudaGetLastError());
 }
 
@@ -632,20 +632,20 @@ template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip,
           bool skipInput_nhcw, bool output_nhcw>
 void OutputTransform(int N, int C, int se_K, T* output, const T* input,
                      const T* skip, const T* bias, const T* w1, const T* b1,
-                     const T* w2, const T* b2) {
+                     const T* w2, const T* b2, cudaStream_t stream) {
   // Each thread processes entire chess board
   OutputTransform_kernel<T, use_se, relu, use_bias, use_skip, skipInput_nhcw, output_nhcw>
-      <<<N, C>>>(N, C, se_K, output, input, skip, bias, w1, b1, w2, b2);
+      <<<N, C, 0, stream>>>(N, C, se_K, output, input, skip, bias, w1, b1, w2, b2);
   ReportCUDAErrors(cudaGetLastError());
 }
 
 template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
 void OutputInputTransform(int N, int C, int se_K, T* output, const T* input,
                          const T* skip, const T* bias, const T* w1, const T* b1,
-                         const T* w2, const T* b2) {
+                         const T* w2, const T* b2, cudaStream_t stream) {
   // Each thread processes entire chess board
   OutputTransform_SE_relu_InputTransform_kernel<T, use_se, relu, use_bias, use_skip>
-                    <<<N, C>>>(N, C, se_K, output, input, skip, bias, w1, b1, w2, b2);
+                    <<<N, C, 0, stream>>>(N, C, se_K, output, input, skip, bias, w1, b1, w2, b2);
   ReportCUDAErrors(cudaGetLastError());
 }
 

--- a/src/neural/cuda/winograd_helper.inc
+++ b/src/neural/cuda/winograd_helper.inc
@@ -381,13 +381,18 @@ __device__ __forceinline__ float warpReduce(float x)
     return x;
 }
 
+// max supported filter count for this fast path
+// TODO: extend it to cover bigger networks!
+// (We are limited by no of registers per thread)
+#define MAX_SUPPORTED_C 384
+
 // input is in transformed space (HWNC layout) --- output of GEMM
 // output is also in transformed space (HWNC layout) --- input to GEMM (for next layer)
 // 'C' threads per block
 // 'N' blocks
 // every thread generates an entire board/plane (8x8 elements)
 template <typename T, bool use_se, bool relu, bool use_bias, bool use_skip>
-__global__ __launch_bounds__(384, 1)
+__global__ __launch_bounds__(MAX_SUPPORTED_C, 1)
 void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* output,
                                                               const T* input, const T* skip,
                                                               const T* bias, const T* w1, const T* b1,
@@ -444,7 +449,7 @@ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* ou
     }
 
   if (use_se) {
-    __shared__ float shared_data[384];
+    __shared__ float shared_data[MAX_SUPPORTED_C];
     float avg = S / 64;
     shared_data[k] = avg;
 
@@ -457,7 +462,7 @@ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* ou
     // As se_K << C, we want to loop over se_K instead of C
     // even if it means taking the sum across threads
 
-    __shared__ float shared_sums[384/32][384];  // per-warp sums
+    __shared__ float shared_sums[MAX_SUPPORTED_C/32][MAX_SUPPORTED_C];  // per-warp sums
 
     for (int i = 0; i < se_K; i++) {
       float val = shared_data[k] * float(readw1(k, i));
@@ -501,12 +506,6 @@ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* ou
 
     // residual add
     if (use_skip) {
-#if 0
-      T skipInp[8];
-      *((uint4*)(&skipInp[0])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 0)]));
-      if (!fp16)
-        *((uint4*)(&skipInp[4])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 4)]));
-#endif
 #pragma unroll
       for (int w = 0; w < 8; w++) board[h][w] += skipInp[h][w];
     }

--- a/src/neural/cuda/winograd_helper.inc
+++ b/src/neural/cuda/winograd_helper.inc
@@ -371,6 +371,15 @@ __global__ void OutputTransform_kernel(int N, int C, int se_K, T* output,
   }
 }
 
+// fast reduction for the warp
+__device__ __forceinline__ float warpReduce(float x)
+{
+    #pragma unroll
+    for(int mask = 16; mask > 0 ; mask >>= 1)
+        x += __shfl_xor_sync(0xFFFFFFFF, x, mask);
+
+    return x;
+}
 
 // input is in transformed space (HWNC layout) --- output of GEMM
 // output is also in transformed space (HWNC layout) --- input to GEMM (for next layer)
@@ -390,6 +399,14 @@ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* ou
 
   T board[8][8];
   T b = bias[k];
+
+  T skipInp[8][8];
+  #pragma unroll
+  for (int h = 0; h < 8; h++) {
+      *((uint4*)(&skipInp[h][0])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 0)]));
+      if (!fp16)
+        *((uint4*)(&skipInp[h][4])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 4)]));
+  }
 
 #pragma unroll
   for (int hStart = 0; hStart < 8; hStart += 4)
@@ -427,21 +444,39 @@ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* ou
     }
 
   if (use_se) {
-    __shared__ float shared_data[1024];
+    __shared__ float shared_data[384];
     float avg = S / 64;
     shared_data[k] = avg;
+
+    int lane = k & 0x1F;
+    int warp = k >> 5;
     __syncthreads();
 
     // First fully-connected layer for SE
-    if (k < se_K) {
+
+    // As se_K << C, we want to loop over se_K instead of C
+    // even if it means taking the sum across threads
+
+    __shared__ float shared_sums[384/32][384];  // per-warp sums
+
+    for (int i = 0; i < se_K; i++) {
+      float val = shared_data[k] * float(readw1(k, i));
+      val = warpReduce(val);
+      if (lane == 0)
+        shared_sums[warp][i] = val;
+    }
+    __syncthreads();
+    if (k < se_K) 
+    {
       S = 0;
-      for (int i = 0; i < C; i++) {
-        S += shared_data[i] * float(readw1(i, k));
-      }
+      for (int i=0;i<C/32;i++)
+        S += shared_sums[i][k];
+
       S += (float)b1[k];
       if (S < 0) S = 0;  // relu
       shared_data[k] = S;
     }
+
     __syncthreads();
 
     // Second fully-connected layer for SE
@@ -466,12 +501,14 @@ void OutputTransform_SE_relu_InputTransform_kernel(int N, int C, int se_K, T* ou
 
     // residual add
     if (use_skip) {
+#if 0
       T skipInp[8];
       *((uint4*)(&skipInp[0])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 0)]));
       if (!fp16)
         *((uint4*)(&skipInp[4])) = *((uint4*)(&skip[INDEX_NHCW(n, k, h, 4)]));
+#endif
 #pragma unroll
-      for (int w = 0; w < 8; w++) board[h][w] += skipInp[w];
+      for (int w = 0; w < 8; w++) board[h][w] += skipInp[h][w];
     }
 
     // relu


### PR DESCRIPTION
- Create cuda stream and memory needed to run the network for each InputsOutputs object.
- This allows concurrent execution of multiple parallel Eval requests. 
- Note that this PR also include kernel opts from PR #1567 

Some performance nos (for lc0 benchmark running on A100, recent T60 network, minibatch-size=96 all other params default)
```
Baseline       : 54152
Kernel opts    : 57154
+ multi-stream : 67439
+ roundrobin   : 67249 
+ t 3 ( w/ RR) : 70419
  t 4 ( w/ RR) : 72333
  t 4 ( w/Mux) : 73442
```