### PR TITLE
Version detection in meson.build for new editions of Python

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -683,7 +683,7 @@ endif
 if get_option('python_bindings')
   pymod = import('python')
   python = pymod.find_installation('python3')
-  if python.language_version() < '3.7'
+  if not python.language_version().version_compare('>3.7')
     error('You need python 3.7 or newer')
   endif
   py_bindings_generator = find_program('scripts/gen_py_bindings.py')


### PR DESCRIPTION
I just went through the [walkthrough for building the Python-bindings](https://github.com/LeelaChessZero/lc0/pull/1261), and found that my versions of Python above 3.10 are mistaken for being older than 3.7. Using `.version_compare()` instead of direct string comparison fixes this.

I'm guessing that this is pretty niche, but I was able to complete the build process (at least for the bindings) with meson using 3.10.