### PR TITLE
Alphazero TM with scaling based on inc/time ratio and pieces on board

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -167,6 +167,7 @@ files += [
   'src/mcts/params.cc',
   'src/mcts/search.cc',
   'src/mcts/stoppers/alphazero.cc',
+  'src/mcts/stoppers/alphazero_autoscaled.cc',
   'src/mcts/stoppers/common.cc',
   'src/mcts/stoppers/factory.cc',
   'src/mcts/stoppers/legacy.cc',

--- a/src/mcts/stoppers/alphazero_autoscaled.cc
+++ b/src/mcts/stoppers/alphazero_autoscaled.cc
@@ -1,0 +1,111 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2020 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#include "mcts/stoppers/stoppers.h"
+
+namespace lczero {
+
+namespace {
+
+class AlphazeroAutoscaledTimeManager : public TimeManager {
+ public:
+  AlphazeroAutoscaledTimeManager(int64_t move_overhead,
+                                 const OptionsDict& params)
+      : move_overhead_(move_overhead),
+        opening_increments_(
+            params.GetOrDefault<bool>("opening-increments", false)) {
+    if (opening_increments_ != true && opening_increments_ != false) {
+      throw Exception("opening-increments can only be set to true or false.");
+    }
+  }
+  std::unique_ptr<SearchStopper> GetStopper(const GoParams& params,
+                                            const NodeTree& tree) override;
+
+ private:
+  const int64_t move_overhead_;
+  const bool opening_increments_;
+  bool time_control_ratio_set_ = false;
+  float inc_time_ratio_;
+};
+
+std::unique_ptr<SearchStopper> AlphazeroAutoscaledTimeManager::GetStopper(
+    const GoParams& params, const NodeTree& tree) {
+  const Position& position = tree.HeadPosition();
+  const PositionHistory& history = tree.GetPositionHistory();
+  const bool is_black = position.IsBlackToMove();
+  const auto& board = history.Last().GetBoard();
+  const std::optional<int64_t> time = (is_black ? params.btime : params.wtime);
+  const std::optional<int64_t> inc = (is_black ? params.binc : params.winc);
+  const int increment = std::max<int64_t>(0LL, inc.value_or(0));
+  // If no time limit is given, don't stop on this condition.
+  if (params.infinite || params.ponder || !time) return nullptr;
+
+  if (!time_control_ratio_set_) {
+    inc_time_ratio_ = opening_increments_ ? increment * 1.0f / (*time -
+        (std::floor(position.GetGamePly() / 2.0f) + 1.0f) * increment) :
+        increment * 1.0f / *time;
+    time_control_ratio_set_ = true;
+  }
+
+  auto total_moves_time = *time - move_overhead_;
+
+  int pieces_on_board = (board.ours() | board.theirs()).count();
+
+  float time_factor = 28.0f * inc_time_ratio_ + 0.089f;
+  float pieces_factor = (0.81f * inc_time_ratio_ + 0.00097f) * pieces_on_board;
+
+  LOGFILE << "Increment/basetime ratio: " << inc_time_ratio_
+          << ", Time factor: " << time_factor
+          << ", Pieces factor: " << pieces_factor << ".";
+
+  float this_move_time = total_moves_time * std::min(time_factor -
+                                                     pieces_factor, 1.0f);
+
+  // Try to detect if increment time is added only after a move has been made
+  // and recalculate this_move_time (can only happen in the first move of the
+  // game or in the first move of a new game phase with increment).
+  if (*time < increment) {
+    this_move_time = std::min(
+        (total_moves_time + increment * 1.0f) *
+        std::min(time_factor - pieces_factor, 1.0f), total_moves_time * 1.0f);
+  }
+
+  LOGFILE << "Budgeted time for the move: " << this_move_time << "ms."
+          << " Remaining time " << *time << "ms (-" << move_overhead_
+          << "ms overhead).";
+
+  return std::make_unique<TimeLimitStopper>(this_move_time);
+}
+
+}  // namespace
+
+std::unique_ptr<TimeManager> MakeAlphazeroAutoscaledTimeManager(
+    int64_t move_overhead, const OptionsDict& params) {
+  return std::make_unique<AlphazeroAutoscaledTimeManager>(
+      move_overhead, params);
+}
+}  // namespace lczero

--- a/src/mcts/stoppers/alphazero_autoscaled.h
+++ b/src/mcts/stoppers/alphazero_autoscaled.h
@@ -1,0 +1,37 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2020 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#pragma once
+
+#include "utils/optionsdict.h"
+
+namespace lczero {
+
+std::unique_ptr<TimeManager> MakeAlphazeroAutoscaledTimeManager(
+    int64_t move_overhead, const OptionsDict& params);
+
+}  // namespace lczero

--- a/src/mcts/stoppers/factory.cc
+++ b/src/mcts/stoppers/factory.cc
@@ -31,6 +31,7 @@
 
 #include "factory.h"
 #include "mcts/stoppers/alphazero.h"
+#include "mcts/stoppers/alphazero_autoscaled.h"
 #include "mcts/stoppers/legacy.h"
 #include "mcts/stoppers/smooth.h"
 #include "mcts/stoppers/stoppers.h"
@@ -47,7 +48,8 @@ const OptionId kMoveOverheadId{
 const OptionId kTimeManagerId{
     "time-manager", "TimeManager",
     "Name and config of a time manager. "
-    "Possible names are 'legacy' (default), 'smooth' and 'alphazero'."
+    "Possible names are 'legacy' (default), 'smooth', 'alphazero' and "
+    "'alphazero-autoscaled'."
     "See https://lc0.org/timemgr for configuration details."};
 }  // namespace
 
@@ -79,6 +81,9 @@ std::unique_ptr<TimeManager> MakeTimeManager(const OptionsDict& options) {
   } else if (managers[0] == "alphazero") {
     time_manager = MakeAlphazeroTimeManager(move_overhead,
                                             tm_options.GetSubdict("alphazero"));
+  } else if (managers[0] == "alphazero-autoscaled") {
+    time_manager = MakeAlphazeroAutoscaledTimeManager(move_overhead,
+                                 tm_options.GetSubdict("alphazero-autoscaled"));
   } else if (managers[0] == "smooth") {
     time_manager =
         MakeSmoothTimeManager(move_overhead, tm_options.GetSubdict("smooth"));


### PR DESCRIPTION
PR applies scaling based on increment/basetime ratio (more move time for TC with higher increments, calculated only once in the beginning of the game) and additionally a term reducing move time based on number of pieces on the board (reducing more for the full board, less in endgames). Resulting move time factor ranges between 0.058 (full board, no increment) and 1.0 (endgames, high increment).

Some UCI hosts add increment time for opening moves, some don't (including Cutechess since https://github.com/cutechess/cutechess/pull/174), so the calculation needs correct user input for parameter opening-increments=true or false (default).

Tuned and tested with dag-bord version.

increment = 0
TC: 24s/game+0s/move (LC0), 6.9s/game+0s/move (SF)
```
   # ENGINE                               :  RATING  ERROR  CFS(%)   GAMES  DRAWS(%)  OppN
   1 stockfish-dev                        :    22.5    6.4   100.0    8000      64.9     2
   2 lc0.net.791557_dag-bord_89ec04_PR    :     7.1    8.9    94.1    4000      65.9     1
   3 lc0.net.791557_dag-bord_89ec04       :     0.0   ----     ---    4000      63.9     1
```

increment = 1/60 of basetime
TC: 12s/game+0.2s/move (LC0), 3.42s/game+0.057s/move (SF)
```
Increment 1/60 of base time
TC: 12s/game+0.2s/move (LC0), 3.42s/game+0.057s/move (SF)
   # ENGINE                               :  RATING  ERROR  CFS(%)   GAMES  DRAWS(%)  OppN
   1 stockfish-dev                        :     9.9    5.9    95.8    8000      68.9     2
   2 lc0.net.791557_dag-bord_89ec04_PR    :     4.6    8.3    86.0    4000      69.2     1
   3 lc0.net.791557_dag-bord_89ec04       :     0.0   ----     ---    4000      68.5     1
```