### PR TITLE
Alphazero TM revised

### DIFF
--- a/src/mcts/stoppers/alphazero.cc
+++ b/src/mcts/stoppers/alphazero.cc
@@ -35,8 +35,8 @@ class AlphazeroTimeManager : public TimeManager {
  public:
   AlphazeroTimeManager(int64_t move_overhead, const OptionsDict& params)
       : move_overhead_(move_overhead),
-        minpct_(params.GetOrDefault<float>("min-pct", 8.84f)),
-        plymult_(params.GetOrDefault<float>("ply-mult", 0.269f)) {
+        minpct_(params.GetOrDefault<float>("min-pct", 7.48f)),
+        plymult_(params.GetOrDefault<float>("ply-mult", 0.248f)) {
     if (minpct_ <= 0.0f || minpct_ > 100.0f)
       throw Exception("min-pct value to be in range [0.0, 100.0]");
     if (plymult_ < 0.0f || plymult_ > 10.0f)


### PR DESCRIPTION
One downside of current alphazero time management is that it normally never has the ability to use the full time available. For instance if you had a time control of 60s+1s and chose a percentage of 5%, then it would end every game with no less than 20 seconds on the clock, which is a significant amount of time to be left unused at that tc.

The goal with this pr was to make a version of a0 tm that increases the percentage of time available every move until it eventually reaches 100%. Also hoping that it would better scale from vstc to vltc, and thus be easier to tune.

The a0_revised params have been tuned at vstc and the test results indicate good scaling to ltc.

lc0 @ 6s+0.1s
```
   # PLAYER            :  RATING  ERROR  POINTS  PLAYED   (%)  CFS(%)    W     D    L  D(%)
   1 sf                :     0.0   ----  1313.5    2500    53      91  672  1283  545    51
   2 lc0-a0_revised    :    -9.0   13.2   609.0    1250    49      96  281   656  313    52
   3 lc0-legacy        :   -26.8   14.1   577.5    1250    46     ---  264   627  359    50
```

lc0 @ 120s+2s
```
   # PLAYER            :  RATING  ERROR  POINTS  PLAYED   (%)  CFS(%)    W    D    L  D(%)
   1 lc0-a0_revised    :    12.3   15.4   103.5     200    52      94   13  181    6    91
   2 lc0-legacy        :     0.0   ----    96.5     200    48     ---    6  181   13    91
```

Note also that I first tried a log scale for increasing the a0 pct to 100, but it didnt perform as well as the flat increase per ply that was settled on here.
