### PR TITLE
fix syzygy loading

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -134,7 +134,7 @@ void EngineController::UpdateFromUciOptions() {
       syzygy_tb_ = nullptr;
     }
     tb_paths_ = tb_paths;
-  } else if (tb_paths.empty() && syzygy_tb_) {
+  } else if (tb_paths.empty()) {
     syzygy_tb_ = nullptr;
     tb_paths_.clear();
   }

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -132,9 +132,8 @@ void EngineController::UpdateFromUciOptions() {
     if (!syzygy_tb_->init(tb_paths)) {
       CERR << "Failed to load Syzygy tablebases!";
       syzygy_tb_ = nullptr;
-    } else {
-      tb_paths_ = tb_paths;
     }
+    tb_paths_ = tb_paths;
   }
 
   // Network.

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -134,6 +134,9 @@ void EngineController::UpdateFromUciOptions() {
       syzygy_tb_ = nullptr;
     }
     tb_paths_ = tb_paths;
+  } else if (tb_paths.empty() && syzygy_tb_) {
+    syzygy_tb_ = nullptr;
+    tb_paths_.clear();
   }
 
   // Network.


### PR DESCRIPTION
If you change the syzygy path to something invalid in order to disable tb use and later back to the original path to use the tb again it doesn't work. 