### PR TITLE
change default winograd on gtx16x0

### DIFF
--- a/src/neural/cuda/network_cudnn.cc
+++ b/src/neural/cuda/network_cudnn.cc
@@ -235,7 +235,7 @@ class CudnnNetwork : public Network {
       int cuda_version;
       cudaRuntimeGetVersion(&cuda_version);
       if (!hasTensorCores)
-        use_custom_winograd_ = true;
+        use_custom_winograd_ = false;
       else if (kNumFilters >= 256 &&
                !(deviceProp.major == 7 && deviceProp.minor == 5 &&
                  cuda_version < 11000))


### PR DESCRIPTION
recent changes in PR1567 seems to cause GTX16x0 to crash when using custom_winograd
may need to add extra code to throw exception when set to true