### PR TITLE
Add support for cuda graphs and async copy of policy output

### DIFF
--- a/src/neural/cuda/inputs_outputs.h
+++ b/src/neural/cuda/inputs_outputs.h
@@ -71,6 +71,8 @@ struct InputsOutputs {
     if (tensor_mem_size) {
       multi_stream_ = true;
       ReportCUDAErrors(cudaStreamCreate(&stream_));
+      ReportCUDAErrors(cudaStreamCreate(&stream_copy_));
+      ReportCUDAErrors(cudaEventCreate(&policy_ready_event_));
       ReportCUDAErrors(cudaMalloc(&scratch_mem_, scratch_size));
       for (auto& mem : tensor_mem_) {
         ReportCUDAErrors(cudaMalloc(&mem, tensor_mem_size));
@@ -97,6 +99,8 @@ struct InputsOutputs {
       if (scratch_mem_) ReportCUDAErrors(cudaFree(scratch_mem_));
 
       cudaStreamDestroy(stream_);
+      cudaStreamDestroy(stream_copy_);
+      cudaEventDestroy(policy_ready_event_);
       cublasDestroy(cublas_);
     }
   
@@ -123,9 +127,9 @@ struct InputsOutputs {
   void* scratch_mem_;
 
   // cuda stream used to run the network
-  cudaStream_t stream_;
+  cudaStream_t stream_, stream_copy_;
   cublasHandle_t cublas_;
-
+  cudaEvent_t policy_ready_event_;
   // cublas handle used to run the network
 
 };


### PR DESCRIPTION
- Async policy output allows running the policy output copy from GPU memory to system memory run in parallel with value and mlh head computation - which is about 2-3% of network execution time.
- Using CUDA graphs helps with reducing the overhead of kernel launches.
- The two optimizations combined is worth about 5% speedup in benchmark with 384fx30b network on A100 (more improvement in backendbench, but it doesn't translate to full benchmark speedup because multi_stream opt was already achieving parallelism by running multiple inferences in parallel).
- Here are some detailed performance nos on A100:
```
Backend Bench (multi_stream enabled):
=====================================
384fx30b:
baseline: Benchmark batch size 96 with inference average time 3.43217ms - throughput 27970.6 nps.
opt:      Benchmark batch size 96 with inference average time 3.16205ms - throughput 30360.1 nps.
baseline: Benchmark batch size 192 with inference average time 6.52237ms - throughput 29437.2 nps
opt:      Benchmark batch size 192 with inference average time 6.28403ms - throughput 30553.6 nps.

512fx40b:
baseline: Benchmark batch size 96 with inference average time 6.23764ms - throughput 15390.4 nps.
opt:      Benchmark batch size 96 with inference average time 5.94518ms - throughput 16147.5 nps.
baseline: Benchmark batch size 192 with inference average time 11.9312ms - throughput 16092.2 nps.
opt:      Benchmark batch size 192 with inference average time 11.5244ms - throughput 16660.3 nps.


Benchmark (with multi_stream enabled, default params, num_positions=1):
=======================================================================
384fx30b:
baseline: Nodes/second    : 63883
opt:      Nodes/second    : 66878

512fx40b:
baseline: Nodes/second    : 34284
opt:      Nodes/second    : 35525
```