### PR TITLE
Add ability to generate 'validation' training data.

### DIFF
--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -97,7 +97,7 @@ SelfPlayGame::SelfPlayGame(PlayerOptions white, PlayerOptions black,
   }
 }
 
-void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
+void SelfPlayGame::Play(int white_threads, int black_threads, bool training, bool validation,
                         SyzygyTablebase* syzygy_tb, bool enable_resign) {
   bool blacks_move = tree_[0]->IsBlackToMove();
 
@@ -268,7 +268,7 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
           search_->GetCachedNNEval(tree_[idx]->GetCurrentHead());
       training_data_.Add(tree_[idx]->GetCurrentHead(),
                          tree_[idx]->GetPositionHistory(), best_eval,
-                         played_eval, best_is_proof, best_move, move, nneval);
+                         played_eval, best_is_proof, best_move, move, nneval, validation);
     }
     // Must reset the search before mutating the tree.
     search_.reset();
@@ -323,8 +323,8 @@ void SelfPlayGame::Abort() {
   if (search_) search_->Abort();
 }
 
-void SelfPlayGame::WriteTrainingData(TrainingDataWriter* writer) const {
-  training_data_.Write(writer, game_result_, adjudicated_);
+void SelfPlayGame::WriteTrainingData(TrainingDataWriter* writer, bool validation) const {
+  training_data_.Write(writer, game_result_, adjudicated_, validation);
 }
 
 std::unique_ptr<ChainedSearchStopper> SelfPlayLimits::MakeSearchStopper()

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -79,14 +79,14 @@ class SelfPlayGame {
   static void PopulateUciParams(OptionsParser* options);
 
   // Starts the game and blocks until the game is finished.
-  void Play(int white_threads, int black_threads, bool training,
+  void Play(int white_threads, int black_threads, bool training, bool validation,
             SyzygyTablebase* syzygy_tb, bool enable_resign = true);
   // Aborts the game currently played, doesn't matter if it's synchronous or
   // not.
   void Abort();
 
   // Writes training data to a file.
-  void WriteTrainingData(TrainingDataWriter* writer) const;
+  void WriteTrainingData(TrainingDataWriter* writer, bool validation) const;
 
   GameResult GetGameResult() const { return game_result_; }
   std::vector<Move> GetMoves() const;

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -59,6 +59,9 @@ const OptionId kTrainingId{
     "training", "Training",
     "Enables writing training data. The training data is stored into a "
     "temporary subdirectory that the engine creates."};
+const OptionId kValidationId{
+    "validation", "Validation",
+    "Overrides standard training data generation to generate 'validation' data instead."};
 const OptionId kVerboseThinkingId{"verbose-thinking", "VerboseThinking",
                                   "Show verbose thinking messages."};
 const OptionId kMoveThinkingId{"move-thinking", "MoveThinking",
@@ -110,6 +113,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   options->Add<IntOption>(kVisitsId, -1, 999999999) = -1;
   options->Add<IntOption>(kTimeMsId, -1, 999999999) = -1;
   options->Add<BoolOption>(kTrainingId) = false;
+  options->Add<BoolOption>(kValidationId) = false;
   options->Add<BoolOption>(kVerboseThinkingId) = false;
   options->Add<BoolOption>(kMoveThinkingId) = false;
   options->Add<FloatOption>(kResignPlaythroughId, 0.0f, 100.0f) = 0.0f;
@@ -159,6 +163,7 @@ SelfPlayTournament::SelfPlayTournament(
       kShareTree(options.Get<bool>(kShareTreesId)),
       kParallelism(options.Get<int>(kParallelGamesId)),
       kTraining(options.Get<bool>(kTrainingId)),
+      kValidation(options.Get<bool>(kValidationId)),
       kResignPlaythrough(options.Get<float>(kResignPlaythroughId)),
       kDiscardedStartChance(options.Get<float>(kDiscardedStartChanceId)) {
   std::string book = options.Get<std::string>(kOpeningsFileId);
@@ -350,7 +355,7 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
   // PLAY GAME!
   auto player1_threads = player_options_[0][color_idx[0]].Get<int>(kThreadsId);
   auto player2_threads = player_options_[1][color_idx[1]].Get<int>(kThreadsId);
-  game.Play(player1_threads, player2_threads, kTraining, syzygy_tb_.get(),
+  game.Play(player1_threads, player2_threads, kTraining, kValidation, syzygy_tb_.get(),
             enable_resign);
   
   // If game was aborted, it's still undecided.
@@ -369,7 +374,7 @@ void SelfPlayTournament::PlayOneGame(int game_number) {
     }
     if (kTraining) {
       TrainingDataWriter writer(game_number);
-      game.WriteTrainingData(&writer);
+      game.WriteTrainingData(&writer, kValidation);
       writer.Finalize();
       game_info.training_filename = writer.GetFileName();
     }

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -106,6 +106,7 @@ class SelfPlayTournament {
   const bool kShareTree;
   const size_t kParallelism;
   const bool kTraining;
+  const bool kValidation;
   const float kResignPlaythrough;
   const float kDiscardedStartChance;
 

--- a/src/trainingdata/trainingdata.cc
+++ b/src/trainingdata/trainingdata.cc
@@ -78,26 +78,28 @@ void DriftCorrect(float* q, float* d) {
 
 
 void V6TrainingDataArray::Write(TrainingDataWriter* writer, GameResult result,
-                                bool adjudicated) const {
+                                bool adjudicated, bool validation) const {
   if (training_data_.empty()) return;
   // Base estimate off of best_m.  If needed external processing can use a
   // different approach.
   float m_estimate = training_data_.back().best_m + training_data_.size() - 1;
   for (auto chunk : training_data_) {
-    bool black_to_move = chunk.side_to_move_or_enpassant;
-    if (IsCanonicalFormat(static_cast<pblczero::NetworkFormat::InputFormat>(
-            chunk.input_format))) {
-      black_to_move = (chunk.invariance_info & (1u << 7)) != 0;
-    }
-    if (result == GameResult::WHITE_WON) {
-      chunk.result_q = black_to_move ? -1 : 1;
-      chunk.result_d = 0;
-    } else if (result == GameResult::BLACK_WON) {
-      chunk.result_q = black_to_move ? 1 : -1;
-      chunk.result_d = 0;
-    } else {
-      chunk.result_q = 0;
-      chunk.result_d = 1;
+    if (!validation) {
+      bool black_to_move = chunk.side_to_move_or_enpassant;
+      if (IsCanonicalFormat(static_cast<pblczero::NetworkFormat::InputFormat>(
+              chunk.input_format))) {
+        black_to_move = (chunk.invariance_info & (1u << 7)) != 0;
+      }
+      if (result == GameResult::WHITE_WON) {
+        chunk.result_q = black_to_move ? -1 : 1;
+        chunk.result_d = 0;
+      } else if (result == GameResult::BLACK_WON) {
+        chunk.result_q = black_to_move ? 1 : -1;
+        chunk.result_d = 0;
+      } else {
+        chunk.result_q = 0;
+        chunk.result_d = 1;
+      }
     }
     if (adjudicated) {
       chunk.invariance_info |= 1u << 5;  // Game adjudicated.
@@ -105,8 +107,10 @@ void V6TrainingDataArray::Write(TrainingDataWriter* writer, GameResult result,
     if (adjudicated && result == GameResult::UNDECIDED) {
       chunk.invariance_info |= 1u << 4;  // Max game length exceeded.
     }
-    chunk.plies_left = m_estimate;
-    m_estimate -= 1.0f;
+    if (!validation) {
+      chunk.plies_left = m_estimate;
+      m_estimate -= 1.0f;
+    }
     writer->WriteChunk(chunk);
   }
 }
@@ -114,7 +118,7 @@ void V6TrainingDataArray::Write(TrainingDataWriter* writer, GameResult result,
 void V6TrainingDataArray::Add(const Node* node, const PositionHistory& history,
                               Eval best_eval, Eval played_eval,
                               bool best_is_proven, Move best_move,
-                              Move played_move, const NNCacheLock& nneval) {
+                              Move played_move, const NNCacheLock& nneval, bool validation) {
   V6TrainingData result;
   const auto& position = history.Last();
 
@@ -137,7 +141,7 @@ void V6TrainingDataArray::Add(const Node* node, const PositionHistory& history,
   // Prevent garbage/invalid training data from being uploaded to server.
   // It's possible to have N=0 when there is only one legal move in position
   // (due to smart pruning).
-  if (total_n == 0 && node->GetNumEdges() != 1) {
+  if (!validation && total_n == 0 && node->GetNumEdges() != 1) {
     throw Exception("Search generated invalid data!");
   }
   // Set illegal moves to have -1 probability.
@@ -171,6 +175,9 @@ void V6TrainingDataArray::Add(const Node* node, const PositionHistory& history,
   for (const auto& child : node->Edges()) {
     auto nn_idx = child.edge()->GetMove().as_nn_index(transform);
     float fracv = total_n > 0 ? child.GetN() / static_cast<float>(total_n) : 1;
+    if (validation) {
+      fracv = child.GetP();
+    }
     if (nneval) {
       float P = std::exp(*it - max_p);
       if (fracv > 0) {
@@ -246,12 +253,26 @@ void V6TrainingDataArray::Add(const Node* node, const PositionHistory& history,
   result.best_q = best_eval.wl;
   result.played_q = played_eval.wl;
   result.orig_q = orig_eval.wl;
+  if (validation) {
+    if (nneval) {
+      result.result_q = result.orig_q;
+    } else {
+      result.result_q = result.root_q;
+    }
+  }
 
   // Draw probability of WDL head.
   result.root_d = node->GetD();
   result.best_d = best_eval.d;
   result.played_d = played_eval.d;
   result.orig_d = orig_eval.d;
+  if (validation) {
+    if (nneval) {
+      result.result_d = result.orig_d;
+    } else {
+      result.result_d = result.root_d;
+    }
+  }
 
   DriftCorrect(&result.best_q, &result.best_d);
   DriftCorrect(&result.root_q, &result.root_d);
@@ -273,6 +294,13 @@ void V6TrainingDataArray::Add(const Node* node, const PositionHistory& history,
 
   // Unknown here - will be filled in once the full data has been collected.
   result.plies_left = 0;
+  if (validation) {
+    if (nneval) {
+      result.plies_left = result.orig_m;
+    } else {
+      result.plies_left = result.root_m;
+    }
+  }
   training_data_.push_back(result);
 }
 

--- a/src/trainingdata/trainingdata.h
+++ b/src/trainingdata/trainingdata.h
@@ -98,11 +98,11 @@ class V6TrainingDataArray {
   // Add a chunk.
   void Add(const Node* node, const PositionHistory& history, Eval best_eval,
            Eval played_eval, bool best_is_proven, Move best_move,
-           Move played_move, const NNCacheLock& nneval);
+           Move played_move, const NNCacheLock& nneval, bool validation);
 
   // Writes training data to a file.
   void Write(TrainingDataWriter* writer, GameResult result,
-             bool adjudicated) const;
+             bool adjudicated, bool validation) const;
 
  private:
   std::vector<V6TrainingData> training_data_;


### PR DESCRIPTION
For use in a form like this:
```
.\lc0 selfplay -w 192x15-baseline-swa-300000.pb.gz --openings-pgn=openings-6ply-1000.pgn --games=-2 --visits=1 --training --validation --policy-softmax-temp=1.0 --parallelism=32  --noise-epsilon=0.0
```
Produces data which can then be used as 'test' or 'validation' data as input to training and get loss and accuracy comparing the network outputs to the model.  This has value in ensuring that model and our backend implementations are in agreement.
Accuracies over 99.7% should be expected even with an fp16 backend doing the original selfplay generation, if the network used is the same as the model used to generate it. (Some editing of the training script may be required to ensure the network doesn't change between loading and running 'test' or 'validation'.)
It also potentially works for normal validation data - just with a more achievable target than the outcome of search is. (So less useful as a net starts to potentially surpass the net which created the validation data.)