### PR TITLE
set cuda multi_stream off by default

### DIFF
--- a/src/neural/cuda/network_cuda.cc
+++ b/src/neural/cuda/network_cuda.cc
@@ -143,7 +143,7 @@ class CudaNetwork : public Network {
     // Select GPU to run on (for *the current* thread).
     ReportCUDAErrors(cudaSetDevice(gpu_id_));
 
-    multi_stream_ = options.GetOrDefault<bool>("multi_stream", true);
+    multi_stream_ = options.GetOrDefault<bool>("multi_stream", false);
 
     // Default layout is nchw.
     bool hasTensorCores = false;


### PR DESCRIPTION
We need some heuristic for when to turn it on, some cards can't handle it. So make it default off for now,