### PR TITLE
Update linux build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Given those basics, the OS and backend specific instructions are below.
 3. Go to `lc0/`
 4. Run `./build.sh`
 5. `lc0` will be in `lc0/build/release/` directory
+6. Unzip a [neural network](https://lczero.org/play/networks/bestnets/) in the same directory as the binary.
 
 If you want to build with a different compiler, pass the `CC` and `CXX` environment variables:
 

--- a/openSUSE_install.md
+++ b/openSUSE_install.md
@@ -84,7 +84,7 @@ Otherwise, if you skipped most of what is described above because you want to us
 
 The Install script automates practically everything needed for the lc0 Engine to run when hooked up to a graphical chessboard. The one thing missing that you, the User has to do on your own is to select a "Networks" file which contains the game data for its thinking. New data is generated continuously and players may want to try different files so this can't be automated. You need to select a file from the following page (usually under 50MBytes) and drop the file into the same folder as your lc0 binary.
 
-[http://lczero.org/networks](http://lczero.org/networks/)
+[https://lczero.org/play/networks/bestnets/](https://lczero.org/play/networks/bestnets/)
 
 ## An example setup with the Arena graphical chessboard
 


### PR DESCRIPTION
Following the default build instructions (Openblas) leaves the user without a neural network to use.
```
holmanb ~/workspace/lc0> ./build/release/lc0 benchmark    
       _
|   _ | |
|_ |_ |_| v0.29.0-dev+git.aa9da88 built Oct 25 2021
Creating backend [eigen]...
The eigen backend requires a network file.
```

Add location details for acquiring and installing the neural network in the primary readme.

 Update the Suse install instructions to a valid URL.