### PR TITLE
only use thread binding with blas backend

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -36,7 +36,6 @@
 #include "utils/commandline.h"
 #include "utils/esc_codes.h"
 #include "utils/logging.h"
-#include "utils/numa.h"
 #include "version.h"
 
 int main(int argc, const char** argv) {
@@ -49,8 +48,6 @@ int main(int argc, const char** argv) {
        << " built " << __DATE__;
 
   try {
-    Numa::Init();
-    Numa::BindThread(0);
     InitializeMagicBitboards();
 
     CommandLine::Init(argc, argv);

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -39,7 +39,6 @@
 #include "neural/network.h"
 #include "utils/exception.h"
 #include "utils/hashcat.h"
-#include "utils/numa.h"
 
 namespace lczero {
 
@@ -99,9 +98,6 @@ class NodeGarbageCollector {
   }
 
   void Worker() {
-    // Keep garbage collection on same core as where search workers are most
-    // likely to be to make any lock conention on gc mutex cheaper.
-    Numa::BindThread(0);
     while (!stop_.load()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(kGCIntervalMs));
       GarbageCollect();

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -886,7 +886,6 @@ void Search::PopulateCommonIterationStats(IterationStats* stats) {
 }
 
 void Search::WatchdogThread() {
-  Numa::BindThread(0);
   LOGFILE << "Start a watchdog thread.";
   StoppersHints hints;
   IterationStats stats;

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -44,7 +44,6 @@
 #include "syzygy/syzygy.h"
 #include "utils/logging.h"
 #include "utils/mutex.h"
-#include "utils/numa.h"
 
 namespace lczero {
 
@@ -216,11 +215,10 @@ class SearchWorker {
         params_(params),
         moves_left_support_(search_->network_->GetCapabilities().moves_left !=
                             pblczero::NetworkFormat::MOVES_LEFT_NONE) {
-    Numa::BindThread(id);
+    search_->network_->InitThread(id);
     for (int i = 0; i < params.GetTaskWorkersPerSearchWorker(); i++) {
       task_workspaces_.emplace_back();
       task_threads_.emplace_back([this, i]() {
-        Numa::BindThread(i);
         this->RunTasks(i);
       });
     }

--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -35,6 +35,7 @@
 #include "neural/shared/attention_policy_map.h"
 #include "neural/shared/policy_map.h"
 #include "neural/shared/winograd_filter.h"
+#include "utils/numa.h"
 
 #ifdef USE_DNNL
 #include <omp.h>
@@ -134,6 +135,8 @@ class BlasNetwork : public Network {
   const NetworkCapabilities& GetCapabilities() const override {
     return capabilities_;
   }
+
+  void InitThread(int id) override { Numa::BindThread(id); }
 
  private:
   // A cap on the max batch size since it consumes a lot of memory
@@ -648,6 +651,8 @@ BlasNetwork<use_eigen>::BlasNetwork(const WeightsFile& file,
     : capabilities_{file.format().network_format().input(),
                     file.format().network_format().moves_left()},
       weights_(file.weights()) {
+    Numa::Init();
+
   max_batch_size_ =
       static_cast<size_t>(options.GetOrDefault<int>("batch_size", 256));
 

--- a/src/neural/network.h
+++ b/src/neural/network.h
@@ -107,6 +107,7 @@ class Network {
  public:
   virtual const NetworkCapabilities& GetCapabilities() const = 0;
   virtual std::unique_ptr<NetworkComputation> NewComputation() = 0;
+  virtual void InitThread(int /*id*/) {}
   virtual ~Network() = default;
 };
 

--- a/src/neural/network_demux.cc
+++ b/src/neural/network_demux.cc
@@ -31,7 +31,6 @@
 
 #include "neural/factory.h"
 #include "utils/exception.h"
-#include "utils/numa.h"
 
 namespace lczero {
 namespace {
@@ -135,7 +134,7 @@ class DemuxingNetwork : public Network {
     }
 
     for (int i = 0; i < nn_threads; ++i) {
-      threads_.emplace_back([this, i]() { Worker(i); });
+      threads_.emplace_back([this, i]() { Worker(); });
     }
   }
 
@@ -163,9 +162,7 @@ class DemuxingNetwork : public Network {
     }
   }
 
-  void Worker(int id) {
-    // Add one to the id in order to leave space for an active search thread.
-    Numa::BindThread(id + 1);
+  void Worker() {
     // While Abort() is not called (and it can only be called from destructor).
     while (!abort_) {
       {

--- a/src/neural/network_mux.cc
+++ b/src/neural/network_mux.cc
@@ -31,7 +31,6 @@
 
 #include "neural/factory.h"
 #include "utils/exception.h"
-#include "utils/numa.h"
 
 namespace lczero {
 namespace {
@@ -126,7 +125,7 @@ class MuxingNetwork : public Network {
 
     for (int i = 0; i < nn_threads; ++i) {
       threads_.emplace_back(
-          [this, net, max_batch, i]() { Worker(net, max_batch, i); });
+          [this, net, max_batch]() { Worker(net, max_batch); });
     }
   }
 
@@ -154,9 +153,7 @@ class MuxingNetwork : public Network {
     }
   }
 
-  void Worker(Network* network, const int max_batch, int id) {
-    // Add one to the id in order to leave space for an active search thread.
-    Numa::BindThread(id + 1);
+  void Worker(Network* network, const int max_batch) {
     // While Abort() is not called (and it can only be called from destructor).
     while (!abort_) {
       std::vector<MuxingComputation*> children;

--- a/src/utils/numa.cc
+++ b/src/utils/numa.cc
@@ -39,7 +39,7 @@ namespace lczero {
 int Numa::threads_per_core_ = 1;
 
 void Numa::Init() {
-#if defined(_WIN64) && _WIN32_WINNT >= 0x0601
+#if defined(USE_BLAS) && defined(_WIN64) && _WIN32_WINNT >= 0x0601
   SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX* buffer;
   DWORD len;
   GetLogicalProcessorInformationEx(RelationProcessorCore, NULL, &len);
@@ -65,7 +65,7 @@ void Numa::Init() {
 }
 
 void Numa::BindThread(int id) {
-#if defined(_WIN64) && _WIN32_WINNT >= 0x0601
+#if defined(USE_BLAS) && defined(_WIN64) && _WIN32_WINNT >= 0x0601
   int group_count = GetActiveProcessorGroupCount();
   int thread_count = GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
   int core_count = thread_count / threads_per_core_;

--- a/src/utils/numa.cc
+++ b/src/utils/numa.cc
@@ -39,7 +39,7 @@ namespace lczero {
 int Numa::threads_per_core_ = 1;
 
 void Numa::Init() {
-#if defined(USE_BLAS) && defined(_WIN64) && _WIN32_WINNT >= 0x0601
+#if defined(_WIN64) && _WIN32_WINNT >= 0x0601
   SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX* buffer;
   DWORD len;
   GetLogicalProcessorInformationEx(RelationProcessorCore, NULL, &len);
@@ -65,7 +65,7 @@ void Numa::Init() {
 }
 
 void Numa::BindThread(int id) {
-#if defined(USE_BLAS) && defined(_WIN64) && _WIN32_WINNT >= 0x0601
+#if defined(_WIN64) && _WIN32_WINNT >= 0x0601
   int group_count = GetActiveProcessorGroupCount();
   int thread_count = GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
   int core_count = thread_count / threads_per_core_;


### PR DESCRIPTION
Apparently binding threads to a windows processor group is a bad idea if lc0 is used simultaneously with SF for analysis: both engines try to use the same cores.
Since thread binding is only useful for more than 32 threads, in most cases it may be better to let windows handle the allocation.
The only real use case is with the blas backend, so here thread binding is made conditional on `USE_BLAS`. This does not include the eigen backend, but I think this is acceptable as it is mainly intended as a reference implementation.