### PR TITLE
Quickfix for smooth TM nps misprediction.

### DIFF
--- a/src/chess/position.cc
+++ b/src/chess/position.cc
@@ -62,8 +62,7 @@ char GetPieceAt(const lczero::ChessBoard& board, int row, int col) {
 namespace lczero {
 
 Position::Position(const Position& parent, Move m)
-    : rule50_ply_(parent.rule50_ply_ + 1),
-      ply_count_(parent.ply_count_ + 1) {
+    : rule50_ply_(parent.rule50_ply_ + 1), ply_count_(parent.ply_count_ + 1) {
   them_board_ = parent.us_board_;
   const bool is_zeroing = them_board_.ApplyMove(m);
   us_board_ = them_board_;
@@ -85,9 +84,9 @@ uint64_t Position::Hash() const {
 std::string Position::DebugString() const { return us_board_.DebugString(); }
 
 GameResult operator-(const GameResult& res) {
-  return res == GameResult::BLACK_WON
-             ? GameResult::WHITE_WON
-             : res == GameResult::WHITE_WON ? GameResult::BLACK_WON : res;
+  return res == GameResult::BLACK_WON   ? GameResult::WHITE_WON
+         : res == GameResult::WHITE_WON ? GameResult::BLACK_WON
+                                        : res;
 }
 
 GameResult PositionHistory::ComputeGameResult() const {

--- a/src/mcts/stoppers/smooth.cc
+++ b/src/mcts/stoppers/smooth.cc
@@ -178,13 +178,14 @@ float LinearDecay(float cur_value, float target_value,
   if (time_since_last_update_ms <= 0) return cur_value;
   // If window is large enough, we consider
   if (time_since_reliable_ms >= window_size_ms) return target_value;
-  // How long there was a reliable nps in the window, in ms.
-  const float time_reliable = time_since_reliable_ms - window_size_ms;
+  // time_since_reliable_ms during the previous call of this function.
+  const float prev_time_since_reliable_ms =
+      time_since_reliable_ms - time_since_last_update_ms;
   // The same, but as fraction of window size.
-  const float reliable_frac = time_reliable / window_size_ms;
+  const float prev_reliable_frac = prev_time_since_reliable_ms / window_size_ms;
   // What was the value when it was reliable.
-  const float reliable_value =
-      (reliable_frac * target_value - cur_value) / (reliable_frac - 1);
+  const float reliable_value = (prev_reliable_frac * target_value - cur_value) /
+                               (prev_reliable_frac - 1);
   // Now we know window width, nps when it was reliable, and time since that,
   // and time to converge, interpolate.
   return LinearInterpolate(reliable_value, target_value,

--- a/src/mcts/stoppers/smooth.cc
+++ b/src/mcts/stoppers/smooth.cc
@@ -178,6 +178,10 @@ float LinearDecay(float cur_value, float target_value,
   if (time_since_last_update_ms <= 0) return cur_value;
   // If window is large enough, we consider
   if (time_since_reliable_ms >= window_size_ms) return target_value;
+  if (time_since_last_update_ms > time_since_reliable_ms) {
+    // Should never happen, but just for the case.
+    time_since_last_update_ms = time_since_reliable_ms;
+  }
   // time_since_reliable_ms during the previous call of this function.
   const float prev_time_since_reliable_ms =
       time_since_reliable_ms - time_since_last_update_ms;

--- a/src/mcts/stoppers/smooth.cc
+++ b/src/mcts/stoppers/smooth.cc
@@ -25,12 +25,11 @@
   Program grant you additional permission to convey the resulting work.
 */
 
-#include "mcts/stoppers/smooth.h"
-
 #include <functional>
 #include <iomanip>
 
 #include "mcts/stoppers/legacy.h"
+#include "mcts/stoppers/smooth.h"
 #include "mcts/stoppers/stoppers.h"
 #include "utils/mutex.h"
 
@@ -51,8 +50,8 @@ class Params {
   float tree_reuse_halfupdate_moves() const {
     return tree_reuse_halfupdate_moves_;
   }
-  // Number of seconds to update nps estimation halfway.
-  float nps_halfupdate_seconds() const { return nps_halfupdate_seconds_; }
+  // Number of seconds to update nps estimation.
+  float nps_update_seconds() const { return nps_update_seconds_; }
   // Fraction of the allocated time the engine uses, initial estimation.
   float initial_smartpruning_timeuse() const {
     return initial_smartpruning_timeuse_;
@@ -95,7 +94,7 @@ class Params {
   const float initial_tree_reuse_;
   const float max_tree_reuse_;
   const float tree_reuse_halfupdate_moves_;
-  const float nps_halfupdate_seconds_;
+  const float nps_update_seconds_;
   const float initial_smartpruning_timeuse_;
   const float min_smartpruning_timeuse_;
   const float smartpruning_timeuse_halfupdate_moves_;
@@ -126,8 +125,8 @@ Params::Params(const OptionsDict& params, int64_t move_overhead)
       max_tree_reuse_(params.GetOrDefault<float>("max-tree-reuse", 0.8f)),
       tree_reuse_halfupdate_moves_(
           params.GetOrDefault<float>("tree-reuse-update-rate", 3.0f)),
-      nps_halfupdate_seconds_(
-          params.GetOrDefault<float>("nps-update-rate", 5.0f)),
+      nps_update_seconds_(
+          params.GetOrDefault<float>("nps-update-period", 20.0f)),
       initial_smartpruning_timeuse_(
           params.GetOrDefault<float>("init-timeuse", 0.5f)),
       min_smartpruning_timeuse_(
@@ -152,6 +151,43 @@ Params::Params(const OptionsDict& params, int64_t move_overhead)
 // value=3*step, return (1*from + 7*to)/7, if value=0, returns from.
 float ExponentialDecay(float from, float to, float step, float value) {
   return to - (to - from) * std::pow(0.5f, value / step);
+}
+
+float LinearInterpolate(float a, float b, float theta) {
+  if (theta <= 0) return a;
+  if (theta >= 1) return b;
+  return a + (b - a) * theta;
+}
+
+// @cur_value -- current "average", returned from the previous call of this
+//   function.
+// @target_value -- current "correct but noisy" value, that we slowly go to.
+// @time_since_reliable -- time since we had reliable nps in target_value. For
+//    the case of nps, end of the previous move is considered reliable point).
+// @time_since_last_update_ms -- how long ago was this function last called.
+// @window_size_ms -- in what time should the output converge to @target_value.
+float LinearDecay(float cur_value, float target_value,
+                  float time_since_reliable_ms, float time_since_last_update_ms,
+                  float window_size_ms) {
+  // If target is higher than cur value, just return target without any
+  // smoothing. That makes sense for nps, but for other averages we should look
+  // a bit closer.
+  if (cur_value <= target_value) return target_value;
+  // If no time passed since last update, return previous value.
+  if (time_since_last_update_ms <= 0) return cur_value;
+  // If window is large enough, we consider
+  if (time_since_reliable_ms >= window_size_ms) return target_value;
+  // How long there was a reliable nps in the window, in ms.
+  const float time_reliable = time_since_reliable_ms - window_size_ms;
+  // The same, but as fraction of window size.
+  const float reliable_frac = time_reliable / window_size_ms;
+  // What was the value when it was reliable.
+  const float reliable_value =
+      (reliable_frac * target_value - cur_value) / (reliable_frac - 1);
+  // Now we know window width, nps when it was reliable, and time since that,
+  // and time to converge, interpolate.
+  return LinearInterpolate(reliable_value, target_value,
+                           time_since_reliable_ms / window_size_ms);
 }
 
 class SmoothTimeManager;
@@ -181,11 +217,12 @@ class SmoothTimeManager : public TimeManager {
                   int64_t nodes_since_movestart) {
     Mutex::Lock lock(mutex_);
     if (time_since_movestart_ms <= 0) return nps_;
-    if (nps_is_reliable_ && time_since_movestart_ms >= last_time_) {
+    if (nps_is_reliable_ && time_since_movestart_ms > last_time_) {
       const float nps =
           1000.0f * nodes_since_movestart / time_since_movestart_ms;
-      nps_ = ExponentialDecay(nps_, nps, params_.nps_halfupdate_seconds(),
-                              (time_since_movestart_ms - last_time_) / 1000.0f);
+      nps_ = LinearDecay(nps_, nps, time_since_movestart_ms,
+                         time_since_movestart_ms - last_time_,
+                         params_.nps_update_seconds() * 1000.0f);
     } else {
       nps_ = 1000.0f * nodes_since_movestart / time_since_movestart_ms;
     }

--- a/src/mcts/stoppers/smooth.cc
+++ b/src/mcts/stoppers/smooth.cc
@@ -25,11 +25,12 @@
   Program grant you additional permission to convey the resulting work.
 */
 
+#include "mcts/stoppers/smooth.h"
+
 #include <functional>
 #include <iomanip>
 
 #include "mcts/stoppers/legacy.h"
-#include "mcts/stoppers/smooth.h"
 #include "mcts/stoppers/stoppers.h"
 #include "utils/mutex.h"
 


### PR DESCRIPTION
Fixes #1585.

There are surely more to fix, including some simple and obvious things, but in this PR I'd really like only to fix the most urgent issue of instamoving due to nps misprediction.

What it PR does:
1. If at any moment, the current avg move nps (move nodes / move time, the thing that is displayed in `uci`) is higher than predicted, just assign that nps to whatever time manager uses.
2. If we are longer than `nps-update-period` (default is 20 seconds) in the move, also use "displayed move nps" as time manager nps.
3. Otherwise linearly decrease nps at the rate so that `nps-update-period` after the move start it lands exactly at current move's nps.

The graph of nps estimation for 14 seconds nps-update-period:
![image](https://user-images.githubusercontent.com/11266455/124018064-beff3080-d9e7-11eb-95f5-5cfdfe423291.png)
