### PR TITLE
Onednn improvements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -110,9 +110,11 @@ before_build:
 - cmd: IF %DX%==true SET BUILD_BLAS=true
 - cmd: SET EMBED=false
 - cmd: IF %APPVEYOR_REPO_TAG%==true IF %ANDROID%==true SET EMBED=true
+- cmd: SET POPCNT=true
+- cmd: IF %NAME%==cpu-openblas SET POPCNT=false
 - cmd: SET EXTRA=
 - cmd: IF %ANDROID%==false SET EXTRA=-Db_vscrt=md
-- cmd: IF %ANDROID%==false meson build --backend vs2017 --buildtype release -Dgtest=%GTEST% -Dopencl=%OPENCL% -Dblas=%BUILD_BLAS% -Ddnnl=true -Ddx=%DX% -Dcudnn=%CUDNN% -Donednn=%ONEDNN% -Dispc_native_only=false -Dpopcnt=false -Dcudnn_include="%CUDA_PATH%\include","%CUDA_PATH%\cuda\include" -Dcudnn_libdirs="%CUDA_PATH%\lib\x64","%CUDA_PATH%\cuda\lib\x64" -Dopenblas_include="%PKG_FOLDER%\OpenBLAS\dist64\include" -Dopenblas_libdirs="%PKG_FOLDER%\OpenBLAS\dist64\lib" -Ddnnl_dir="%PKG_FOLDER%\%DNNL_NAME%" -Dopencl_include="%PKG_FOLDER%\opencl-nug.0.777.77\build\native\include" -Dopencl_libdirs="%PKG_FOLDER%\opencl-nug.0.777.77\build\native\lib\x64" -Ddefault_library=static -Dmalloc=mimalloc -Dmimalloc_libdir="%MIMALLOC_PATH%"\out\msvc-x64\Release %EXTRA%
+- cmd: IF %ANDROID%==false meson build --backend vs2017 --buildtype release -Dgtest=%GTEST% -Dopencl=%OPENCL% -Dblas=%BUILD_BLAS% -Ddnnl=true -Ddx=%DX% -Dcudnn=%CUDNN% -Donednn=%ONEDNN% -Dispc_native_only=false -Dpopcnt=%POPCNT% -Dcudnn_include="%CUDA_PATH%\include","%CUDA_PATH%\cuda\include" -Dcudnn_libdirs="%CUDA_PATH%\lib\x64","%CUDA_PATH%\cuda\lib\x64" -Dopenblas_include="%PKG_FOLDER%\OpenBLAS\dist64\include" -Dopenblas_libdirs="%PKG_FOLDER%\OpenBLAS\dist64\lib" -Ddnnl_dir="%PKG_FOLDER%\%DNNL_NAME%" -Dopencl_include="%PKG_FOLDER%\opencl-nug.0.777.77\build\native\include" -Dopencl_libdirs="%PKG_FOLDER%\opencl-nug.0.777.77\build\native\lib\x64" -Ddefault_library=static -Dmalloc=mimalloc -Dmimalloc_libdir="%MIMALLOC_PATH%"\out\msvc-x64\Release %EXTRA%
 - cmd: IF %ANDROID%==true meson arm64-v8a --buildtype release -Dgtest=false -Dopenblas_include="%PKG_FOLDER%\OpenBLAS\android-aarch64\include" -Dopenblas_libdirs="%PKG_FOLDER%\OpenBLAS\android-aarch64\lib" -Dembed=%EMBED% -Ddefault_library=static --cross-file crossfile-aarch64
 - cmd: IF %ANDROID%==true meson armeabi-v7a --buildtype release -Dgtest=false -Dopenblas_include="%PKG_FOLDER%\OpenBLAS\android-armv7a\include" -Dopenblas_libdirs="%PKG_FOLDER%\OpenBLAS\android-armv7a\lib" -Dembed=%EMBED% -Ddefault_library=static --cross-file crossfile-armv7a -Dispc=false -Dneon=false
 build_script:

