### PR TITLE
WAR for cublas issue on TU11x GPUs with version CUDA 11.0+

### DIFF
--- a/src/neural/cuda/cuda_common.h
+++ b/src/neural/cuda/cuda_common.h
@@ -37,6 +37,10 @@
 typedef void* cudnnHandle_t;
 #endif
 
+#if CUBLAS_VER_MAJOR < 11
+#define CUBLAS_PEDANTIC_MATH CUBLAS_DEFAULT_MATH
+#endif
+
 namespace lczero {
 namespace cudnn_backend {
 

--- a/src/neural/cuda/inputs_outputs.h
+++ b/src/neural/cuda/inputs_outputs.h
@@ -32,7 +32,8 @@ namespace cudnn_backend {
 
 struct InputsOutputs {
   InputsOutputs(int maxBatchSize, bool wdl, bool moves_left,
-                size_t tensor_mem_size = 0, size_t scratch_size = 0) {
+                size_t tensor_mem_size = 0, size_t scratch_size = 0,
+                bool cublasDisableTensorCores = false) {
     ReportCUDAErrors(cudaHostAlloc(
         &input_masks_mem_, maxBatchSize * kInputPlanes * sizeof(uint64_t),
         cudaHostAllocMapped));
@@ -77,7 +78,9 @@ struct InputsOutputs {
         ReportCUDAErrors(cudaMemsetAsync(mem, 0, tensor_mem_size, stream_));
       }
       ReportCUBLASErrors(cublasCreate(&cublas_));
-      ReportCUBLASErrors(cublasSetMathMode(cublas_, CUBLAS_TENSOR_OP_MATH));
+      ReportCUBLASErrors(cublasSetMathMode(
+          cublas_, cublasDisableTensorCores ? CUBLAS_PEDANTIC_MATH
+                                            : CUBLAS_TENSOR_OP_MATH));
       ReportCUBLASErrors(cublasSetStream(cublas_, stream_));
     } else {
       multi_stream_ = false;


### PR DESCRIPTION
- set CUBLAS_PEDANTIC_MATH to avoid cublas making use of tensor math on TU11x GPUs.
- From documentation:
"Starting with cuBLAS version 11.0.0, the library will automatically make use of Tensor Core capabilities wherever possible, unless they are explicitly disabled by selecting pedantic compute modes in cuBLAS (see cublasSetMathMode(), cublasMath_t)."
- Unfortunately there is a bug in cublas which enables tensor math even on TU11x GPUs which is emulated in software is orders of magnitude slower, so this PR is a workaround to disable tensor math to make cublas pick 2xFP16 math kernels on TU11x.