### PR TITLE
fix ordering of multiPV lines.

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -290,7 +290,12 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
   if (current_best_edge_ && !edges.empty()) {
     last_outputted_info_edge_ = current_best_edge_.edge();
   }
-
+  // Cutechess treats each UCI-info line atomically, and if we send
+  // multiple lines we have to send the best line last for it to stay
+  // on top. This only matters if multipv is set (above one).
+  if (max_pv > 1) {
+    std::reverse(uci_infos.begin(), uci_infos.end());
+  }
   uci_responder_->OutputThinkingInfo(&uci_infos);
 }
 


### PR DESCRIPTION
When multiPV is above 1, several lines are send by `SendUciInfo()`, and they are order by how good Leela thinks they are, so that the first line has the move that will be played. When chess GUI:s like cutechess display these UCI-info lines, they treat them atomistically, and every subsequent line pushes the previous line down the display, which make the most important line drop to the bottom of the list. To work around this problem, this patch reverses the order of the `uci_infos` vector before it is handled over to `OutputThinkingInfo()`, if multiPV is above 1. See the two screen-shots that illustrate the effect.

This is without the patch
![bar](https://user-images.githubusercontent.com/551014/161393048-3b93e951-7676-4cc6-b7f2-6e87ac777a67.png)

This is how it looks with the patch applied
![foo](https://user-images.githubusercontent.com/551014/161393052-f336f2a3-5a65-4da3-be4d-6f8131076cfb.png)
