### PR TITLE
save trainingdata from undecided games

### DIFF
--- a/src/trainingdata/trainingdata.cc
+++ b/src/trainingdata/trainingdata.cc
@@ -105,6 +105,11 @@ void V6TrainingDataArray::Write(TrainingDataWriter* writer, GameResult result,
     if (adjudicated && result == GameResult::UNDECIDED) {
       chunk.invariance_info |= 1u << 4;  // Max game length exceeded.
     }
+    if (result == GameResult::UNDECIDED) {
+      // If the game is undecided use the final evaluation as result.
+      chunk.result_q = training_data_.back().best_q;
+      chunk.result_d = training_data_.back().best_d;
+    }
     chunk.plies_left = m_estimate;
     m_estimate -= 1.0f;
     writer->WriteChunk(chunk);


### PR DESCRIPTION
For game result the final evaluation of the game is used - this means the rescorer will delete them so no overall change to training. Currently this is only for games exceeding the 450 ply limit, and we already have a flag to identify those if we want to change behavior at some point, e.g. allow the ones that end in a TB position.