### PR TITLE
onednn backend support for mish and attention policy

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,12 +44,13 @@ install:
 - cmd: set NET_HASH=0f2f738e314bf618384045d4320a55333375d273d093adb805a4268ee53b519c
 - cmd: IF NOT %BLAS%==true IF NOT %ANDROID%==true set NET=753723
 - cmd: IF NOT %BLAS%==true IF NOT %ANDROID%==true set NET_HASH=3e3444370b9fe413244fdc79671a490e19b93d3cca1669710ffeac890493d198
-- cmd: IF %NAME%==cpu-dnnl IF NOT EXIST C:\cache\dnnl_win_1.5.0_cpu_vcomp appveyor DownloadFile https://github.com/oneapi-src/oneDNN/releases/download/v1.5/dnnl_win_1.5.0_cpu_vcomp.zip
-- cmd: IF %NAME%==cpu-dnnl IF NOT EXIST C:\cache\dnnl_win_1.5.0_cpu_vcomp 7z x dnnl_win_1.5.0_cpu_vcomp.zip -oC:\cache
+- cmd: call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
 - cmd: set DNNL_NAME=dnnl_win_1.5.0_cpu_vcomp
-- cmd: IF %NAME%==onednn IF NOT EXIST C:\cache\dnnl_win_1.8.0_cpu_vcomp appveyor DownloadFile https://github.com/oneapi-src/oneDNN/releases/download/v1.8/dnnl_win_1.8.0_cpu_vcomp.zip
-- cmd: IF %NAME%==onednn IF NOT EXIST C:\cache\dnnl_win_1.8.0_cpu_vcomp 7z x dnnl_win_1.8.0_cpu_vcomp.zip -oC:\cache
-- cmd: IF %NAME%==onednn set DNNL_NAME=dnnl_win_1.8.0_cpu_vcomp
+- cmd: IF %NAME%==cpu-dnnl IF NOT EXIST C:\cache\%DNNL_NAME% appveyor DownloadFile https://github.com/oneapi-src/oneDNN/releases/download/v1.5/dnnl_win_1.5.0_cpu_vcomp.zip
+- cmd: IF %NAME%==cpu-dnnl IF NOT EXIST C:\cache\%DNNL_NAME% 7z x dnnl_win_1.5.0_cpu_vcomp.zip -oC:\cache
+- cmd: IF %NAME%==onednn set DNNL_NAME=dnnl_win_2.6.0_cpu_vcomp_gpu_vcomp
+- cmd: IF %NAME%==onednn IF NOT EXIST C:\cache\%DNNL_NAME% appveyor DownloadFile https://github.com/borg323/oneDNN/releases/download/v2.6/dnnl_win_2.6.0_cpu_vcomp_gpu_vcomp.zip
+- cmd: IF %NAME%==onednn IF NOT EXIST C:\cache\%DNNL_NAME% 7z x dnnl_win_2.6.0_cpu_vcomp_gpu_vcomp.zip -oC:\cache
 - cmd: IF %NAME%==cpu-openblas IF NOT EXIST C:\cache\OpenBLAS appveyor DownloadFile https://sjeng.org/ftp/OpenBLAS-0.3.3-win-oldthread.zip
 - cmd: IF %NAME%==cpu-openblas IF NOT EXIST C:\cache\OpenBLAS 7z x OpenBLAS-0.3.3-win-oldthread.zip -oC:\cache\OpenBLAS
 - cmd: IF %OPENCL%==true nuget install opencl-nug -Version 0.777.77 -OutputDirectory C:\cache
@@ -71,7 +72,6 @@ install:
 - cmd: IF %CUDA%==true set PATH=%CUDA_PATH%\bin;%PATH%
 - cmd: set PATH=C:\Python36;C:\Python36\scripts;%PATH%
 - cmd: pip3 install --upgrade meson==0.55.3
-- cmd: call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
 - cmd: set MIMALLOC_PATH=C:\cache\mimalloc-1.7.1
 - cmd: IF %ANDROID%==false IF NOT EXIST "%MIMALLOC_PATH%" appveyor DownloadFile https://github.com/microsoft/mimalloc/archive/refs/tags/v1.7.1.zip
 - cmd: IF %ANDROID%==false IF NOT EXIST "%MIMALLOC_PATH%" 7z x v1.7.1.zip -oC:\cache\
@@ -136,6 +136,8 @@ artifacts:
     name: lc0-debug-symbols
   - path: /lc0*.apk/
     name: lc0-$(APPVEYOR_REPO_TAG_NAME)-android-apk
