### PR TITLE
In smooth TM, use piggybank when it seems like the bestmove can be overtaken.

### DIFF
--- a/src/mcts/stoppers/smooth.cc
+++ b/src/mcts/stoppers/smooth.cc
@@ -164,9 +164,9 @@ Params::Params(const OptionsDict& params, int64_t move_overhead)
           params.GetOrDefault<float>("max-piggybank-moves", 36.5f)),
       trend_nps_update_period_ms_(
           params.GetOrDefault<int>("trend-nps-update-period-ms", 200)),
-      bestmove_optimism_(params.GetOrDefault<float>("bestmove-optimism", 0.5f)),
+      bestmove_optimism_(params.GetOrDefault<float>("bestmove-optimism", 0.2f)),
       overtaker_optimism_(
-          params.GetOrDefault<float>("overtaker-optimism", 2.0f)),
+          params.GetOrDefault<float>("overtaker-optimism", 4.0f)),
       force_piggybank_ms_(params.GetOrDefault<int>("force-piggybank-ms", 500)),
       moves_left_estimator_(CreateMovesLeftEstimator(params)) {}
 

--- a/src/mcts/stoppers/smooth.cc
+++ b/src/mcts/stoppers/smooth.cc
@@ -304,19 +304,19 @@ class SmoothTimeManager : public TimeManager {
             : total_move_time / move_allocated_time_ms_;
     // Recompute expected move time for logging.
     const float expected_move_time = move_allocated_time_ms_ * timeuse_;
-    // If piggybank was used, cannot update timeuse_.
+
     int64_t piggybank_time_used = 0;
     if (used_piggybank) {
       piggybank_time_used = std::max(int64_t(), total_move_time - time_budget);
       piggybank_time_ -= piggybank_time_used;
-    } else {
-      timeuse_ =
-          ExponentialDecay(timeuse_, this_move_time_use,
-                           params_.smartpruning_timeuse_halfupdate_moves(),
-                           this_move_time_fraction);
-      if (timeuse_ < params_.min_smartpruning_timeuse()) {
-        timeuse_ = params_.min_smartpruning_timeuse();
-      }
+    }
+    // If piggybank was used, time use is 100%.
+    timeuse_ =
+        ExponentialDecay(timeuse_, used_piggybank ? 1.0f : this_move_time_use,
+                         params_.smartpruning_timeuse_halfupdate_moves(),
+                         this_move_time_fraction);
+    if (timeuse_ < params_.min_smartpruning_timeuse()) {
+      timeuse_ = params_.min_smartpruning_timeuse();
     }
     // Remember final number of nodes for tree reuse estimation.
     last_move_final_nodes_ = total_nodes;

--- a/src/mcts/stoppers/smooth.cc
+++ b/src/mcts/stoppers/smooth.cc
@@ -575,7 +575,7 @@ bool SmoothStopper::ShouldStop(const IterationStats& stats,
     // It's not entirely correct as due to extended remaining time smart pruning
     // will trigger later and we spend more time than if use_piggyback was
     // false, even before reaching the deadline.
-    if (used_piggybank_.test_and_set()) {
+    if (!used_piggybank_.test_and_set()) {
       LOGFILE << "Entering piggybank, reason: "
               << (stats.time_usage_hint_ ==
                           IterationStats::TimeUsageHint::kNeedMoreTime

--- a/src/mcts/stoppers/smooth.cc
+++ b/src/mcts/stoppers/smooth.cc
@@ -497,7 +497,7 @@ class SmoothTimeManager : public TimeManager {
 
 void VisitsTrendWatcher::Update(uint64_t timestamp,
                                 const std::vector<uint32_t>& visits) {
-  std::lock_guard<Mutex> lock(mutex_);
+  Mutex::Lock lock(mutex_);
   if (timestamp <= last_timestamp_) return;
   nps_.resize(visits.size());
   if (visits.size() != last_visits_.size()) {
@@ -524,7 +524,7 @@ void VisitsTrendWatcher::Update(uint64_t timestamp,
 
 bool VisitsTrendWatcher::IsBestmoveBeingOvertaken(
     uint64_t by_which_time) const {
-  std::lock_guard<Mutex> lock(mutex_);
+  Mutex::Lock lock(mutex_);
   // If we don't have any stats yet, always tell that it can be overtaken.
   if (std::numeric_limits<size_t>::max() == largest_visits_idx_) return true;
   if (by_which_time <= last_timestamp_) return false;

--- a/src/mcts/stoppers/smooth.cc
+++ b/src/mcts/stoppers/smooth.cc
@@ -223,7 +223,8 @@ class VisitsTrendWatcher {
   const float bestmove_optimism_;
 
   mutable Mutex mutex_;
-  size_t largest_visits_idx_ GUARDED_BY(mutex_) = 0;
+  size_t largest_visits_idx_ GUARDED_BY(mutex_) =
+      std::numeric_limits<size_t>::max();
   uint64_t last_timestamp_ GUARDED_BY(mutex_) = 0;
   std::vector<uint32_t> last_visits_ GUARDED_BY(mutex_);
   std::vector<uint32_t> nps_ GUARDED_BY(mutex_);
@@ -524,6 +525,8 @@ void VisitsTrendWatcher::Update(uint64_t timestamp,
 bool VisitsTrendWatcher::IsBestmoveBeingOvertaken(
     uint64_t by_which_time) const {
   std::lock_guard<Mutex> lock(mutex_);
+  // If we don't have any stats yet, always tell that it can be overtaken.
+  if (std::numeric_limits<size_t>::max() == largest_visits_idx_) return true;
   if (by_which_time <= last_timestamp_) return false;
   const auto planned_bestmove_visits =
       last_visits_[largest_visits_idx_] +

--- a/src/mcts/stoppers/smooth.cc
+++ b/src/mcts/stoppers/smooth.cc
@@ -519,12 +519,6 @@ void VisitsTrendWatcher::Update(uint64_t timestamp,
                                 const std::vector<uint32_t>& visits) {
   Mutex::Lock lock(mutex_);
   if (timestamp <= last_timestamp_) return;
-  if (cur_timestamp_ + nps_update_period_ >= timestamp) {
-    prev_timestamp_ = cur_timestamp_;
-    prev_visits_ = std::move(cur_visits_);
-    cur_visits_ = last_visits_;
-    cur_timestamp_ = last_timestamp_;
-  }
   if (prev_visits_.empty()) {
     prev_visits_ = visits;
     cur_visits_ = visits;
@@ -533,6 +527,12 @@ void VisitsTrendWatcher::Update(uint64_t timestamp,
   }
   last_timestamp_ = timestamp;
   last_visits_ = visits;
+  if (cur_timestamp_ + nps_update_period_ >= timestamp) {
+    prev_timestamp_ = cur_timestamp_;
+    prev_visits_ = std::move(cur_visits_);
+    cur_visits_ = last_visits_;
+    cur_timestamp_ = last_timestamp_;
+  }
 }
 
 bool VisitsTrendWatcher::IsBestmoveBeingOvertaken(

--- a/src/mcts/stoppers/smooth.cc
+++ b/src/mcts/stoppers/smooth.cc
@@ -572,7 +572,7 @@ bool SmoothStopper::ShouldStop(const IterationStats& stats,
   visits_trend_watcher_.Update(stats.time_since_movestart, stats.edge_n);
   const auto deadline_with_piggybank = deadline_ms_ + allowed_piggybank_use_ms_;
   const bool force_use_piggybank =
-      forced_piggybank_use_ms_ <= stats.time_since_first_batch;
+      stats.time_since_first_batch <= forced_piggybank_use_ms_;
   const bool use_piggybank =
       (stats.time_usage_hint_ == IterationStats::TimeUsageHint::kNeedMoreTime ||
        force_use_piggybank ||

--- a/src/mcts/stoppers/stoppers.cc
+++ b/src/mcts/stoppers/stoppers.cc
@@ -242,8 +242,9 @@ bool SmartPruningStopper::ShouldStop(const IterationStats& stats,
   }
 
   if (remaining_playouts < (largest_n - second_largest_n)) {
-    LOGFILE << remaining_playouts << " playouts remaining. Best move has "
-            << largest_n << " visits, second best -- " << second_largest_n
+    LOGFILE << std::fixed << remaining_playouts
+            << " playouts remaining. Best move has " << largest_n
+            << " visits, second best -- " << second_largest_n
             << ". Difference is " << (largest_n - second_largest_n)
             << ", so stopping the search after "
             << stats.batches_since_movestart << " batches.";


### PR DESCRIPTION
Should help against this:
![image](https://user-images.githubusercontent.com/11266455/179393565-9f024404-3d10-4cd3-9af5-bb16c6b10b2d.png)


Not tested, likely also fixes #1582.