### PR TITLE
Functionality for choosing a move randomly weighted by the move probability outputs.

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -333,7 +333,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctFactorAtRootId, 0.0f, 1000.0f) = 3.894f;
   options->Add<BoolOption>(kRootHasOwnCpuctParamsId) = false;
   options->Add<BoolOption>(kTwoFoldDrawsId) = true;
-	options->Add<BoolOption>(kRandombyP) = false;
+  options->Add<BoolOption>(kRandombyP) = false;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 640) = 0;
   options->Add<IntOption>(kTempDecayDelayMovesId, 0, 100) = 0;

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -99,6 +99,9 @@ const OptionId SearchParams::kTwoFoldDrawsId{
     "Evaluates twofold repetitions in the search tree as draws. Visits to "
     "these positions are reverted when the first occurrence is played "
     "and not in the search tree anymore."};
+const OptionId SearchParams::kRandombyP{
+    "randombyp", "RandombyP",
+    "If enabled, move is chosen randomly weighted by move probabilities."};
 const OptionId SearchParams::kTemperatureId{
     "temperature", "Temperature",
     "Tau value from softmax formula for the first move. If equal to 0, the "
@@ -330,6 +333,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctFactorAtRootId, 0.0f, 1000.0f) = 3.894f;
   options->Add<BoolOption>(kRootHasOwnCpuctParamsId) = false;
   options->Add<BoolOption>(kTwoFoldDrawsId) = true;
+	options->Add<BoolOption>(kRandombyP) = false;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 640) = 0;
   options->Add<IntOption>(kTempDecayDelayMovesId, 0, 100) = 0;

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -54,6 +54,7 @@ class SearchParams {
     return at_root ? kCpuctFactorAtRoot : kCpuctFactor;
   }
   bool GetTwoFoldDraws() const { return kTwoFoldDraws; }
+	float GetRandombyP() const { return options_.Get<bool>(kRandombyP); }
   float GetTemperature() const { return options_.Get<float>(kTemperatureId); }
   float GetTemperatureVisitOffset() const {
     return options_.Get<float>(kTemperatureVisitOffsetId);
@@ -150,6 +151,7 @@ class SearchParams {
   static const OptionId kCpuctFactorAtRootId;
   static const OptionId kRootHasOwnCpuctParamsId;
   static const OptionId kTwoFoldDrawsId;
+	static const OptionId kRandombyP;
   static const OptionId kTemperatureId;
   static const OptionId kTempDecayMovesId;
   static const OptionId kTempDecayDelayMovesId;

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -54,7 +54,7 @@ class SearchParams {
     return at_root ? kCpuctFactorAtRoot : kCpuctFactor;
   }
   bool GetTwoFoldDraws() const { return kTwoFoldDraws; }
-	float GetRandombyP() const { return options_.Get<bool>(kRandombyP); }
+  float GetRandombyP() const { return options_.Get<bool>(kRandombyP); }
   float GetTemperature() const { return options_.Get<float>(kTemperatureId); }
   float GetTemperatureVisitOffset() const {
     return options_.Get<float>(kTemperatureVisitOffsetId);
@@ -151,7 +151,7 @@ class SearchParams {
   static const OptionId kCpuctFactorAtRootId;
   static const OptionId kRootHasOwnCpuctParamsId;
   static const OptionId kTwoFoldDrawsId;
-	static const OptionId kRandombyP;
+  static const OptionId kRandombyP;
   static const OptionId kTemperatureId;
   static const OptionId kTempDecayMovesId;
   static const OptionId kTempDecayDelayMovesId;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -597,7 +597,7 @@ void Search::EnsureBestMoveKnown() REQUIRES(nodes_mutex_)
   if (!root_node_->HasChildren()) return;
 
   float temperature = params_.GetTemperature();
-	bool randombyp = params_.GetRandombyP();
+  bool randombyp = params_.GetRandombyP();
   const int cutoff_move = params_.GetTemperatureCutoffMove();
   const int decay_delay_moves = params_.GetTempDecayDelayMoves();
   const int decay_moves = params_.GetTempDecayMoves();

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -803,20 +803,20 @@ EdgeAndNode Search::GetBestRootChildWithTemperature(float temperature) const {
   return {};
 }
 
-// Returns a child of a root weighted by P
+// Returns a random child of a root weighted by move probability.
 EdgeAndNode Search::GetRandomChildbyP() const {
-  //Get sum of weights
+  // Get sum of weights for roll.
   float total_weights = 0.0;
   for (auto& edge : root_node_->Edges()) {
     total_weights += edge.GetP();
   }
 
-  //Choose edge from roll
+  // Choose edge with roll.
   float roll = Random::Get().GetFloat(total_weights);
   for (auto& edge : root_node_->Edges()) {
     if (roll < edge.GetP()) return edge;
     roll -= edge.GetP();
-    if (roll <= 0.0) return edge; //just in case floating point nonsense
+    if (roll <= 0.0) return edge; // In case of floating point nonsense.
   }
   assert(false);
   return {};

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -110,7 +110,7 @@ class Search {
   std::vector<EdgeAndNode> GetBestChildrenNoTemperature(Node* parent, int count,
                                                         int depth) const;
   EdgeAndNode GetBestRootChildWithTemperature(float temperature) const;
-	EdgeAndNode GetRandomChildbyP() const;
+  EdgeAndNode GetRandomChildbyP() const;
 
   int64_t GetTimeSinceStart() const;
   int64_t GetTimeSinceFirstBatch() const;

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -110,6 +110,7 @@ class Search {
   std::vector<EdgeAndNode> GetBestChildrenNoTemperature(Node* parent, int count,
                                                         int depth) const;
   EdgeAndNode GetBestRootChildWithTemperature(float temperature) const;
+	EdgeAndNode GetRandomChildbyP() const;
 
   int64_t GetTimeSinceStart() const;
   int64_t GetTimeSinceFirstBatch() const;


### PR DESCRIPTION
I added this for the intent of allowing Maia nets to play with randomized variety when `randompyp` is set to `true`.