### PR TITLE
Fix typo in comment about net input format

### DIFF
--- a/src/neural/encoder.cc
+++ b/src/neural/encoder.cc
@@ -157,7 +157,7 @@ InputPlanes EncodePositionForNN(
         // - Plane 104 (0-based) filled with 1 if white can castle queenside.
         // - Plane 105 filled with ones if white can castle kingside.
         // - Plane 106 filled with ones if black can castle queenside.
-        // - Plane 107 filled with ones if white can castle kingside.
+        // - Plane 107 filled with ones if black can castle kingside.
         if (board.castlings().we_can_000()) result[kAuxPlaneBase + 0].SetAll();
         if (board.castlings().we_can_00()) result[kAuxPlaneBase + 1].SetAll();
         if (board.castlings().they_can_000()) {

--- a/src/neural/encoder.cc
+++ b/src/neural/encoder.cc
@@ -154,10 +154,10 @@ InputPlanes EncodePositionForNN(
     switch (input_format) {
       case pblczero::NetworkFormat::INPUT_CLASSICAL_112_PLANE: {
         // "Legacy" input planes with:
-        // - Plane 104 (0-based) filled with 1 if white can castle queenside.
-        // - Plane 105 filled with ones if white can castle kingside.
-        // - Plane 106 filled with ones if black can castle queenside.
-        // - Plane 107 filled with ones if black can castle kingside.
+        // - Plane 104 (0-based) filled with 1 if we can castle queenside.
+        // - Plane 105 filled with ones if we can castle kingside.
+        // - Plane 106 filled with ones if they can castle queenside.
+        // - Plane 107 filled with ones if they can castle kingside.
         if (board.castlings().we_can_000()) result[kAuxPlaneBase + 0].SetAll();
         if (board.castlings().we_can_00()) result[kAuxPlaneBase + 1].SetAll();
         if (board.castlings().they_can_000()) {


### PR DESCRIPTION
The current comment has two versions of "white can castle kingside".

It seems that "black" is "they", and therefore the latter instance should say black.

---

Possible I should modify the comments to say "us" and "them" instead of "black" and "white" while I'm at it?