### PR TITLE
Speed optimizations for the blas backend.

### DIFF
--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -271,17 +271,14 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
                         conv2.weights.data(), conv_out);
 
       if (residual.has_se) {
-        // No relu if followed by SE-unit and residual is added later
-        BiasActivate(batch_size, output_channels, &conv_out[0],
-                     conv2.biases.data(), NONE);
-
+        // No relu if followed by SE-unit and residual/bias is added later
         std::swap(conv_out, conv_in);
 
         auto se_fc_outputs = se.b1.size();
         ApplySEUnit<use_eigen>(batch_size, output_channels, se_fc_outputs,
-                               conv_in, res, se.w1.data(), se.b1.data(),
-                               se.w2.data(), se.b2.data(), conv_out,
-                               default_activation_);
+                               conv_in, conv2.biases.data(), res, se.w1.data(),
+                               se.b1.data(), se.w2.data(), se.b2.data(),
+                               conv_out, default_activation_);
       } else {
         BiasResidual(batch_size, output_channels, &conv_out[0],
                      conv2.biases.data(), res, default_activation_);

--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -168,6 +168,13 @@ BlasComputation<use_eigen>::BlasComputation(
 #endif
 }
 
+template <typename T>
+using EigenMatrixMap =
+    Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>;
+template <typename T>
+using ConstEigenMatrixMap =
+    Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>;
+
 template <bool use_eigen>
 void BlasComputation<use_eigen>::ComputeBlocking() {
   // Retrieve network key dimensions from the weights structure.
@@ -285,11 +292,12 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
       }
     }
 