+  - path: dnnl.dll
+    name: dnnl-dll
 deploy:
   - provider: GitHub
     artifact: /.*\.zip/

--- a/scripts/appveyor_win_build.cmd
+++ b/scripts/appveyor_win_build.cmd
@@ -6,8 +6,9 @@ IF %PGO%==true msbuild "C:\projects\lc0\build\lc0.sln" /m /p:WholeProgramOptimiz
 IF ERRORLEVEL 1 EXIT
 cd build
 IF %NAME%==cpu-openblas copy C:\cache\OpenBLAS\dist64\bin\libopenblas.dll
-IF %NAME%==cpu-dnnl copy C:\cache\dnnl_win_1.5.0_cpu_vcomp\bin\dnnl.dll
-IF %NAME%==onednn copy C:\cache\dnnl_win_1.8.0_cpu_vcomp\bin\dnnl.dll
+IF %NAME%==cpu-dnnl copy C:\cache\%DNNL_NAME%\bin\dnnl.dll
+IF %NAME%==onednn copy C:\cache\%DNNL_NAME%\bin\dnnl.dll
+IF %NAME%==onednn copy dnnl.dll ..
 copy "%MIMALLOC_PATH%"\out\msvc-x64\Release\mimalloc-override.dll
 copy "%MIMALLOC_PATH%"\out\msvc-x64\Release\mimalloc-redirect.dll
 IF %PGO%==true (

--- a/scripts/appveyor_win_package.cmd
+++ b/scripts/appveyor_win_package.cmd
@@ -12,18 +12,18 @@ type "%MIMALLOC_PATH%"\LICENSE |more /P > dist\mimalloc-LICENSE
 7z a lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%.zip .\dist\mimalloc-LICENSE
 IF %CUDA%==true copy lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%.zip lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%-nodll.zip
 IF %NAME%==cpu-openblas 7z a lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%.zip C:\cache\OpenBLAS\dist64\bin\libopenblas.dll
-IF %NAME%==cpu-dnnl 7z a lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%.zip C:\cache\dnnl_win_1.5.0_cpu_vcomp\bin\dnnl.dll
-IF %NAME%==onednn 7z a lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%.zip C:\cache\dnnl_win_1.8.0_cpu_vcomp\bin\dnnl.dll
+IF %NAME%==cpu-dnnl 7z a lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%.zip C:\cache\%DNNL_NAME%\bin\dnnl.dll
+IF %NAME%==onednn 7z a lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%.zip C:\cache\%DNNL_NAME%\bin\dnnl.dll
 IF %OPENCL%==true 7z a lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%.zip C:\cache\opencl-nug.0.777.77\build\native\bin\OpenCL.dll
 IF %CUDNN%==true 7z a lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%.zip "%CUDA_PATH%\bin\cudart64_100.dll" "%CUDA_PATH%\bin\cublas64_100.dll"
 IF %CUDNN%==true 7z a lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%.zip "%CUDA_PATH%\cuda\bin\cudnn64_7.dll"
 IF %CUDA%==true 7z a lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%.zip "%CUDA_PATH%\bin\cudart64_110.dll" "%CUDA_PATH%\bin\cublas64_11.dll" "%CUDA_PATH%\bin\cublasLt64_11.dll"
-IF %NAME%==cpu-dnnl copy "%PKG_FOLDER%\dnnl_win_1.5.0_cpu_vcomp\LICENSE" dist\DNNL-LICENSE
-IF %NAME%==cpu-dnnl copy "%PKG_FOLDER%\dnnl_win_1.5.0_cpu_vcomp\THIRD-PARTY-PROGRAMS" dist\DNNL-THIRD-PARTY-PROGRAMS
+IF %NAME%==cpu-dnnl copy "%PKG_FOLDER%\%DNNL_NAME%\LICENSE" dist\DNNL-LICENSE
+IF %NAME%==cpu-dnnl copy "%PKG_FOLDER%\%DNNL_NAME%\THIRD-PARTY-PROGRAMS" dist\DNNL-THIRD-PARTY-PROGRAMS
 IF %NAME%==cpu-dnnl 7z a lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%.zip .\dist\DNNL-LICENSE
 IF %NAME%==cpu-dnnl 7z a lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%.zip .\dist\DNNL-THIRD-PARTY-PROGRAMS
-IF %NAME%==onednn copy "%PKG_FOLDER%\dnnl_win_1.8.0_cpu_vcomp\LICENSE" dist\DNNL-LICENSE
-IF %NAME%==onednn copy "%PKG_FOLDER%\dnnl_win_1.8.0_cpu_vcomp\THIRD-PARTY-PROGRAMS" dist\DNNL-THIRD-PARTY-PROGRAMS
+IF %NAME%==onednn copy "%PKG_FOLDER%\%DNNL_NAME%\LICENSE" dist\DNNL-LICENSE
+IF %NAME%==onednn copy "%PKG_FOLDER%\%DNNL_NAME%\THIRD-PARTY-PROGRAMS" dist\DNNL-THIRD-PARTY-PROGRAMS
 IF %NAME%==onednn 7z a lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%.zip .\dist\DNNL-LICENSE
 IF %NAME%==onednn 7z a lc0-%APPVEYOR_REPO_TAG_NAME%-windows-%NAME%.zip .\dist\DNNL-THIRD-PARTY-PROGRAMS
 IF %OPENCL%==true type scripts\check_opencl.bat |more /P > dist\check_opencl.bat

--- a/src/neural/onednn/layers.cc
+++ b/src/neural/onednn/layers.cc
@@ -27,12 +27,9 @@
 
 #include "layers.h"
 #include <cassert>
+#include <cmath>
 #include <cstring>
 #include <vector>
-
-#include <cmath>
-#include "neural/blas/blas.h"
-#include "neural/blas/fully_connected_layer.h"
 
 namespace lczero {
 

--- a/src/neural/onednn/layers.cc
+++ b/src/neural/onednn/layers.cc
@@ -521,9 +521,8 @@ void AttentionPolicyHead::LoadWeights(dnnl::memory& w1, dnnl::memory& b1,
                                          dnnl::memory::format_tag::ab);
   fc_filter_mem = dnnl::memory(fc_filter_md, eng);
   dnnl::reorder(w1, fc_filter_mem).execute(stream, w1, fc_filter_mem);
-  auto fc_bias_md =
-      dnnl::memory::desc({embedding_size_}, dnnl::memory::data_type::f32,
-                         dnnl::memory::format_tag::a);
+  auto fc_bias_md = dnnl::memory::desc({embedding_size_}, data_type_,
+                                       dnnl::memory::format_tag::a);
   fc_bias_mem = dnnl::memory(fc_bias_md, eng);
   dnnl::reorder(b1, fc_bias_mem).execute(stream, b1, fc_bias_mem);
 
@@ -533,9 +532,8 @@ void AttentionPolicyHead::LoadWeights(dnnl::memory& w1, dnnl::memory& b1,
 
   fcQ_filter_mem = dnnl::memory(fcQK_filter_md, eng);
   dnnl::reorder(w2, fcQ_filter_mem).execute(stream, w2, fcQ_filter_mem);
-  auto fcQK_bias_md =
-      dnnl::memory::desc({policy_d_model_}, dnnl::memory::data_type::f32,
-                         dnnl::memory::format_tag::a);
+  auto fcQK_bias_md = dnnl::memory::desc({policy_d_model_}, data_type_,
+                                         dnnl::memory::format_tag::a);
   fcQ_bias_mem = dnnl::memory(fcQK_bias_md, eng);
   dnnl::reorder(b2, fcQ_bias_mem).execute(stream, b2, fcQ_bias_mem);
 

--- a/src/neural/onednn/layers.h
+++ b/src/neural/onednn/layers.h
@@ -26,7 +26,6 @@
 */
 #pragma once
 
-#include "neural/network_legacy.h"
 #include "neural/shared/activation.h"
 #include "utils/exception.h"
 

--- a/src/neural/onednn/layers.h
+++ b/src/neural/onednn/layers.h
@@ -211,6 +211,8 @@ class AttentionPolicyHead : public BaseLayer {
   dnnl::matmul pmul_;
   dnnl::binary add_;
   dnnl::binary add2_;
+  // For gpu bug workaround.
+  dnnl::reorder hack_reorder_;
 };
 
 }  // namespace onednn_backend

--- a/src/neural/onednn/layers.h
+++ b/src/neural/onednn/layers.h
@@ -87,6 +87,7 @@ class ConvLayer : public BaseLayer {
   // Cache previous convolution primitive in case the batch size is the same.
   int last_batch_ = 0;
   dnnl::convolution_forward conv_;
+  dnnl::eltwise_forward mish_;
   dnnl::reorder in_reorder_;
   dnnl::reorder skip_reorder_;
   dnnl::memory scratchpad_mem;

--- a/src/neural/onednn/layers.h
+++ b/src/neural/onednn/layers.h
@@ -213,6 +213,7 @@ class AttentionPolicyHead : public BaseLayer {
   dnnl::binary add2_;
   // For gpu bug workaround.
   dnnl::reorder hack_reorder_;
+  dnnl::reorder hack_reorder_2_;
 };
 
 }  // namespace onednn_backend

--- a/src/neural/onednn/layers.h
+++ b/src/neural/onednn/layers.h
@@ -157,12 +157,8 @@ class SELayer : public BaseLayer {
   dnnl::reorder fc1_reorder_;
   dnnl::reorder mul_reorder_;
   dnnl::reorder add_reorder_;
-  dnnl::memory pooling_scratchpad_mem;
-  dnnl::memory fc_scratchpad_mem;
-  dnnl::memory fc2_scratchpad_mem;
-  dnnl::memory sigmoid_scratchpad_mem;
-  dnnl::memory mul_scratchpad_mem;
-  dnnl::memory add_scratchpad_mem;
+  dnnl::memory scratchpad_mem;
+
   // Cached values to change tensors for best performance.
   dnnl::memory::desc pool_out_md;
   dnnl::memory::desc fc1_in_md;

--- a/src/neural/onednn/network_onednn.cc
+++ b/src/neural/onednn/network_onednn.cc
@@ -331,9 +331,9 @@ class OnednnNetwork : public Network {
 
         auto attn = std::make_unique<AttentionPolicyHead>(
             resi_last, embedding_size, policy_d_model);
-        auto ip_w_md =
-            dnnl::memory::desc({numFilters_, embedding_size}, data_type_,
-                               dnnl::memory::format_tag::ab);
+        auto ip_w_md = dnnl::memory::desc({numFilters_, embedding_size},
+                                          dnnl::memory::data_type::f32,
+                                          dnnl::memory::format_tag::ab);
         auto ip_w_mem =
             dnnl::memory(ip_w_md, cpu_eng_, weights.ip_pol_w.data());
         auto ip_b_md =
@@ -341,9 +341,9 @@ class OnednnNetwork : public Network {
                                dnnl::memory::format_tag::a);
         auto ip_b_mem =
             dnnl::memory(ip_b_md, cpu_eng_, weights.ip_pol_b.data());
-        auto ip23_w_md =
-            dnnl::memory::desc({embedding_size, policy_d_model}, data_type_,
-                               dnnl::memory::format_tag::ab);
+        auto ip23_w_md = dnnl::memory::desc({embedding_size, policy_d_model},
+                                            dnnl::memory::data_type::f32,
+                                            dnnl::memory::format_tag::ab);
         auto ip2_w_mem =
             dnnl::memory(ip23_w_md, cpu_eng_, weights.ip2_pol_w.data());
         auto ip23_b_md =
@@ -355,7 +355,8 @@ class OnednnNetwork : public Network {
             dnnl::memory(ip23_w_md, cpu_eng_, weights.ip3_pol_w.data());
         auto ip3_b_mem =
             dnnl::memory(ip23_b_md, cpu_eng_, weights.ip3_pol_b.data());
-        auto ip4_w_md = dnnl::memory::desc({1, 4, policy_d_model}, data_type_,
+        auto ip4_w_md = dnnl::memory::desc({1, 4, policy_d_model},
+                                           dnnl::memory::data_type::f32,
                                            dnnl::memory::format_tag::abc);
         auto ip4_w_mem =
             dnnl::memory(ip4_w_md, cpu_eng_, weights.ip4_pol_w.data());

--- a/src/neural/onednn/network_onednn.cc
+++ b/src/neural/onednn/network_onednn.cc
@@ -705,6 +705,8 @@ class OnednnNetwork : public Network {
         opMov_mem = tmp;
       }
 
+      eng_stream_.wait();
+
       // Copy memory to output buffers and do final transformations.
       if (wdl_) {
         // Value softmax done cpu side.


### PR DESCRIPTION
This is not yet fully optimized, but works well enough. 
Note that it needs a new `dnnl.dll` to work, and the latest one is uploaded on appveyor, compiled with cpu and gpu support. To use the igpu you add `--backend-opts=gpu=0` to the command line. Similarly, the latest `dnnl.dll` versions seem to have trouble selecting Winograd convolution automatically, so `--backend-opts=winograd=true` is worth trying on a cpu.
Also for nets larger than T74 it seems a single search thread is better than two, at least on my test system.