### PR TITLE
inform time manager of any nps limit

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -521,6 +521,9 @@ NNCacheLock Search::GetCachedNNEval(const Node* node) const {
 void Search::MaybeTriggerStop(const IterationStats& stats,
                               StoppersHints* hints) {
   hints->Reset();
+  if (params_.GetNpsLimit() > 0) {
+    hints->UpdateEstimatedNps(params_.GetNpsLimit());
+  }
   SharedMutex::Lock nodes_lock(nodes_mutex_);
   Mutex::Lock lock(counters_mutex_);
   // Already responded bestmove, nothing to do here.
@@ -889,6 +892,9 @@ void Search::WatchdogThread() {
   IterationStats stats;
   while (true) {
     hints.Reset();
+    if (params_.GetNpsLimit() > 0) {
+      hints.UpdateEstimatedNps(params_.GetNpsLimit());
+    }
     PopulateCommonIterationStats(&stats);
     MaybeTriggerStop(stats, &hints);
     MaybeOutputInfo();

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -891,10 +891,6 @@ void Search::WatchdogThread() {
   StoppersHints hints;
   IterationStats stats;
   while (true) {
-    hints.Reset();
-    if (params_.GetNpsLimit() > 0) {
-      hints.UpdateEstimatedNps(params_.GetNpsLimit());
-    }
     PopulateCommonIterationStats(&stats);
     MaybeTriggerStop(stats, &hints);
     MaybeOutputInfo();


### PR DESCRIPTION
This should allow smart pruning to work with low nps limits.