### PR TITLE
ispc mish version for better vectorization

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 # This file is part of Leela Chess Zero.
-# Copyright (C) 2018-2020 The LCZero Authors
+# Copyright (C) 2018-2022 The LCZero Authors
 #
 # Leela Chess is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -376,6 +376,7 @@ if get_option('build_backends')
 
     if get_option('ispc') and ispc.found()
       files += iscp_gen.process('src/neural/blas/winograd_transform.ispc')
+      files += iscp_gen.process('src/neural/shared/activation.ispc')
       add_project_arguments('-DUSE_ISPC', language : 'cpp')
     endif
 

--- a/src/neural/blas/fully_connected_layer.cc
+++ b/src/neural/blas/fully_connected_layer.cc
@@ -1,6 +1,6 @@
 /*
  This file is part of Leela Chess Zero.
- Copyright (C) 2018 The LCZero Authors
+ Copyright (C) 2018-2022 The LCZero Authors
 
  Leela Chess is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -1,6 +1,6 @@
 /*
  This file is part of Leela Chess Zero.
- Copyright (C) 2018-2020 The LCZero Authors
+ Copyright (C) 2018-2022 The LCZero Authors
 
  Leela Chess is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/src/neural/shared/activation.h
+++ b/src/neural/shared/activation.h
@@ -1,6 +1,6 @@
 /*
  This file is part of Leela Chess Zero.
- Copyright (C) 2018 The LCZero Authors
+ Copyright (C) 2018-2022 The LCZero Authors
 
  Leela Chess is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/src/neural/shared/activation.ispc
+++ b/src/neural/shared/activation.ispc
@@ -1,0 +1,37 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2022 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+static inline float mish(float val) {
+  float e = exp(val);
+  float n = e * e + 2.0f * e;
+  float d = val / (n + 2.0f);
+  if (val <= -0.125f) {
+    return n * d;
+  } else {
+    return val - 2.0f * d;
+  }
+}
+
+export void ActivateMish(uniform const size_t len, uniform float gamma,
+                         const uniform float data[], const uniform float bias[],
+                         uniform float beta, uniform float output[]) {
+  foreach (b = 0 ... len) {
+    float val = gamma * data[b] + bias[b] + beta;
+    output[b] = mish(val);
+  }
+}

--- a/src/neural/shared/activation.ispc
+++ b/src/neural/shared/activation.ispc
@@ -20,7 +20,7 @@ static inline float mish(float val) {
   float e = exp(val);
   float n = e * e + 2.0f * e;
   float d = val / (n + 2.0f);
-  if (val <= -0.125f) {
+  if (val <= -0.5f) {
     return n * d;
   } else {
     return val - 2.0f * d;


### PR DESCRIPTION
This brings evaluation speed for T79 very close to T75 when compiled with ispc, compared to almost half without.