### PR TITLE
Implementation of a new Q function

### DIFF
--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -168,9 +168,8 @@ class Node {
                   float LoseFactor) const {
     float L = std::fmax((1 - wl_ - d_) * 0.5f, 0);
     float W = std::fmax(wl_ + L, 0);
-    return L != 0 ? std::pow(W, WinFactor + DrawFactorW * d_) -
-                        std::pow(L, LoseFactor + DrawFactorL * d_)
-                  : std::pow(W, WinFactor + DrawFactorW * d_);
+    return std::pow(W, WinFactor + DrawFactorW * d_) -
+                        std::pow(L, LoseFactor + DrawFactorL * d_);
 
       //return std::pow(std::fmax(wl_ + std::fmax((1 - wl_ - d_) * 0.5f, 0), 0),
       //              WinFactor + DrawFactorW * d_) -

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -164,11 +164,17 @@ class Node {
   uint32_t GetChildrenVisits() const { return n_ > 0 ? n_ - 1 : 0; }
   // Returns n = n_if_flight.
   int GetNStarted() const { return n_ + n_in_flight_; }
-  float GetQ(float draw_score, float DrawFactor, float WinFactor,
+  float GetQ(float draw_score, float DrawFactorW, float WinFactor, float DrawFactorL,
                   float LoseFactor) const {
-    return std::pow(std::fmax(wl_ + std::fmax((1 - wl_ - d_) * 0.5f, 0), 0),
-                    WinFactor + DrawFactor * d_) -
-           std::pow(std::fmax((1 - wl_ - d_) * 0.5f, 0), LoseFactor);
+    float L = std::fmax((1 - wl_ - d_) * 0.5f, 0);
+    float W = std::fmax(wl_ + L, 0);
+    return L != 0 ? std::pow(W, WinFactor + DrawFactorW * d_) -
+                        std::pow(L, LoseFactor + DrawFactorL * d_)
+                  : std::pow(W, WinFactor + DrawFactorW * d_);
+
+      //return std::pow(std::fmax(wl_ + std::fmax((1 - wl_ - d_) * 0.5f, 0), 0),
+      //              WinFactor + DrawFactorW * d_) -
+      //     std::pow(std::fmax((1 - wl_ - d_) * 0.5f, 0), LoseFactor + DrawFactorL * d_);
   }
   // Returns node eval, i.e. average subtree V for non-terminal node and -1/0/1
   // for terminal nodes.
@@ -376,10 +382,10 @@ class EdgeAndNode {
   Node* node() const { return node_; }
 
   // Proxy functions for easier access to node/edge.
-  float GetQ(float default_q, float draw_score, float DrawFactor,
-             float WinFactor, float LoseFactor) const {
+  float GetQ(float default_q, float draw_score, float DrawFactorW,
+             float WinFactor, float DrawFactorL, float LoseFactor) const {
     return (node_ && node_->GetN() > 0)
-               ? node_->GetQ(draw_score, DrawFactor, WinFactor, LoseFactor)
+               ? node_->GetQ(draw_score, DrawFactorW, WinFactor, DrawFactorL, LoseFactor)
                : default_q;
   }
   float GetWL(float default_wl) const {

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -164,7 +164,12 @@ class Node {
   uint32_t GetChildrenVisits() const { return n_ > 0 ? n_ - 1 : 0; }
   // Returns n = n_if_flight.
   int GetNStarted() const { return n_ + n_in_flight_; }
-  float GetQ(float draw_score) const { return wl_ + draw_score * d_; }
+  float GetQ(float draw_score, float DrawFactor, float WinFactor,
+                  float LoseFactor) const {
+    return std::pow(std::fmax(wl_ + std::fmax((1 - wl_ - d_) * 0.5f, 0), 0),
+                    WinFactor) -
+           std::pow(std::fmax((1 - wl_ - d_) * 0.5f, 0), LoseFactor);
+  }
   // Returns node eval, i.e. average subtree V for non-terminal node and -1/0/1
   // for terminal nodes.
   float GetWL() const { return wl_; }
@@ -371,8 +376,11 @@ class EdgeAndNode {
   Node* node() const { return node_; }
 
   // Proxy functions for easier access to node/edge.
-  float GetQ(float default_q, float draw_score) const {
-    return (node_ && node_->GetN() > 0) ? node_->GetQ(draw_score) : default_q;
+  float GetQ(float default_q, float draw_score, float DrawFactor,
+             float WinFactor, float LoseFactor) const {
+    return (node_ && node_->GetN() > 0)
+               ? node_->GetQ(draw_score, DrawFactor, WinFactor, LoseFactor)
+               : default_q;
   }
   float GetWL(float default_wl) const {
     return (node_ && node_->GetN() > 0) ? node_->GetWL() : default_wl;

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -168,8 +168,9 @@ class Node {
                   float LoseFactor) const {
     float L = std::fmax((1 - wl_ - d_) * 0.5f, 0);
     float W = std::fmax(wl_ + L, 0);
-    return std::pow(W, WinFactor + DrawFactorW * d_) -
-                        std::pow(L, LoseFactor + DrawFactorL * d_);
+    return L != 0 && W != 0 ? std::pow(W, WinFactor + DrawFactorW * d_) -
+                                  std::pow(L, LoseFactor + DrawFactorL * d_)
+                            : wl_;
   }
   // Returns node eval, i.e. average subtree V for non-terminal node and -1/0/1
   // for terminal nodes.

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -167,7 +167,7 @@ class Node {
   float GetQ(float draw_score, float DrawFactor, float WinFactor,
                   float LoseFactor) const {
     return std::pow(std::fmax(wl_ + std::fmax((1 - wl_ - d_) * 0.5f, 0), 0),
-                    WinFactor) -
+                    WinFactor + DrawFactor * d_) -
            std::pow(std::fmax((1 - wl_ - d_) * 0.5f, 0), LoseFactor);
   }
   // Returns node eval, i.e. average subtree V for non-terminal node and -1/0/1

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -170,10 +170,6 @@ class Node {
     float W = std::fmax(wl_ + L, 0);
     return std::pow(W, WinFactor + DrawFactorW * d_) -
                         std::pow(L, LoseFactor + DrawFactorL * d_);
-
-      //return std::pow(std::fmax(wl_ + std::fmax((1 - wl_ - d_) * 0.5f, 0), 0),
-      //              WinFactor + DrawFactorW * d_) -
-      //     std::pow(std::fmax((1 - wl_ - d_) * 0.5f, 0), LoseFactor + DrawFactorL * d_);
   }
   // Returns node eval, i.e. average subtree V for non-terminal node and -1/0/1
   // for terminal nodes.

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -406,7 +406,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kIdlingMinimumWorkId, 0, 10000) = 0;
   options->Add<IntOption>(kThreadIdlingThresholdId, 0, 128) = 1;
   options->Add<FloatOption>(kDrawFactorWId, 0.0f, 2.0f) = 0.0f;
-  options->Add<FloatOption>(kDrawFactorLId, -1.0f, 2.0f) = 0.0f;
+  options->Add<FloatOption>(kDrawFactorLId, 0.0f, 2.0f) = 0.0f;
   options->Add<FloatOption>(kWinFactorId, 0.0f, 2.0f) = 1.0f;
   options->Add<FloatOption>(kLoseFactorId, 0.0f, 2.0f) = 1.0f;
 

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -316,8 +316,10 @@ const OptionId SearchParams::kMaxCollisionVisitsScalingEndId{
 const OptionId SearchParams::kMaxCollisionVisitsScalingPowerId{
     "max-collision-visits-scaling-power", "MaxCollisionVisitsScalingPower",
     "Power to apply to the interpolation between 1 and max to make it curved."};
-const OptionId SearchParams::kDrawFactorId{"draw-factor", "DrawFactor",
-                                           "DrawFactor"};
+const OptionId SearchParams::kDrawFactorWId{"draw-factor-W", "DrawFactorW",
+                                           "DrawFactorW"};
+const OptionId SearchParams::kDrawFactorLId{"draw-factor-L", "DrawFactorL",
+                                            "DrawFactorL"};
 const OptionId SearchParams::kWinFactorId{"win-factor", "WinFactor",
                                           "Win Factor"};
 const OptionId SearchParams::kLoseFactorId{"lose-factor", "LoseFactor",
@@ -403,7 +405,8 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kMinimumWorkPerTaskForProcessingId, 1, 100000) = 8;
   options->Add<IntOption>(kIdlingMinimumWorkId, 0, 10000) = 0;
   options->Add<IntOption>(kThreadIdlingThresholdId, 0, 128) = 1;
-  options->Add<FloatOption>(kDrawFactorId, 0.0f, 2.0f) = 0.0f;
+  options->Add<FloatOption>(kDrawFactorWId, 0.0f, 2.0f) = 0.0f;
+  options->Add<FloatOption>(kDrawFactorLId, -1.0f, 2.0f) = 0.0f;
   options->Add<FloatOption>(kWinFactorId, 0.0f, 2.0f) = 1.0f;
   options->Add<FloatOption>(kLoseFactorId, 0.0f, 2.0f) = 1.0f;
 
@@ -497,7 +500,8 @@ SearchParams::SearchParams(const OptionsDict& options)
           options.Get<int>(kMaxCollisionVisitsScalingEndId)),
       kMaxCollisionVisitsScalingPower(
           options.Get<float>(kMaxCollisionVisitsScalingPowerId)),
-      kDrawFactor(options.Get<float>(kDrawFactorId)),
+      kDrawFactorW(options.Get<float>(kDrawFactorWId)),
+      kDrawFactorL(options.Get<float>(kDrawFactorLId)),
       kWinFactor(options.Get<float>(kWinFactorId)),
       kLoseFactor(options.Get<float>(kLoseFactorId)) {
   if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -316,6 +316,12 @@ const OptionId SearchParams::kMaxCollisionVisitsScalingEndId{
 const OptionId SearchParams::kMaxCollisionVisitsScalingPowerId{
     "max-collision-visits-scaling-power", "MaxCollisionVisitsScalingPower",
     "Power to apply to the interpolation between 1 and max to make it curved."};
+const OptionId SearchParams::kDrawFactorId{"draw-factor", "DrawFactor",
+                                           "DrawFactor"};
+const OptionId SearchParams::kWinFactorId{"win-factor", "WinFactor",
+                                          "Win Factor"};
+const OptionId SearchParams::kLoseFactorId{"lose-factor", "LoseFactor",
+                                           "Lose Factor"};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -397,6 +403,9 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<IntOption>(kMinimumWorkPerTaskForProcessingId, 1, 100000) = 8;
   options->Add<IntOption>(kIdlingMinimumWorkId, 0, 10000) = 0;
   options->Add<IntOption>(kThreadIdlingThresholdId, 0, 128) = 1;
+  options->Add<FloatOption>(kDrawFactorId, 0.0f, 2.0f) = 0.0f;
+  options->Add<FloatOption>(kWinFactorId, 0.0f, 2.0f) = 1.0f;
+  options->Add<FloatOption>(kLoseFactorId, 0.0f, 2.0f) = 1.0f;
 
   options->HideOption(kNoiseEpsilonId);
   options->HideOption(kNoiseAlphaId);
@@ -470,7 +479,8 @@ SearchParams::SearchParams(const OptionsDict& options)
                               options.Get<int>(kMiniBatchSizeId)))),
       kNpsLimit(options.Get<float>(kNpsLimitId)),
       kSolidTreeThreshold(options.Get<int>(kSolidTreeThresholdId)),
-      kTaskWorkersPerSearchWorker(options.Get<int>(kTaskWorkersPerSearchWorkerId)),
+      kTaskWorkersPerSearchWorker(
+          options.Get<int>(kTaskWorkersPerSearchWorkerId)),
       kMinimumWorkSizeForProcessing(
           options.Get<int>(kMinimumWorkSizeForProcessingId)),
       kMinimumWorkSizeForPicking(
@@ -486,7 +496,10 @@ SearchParams::SearchParams(const OptionsDict& options)
       kMaxCollisionVisitsScalingEnd(
           options.Get<int>(kMaxCollisionVisitsScalingEndId)),
       kMaxCollisionVisitsScalingPower(
-          options.Get<float>(kMaxCollisionVisitsScalingPowerId)) {
+          options.Get<float>(kMaxCollisionVisitsScalingPowerId)),
+      kDrawFactor(options.Get<float>(kDrawFactorId)),
+      kWinFactor(options.Get<float>(kWinFactorId)),
+      kLoseFactor(options.Get<float>(kLoseFactorId)) {
   if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +
           std::max(std::abs(kDrawScoreWhite), std::abs(kDrawScoreBlack)) >
       1.0f) {

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -138,6 +138,9 @@ class SearchParams {
   float GetMaxCollisionVisitsScalingPower() const {
     return kMaxCollisionVisitsScalingPower;
   }
+  float GetDrawFactor() const { return kDrawFactor; }
+  float GetWinFactor() const { return kWinFactor; }
+  float GetLoseFactor() const { return kLoseFactor; }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -201,6 +204,9 @@ class SearchParams {
   static const OptionId kMaxCollisionVisitsScalingStartId;
   static const OptionId kMaxCollisionVisitsScalingEndId;
   static const OptionId kMaxCollisionVisitsScalingPowerId;
+  static const OptionId kDrawFactorId;
+  static const OptionId kWinFactorId;
+  static const OptionId kLoseFactorId;
 
  private:
   const OptionsDict& options_;
@@ -257,6 +263,9 @@ class SearchParams {
   const int kMaxCollisionVisitsScalingStart;
   const int kMaxCollisionVisitsScalingEnd;
   const float kMaxCollisionVisitsScalingPower;
+  const float kDrawFactor;
+  const float kWinFactor;
+  const float kLoseFactor;
 };
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -138,7 +138,8 @@ class SearchParams {
   float GetMaxCollisionVisitsScalingPower() const {
     return kMaxCollisionVisitsScalingPower;
   }
-  float GetDrawFactor() const { return kDrawFactor; }
+  float GetDrawFactorW() const { return kDrawFactorW; }
+  float GetDrawFactorL() const { return kDrawFactorL; }
   float GetWinFactor() const { return kWinFactor; }
   float GetLoseFactor() const { return kLoseFactor; }
 
@@ -204,7 +205,8 @@ class SearchParams {
   static const OptionId kMaxCollisionVisitsScalingStartId;
   static const OptionId kMaxCollisionVisitsScalingEndId;
   static const OptionId kMaxCollisionVisitsScalingPowerId;
-  static const OptionId kDrawFactorId;
+  static const OptionId kDrawFactorWId;
+  static const OptionId kDrawFactorLId;
   static const OptionId kWinFactorId;
   static const OptionId kLoseFactorId;
 
@@ -263,7 +265,8 @@ class SearchParams {
   const int kMaxCollisionVisitsScalingStart;
   const int kMaxCollisionVisitsScalingEnd;
   const float kMaxCollisionVisitsScalingPower;
-  const float kDrawFactor;
+  const float kDrawFactorW;
+  const float kDrawFactorL;
   const float kWinFactor;
   const float kLoseFactor;
 };

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -129,7 +129,7 @@ class MEvaluator {
 
  private:
   static bool WithinThreshold(const Node* parent, float q_threshold) {
-    return std::abs(parent->GetQ(0.0f)) > q_threshold;
+    return std::abs(parent->GetQ(0.0f, 0.0f, 1.0f, 1.0f)) > q_threshold;
   }
 
   const bool enabled_;
@@ -228,7 +228,9 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
   common_info.tb_hits = tb_hits_.load(std::memory_order_acquire);
 
   int multipv = 0;
-  const auto default_q = -root_node_->GetQ(-draw_score);
+  const auto default_q =
+      -root_node_->GetQ(-draw_score, params_.GetDrawFactor(),
+                        params_.GetWinFactor(), params_.GetLoseFactor());
   const auto default_wl = -root_node_->GetWL();
   const auto default_d = root_node_->GetD();
   for (const auto& edge : edges) {
@@ -237,7 +239,8 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
     auto& uci_info = uci_infos.back();
     const auto wl = edge.GetWL(default_wl);
     const auto floatD = edge.GetD(default_d);
-    const auto q = edge.GetQ(default_q, draw_score);
+    const auto q = edge.GetQ(default_q, draw_score, params_.GetDrawFactor(),
+                             params_.GetWinFactor(), params_.GetLoseFactor());
     if (edge.IsTerminal() && wl != 0.0f) {
       uci_info.mate = std::copysign(
           std::round(edge.GetM(0.0f)) / 2 + (edge.IsTbTerminal() ? 101 : 1),
@@ -344,21 +347,24 @@ float Search::GetDrawScore(bool is_odd_depth) const {
 
 namespace {
 inline float GetFpu(const SearchParams& params, Node* node, bool is_root_node,
-                    float draw_score) {
+                    float draw_score, float DrawFactor, float WinFactor,
+                    float LoseFactor) {
   const auto value = params.GetFpuValue(is_root_node);
   return params.GetFpuAbsolute(is_root_node)
              ? value
-             : -node->GetQ(-draw_score) -
+             : -node->GetQ(-draw_score, DrawFactor, WinFactor, LoseFactor) -
                    value * std::sqrt(node->GetVisitedPolicy());
 }
 
 // Faster version for if visited_policy is readily available already.
 inline float GetFpu(const SearchParams& params, Node* node, bool is_root_node,
-                    float draw_score, float visited_pol) {
+                    float draw_score, float visited_pol, float DrawFactor,
+                    float WinFactor, float LoseFactor) {
   const auto value = params.GetFpuValue(is_root_node);
   return params.GetFpuAbsolute(is_root_node)
              ? value
-             : -node->GetQ(-draw_score) - value * std::sqrt(visited_pol);
+             : -node->GetQ(-draw_score, DrawFactor, WinFactor, LoseFactor) -
+                   value * std::sqrt(visited_pol);
 }
 
 inline float ComputeCpuct(const SearchParams& params, uint32_t N,
@@ -376,7 +382,9 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
   const bool is_odd_depth = !is_root;
   const bool is_black_to_move = (played_history_.IsBlackToMove() == is_root);
   const float draw_score = GetDrawScore(is_odd_depth);
-  const float fpu = GetFpu(params_, node, is_root, draw_score);
+  const float fpu =
+      GetFpu(params_, node, is_root, draw_score, params_.GetDrawFactor(),
+             params_.GetWinFactor(), params_.GetLoseFactor());
   const float cpuct = ComputeCpuct(params_, node->GetN(), is_root);
   const float U_coeff =
       cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
@@ -384,11 +392,17 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
   for (const auto& edge : node->Edges()) edges.push_back(edge);
 
   std::sort(edges.begin(), edges.end(),
-            [&fpu, &U_coeff, &draw_score](EdgeAndNode a, EdgeAndNode b) {
+            [&](EdgeAndNode a, EdgeAndNode b) {
               return std::forward_as_tuple(
-                         a.GetN(), a.GetQ(fpu, draw_score) + a.GetU(U_coeff)) <
+               a.GetN(),
+               a.GetQ(fpu, draw_score, params_.GetDrawFactor(),
+                      params_.GetWinFactor(), params_.GetLoseFactor()) +
+                   a.GetU(U_coeff)) <
                      std::forward_as_tuple(
-                         b.GetN(), b.GetQ(fpu, draw_score) + b.GetU(U_coeff));
+               b.GetN(),
+               b.GetQ(fpu, draw_score, params_.GetDrawFactor(),
+                      params_.GetWinFactor(), params_.GetLoseFactor()) +
+                   b.GetU(U_coeff));
             });
 
   auto print = [](auto* oss, auto pre, auto v, auto post, auto w, int p = 0) {
@@ -412,13 +426,18 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
     } else {
       *oss << "(WL:  -.-----) (D: -.---) (M:  -.-) ";
     }
-    print(oss, "(Q: ", n ? sign * n->GetQ(sign * draw_score) : fpu, ") ", 8, 5);
+    print(oss, "(Q: ",
+          n ? sign * n->GetQ(sign * draw_score, params_.GetDrawFactor(),
+                             params_.GetWinFactor(), params_.GetLoseFactor())
+            : fpu,
+          ") ", 8, 5);
   };
   auto print_tail = [&](auto* oss, const auto* n) {
     const auto sign = n == node ? -1 : 1;
     std::optional<float> v;
     if (n && n->IsTerminal()) {
-      v = n->GetQ(sign * draw_score);
+      v = n->GetQ(sign * draw_score, params_.GetDrawFactor(),
+                  params_.GetWinFactor(), params_.GetLoseFactor());
     } else {
       NNCacheLock nneval = GetCachedNNEval(n);
       if (nneval) v = -nneval->q;
@@ -448,7 +467,8 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
                                ? MEvaluator(params_, node)
                                : MEvaluator();
   for (const auto& edge : edges) {
-    float Q = edge.GetQ(fpu, draw_score);
+    float Q = edge.GetQ(fpu, draw_score, params_.GetDrawFactor(),
+                        params_.GetWinFactor(), params_.GetLoseFactor());
     float M = m_evaluator.GetM(edge, Q);
     std::ostringstream oss;
     oss << std::left;
@@ -653,7 +673,7 @@ std::vector<EdgeAndNode> Search::GetBestChildrenNoTemperature(Node* parent,
                           : edges.end();
   std::partial_sort(
       edges.begin(), middle, edges.end(),
-      [draw_score](const auto& a, const auto& b) {
+      [draw_score, this](const auto& a, const auto& b) {
         // The function returns "true" when a is preferred to b.
 
         // Lists edge types from less desirable to more desirable.
@@ -703,8 +723,14 @@ std::vector<EdgeAndNode> Search::GetBestChildrenNoTemperature(Node* parent,
           // Default doesn't matter here so long as they are the same as either
           // both are N==0 (thus we're comparing equal defaults) or N!=0 and
           // default isn't used.
-          if (a.GetQ(0.0f, draw_score) != b.GetQ(0.0f, draw_score)) {
-            return a.GetQ(0.0f, draw_score) > b.GetQ(0.0f, draw_score);
+          if (a.GetQ(0.0f, draw_score, params_.GetDrawFactor(),
+                     params_.GetWinFactor(), params_.GetLoseFactor()) !=
+              b.GetQ(0.0f, draw_score, params_.GetDrawFactor(),
+                     params_.GetWinFactor(), params_.GetLoseFactor())) {
+            return a.GetQ(0.0f, draw_score, params_.GetDrawFactor(),
+                          params_.GetWinFactor(), params_.GetLoseFactor()) >
+                   b.GetQ(0.0f, draw_score, params_.GetDrawFactor(),
+                          params_.GetWinFactor(), params_.GetLoseFactor());
           }
           return a.GetP() > b.GetP();
         }
@@ -741,8 +767,9 @@ EdgeAndNode Search::GetBestRootChildWithTemperature(float temperature) const {
   float max_n = 0.0;
   const float offset = params_.GetTemperatureVisitOffset();
   float max_eval = -1.0f;
-  const float fpu =
-      GetFpu(params_, root_node_, /* is_root= */ true, draw_score);
+  const float fpu = GetFpu(params_, root_node_, /* is_root= */ true, draw_score,
+                           params_.GetDrawFactor(), params_.GetWinFactor(),
+                           params_.GetLoseFactor());
 
   for (auto& edge : root_node_->Edges()) {
     if (!root_move_filter_.empty() &&
@@ -752,7 +779,8 @@ EdgeAndNode Search::GetBestRootChildWithTemperature(float temperature) const {
     }
     if (edge.GetN() + offset > max_n) {
       max_n = edge.GetN() + offset;
-      max_eval = edge.GetQ(fpu, draw_score);
+      max_eval = edge.GetQ(fpu, draw_score, params_.GetDrawFactor(),
+                           params_.GetWinFactor(), params_.GetLoseFactor());
     }
   }
 
@@ -765,7 +793,9 @@ EdgeAndNode Search::GetBestRootChildWithTemperature(float temperature) const {
                   edge.GetMove()) == root_move_filter_.end()) {
       continue;
     }
-    if (edge.GetQ(fpu, draw_score) < min_eval) continue;
+    if (edge.GetQ(fpu, draw_score, params_.GetDrawFactor(),
+                  params_.GetWinFactor(), params_.GetLoseFactor()) < min_eval)
+      continue;
     sum += std::pow(
         std::max(0.0f,
                  (max_n <= 0.0f
@@ -787,7 +817,9 @@ EdgeAndNode Search::GetBestRootChildWithTemperature(float temperature) const {
                   edge.GetMove()) == root_move_filter_.end()) {
       continue;
     }
-    if (edge.GetQ(fpu, draw_score) < min_eval) continue;
+    if (edge.GetQ(fpu, draw_score, params_.GetDrawFactor(),
+                  params_.GetWinFactor(), params_.GetLoseFactor()) < min_eval)
+      continue;
     if (idx-- == 0) return edge;
   }
   assert(false);
@@ -847,8 +879,9 @@ void Search::PopulateCommonIterationStats(IterationStats* stats) {
   // If root node hasn't finished first visit, none of this code is safe.
   if (root_node_->GetN() > 0) {
     const auto draw_score = GetDrawScore(true);
-    const float fpu =
-        GetFpu(params_, root_node_, /* is_root_node */ true, draw_score);
+    const float fpu = GetFpu(params_, root_node_, /* is_root_node */ true,
+                             draw_score, params_.GetDrawFactor(),
+                             params_.GetWinFactor(), params_.GetLoseFactor());
     float max_q_plus_m = -1000;
     uint64_t max_n = 0;
     bool max_n_has_max_q_plus_m = true;
@@ -857,7 +890,8 @@ void Search::PopulateCommonIterationStats(IterationStats* stats) {
                                  : MEvaluator();
     for (const auto& edge : root_node_->Edges()) {
       const auto n = edge.GetN();
-      const auto q = edge.GetQ(fpu, draw_score);
+      const auto q = edge.GetQ(fpu, draw_score, params_.GetDrawFactor(),
+                               params_.GetWinFactor(), params_.GetLoseFactor());
       const auto m = m_evaluator.GetM(edge, q);
       const auto q_plus_m = q + m;
       stats->edge_n.push_back(n);
@@ -1590,11 +1624,13 @@ void SearchWorker::PickNodesToExtendTask(
       for (Node* child : node->VisitedNodes()) {
         int index = child->Index();
         visited_pol += current_pol[index];
-        float q = child->GetQ(draw_score);
+        float q = child->GetQ(draw_score, params_.GetDrawFactor(),
+                              params_.GetWinFactor(), params_.GetLoseFactor());
         current_util[index] = q + m_evaluator.GetM(child, q);
       }
-      const float fpu =
-          GetFpu(params_, node, is_root_node, draw_score, visited_pol);
+      const float fpu = GetFpu(params_, node, is_root_node, draw_score,
+                               visited_pol, params_.GetDrawFactor(),
+                               params_.GetWinFactor(), params_.GetLoseFactor());
       for (int i = 0; i < max_needed; i++) {
         if (current_util[i] == std::numeric_limits<float>::lowest()) {
           current_util[i] = fpu + m_evaluator.GetDefaultM();
@@ -1995,13 +2031,17 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget, bool is_odd_depth) {
       ComputeCpuct(params_, node->GetN(), node == search_->root_node_);
   const float puct_mult =
       cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
-  const float fpu =
-      GetFpu(params_, node, node == search_->root_node_, draw_score);
+  const float fpu = GetFpu(params_, node, node == search_->root_node_,
+                           draw_score, params_.GetDrawFactor(),
+                           params_.GetWinFactor(), params_.GetLoseFactor());
   for (auto& edge : node->Edges()) {
     if (edge.GetP() == 0.0f) continue;
     // Flip the sign of a score to be able to easily sort.
     // TODO: should this use logit_q if set??
-    scores.emplace_back(-edge.GetU(puct_mult) - edge.GetQ(fpu, draw_score),
+    scores.emplace_back(
+        -edge.GetU(puct_mult) -
+            edge.GetQ(fpu, draw_score, params_.GetDrawFactor(),
+                      params_.GetWinFactor(), params_.GetLoseFactor()),
                         edge);
   }
 
@@ -2033,7 +2073,9 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget, bool is_odd_depth) {
       // Sign of the score was flipped for sorting, so flip it back.
       const float next_score = -scores[i + 1].first;
       // TODO: As above - should this use logit_q if set?
-      const float q = edge.GetQ(-fpu, draw_score);
+      const float q =
+          edge.GetQ(-fpu, draw_score, params_.GetDrawFactor(),
+                    params_.GetWinFactor(), params_.GetLoseFactor());
       if (next_score > q) {
         budget_to_spend =
             std::min(budget, int(edge.GetP() * puct_mult / (next_score - q) -


### PR DESCRIPTION
Following Crem’s idea in early august to change the Q function after wccc, I used his code to test different functions.
The current Q function is Q = W – L. It doesn’t take into account D. So, between two lines with the same W-L, there is no way to favor the line with the lower D. That might lead Leela into more drawish lines and result into « wasted » opportunities. The goal of the new function is to :
- 	Include D in some way in the calculation of Q,
- 	Return to the current Q function with a specific set of parameters,
- 	At least not lose elo against superior opponent and gain elo against weaker one.

### Functions tested

Qtest3 : Q=(W-L) (1-D)^Drawfactor
Qtest3bis : Q=(W-L)(1-D^Drawfactor )
Qtest4 : Q=W^Winfactor-L^Losefactor
Qtest5 : Q=(W^Winfactor-L^Losefactor)(1-D)^Drawfactor
Qtest6 : Q=W^(Winfactor+DrawfactorW×D)-L^(Losefactor+DrawfactorL×D)

To test a function, a tune is performed against lc0 master at first to know if a parameter exists that increases elo. If the tuned parameter shows an elo gain against lc0 master, a second test (and / or tune) is performed against stockfish.

### Results
Qtest3, Qtest3bis and Qtest5 were discarded. The results showed a higher drawrate without conclusive elo gains.
Qtest4 barely showed any gains (+5.4 against lc0 master and ≈-0 against sf).
Qtest6 showed good results against lc0 master (from +19.1 (T79) to +24.1 (T80)). A test against SF was not conclusive with the same parameters. A second tune was performed against SF and the result showed no elo loss against sf15 and +16.7 against sf14.
That new Q function was implemented in dag-master. The previous parameters showed no gains. A new tune is currently ongoing with some results showing +12.9 elo gain against sf.
The different results are detailed in #test-results on discord.

### **Qtest6 parameters :**
_Based on lc0 master :_
**Vs lc0 :** 
WinFactor = 0.66302, 
DrawFactorW = 0.68633, 
LoseFactor = 0.85416, 
DrawFactorL = 1.0

**Vs SF :** 
WinFactor = 0.584075451002713, 
DrawFactorW = 1.08833880420444, 
LoseFactor = 1.27491899534857, 
DrawFactorL = 0.0

_Based on dag-master :_
WinFactor = 0.46736995442197293, 
DrawFactorW = 1.3447065755753542, 
LoseFactor = 0.8100584463933771, 
DrawFactorL = 1.0148543577433364

### **Issues :**

- 	There is no implementation of drawscore,
- 	No test with long TC / node count have been performed,
- 	The tests showed that a set of parameters working against lc0 master does not work against SF. Does a set tuned against SF work for any engine ?
- 	A set of parameters working for lc0 master didn’t for dag-master. A major change in the engine might need new parameters.
- 	A test with T74 showed poor results while good results were obtained with T79 and T80. How does other net behave ?
