### PR TITLE
onednn winograd selection heuristic

### DIFF
--- a/src/neural/onednn/network_onednn.cc
+++ b/src/neural/onednn/network_onednn.cc
@@ -199,11 +199,7 @@ class OnednnNetwork : public Network {
     auto convolution_type = dnnl::algorithm::convolution_auto;
     if (!options.IsDefault<bool>("winograd")) {
       if (options.Get<bool>("winograd")) {
-        if (eng_.get_kind() == dnnl::engine::kind::cpu) {
-          convolution_type = dnnl::algorithm::convolution_winograd;
-        } else {
-          CERR << "Winograd convolution not supported on GPU.";
-        }
+        convolution_type = dnnl::algorithm::convolution_winograd;
       } else {
         convolution_type = dnnl::algorithm::convolution_direct;
       }


### PR DESCRIPTION
The new dnnl.dll (that we need for mish) on its own chooses Winograd convolution on the igpu and not on the cpu (probably confused by the 8x8 planes). Tests show that for us Winograd convolution on the igpu is form slightly to a lot worse, but a big gain on the cpus where it is available.

During those tests it was also noticed that mish fused with convolutions always has a big performance overhead on the gpu, so now it is a separate primitive unconditionally.