### PR TITLE
Warning cleanup 🧹

### DIFF
--- a/src/neural/network_check.cc
+++ b/src/neural/network_check.cc
@@ -114,7 +114,6 @@ class CheckComputation : public NetworkComputation {
   }
 
  private:
-  static constexpr int kNumOutputPolicies = 1858;
   const CheckParams& params_;
   std::vector<MoveList> moves_;
 


### PR DESCRIPTION
Removing 🧹 the const variable that generates the following compiler warning:

```
../../src/neural/network_check.cc:117:24: warning: unused variable 'kNumOutputPolicies' [-Wunused-const-variable]
  static constexpr int kNumOutputPolicies = 1858;
                       ^
1 warning generated.
```