+    // Need to preserve conv_out which is used for value and moves left heads.
     if (attn_policy_) {
       // NCHW to NHWC conversion.
       for (auto batch = size_t{0}; batch < batch_size; batch++) {
         for (auto i = 0; i < kSquares; i++) {
-          for (auto j = 0; j < output_channels; j++) {
+          for (auto j = size_t{0}; j < output_channels; j++) {
             res[batch * kSquares * output_channels + i * output_channels + j] =
                 conv_out[batch * kSquares * output_channels + j * kSquares + i];
           }
@@ -304,7 +312,7 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
           head_buffer.data());
 
       for (auto layer : weights_.pol_encoder) {
-        // TODO: support encoder heds.
+        // TODO: support encoder heads.
         throw Exception(
             "Eigen/Blas backend doesn't support encoder heads yet.");
       }
@@ -323,30 +331,37 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
           batch_size * kSquares, embedding_size, policy_d_model,
           head_buffer.data(), weights_.ip3_pol_w.data(),
           weights_.ip3_pol_b.data(), NONE, head_buffer3.data());
-      // TODO: perform dotproduct with Eigen/Blas rather than handrolled?
-      const float scaling = sqrtf(policy_d_model);
+      const float scaling = 1.0f / sqrtf(policy_d_model);
       for (auto batch = size_t{0}; batch < batch_size; batch++) {
-        for (auto i = 0; i < kSquares; i++) {
-          for (auto j = 0; j < kSquares; j++) {
-            float sum = 0.0f;
-            for (auto k = 0; k < policy_d_model; k++) {
-              sum += head_buffer2.data()[batch * 64 * policy_d_model +
-                                         i * policy_d_model + k] *
-                     head_buffer3.data()[batch * 64 * policy_d_model +
-                                         j * policy_d_model + k];
-            }
-            head_buffer.data()[batch * (64 * 64 + 8 * 24) + i * 64 + j] =
-                sum / scaling;
-          }
+        const float* A = &head_buffer2[batch * 64 * policy_d_model];
+        const float* B = &head_buffer3[batch * 64 * policy_d_model];
+        float* C = &head_buffer[batch * (64 * 64 + 8 * 24)];
+        if (use_eigen) {
+          auto C_mat = EigenMatrixMap<float>(C, kSquares, kSquares);
+          C_mat.noalias() =
+              scaling *
+              ConstEigenMatrixMap<float>(B, policy_d_model, kSquares)
+                  .transpose() *
+              ConstEigenMatrixMap<float>(A, policy_d_model, kSquares);
+        } else {
+#ifdef USE_BLAS
+          cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, kSquares,
+                      kSquares, policy_d_model, scaling, A, policy_d_model, B,
+                      policy_d_model, 0.0f, C, 64);
+#else
+          // Should never get here.
+          throw Exception("Blas backend internal error");
+#endif
         }
       }
       // Promotion offset calculation.
       for (auto batch = size_t{0}; batch < batch_size; batch++) {
         float promotion_offsets[4][8];
+        // This is so small that SGEMM seems slower.
         for (int i = 0; i < 4; i++) {
           for (int j = 0; j < 8; j++) {
             float sum = 0;
-            for (int k = 0; k < policy_d_model; k++) {
+            for (size_t k = 0; k < policy_d_model; k++) {
               sum += head_buffer3.data()[batch * kSquares * policy_d_model +
                                          (56 + j) * policy_d_model + k] *
                      weights_.ip4_pol_w.data()[i * policy_d_model + k];
@@ -382,7 +397,6 @@ void BlasComputation<use_eigen>::ComputeBlocking() {
         }
       }
     } else if (conv_policy_) {
-      // Need to preserve conv_out which is used for value head
       convolve3.Forward(batch_size, output_channels, output_channels, conv_out,
                         weights_.policy1.weights.data(), res);
 

--- a/src/neural/blas/se_unit.h
+++ b/src/neural/blas/se_unit.h
@@ -27,9 +27,9 @@ namespace lczero {
 template <bool use_eigen>
 void ApplySEUnit(const size_t batch_size, const size_t channels,
                  const size_t se_fc_outputs, const float* input,
-                 const float* residual, const float* weights_w1,
-                 const float* weights_b1, const float* weights_w2,
-                 const float* weights_b2, float* output,
-                 const ActivationFunction activation);
+                 const float* bias, const float* residual,
+                 const float* weights_w1, const float* weights_b1,
+                 const float* weights_w2, const float* weights_b2,
+                 float* output, const ActivationFunction activation);
 
 }  // namespace lczero

--- a/src/neural/blas/winograd_transform.ispc
+++ b/src/neural/blas/winograd_transform.ispc
@@ -47,19 +47,75 @@ export void winograd_TransformIn_ispc(uniform size_t batch_size,
 
         foreach (channel = 0 ... channels) {
           size_t V_channel = V_batch + channel;
-          size_t input_channel = input_batch + channel * (kWidth * kHeight);
+          const float* input_channel = input + input_batch + channel * kSquares;
 
-          for (uniform int i = 0; i < kWinogradAlpha; i++) {
+          if (block_y == 0) {
             for (uniform int j = 0; j < kWinogradAlpha; j++) {
-              if ((yin + i) >= 0 && (xin + j) >= 0 && (yin + i) < kHeight &&
-                  (xin + j) < kWidth) {
-                x[i][j] = input[input_channel + (yin + i) * kWidth + (xin + j)];
-              } else {
-                x[i][j] = 0.0f;
+              x[0][j] = 0.0f;
+            }
+            for (uniform int i = 1; i < kWinogradAlpha; i++) {
+              for (uniform int j = 0; j < kWinogradAlpha / 2; j++) {
+                if ((xin + j) >= 0) {
+                  x[i][j] =
+                      input_channel[(yin + i) * kWidth + (xin + j)];
+                } else {
+                  x[i][j] = 0.0f;
+                }
+              }
+              for (uniform int j = kWinogradAlpha / 2; j < kWinogradAlpha;
+                   j++) {
+                if ((xin + j) < kWidth) {
+                  x[i][j] =
+                      input_channel[(yin + i) * kWidth + (xin + j)];
+                } else {
+                  x[i][j] = 0.0f;
+                }
+              }
+            }
+          } else if (block_y == kWtiles - 1) {
+            for (uniform int i = 0; i < kWinogradAlpha - 1; i++) {
+              for (uniform int j = 0; j < kWinogradAlpha / 2; j++) {
+                if ((xin + j) >= 0) {
+                  x[i][j] =
+                      input_channel[(yin + i) * kWidth + (xin + j)];
+                } else {
+                  x[i][j] = 0.0f;
+                }
+              }
+              for (uniform int j = kWinogradAlpha / 2; j < kWinogradAlpha;
+                   j++) {
+                if ((xin + j) < kWidth) {
+                  x[i][j] =
+                      input_channel[(yin + i) * kWidth + (xin + j)];
+                } else {
+                  x[i][j] = 0.0f;
+                }
+              }
+            }
+            for (uniform int j = 0; j < kWinogradAlpha; j++) {
+              x[kWinogradAlpha - 1][j] = 0.0f;
+            }
+          } else {
+            for (uniform int i = 0; i < kWinogradAlpha; i++) {
+              for (uniform int j = 0; j < kWinogradAlpha / 2; j++) {
+                if ((xin + j) >= 0) {
+                  x[i][j] =
+                      input_channel[(yin + i) * kWidth + (xin + j)];
+                } else {
+                  x[i][j] = 0.0f;
+                }
+              }
+              for (uniform int j = kWinogradAlpha / 2; j < kWinogradAlpha;
+                   j++) {
+                if ((xin + j) < kWidth) {
+                  x[i][j] =
+                      input_channel[(yin + i) * kWidth + (xin + j)];
+                } else {
+                  x[i][j] = 0.0f;
+                }
               }
             }
           }
-
           T1[0][0] = x[0][0] - x[2][0];
           T1[0][1] = x[0][1] - x[2][1];
           T1[0][2] = x[0][2] - x[2][2];
@@ -107,8 +163,6 @@ export void winograd_TransformOut_ispc(uniform size_t batch_size,
                                        const uniform float input[],
                                        uniform size_t channels,
                                        uniform float output[]) {
-  float m[kWinogradTile];
-
   for (uniform size_t batch_index = 0; batch_index < batch_size;
        batch_index++) {
     const uniform size_t M_batch = channels * kTiles * batch_index;
@@ -123,28 +177,61 @@ export void winograd_TransformOut_ispc(uniform size_t batch_size,
           const size_t M_channel = M_batch + channel;
           const size_t output_channel = output_batch + channel * kSquares;
           const uniform int b = block_y * kWtiles + block_x;
-          const size_t M_wtile = M_channel + channels * b;
+
+          const float* M_wtile = input + M_channel + channels * b;
           const uniform int M_incr = channels * kTiles * batch_size;
 
-          for (uniform int wTile = 0; wTile < kWinogradTile; wTile++) {
-            m[wTile] = input[M_wtile + wTile * M_incr];
-          }
-
-          float o11 = m[0 * 4 + 0] + m[0 * 4 + 1] + m[0 * 4 + 2] +
-                      m[1 * 4 + 0] + m[1 * 4 + 1] + m[1 * 4 + 2] +
-                      m[2 * 4 + 0] + m[2 * 4 + 1] + m[2 * 4 + 2];
-
-          float o12 = m[0 * 4 + 1] - m[0 * 4 + 2] - m[0 * 4 + 3] +
-                      m[1 * 4 + 1] - m[1 * 4 + 2] - m[1 * 4 + 3] +
-                      m[2 * 4 + 1] - m[2 * 4 + 2] - m[2 * 4 + 3];
-
-          float o21 = m[1 * 4 + 0] + m[1 * 4 + 1] + m[1 * 4 + 2] -
-                      m[2 * 4 + 0] - m[2 * 4 + 1] - m[2 * 4 + 2] -
-                      m[3 * 4 + 0] - m[3 * 4 + 1] - m[3 * 4 + 2];
-
-          float o22 = m[1 * 4 + 1] - m[1 * 4 + 2] - m[1 * 4 + 3] -
-                      m[2 * 4 + 1] + m[2 * 4 + 2] + m[2 * 4 + 3] -
-                      m[3 * 4 + 1] + m[3 * 4 + 2] + m[3 * 4 + 3];
+          float o11 = M_wtile[0];
+          M_wtile += M_incr;
+          o11 += M_wtile[0];
+          float o12 = M_wtile[0];
+          M_wtile += M_incr;
+          o11 += M_wtile[0];
+          o12 -= M_wtile[0];
+          M_wtile += M_incr;
+          o12 -= M_wtile[0];
+          M_wtile += M_incr;
+          o11 += M_wtile[0];
+          float o21 = M_wtile[0];
+          M_wtile += M_incr;
+          o11 += M_wtile[0];
+          o12 += M_wtile[0];
+          o21 += M_wtile[0];
+          float o22 = M_wtile[0];
+          M_wtile += M_incr;
+          o11 += M_wtile[0];
+          o12 -= M_wtile[0];
+          o21 += M_wtile[0];
+          o22 -= M_wtile[0];
+          M_wtile += M_incr;
+          o12 -= M_wtile[0];
+          o22 -= M_wtile[0];
+          M_wtile += M_incr;
+          o11 += M_wtile[0];
+          o21 -= M_wtile[0];
+          M_wtile += M_incr;
+          o11 += M_wtile[0];
+          o12 += M_wtile[0];
+          o21 -= M_wtile[0];
+          o22 -= M_wtile[0];
+          M_wtile += M_incr;
+          o11 += M_wtile[0];
+          o12 -= M_wtile[0];
+          o21 -= M_wtile[0];
+          o22 += M_wtile[0];
+          M_wtile += M_incr;
+          o12 -= M_wtile[0];
+          o22 += M_wtile[0];
+          M_wtile += M_incr;
+          o21 -= M_wtile[0];
+          M_wtile += M_incr;
+          o21 -= M_wtile[0];
+          o22 -= M_wtile[0];
+          M_wtile += M_incr;
+          o21 -= M_wtile[0];
+          o22 += M_wtile[0];
+          M_wtile += M_incr;
+          o22 += M_wtile[0];
 
           output[output_channel + (y)*kWidth + (x)] = o11;
           output[output_channel + (y)*kWidth + (x + 1)] = o12;

--- a/src/neural/blas/winograd_transform.ispc
+++ b/src/neural/blas/winograd_transform.ispc
@@ -33,7 +33,6 @@ export void winograd_TransformIn_ispc(uniform size_t batch_size,
                                       uniform size_t channels,
                                       uniform float output[]) {
   float x[kWinogradAlpha][kWinogradAlpha];
-  float T1[kWinogradAlpha][kWinogradAlpha];
 
   for (uniform size_t batch_index = 0; batch_index < batch_size;
        batch_index++) {
@@ -44,6 +43,7 @@ export void winograd_TransformIn_ispc(uniform size_t batch_size,
       for (uniform int block_x = 0; block_x < kWtiles; block_x++) {
         const uniform int yin = 2 * block_y - 1;
         const uniform int xin = 2 * block_x - 1;
+        const uniform size_t V_incr = channels * kTiles * batch_size;
 
         foreach (channel = 0 ... channels) {
           size_t V_channel = V_batch + channel;
@@ -56,8 +56,7 @@ export void winograd_TransformIn_ispc(uniform size_t batch_size,
             for (uniform int i = 1; i < kWinogradAlpha; i++) {
               for (uniform int j = 0; j < kWinogradAlpha / 2; j++) {
                 if ((xin + j) >= 0) {
-                  x[i][j] =
-                      input_channel[(yin + i) * kWidth + (xin + j)];
+                  x[i][j] = input_channel[(yin + i) * kWidth + (xin + j)];
                 } else {
                   x[i][j] = 0.0f;
                 }
@@ -65,8 +64,7 @@ export void winograd_TransformIn_ispc(uniform size_t batch_size,
               for (uniform int j = kWinogradAlpha / 2; j < kWinogradAlpha;
                    j++) {
                 if ((xin + j) < kWidth) {
-                  x[i][j] =
-                      input_channel[(yin + i) * kWidth + (xin + j)];
+                  x[i][j] = input_channel[(yin + i) * kWidth + (xin + j)];
                 } else {
                   x[i][j] = 0.0f;
                 }
@@ -76,8 +74,7 @@ export void winograd_TransformIn_ispc(uniform size_t batch_size,
             for (uniform int i = 0; i < kWinogradAlpha - 1; i++) {
               for (uniform int j = 0; j < kWinogradAlpha / 2; j++) {
                 if ((xin + j) >= 0) {
-                  x[i][j] =
-                      input_channel[(yin + i) * kWidth + (xin + j)];
+                  x[i][j] = input_channel[(yin + i) * kWidth + (xin + j)];
                 } else {
                   x[i][j] = 0.0f;
                 }
@@ -85,8 +82,7 @@ export void winograd_TransformIn_ispc(uniform size_t batch_size,
               for (uniform int j = kWinogradAlpha / 2; j < kWinogradAlpha;
                    j++) {
                 if ((xin + j) < kWidth) {
-                  x[i][j] =
-                      input_channel[(yin + i) * kWidth + (xin + j)];
+                  x[i][j] = input_channel[(yin + i) * kWidth + (xin + j)];
                 } else {
                   x[i][j] = 0.0f;
                 }
@@ -99,8 +95,7 @@ export void winograd_TransformIn_ispc(uniform size_t batch_size,
             for (uniform int i = 0; i < kWinogradAlpha; i++) {
               for (uniform int j = 0; j < kWinogradAlpha / 2; j++) {
                 if ((xin + j) >= 0) {
-                  x[i][j] =
-                      input_channel[(yin + i) * kWidth + (xin + j)];
+                  x[i][j] = input_channel[(yin + i) * kWidth + (xin + j)];
                 } else {
                   x[i][j] = 0.0f;
                 }
@@ -108,51 +103,33 @@ export void winograd_TransformIn_ispc(uniform size_t batch_size,
               for (uniform int j = kWinogradAlpha / 2; j < kWinogradAlpha;
                    j++) {
                 if ((xin + j) < kWidth) {
-                  x[i][j] =
-                      input_channel[(yin + i) * kWidth + (xin + j)];
+                  x[i][j] = input_channel[(yin + i) * kWidth + (xin + j)];
                 } else {
                   x[i][j] = 0.0f;
                 }
               }
             }
           }
-          T1[0][0] = x[0][0] - x[2][0];
-          T1[0][1] = x[0][1] - x[2][1];
-          T1[0][2] = x[0][2] - x[2][2];
-          T1[0][3] = x[0][3] - x[2][3];
-          T1[1][0] = x[1][0] + x[2][0];
-          T1[1][1] = x[1][1] + x[2][1];
-          T1[1][2] = x[1][2] + x[2][2];
-          T1[1][3] = x[1][3] + x[2][3];
-          T1[2][0] = x[2][0] - x[1][0];
-          T1[2][1] = x[2][1] - x[1][1];
-          T1[2][2] = x[2][2] - x[1][2];
-          T1[2][3] = x[2][3] - x[1][3];
-          T1[3][0] = x[1][0] - x[3][0];
-          T1[3][1] = x[1][1] - x[3][1];
-          T1[3][2] = x[1][2] - x[3][2];
-          T1[3][3] = x[1][3] - x[3][3];
 
-          const size_t V_incr = channels * kTiles * batch_size;
           const size_t wTile_V =
               V_channel + channels * (block_y * kWtiles + block_x);
 
-          output[wTile_V + V_incr * 0] = T1[0][0] - T1[0][2];
-          output[wTile_V + V_incr * 1] = T1[0][1] + T1[0][2];
-          output[wTile_V + V_incr * 2] = T1[0][2] - T1[0][1];
-          output[wTile_V + V_incr * 3] = T1[0][1] - T1[0][3];
-          output[wTile_V + V_incr * 4] = T1[1][0] - T1[1][2];
-          output[wTile_V + V_incr * 5] = T1[1][1] + T1[1][2];
-          output[wTile_V + V_incr * 6] = T1[1][2] - T1[1][1];
-          output[wTile_V + V_incr * 7] = T1[1][1] - T1[1][3];
-          output[wTile_V + V_incr * 8] = T1[2][0] - T1[2][2];
-          output[wTile_V + V_incr * 9] = T1[2][1] + T1[2][2];
-          output[wTile_V + V_incr * 10] = T1[2][2] - T1[2][1];
-          output[wTile_V + V_incr * 11] = T1[2][1] - T1[2][3];
-          output[wTile_V + V_incr * 12] = T1[3][0] - T1[3][2];
-          output[wTile_V + V_incr * 13] = T1[3][1] + T1[3][2];
-          output[wTile_V + V_incr * 14] = T1[3][2] - T1[3][1];
-          output[wTile_V + V_incr * 15] = T1[3][1] - T1[3][3];
+          output[wTile_V + V_incr * 0] = x[0][0] - x[2][0] - x[0][2] + x[2][2];
+          output[wTile_V + V_incr * 1] = x[0][1] - x[2][1] + x[0][2] - x[2][2];
+          output[wTile_V + V_incr * 2] = x[0][2] - x[2][2] - x[0][1] + x[2][1];
+          output[wTile_V + V_incr * 3] = x[0][1] - x[2][1] - x[0][3] + x[2][3];
+          output[wTile_V + V_incr * 4] = x[1][0] + x[2][0] - x[1][2] - x[2][2];
+          output[wTile_V + V_incr * 5] = x[1][1] + x[2][1] + x[1][2] + x[2][2];
+          output[wTile_V + V_incr * 6] = x[1][2] + x[2][2] - x[1][1] - x[2][1];
+          output[wTile_V + V_incr * 7] = x[1][1] + x[2][1] - x[1][3] - x[2][3];
+          output[wTile_V + V_incr * 8] = x[2][0] - x[1][0] - x[2][2] + x[1][2];
+          output[wTile_V + V_incr * 9] = x[2][1] - x[1][1] + x[2][2] - x[1][2];
+          output[wTile_V + V_incr * 10] = x[2][2] - x[1][2] - x[2][1] + x[1][1];
+          output[wTile_V + V_incr * 11] = x[2][1] - x[1][1] - x[2][3] + x[1][3];
+          output[wTile_V + V_incr * 12] = x[1][0] - x[3][0] - x[1][2] + x[3][2];
+          output[wTile_V + V_incr * 13] = x[1][1] - x[3][1] + x[1][2] - x[3][2];
+          output[wTile_V + V_incr * 14] = x[1][2] - x[3][2] - x[1][1] + x[3][1];
+          output[wTile_V + V_incr * 15] = x[1][1] - x[3][1] - x[1][3] + x[3][3];
         }
       }
     }
@@ -172,14 +149,13 @@ export void winograd_TransformOut_ispc(uniform size_t batch_size,
       for (uniform int block_x = 0; block_x < kWtiles; block_x++) {
         const uniform int x = 2 * block_x;
         const uniform int y = 2 * block_y;
+        const uniform int b = block_y * kWtiles + block_x;
+        const uniform int M_incr = channels * kTiles * batch_size;
 
         foreach (channel = 0 ... channels) {
           const size_t M_channel = M_batch + channel;
           const size_t output_channel = output_batch + channel * kSquares;
-          const uniform int b = block_y * kWtiles + block_x;
-
           const float* M_wtile = input + M_channel + channels * b;
-          const uniform int M_incr = channels * kTiles * batch_size;
 
           float o11 = M_wtile[0];
           M_wtile += M_incr;


### PR DESCRIPTION
 Big update: Using SGEMM instead of hardcoded multiplication is a big gain for attention policy, >6% for T79.
~~This~~The rest is worth about 3% for 10b nets, less for larger ones. There are two parts:
1. Optimization of the ispc Winograd transform code.
2. Fusion of the bias addition with the SE unit, where it can be done at the channel level. (So each channel bias is added twice, once in the global pooling and once together with the SE bias addition (but scaled), so 2 additions and 1 multiplication per channel instead of 64 additions and the corresponding memory accesses.