--- a/src/neural/onednn/layers.cc
+++ b/src/neural/onednn/layers.cc
@@ -72,7 +72,6 @@ void ConvLayer::LoadWeights(dnnl::memory& w1, dnnl::memory& b1,
 void ConvLayer::Eval(int N, dnnl::memory& output, const dnnl::memory& input,
                      const dnnl::memory& scratch, const dnnl::engine& eng,
                      const dnnl::stream& stream, dnnl::memory& scratchpad_mem) {
-  std::lock_guard<std::mutex> lock(lock_);
   if (last_batch_ != N) {
     auto t_in_md = dnnl::memory::desc({N, c_input_, H, W}, data_type_,
                                       dnnl::memory::format_tag::any);
@@ -489,7 +488,6 @@ void FCLayer::LoadWeights(dnnl::memory& w1, dnnl::memory& b1,
 void FCLayer::Eval(int N, dnnl::memory& output, const dnnl::memory& input,
                    const dnnl::memory& scratch, const dnnl::engine& eng,
                    const dnnl::stream& stream, dnnl::memory& scratchpad_mem) {
-  std::lock_guard<std::mutex> lock(lock_);
   if (last_batch_ != N) {
     const int num_outputs = C * H * W;
 

--- a/src/neural/onednn/layers.h
+++ b/src/neural/onednn/layers.h
@@ -48,9 +48,9 @@ class BaseLayer {
   size_t GetOutputSize(int N) const { return sizeof(float) * N * C * H * W; }
   void SetDataType(dnnl::memory::data_type type) { data_type_ = type; }
   void SetConvolutionType(dnnl::algorithm type) { convolution_type_ = type; }
-  virtual void Eval(int N, dnnl::memory& output, dnnl::memory& input,
-                    dnnl::memory& scratch, dnnl::engine& eng,
-                    dnnl::stream& stream) = 0;
+  virtual void Eval(int N, dnnl::memory& output, const dnnl::memory& input,
+                    const dnnl::memory& scratch, const dnnl::engine& eng,
+                    const dnnl::stream& stream) = 0;
 
  protected:
   BaseLayer* input_;
@@ -68,13 +68,13 @@ class ConvLayer : public BaseLayer {
   ConvLayer(BaseLayer* ip, int C, int H, int W, int size, int Cin,
             ActivationFunction activation = NONE, bool skip = false);
 
-  void LoadWeights(dnnl::memory& w1, dnnl::memory& b1, dnnl::engine& eng,
-                   dnnl::stream& stream);
+  void LoadWeights(dnnl::memory& w1, dnnl::memory& b1, const dnnl::engine& eng,
+                   const dnnl::stream& stream);
 
   // If there is a skip connection the output doubles as an input.
-  void Eval(int N, dnnl::memory& output, dnnl::memory& input,
-            dnnl::memory& scratch, dnnl::engine& eng,
-            dnnl::stream& stream) override;
+  void Eval(int N, dnnl::memory& output, const dnnl::memory& input,
+            const dnnl::memory& scratch, const dnnl::engine& eng,
+            const dnnl::stream& stream) override;
 
  private:
   const int c_input_;
@@ -101,11 +101,11 @@ class FCLayer : public BaseLayer {
  public:
   FCLayer(BaseLayer* ip, int C, int H, int W, ActivationFunction activation);
 
-  void LoadWeights(dnnl::memory& w1, dnnl::memory& b1, dnnl::engine& eng,
-                   dnnl::stream& stream);
-  void Eval(int N, dnnl::memory& output, dnnl::memory& input,
-            dnnl::memory& scratch, dnnl::engine& eng,
-            dnnl::stream& stream) override;
+  void LoadWeights(dnnl::memory& w1, dnnl::memory& b1, const dnnl::engine& eng,
+                   const dnnl::stream& stream);
+  void Eval(int N, dnnl::memory& output, const dnnl::memory& input,
+            const dnnl::memory& scratch, const dnnl::engine& eng,
+            const dnnl::stream& stream) override;
 
  private:
   ActivationFunction activation_;
@@ -131,13 +131,14 @@ class SELayer : public BaseLayer {
   SELayer(BaseLayer* ip, int numFc1Out, ActivationFunction activation);
 
   void LoadWeights(dnnl::memory& w1, dnnl::memory& b1, dnnl::memory& w2,
-                   dnnl::memory& b2, dnnl::engine& eng, dnnl::stream& stream);
+                   dnnl::memory& b2, const dnnl::engine& eng,
+                   const dnnl::stream& stream);
 
   // Initially output holds the skip connection. Both input and output are
   // assumed to be the same memory format.
-  void Eval(int N, dnnl::memory& output, dnnl::memory& input,
-            dnnl::memory& scratch, dnnl::engine& eng,
-            dnnl::stream& stream) override;
+  void Eval(int N, dnnl::memory& output, const dnnl::memory& input,
+            const dnnl::memory& scratch, const dnnl::engine& eng,
+            const dnnl::stream& stream) override;
 
  private:
   dnnl::memory filter_mem;
@@ -180,10 +181,11 @@ class AttentionPolicyHead : public BaseLayer {
         policy_d_model_(policy_d_model) {}
   void LoadWeights(dnnl::memory& w1, dnnl::memory& b1, dnnl::memory& w2,
                    dnnl::memory& b2, dnnl::memory& w3, dnnl::memory& b3,
-                   dnnl::memory& w4, dnnl::engine& eng, dnnl::stream& stream);
-  void Eval(int N, dnnl::memory& output, dnnl::memory& input,
-            dnnl::memory& scratch, dnnl::engine& eng,
-            dnnl::stream& stream) override;
+                   dnnl::memory& w4, const dnnl::engine& eng,
+                   const dnnl::stream& stream);
+  void Eval(int N, dnnl::memory& output, const dnnl::memory& input,
+            const dnnl::memory& scratch, const dnnl::engine& eng,
+            const dnnl::stream& stream) override;
 
  private:
   const int embedding_size_;

--- a/src/neural/onednn/layers.h
+++ b/src/neural/onednn/layers.h
@@ -63,7 +63,6 @@ class BaseLayer {
   dnnl::memory::data_type data_type_;
   dnnl::algorithm convolution_type_;
   dnnl::memory::desc scratchpad_md;
-  std::mutex lock_;
 };
 
 class ConvLayer : public BaseLayer {
@@ -142,6 +141,8 @@ class SELayer : public BaseLayer {
             const dnnl::stream& stream, dnnl::memory& scratchpad_mem) override;
 
  private:
+  std::mutex lock_;
+
   dnnl::memory filter_mem;
   dnnl::memory bias_mem;
   dnnl::memory filter2_mem;
@@ -188,6 +189,8 @@ class AttentionPolicyHead : public BaseLayer {
             const dnnl::stream& stream, dnnl::memory& scratchpad_mem) override;
 
  private:
+  std::mutex lock_;
+
   const int embedding_size_;
   const int policy_d_model_;
 

--- a/src/neural/onednn/layers.h
+++ b/src/neural/onednn/layers.h
@@ -161,6 +161,8 @@ class SELayer : public BaseLayer {
   dnnl::reorder mul_reorder_;
   dnnl::reorder add_reorder_;
   dnnl::memory scratchpad_mem;
+  dnnl::memory buf1;
+  dnnl::memory buf2;
 
   // Cached values to change tensors for best performance.
   dnnl::memory::desc pool_out_md;

--- a/src/neural/onednn/layers.h
+++ b/src/neural/onednn/layers.h
@@ -49,7 +49,8 @@ class BaseLayer {
   void SetDataType(dnnl::memory::data_type type) { data_type_ = type; }
   void SetConvolutionType(dnnl::algorithm type) { convolution_type_ = type; }
   virtual void Eval(int N, dnnl::memory& output, dnnl::memory& input,
-                    dnnl::engine& eng, dnnl::stream& stream) = 0;
+                    dnnl::memory& scratch, dnnl::engine& eng,
+                    dnnl::stream& stream) = 0;
 
  protected:
   BaseLayer* input_;
@@ -71,7 +72,8 @@ class ConvLayer : public BaseLayer {
                    dnnl::stream& stream);
 
   // If there is a skip connection the output doubles as an input.
-  void Eval(int N, dnnl::memory& output, dnnl::memory& input, dnnl::engine& eng,
+  void Eval(int N, dnnl::memory& output, dnnl::memory& input,
+            dnnl::memory& scratch, dnnl::engine& eng,
             dnnl::stream& stream) override;
 
  private:
@@ -89,7 +91,6 @@ class ConvLayer : public BaseLayer {
   dnnl::convolution_forward conv_;
   dnnl::eltwise_forward mish_;
   dnnl::reorder in_reorder_;
-  dnnl::reorder skip_reorder_;
   dnnl::memory scratchpad_mem;
   // Cached values to change in/out tensors for best performance.
   dnnl::memory::desc in_md;
@@ -102,7 +103,8 @@ class FCLayer : public BaseLayer {
 
   void LoadWeights(dnnl::memory& w1, dnnl::memory& b1, dnnl::engine& eng,
                    dnnl::stream& stream);
-  void Eval(int N, dnnl::memory& output, dnnl::memory& input, dnnl::engine& eng,
+  void Eval(int N, dnnl::memory& output, dnnl::memory& input,
+            dnnl::memory& scratch, dnnl::engine& eng,
             dnnl::stream& stream) override;
 
  private:
@@ -133,7 +135,8 @@ class SELayer : public BaseLayer {
 
   // Initially output holds the skip connection. Both input and output are
   // assumed to be the same memory format.
-  void Eval(int N, dnnl::memory& output, dnnl::memory& input, dnnl::engine& eng,
+  void Eval(int N, dnnl::memory& output, dnnl::memory& input,
+            dnnl::memory& scratch, dnnl::engine& eng,
             dnnl::stream& stream) override;
 
  private:
@@ -176,7 +179,8 @@ class AttentionPolicyHead : public BaseLayer {
   void LoadWeights(dnnl::memory& w1, dnnl::memory& b1, dnnl::memory& w2,
                    dnnl::memory& b2, dnnl::memory& w3, dnnl::memory& b3,
                    dnnl::memory& w4, dnnl::engine& eng, dnnl::stream& stream);
-  void Eval(int N, dnnl::memory& output, dnnl::memory& input, dnnl::engine& eng,
+  void Eval(int N, dnnl::memory& output, dnnl::memory& input,
+            dnnl::memory& scratch, dnnl::engine& eng,
             dnnl::stream& stream) override;
 
  private:


### PR DESCRIPTION
Mainly reducing memory overheads for gpu. 
Changes outside onednn are:
1. All binary packages except openblas are built with popcnt and f16c instructions (currently only cuda/dx/onednn may use f16c instructions).
2. The fp16 conversion functions are now defined as `static inline` in the header when using f16c instructions but not the fallback code.