### PR TITLE
Add top-two PUCT search

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -87,6 +87,10 @@ const OptionId SearchParams::kCpuctFactorId{
 const OptionId SearchParams::kCpuctFactorAtRootId{
     "cpuct-factor-at-root", "CPuctFactorAtRoot",
     "Multiplier for the cpuct growth formula at root."};
+const OptionId SearchParams::kCpuctTopTwoPercentageId{
+    "cpuct-top-two-percentage", "CpuctTopTwoPercentage",
+    "Probability with which the second best move is visited in the root "
+    "node. A value of 0 is equivalent to the usual Puct."};
 // Remove this option after 0.25 has been made mandatory in training and the
 // training server stops sending it.
 const OptionId SearchParams::kRootHasOwnCpuctParamsId{
@@ -331,6 +335,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctBaseAtRootId, 1.0f, 1000000000.0f) = 38739.0f;
   options->Add<FloatOption>(kCpuctFactorId, 0.0f, 1000.0f) = 3.894f;
   options->Add<FloatOption>(kCpuctFactorAtRootId, 0.0f, 1000.0f) = 3.894f;
+  options->Add<FloatOption>(kCpuctTopTwoPercentageId, 0.0f, 1.0f) = 0.0f;
   options->Add<BoolOption>(kRootHasOwnCpuctParamsId) = false;
   options->Add<BoolOption>(kTwoFoldDrawsId) = true;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
@@ -433,6 +438,7 @@ SearchParams::SearchParams(const OptionsDict& options)
       kCpuctFactorAtRoot(options.Get<float>(
           options.Get<bool>(kRootHasOwnCpuctParamsId) ? kCpuctFactorAtRootId
                                                       : kCpuctFactorId)),
+      kCpuctTopTwoPercentage(options.Get<float>(kCpuctTopTwoPercentageId)),
       kTwoFoldDraws(options.Get<bool>(kTwoFoldDrawsId)),
       kNoiseEpsilon(options.Get<float>(kNoiseEpsilonId)),
       kNoiseAlpha(options.Get<float>(kNoiseAlphaId)),

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -53,6 +53,7 @@ class SearchParams {
   float GetCpuctFactor(bool at_root) const {
     return at_root ? kCpuctFactorAtRoot : kCpuctFactor;
   }
+  float GetCpuctTopTwoPercentage() const { return kCpuctTopTwoPercentage; }
   bool GetTwoFoldDraws() const { return kTwoFoldDraws; }
   float GetTemperature() const { return options_.Get<float>(kTemperatureId); }
   float GetTemperatureVisitOffset() const {
@@ -149,6 +150,7 @@ class SearchParams {
   static const OptionId kCpuctBaseAtRootId;
   static const OptionId kCpuctFactorId;
   static const OptionId kCpuctFactorAtRootId;
+  static const OptionId kCpuctTopTwoPercentageId;
   static const OptionId kRootHasOwnCpuctParamsId;
   static const OptionId kTwoFoldDrawsId;
   static const OptionId kTemperatureId;
@@ -218,6 +220,7 @@ class SearchParams {
   const float kCpuctBaseAtRoot;
   const float kCpuctFactor;
   const float kCpuctFactorAtRoot;
+  const float kCpuctTopTwoPercentage;
   const bool kTwoFoldDraws;
   const float kNoiseEpsilon;
   const float kNoiseAlpha;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1779,7 +1779,7 @@ void SearchWorker::PickNodesToExtendTask(Node* node, int base_depth,
         // Top two ucb:
         //   Pick best move with probability p and otherwise the second best:
         const float tt_percentage = params_.GetCpuctTopTwoPercentage();
-        if (is_root_node && Random::Get().GetFloat(1.0) <= tt_percentage) {
+        if (is_root_node && second_best_edge && Random::Get().GetFloat(1.0) <= tt_percentage) {
           std::swap(best_edge, second_best_edge);
           std::swap(best_idx, second_best_idx);
         }


### PR DESCRIPTION
Rationale
---------
In PUCT we are solving a nested multi-armed bandit problem where the goal is to find the best move in the root position as quickly as possible. In non-root positions it does not matter so much which exact move is played, but rather that the evaluations coming from these positions is as accurate (in a minimax sense) as possible. That is why cumulative regret minimization which is done by the classical UCB algorithm and by extension also PUCT, is desirable.

In the root position however, we are really interested in finding the best move which coincides with the "best arm identification" (BAI) setting in the multi-armed bandit literature. So why are cumulative regret minimizers (CRMs) not sufficient to also solve the BAI problem? The problem is that CRMs very quickly converge to a promising option and allocate the majority of samples to that option in order to avoid accumulating further regret. Other options are still explored from time to time, but with a vanishingly small frequency [1].
A particularly simple method to convert cumulative regret minimizing algorithms to best arm identification algorithms is to throw a (biased) coin and with probability *p* go with the algorithms’ preferred choice and otherwise with the algorithms second most preferred choice [2]. That way the algorithm is forced to become confident that the first choice is the best arm.

Description
-----------
This pull request implements this simple randomization scheme for the root node:
https://github.com/kiudee/lc0/blob/45e5e073aaab70021e99c27bfb8fb325812a4281/src/mcts/search.cc#L1779-L1785
```c++
        // Top two ucb:
        //   Pick best move with probability p and otherwise the second best:
        const float tt_percentage = params_.GetCpuctTopTwoPercentage();
        if (is_root_node && second_best_edge && Random::Get().GetFloat(1.0) <= tt_percentage) {
          std::swap(best_edge, second_best_edge);
          std::swap(best_idx, second_best_idx);
        }
```
The goal of this pull request is for this change to be testable.

Open questions
----------------
- Does it work at all? (Currently under investigation)
- How high should the percentage be? (Tuning underway)
- Is this also beneficial in non-root nodes (to prevent tactical blind spots for instance)?
- Can this be extended to more than the top two choices (without increasing computational overhead too much)?
- Changing the way nodes are expanded has an impact on batching. Are there other lines in the code which should be changed?


References
-----------
[1] Chen, Chun-Hung, et al. "Simulation budget allocation for further enhancing the efficiency of ordinal optimization." Discrete Event Dynamic Systems 10.3 (2000): 251-270. https://deepblue.lib.umich.edu/bitstream/handle/2027.42/45045/10626_2004_Article_264696.pdf
[2] Russo, Daniel. "Simple bayesian algorithms for best arm identification." Conference on Learning Theory. PMLR, 2016. https://arxiv.org/abs/1602.08448
