### PR TITLE
allways fill history for en passant

### DIFF
--- a/src/neural/encoder.cc
+++ b/src/neural/encoder.cc
@@ -247,7 +247,12 @@ InputPlanes EncodePositionForNN(
         !board.en_passant().empty()) {
       break;
     }
-    if (history_idx < 0 && fill_empty_history == FillEmptyHistory::NO) break;
+    // If en-passant is possible we know the previous move.
+    if (fill_empty_history == FillEmptyHistory::NO &&
+        (history_idx < -1 ||
+         (history_idx == -1 && board.en_passant().empty()))) {
+      break;
+    }
     // Board may be flipped so compare with position.GetBoard().
     if (history_idx < 0 && fill_empty_history == FillEmptyHistory::FEN_ONLY &&
         position.GetBoard() == ChessBoard::kStartposBoard) {


### PR DESCRIPTION
If a position is given by FEN that includes en passant info, we know what the previous move was, so we get one extra history move. This is now used even when no history filling is done.