### PR TITLE
Alternative P value scale method

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -56,6 +56,8 @@ FillEmptyHistory EncodeHistoryFill(std::string history_fill) {
 }
 
 }  // namespace
+const OptionId SearchParams::KPshapeId{"P-shape", "P shape",
+                                       "Adjust P shape."};
 
 const OptionId SearchParams::kMiniBatchSizeId{
     "minibatch-size", "MinibatchSize",
@@ -320,6 +322,7 @@ const OptionId SearchParams::kMaxCollisionVisitsScalingPowerId{
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
   // Many of them are overridden with training specific values in tournament.cc.
+  options->Add<FloatOption>(KPshapeId, 0.0001f, 10.0f) = 0.9f;
   options->Add<IntOption>(kMiniBatchSizeId, 1, 1024) = DEFAULT_MINIBATCH_SIZE;
   options->Add<IntOption>(kMaxPrefetchBatchId, 0, 1024) = DEFAULT_MAX_PREFETCH;
   options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 1.745f;
@@ -419,6 +422,7 @@ void SearchParams::Populate(OptionsParser* options) {
 
 SearchParams::SearchParams(const OptionsDict& options)
     : options_(options),
+    KPshape(options.Get<float>(KPshapeId)),
       kCpuct(options.Get<float>(kCpuctId)),
       kCpuctAtRoot(options.Get<float>(
           options.Get<bool>(kRootHasOwnCpuctParamsId) ? kCpuctAtRootId

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -53,6 +53,7 @@ class SearchParams {
   float GetCpuctFactor(bool at_root) const {
     return at_root ? kCpuctFactorAtRoot : kCpuctFactor;
   }
+  float Pshape() const { return KPshape; }
   bool GetTwoFoldDraws() const { return kTwoFoldDraws; }
   float GetTemperature() const { return options_.Get<float>(kTemperatureId); }
   float GetTemperatureVisitOffset() const {
@@ -140,6 +141,7 @@ class SearchParams {
   }
 
   // Search parameter IDs.
+  static const OptionId KPshapeId;
   static const OptionId kMiniBatchSizeId;
   static const OptionId kMaxPrefetchBatchId;
   static const OptionId kCpuctId;
@@ -232,6 +234,7 @@ class SearchParams {
   const bool kSyzygyFastPlay;
   const FillEmptyHistory kHistoryFill;
   const int kMiniBatchSize;
+  const float KPshape;
   const float kMovesLeftMaxEffect;
   const float kMovesLeftThreshold;
   const float kMovesLeftSlope;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -2095,6 +2095,7 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
   // Intermediate array to store values when processing policy.
   // There are never more than 256 valid legal moves in any legal position.
   std::array<float, 256> intermediate;
+  float p_shape = params_.Pshape();
   int counter = 0;
   for (auto& edge : node->Edges()) {
     float p = computation.GetPVal(
@@ -2114,9 +2115,8 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
   }
   counter = 0;
   // Normalize P values to add up to 1.0.
-  const float scale = total > 0.0f ? 1.0f / total : 1.0f;
   for (auto& edge : node->Edges()) {
-    edge.edge()->SetP(intermediate[counter++] * scale);
+    edge.edge()->SetP(powf(intermediate[counter++] / max_p, p_shape));
   }
   // Add Dirichlet noise if enabled and at root.
   if (params_.GetNoiseEpsilon() && node == search_->root_node_) {


### PR DESCRIPTION
Instead of fixed scale method 1 / total, we can customize the P scaled values shape. A p_shape value of , for example, 0.9 force Lc0 to check more moves. Same nodes/sec but less depth. Conversely, a p_shape value of, for example, 1.5 forces lc0 to focus on a few moves.
![Pshape](https://user-images.githubusercontent.com/45057484/201116308-8458f3c2-f115-417b-8dbe-4d335516e8c7.jpg)

Alternative formula is Pow(Current P  /  Max P,  P_shape) where P_shape must be a positive value.
From my tests, the better values are in the range 0.5-1.5.

