### PR TITLE
Add ability to limit in-flight throughout search tree based on scaling limit.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -319,6 +319,16 @@ const OptionId SearchParams::kMaxCollisionVisitsScalingEndId{
 const OptionId SearchParams::kMaxCollisionVisitsScalingPowerId{
     "max-collision-visits-scaling-power", "MaxCollisionVisitsScalingPower",
     "Power to apply to the interpolation between 1 and max to make it curved."};
+const OptionId SearchParams::kMaxInFlightVisitsId{
+    "max-in-flight-visits", "MaxInFlightVisits",
+    "Maximum number of inflight for any subtree >= max in flight visits scaling end."};
+const OptionId SearchParams::kMaxInFlightVisitsScalingStartId{
+    "max-in-flight-visits-scaling-start", "MaxInFlightVisitsScalingStart",
+    "Tree size where max in flight visits starts scaling up from 1."};
+const OptionId SearchParams::kMaxInFlightVisitsScalingEndId{
+    "max-in-flight-visits-scaling-end", "MaxInFlightVisitsScalingEnd",
+    "Tree size where max in flight visits reaches max. Set to 0 to disable "
+    "scaling entirely."};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -359,6 +369,10 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kMaxCollisionVisitsScalingEndId, 0, 100000000) = 145000;
   options->Add<FloatOption>(kMaxCollisionVisitsScalingPowerId, 0.01, 100) =
       1.25;
+  options->Add<IntOption>(kMaxInFlightVisitsId, 1, 100000000) = 170000;
+  options->Add<IntOption>(kMaxInFlightVisitsScalingStartId, 1, 100000) = 14;
+  options->Add<IntOption>(kMaxInFlightVisitsScalingEndId, 0, 100000000) =
+      145000;
   options->Add<BoolOption>(kOutOfOrderEvalId) = true;
   options->Add<FloatOption>(kMaxOutOfOrderEvalsId, 0.0f, 100.0f) = 2.4f;
   options->Add<BoolOption>(kStickyEndgamesId) = true;
@@ -492,8 +506,13 @@ SearchParams::SearchParams(const OptionsDict& options)
       kMaxCollisionVisitsScalingEnd(
           options.Get<int>(kMaxCollisionVisitsScalingEndId)),
       kMaxCollisionVisitsScalingPower(
-          options.Get<float>(kMaxCollisionVisitsScalingPowerId)) {
-  if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +
+          options.Get<float>(kMaxCollisionVisitsScalingPowerId)),
+      kMaxInFlightVisits(options.Get<int>(kMaxInFlightVisitsId)),
+      kMaxInFlightVisitsScalingStart(
+          options.Get<int>(kMaxInFlightVisitsScalingStartId)),
+      kMaxInFlightVisitsScalingEnd(
+          options.Get<int>(kMaxInFlightVisitsScalingEndId)) {
+    if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +
           std::max(std::abs(kDrawScoreWhite), std::abs(kDrawScoreBlack)) >
       1.0f) {
     throw Exception(

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -139,6 +139,13 @@ class SearchParams {
   float GetMaxCollisionVisitsScalingPower() const {
     return kMaxCollisionVisitsScalingPower;
   }
+  int GetMaxInFlightVisits() const { return kMaxInFlightVisits; }
+  int GetMaxInFlightVisitsScalingStart() const {
+    return kMaxInFlightVisitsScalingStart;
+  }
+  int GetMaxInFlightVisitsScalingEnd() const {
+    return kMaxInFlightVisitsScalingEnd;
+  }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -203,6 +210,9 @@ class SearchParams {
   static const OptionId kMaxCollisionVisitsScalingStartId;
   static const OptionId kMaxCollisionVisitsScalingEndId;
   static const OptionId kMaxCollisionVisitsScalingPowerId;
+  static const OptionId kMaxInFlightVisitsId;
+  static const OptionId kMaxInFlightVisitsScalingStartId;
+  static const OptionId kMaxInFlightVisitsScalingEndId;
 
  private:
   const OptionsDict& options_;
@@ -260,6 +270,9 @@ class SearchParams {
   const int kMaxCollisionVisitsScalingStart;
   const int kMaxCollisionVisitsScalingEnd;
   const float kMaxCollisionVisitsScalingPower;
+  const int kMaxInFlightVisitsScalingStart;
+  const int kMaxInFlightVisitsScalingEnd;
+  const int kMaxInFlightVisits;
 };
 
 }  // namespace lczero

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -405,6 +405,7 @@ class SearchWorker {
     Node* start;
     int base_depth;
     int collision_limit;
+    int extra_collisions;
     std::vector<Move> moves_to_base;
     std::vector<NodeToProcess> results;
 
@@ -415,11 +416,12 @@ class SearchWorker {
     bool complete = false;
 
     PickTask(Node* node, uint16_t depth, const std::vector<Move>& base_moves,
-             int collision_limit)
+             int collision_limit, int extra_collisions)
         : task_type(kGathering),
           start(node),
           base_depth(depth),
           collision_limit(collision_limit),
+          extra_collisions(extra_collisions),
           moves_to_base(base_moves) {}
     PickTask(int start_idx, int end_idx)
         : task_type(kProcessing), start_idx(start_idx), end_idx(end_idx) {}
@@ -437,6 +439,7 @@ class SearchWorker {
   void PickNodesToExtendTask(Node* starting_point, int collision_limit,
                              int base_depth,
                              const std::vector<Move>& moves_to_base,
+                             int extra_collisions,
                              std::vector<NodeToProcess>* receiver,
                              TaskWorkspace* workspace);
   void EnsureNodeTwoFoldCorrectForDepth(Node* node, int depth);


### PR DESCRIPTION
Doesn't appear to work reliably yet.  I think I've probably missed some corner cases.

The NPS impact of the random parameters I made the default isn't as bad I was expecting... when it doesn't just completely break.

This also should be disabled by default in selfplay for training purposes.