### PR TITLE
Move selection based on the beta distribution

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -316,6 +316,10 @@ const OptionId SearchParams::kMaxCollisionVisitsScalingEndId{
 const OptionId SearchParams::kMaxCollisionVisitsScalingPowerId{
     "max-collision-visits-scaling-power", "MaxCollisionVisitsScalingPower",
     "Power to apply to the interpolation between 1 and max to make it curved."};
+const OptionId SearchParams::kMoveSelectionVisitsScalingPowerId{
+    "move-selection-visits-scaling-power", "MoveSelectionVisitsScalingPower",
+    "Power to apply to the total number of visits to get the beta prior used "
+    "in move selection."};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -357,6 +361,8 @@ void SearchParams::Populate(OptionsParser* options) {
       145000;
   options->Add<FloatOption>(kMaxCollisionVisitsScalingPowerId, 0.01, 100) =
       1.25;
+  options->Add<FloatOption>(kMoveSelectionVisitsScalingPowerId, 0.01, 100) =
+      0.3;
   options->Add<BoolOption>(kOutOfOrderEvalId) = true;
   options->Add<FloatOption>(kMaxOutOfOrderEvalsId, 0.0f, 100.0f) = 2.4f;
   options->Add<BoolOption>(kStickyEndgamesId) = true;
@@ -485,6 +491,8 @@ SearchParams::SearchParams(const OptionsDict& options)
           options.Get<int>(kMaxCollisionVisitsScalingStartId)),
       kMaxCollisionVisitsScalingEnd(
           options.Get<int>(kMaxCollisionVisitsScalingEndId)),
+      kMoveSelectionVisitsScalingPower(
+          options.Get<float>(kMoveSelectionVisitsScalingPowerId)),
       kMaxCollisionVisitsScalingPower(
           options.Get<float>(kMaxCollisionVisitsScalingPowerId)) {
   if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -138,6 +138,9 @@ class SearchParams {
   float GetMaxCollisionVisitsScalingPower() const {
     return kMaxCollisionVisitsScalingPower;
   }
+  float GetMoveSelectionVisitsScalingPower() const {
+    return kMoveSelectionVisitsScalingPower;
+  }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -201,8 +204,9 @@ class SearchParams {
   static const OptionId kMaxCollisionVisitsScalingStartId;
   static const OptionId kMaxCollisionVisitsScalingEndId;
   static const OptionId kMaxCollisionVisitsScalingPowerId;
+  static const OptionId kMoveSelectionVisitsScalingPowerId;  
 
- private:
+private:
   const OptionsDict& options_;
   // Cached parameter values. Values have to be cached if either:
   // 1. Parameter is accessed often and has to be cached for performance
@@ -257,6 +261,7 @@ class SearchParams {
   const int kMaxCollisionVisitsScalingStart;
   const int kMaxCollisionVisitsScalingEnd;
   const float kMaxCollisionVisitsScalingPower;
+  const float kMoveSelectionVisitsScalingPower;  
 };
 
 }  // namespace lczero

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -638,7 +638,7 @@ std::vector<EdgeAndNode> Search::GetBestChildrenNoTemperature(Node* parent,
   if (parent->GetN() == 0) return {};
   const bool is_odd_depth = (depth % 2) == 1;
   const float draw_score = GetDrawScore(is_odd_depth);
-  const int parent_n = parent->GetN();
+  const float beta_prior = pow(parent->GetN(), 0.3);
   // Best child is selected using the following criteria:
   // * Prefer shorter terminal wins / avoid shorter terminal losses.
   // * Largest number of playouts.
@@ -659,7 +659,7 @@ std::vector<EdgeAndNode> Search::GetBestChildrenNoTemperature(Node* parent,
                           : edges.end();
   std::partial_sort(
       edges.begin(), middle, edges.end(),
-      [draw_score, parent_n](const auto& a, const auto& b) {
+      [draw_score, beta_prior](const auto& a, const auto& b) {
         // The function returns "true" when a is preferred to b.
 
         // Lists edge types from less desirable to more desirable.
@@ -705,7 +705,7 @@ std::vector<EdgeAndNode> Search::GetBestChildrenNoTemperature(Node* parent,
         // Neither is terminal, use standard rule.
         if (a_rank == kNonTerminal) {
 
-	  float beta_prior = pow(parent_n, 0.3);
+	  // the beta_prior is constant and equals pow(parent->GetN(), 0.3);
 	  float alpha_prior = 1.0f;
 
 	  float winrate_a = (a.GetQ(0.0f, draw_score) + 1) * 0.5;


### PR DESCRIPTION
Instead of making the move with most visits, make the move with the highest expected value based on the beta-distribution and a prior given by the total number of visits raised by the value of the new parameter `MoveSelectionVisitsScalingPower`.