### PR TITLE
Persistent L2 cache opt for cuda backend

### DIFF
--- a/src/neural/cuda/layers.cc
+++ b/src/neural/cuda/layers.cc
@@ -1204,6 +1204,12 @@ void ResidualBlock<DataType>::Eval(int N, DataType* output,
   DataType* transformed_output =
       transformed_input + scratch_size / (2 * sizeof(DataType));
 
+  // caller wants us to sub-allocate all memory we need from "output" tensor
+  if (!scratch) {
+    transformed_input = output; // this is true in normal cases too!
+    transformed_output = transformed_input + (N * C * 8 * 8 * 36 / 16);
+  }
+
   if (first_block_) {
     InputTransform<DataType, true>(N, c_input_, transformed_input, input,
                                    stream);

--- a/src/neural/cuda/network_cuda.cc
+++ b/src/neural/cuda/network_cuda.cc
@@ -545,7 +545,7 @@ class CudaNetwork : public Network {
     DataType* skip_connection =
         use_res_block_winograd_fuse_opt_ ? tensor_mem[1] : tensor_mem[2];
 
-#if CUDART_VERSION >= 1100
+#if CUDART_VERSION >= 11000
     const int pre_transform_tensor_size =
         batchSize * numFilters_ * 8 * 8 * sizeof(DataType);
     const int transformed_tensor_size = pre_transform_tensor_size * 36 / 16;
@@ -596,7 +596,7 @@ class CudaNetwork : public Network {
       }
     }
 
-#if CUDART_VERSION >= 1100
+#if CUDART_VERSION >= 11000
     if (enableCacheOpt) {
       // reset the cache settings
       stream_attribute.accessPolicyWindow.num_bytes = 0;

--- a/src/neural/cuda/network_cuda.cc
+++ b/src/neural/cuda/network_cuda.cc
@@ -545,6 +545,7 @@ class CudaNetwork : public Network {
     DataType* skip_connection =
         use_res_block_winograd_fuse_opt_ ? tensor_mem[1] : tensor_mem[2];
 
+#if CUDART_VERSION >= 1100
     const int pre_transform_tensor_size =
         batchSize * numFilters_ * 8 * 8 * sizeof(DataType);
     const int transformed_tensor_size = pre_transform_tensor_size * 36 / 16;
@@ -569,6 +570,7 @@ class CudaNetwork : public Network {
       skip_connection =
           tensor_mem[2] + 2 * transformed_tensor_size / sizeof(DataType);
     }
+#endif
 
     int l = 0;
     // Input.
@@ -594,6 +596,7 @@ class CudaNetwork : public Network {
       }
     }
 
+#if CUDART_VERSION >= 1100
     if (enableCacheOpt) {
       // reset the cache settings
       stream_attribute.accessPolicyWindow.num_bytes = 0;
@@ -601,6 +604,7 @@ class CudaNetwork : public Network {
                              &stream_attribute);
       cudaCtxResetPersistingL2Cache();
     }
+#endif
 
     // Policy head.
     if (attn_policy_) {

--- a/src/neural/cuda/network_cuda.cc
+++ b/src/neural/cuda/network_cuda.cc
@@ -178,6 +178,10 @@ class CudaNetwork : public Network {
     cudaGetDeviceProperties(&deviceProp, gpu_id_);
     showDeviceInfo(deviceProp);
 
+    l2_cache_size_ = deviceProp.l2CacheSize;
+
+    allow_cache_opt_ = options.GetOrDefault<bool>("cache_opt", true);
+
     // Select GPU to run on (for *the current* thread).
     ReportCUDAErrors(cudaSetDevice(gpu_id_));
 
@@ -225,6 +229,7 @@ class CudaNetwork : public Network {
     const int kNumInputPlanes = kInputPlanes;
     const int kNumFilters = (int)weights.input.biases.size();
     numBlocks_ = (int)weights.residual.size();
+    numFilters_ = kNumFilters;
 
     // Warn if the memory required for storing transformed weights is
     // going to exceed 40% of total video memory, force custom_winograd off
@@ -533,19 +538,50 @@ class CudaNetwork : public Network {
     float* opVal = io->op_value_mem_gpu_;
     float* opMov = io->op_moves_left_mem_gpu_;
 
+
+    // Figure out if the memory requirment for running the res block would fit
+    // in the L2 cache.
+    bool enableCacheOpt = false;
+    DataType* skip_connection =
+        use_res_block_winograd_fuse_opt_ ? tensor_mem[1] : tensor_mem[2];
+
+    const int pre_transform_tensor_size =
+        batchSize * numFilters_ * 8 * 8 * sizeof(DataType);
+    const int transformed_tensor_size = pre_transform_tensor_size * 36 / 16;
+    const int res_block_mem =
+        transformed_tensor_size * 2 + pre_transform_tensor_size;
+
+    cudaStreamAttrValue stream_attribute = {};
+    stream_attribute.accessPolicyWindow.base_ptr = tensor_mem[2];
+    stream_attribute.accessPolicyWindow.num_bytes = res_block_mem;
+    stream_attribute.accessPolicyWindow.hitRatio = 1.0f;
+    stream_attribute.accessPolicyWindow.hitProp = cudaAccessPropertyPersisting;
+    stream_attribute.accessPolicyWindow.missProp = cudaAccessPropertyStreaming;
+
+    if (allow_cache_opt_ && use_res_block_winograd_fuse_opt_ &&
+        (res_block_mem <= scratch_size_) && (res_block_mem <= l2_cache_size_)) {
+      // we can use a single alloc to hold all the required tensors, and enable
+      // persistent L2 caching on it
+      ReportCUDAErrors(cudaStreamSetAttribute(
+          stream, cudaStreamAttributeAccessPolicyWindow, &stream_attribute));
+
+      enableCacheOpt = true;
+      skip_connection =
+          tensor_mem[2] + 2 * transformed_tensor_size / sizeof(DataType);
+    }
+
     int l = 0;
     // Input.
-    network_[l++]->Eval(
-        batchSize,
-        use_res_block_winograd_fuse_opt_ ? tensor_mem[1] : tensor_mem[2],
-        tensor_mem[0], nullptr, scratch_mem, scratch_size_, nullptr, cublas,
-        stream);  // input conv
+    network_[l++]->Eval(batchSize, skip_connection, tensor_mem[0], nullptr,
+                        scratch_mem, scratch_size_, nullptr, cublas,
+                        stream);  // input conv
 
     // Residual block.
     for (int block = 0; block < numBlocks_; block++) {
       if (use_res_block_winograd_fuse_opt_) {
-        network_[l++]->Eval(batchSize, tensor_mem[2], tensor_mem[1], nullptr,
-                            scratch_mem, scratch_size_, nullptr, cublas,
+        network_[l++]->Eval(batchSize, tensor_mem[2], skip_connection, nullptr,
+                            enableCacheOpt ? nullptr : scratch_mem,
+                            scratch_size_, nullptr, cublas,
                             stream);  // block
       } else {
         network_[l++]->Eval(batchSize, tensor_mem[0], tensor_mem[2], nullptr,
@@ -556,6 +592,14 @@ class CudaNetwork : public Network {
                             tensor_mem[2], scratch_mem, scratch_size_, nullptr,
                             cublas, stream);  // conv2
       }
+    }
+
+    if (enableCacheOpt) {
+      // reset the cache settings
+      stream_attribute.accessPolicyWindow.num_bytes = 0;
+      cudaStreamSetAttribute(stream, cudaStreamAttributeAccessPolicyWindow,
+                             &stream_attribute);
+      cudaCtxResetPersistingL2Cache();
     }
 
     // Policy head.
@@ -761,18 +805,21 @@ class CudaNetwork : public Network {
  private:
   const NetworkCapabilities capabilities_;
   int gpu_id_;
+  int l2_cache_size_;
   int max_batch_size_;
   bool wdl_;
   bool moves_left_;
   bool use_res_block_winograd_fuse_opt_;  // fuse operations inside the residual
                                           // tower
   bool multi_stream_;                     // run multiple parallel network evals
+  bool allow_cache_opt_;                  // try to fit residual block activations in L2 cache
 
   // Currently only one NN Eval can happen a time (we can fix this if needed
   // by allocating more memory).
   mutable std::mutex lock_;
 
   int numBlocks_;
+  int numFilters_;
   bool has_se_;
   bool conv_policy_;
   bool attn_policy_;
@@ -840,7 +887,7 @@ class CudaNetwork : public Network {
     CERR << "GPU clock frequency: " << deviceProp.clockRate / 1e3f << " MHz";
     CERR << "GPU compute capability: " << deviceProp.major << "."
          << deviceProp.minor;
-
+    CERR << "L2 cache capacity: " << deviceProp.l2CacheSize;
     if (std::is_same<float, DataType>::value && deviceProp.major >= 7) {
       CERR << "WARNING: you will probably get better performance from the "
               "cuda-fp16 backend.";


### PR DESCRIPTION
- goal is to fit activations of residual block in L2 cache.
- around 6.7% improvement in T80 networks.
- Expected to only help Ada GPUs with larger L2 cache capacities.

With 807647 network on RTX 4090 - 

Before:
```
Benchmark batch size 32 with inference average time 1.58066ms - throughput 20244.6 nps.
Benchmark batch size 64 with inference average time 2.01741ms - throughput 31723.8 nps.
Benchmark batch size 96 with inference average time 2.32485ms - throughput 41293 nps.
Benchmark batch size 128 with inference average time 2.94163ms - throughput 43513.3 nps.
Benchmark batch size 160 with inference average time 3.54371ms - throughput 45150.4 nps.
Benchmark batch size 192 with inference average time 4.34863ms - throughput 44151.8 nps.
Benchmark batch size 224 with inference average time 4.87263ms - throughput 45971.1 nps.
Benchmark batch size 256 with inference average time 5.96631ms - throughput 42907.6 nps.

```
After:
```
Benchmark batch size 32 with inference average time 1.51683ms - throughput 21096.6 nps.
Benchmark batch size 64 with inference average time 2.08826ms - throughput 30647.5 nps.
Benchmark batch size 96 with inference average time 2.08941ms - throughput 45945.9 nps.
Benchmark batch size 128 with inference average time 2.75917ms - throughput 46390.8 nps.
Benchmark batch size 160 with inference average time 3.32101ms - throughput 48178.1 nps.
Benchmark batch size 192 with inference average time 4.02509ms - throughput 47700.8 nps.
Benchmark batch size 224 with inference average time 4.85234ms - throughput 46163.3 nps.
Benchmark batch size 256 with inference average time 5.94875ms - throughput 43034.3 nps.
```