### PR TITLE
Temperature chooses by P instead of N when only 1 node

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -761,9 +761,6 @@ EdgeAndNode Search::GetBestRootChildWithTemperature(float temperature) const {
     }
   }
 
-  // No move had enough visits for temperature, so use default child criteria
-  if (max_n <= 0.0f) return GetBestChildNoTemperature(root_node_, 0);
-
   // TODO(crem) Simplify this code when samplers.h is merged.
   const float min_eval =
       max_eval - params_.GetTemperatureWinpctCutoff() / 50.0f;
@@ -775,8 +772,9 @@ EdgeAndNode Search::GetBestRootChildWithTemperature(float temperature) const {
     }
     if (edge.GetQ(fpu, draw_score) < min_eval) continue;
     sum += std::pow(
-        std::max(0.0f, (static_cast<float>(edge.GetN()) + offset) / max_n),
-        1 / temperature);
+        std::max(0.0f, (max_n <= 0.0f ? edge.GetP()
+				                : ((static_cast<float>(edge.GetN()) + offset) / max_n))),
+                                1 / temperature);
     cumulative_sums.push_back(sum);
   }
   assert(sum);

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -773,8 +773,8 @@ EdgeAndNode Search::GetBestRootChildWithTemperature(float temperature) const {
     if (edge.GetQ(fpu, draw_score) < min_eval) continue;
     sum += std::pow(
         std::max(0.0f, (max_n <= 0.0f ? edge.GetP()
-				                : ((static_cast<float>(edge.GetN()) + offset) / max_n))),
-                                1 / temperature);
+				               : ((static_cast<float>(edge.GetN()) + offset) / max_n))),
+                               1 / temperature);
     cumulative_sums.push_back(sum);
   }
   assert(sum);

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -773,8 +773,8 @@ EdgeAndNode Search::GetBestRootChildWithTemperature(float temperature) const {
     if (edge.GetQ(fpu, draw_score) < min_eval) continue;
     sum += std::pow(
         std::max(0.0f, (max_n <= 0.0f ? edge.GetP()
-				               : ((static_cast<float>(edge.GetN()) + offset) / max_n))),
-                               1 / temperature);
+                       : ((static_cast<float>(edge.GetN()) + offset) / max_n))),
+                             1 / temperature);
     cumulative_sums.push_back(sum);
   }
   assert(sum);


### PR DESCRIPTION
This allows for temperature to perform random move making by policy instead of visits when node limit is 1.

It is recommended that PST is set to 1 if you wish to randomize by the unmodified policy output.