### PR TITLE
Return command name as UCI response after successful parameter setting.

### DIFF
--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -139,6 +139,9 @@ void UciLoop::RunLoop() {
       // Ignore empty line.
       if (command.first.empty()) continue;
       if (!DispatchCommand(command.first, command.second)) break;
+      else {
+        SendResponse(std::string("executed ") + command.first);
+      }
     } catch (Exception& ex) {
       SendResponse(std::string("error ") + ex.what());
     }


### PR DESCRIPTION
Fixed #1598. But still unsure what to return as a confirmation. 