### PR TITLE
optional alternative mish implementation

### DIFF
--- a/src/neural/onnx/builder.cc
+++ b/src/neural/onnx/builder.cc
@@ -374,4 +374,61 @@ std::string OnnxBuilder::LayerNormalization(const std::string& name,
   return out;
 }
 
+std::string OnnxBuilder::Expand(const std::string& name,
+                                const std::string& input,
+                                const std::string& shape) {
+  auto* node = model_.mutable_graph()->add_node();
+  auto out = PopulateStdNodeFields(node, name, input, "Expand");
+  node->add_input(shape);
+  return out;
+}
+
+std::string OnnxBuilder::Shape(const std::string& name,
+                               const std::string& input) {
+  auto* node = model_.mutable_graph()->add_node();
+  return PopulateStdNodeFields(node, name, input, "Shape");
+}
+
+std::string OnnxBuilder::Exp(const std::string& name,
+                             const std::string& input) {
+  auto* node = model_.mutable_graph()->add_node();
+  return PopulateStdNodeFields(node, name, input, "Exp");
+}
+
+std::string OnnxBuilder::Div(const std::string& name, const std::string& input1,
+                             const std::string& input2) {
+  auto* node = model_.mutable_graph()->add_node();
+  auto out = PopulateStdNodeFields(node, name, input1, "Div");
+  node->add_input(input2);
+  return out;
+}
+
+std::string OnnxBuilder::Sub(const std::string& name, const std::string& input1,
+                             const std::string& input2) {
+  auto* node = model_.mutable_graph()->add_node();
+  auto out = PopulateStdNodeFields(node, name, input1, "Sub");
+  node->add_input(input2);
+  return out;
+}
+
+std::string OnnxBuilder::Greater(const std::string& name,
+                                 const std::string& input1,
+                                 const OnnxConst& input2) {
+  auto* node = model_.mutable_graph()->add_node();
+  auto out = PopulateStdNodeFields(node, name, input1, "Greater");
+  node->add_input(AddInitializer(name + "/threshold", input2));
+  return out;
+}
+
+std::string OnnxBuilder::Where(const std::string& name,
+                               const std::string& input1,
+                               const std::string& input2,
+                               const std::string& input3) {
+  auto* node = model_.mutable_graph()->add_node();
+  auto out = PopulateStdNodeFields(node, name, input1, "Where");
+  node->add_input(input2);
+  node->add_input(input3);
+  return out;
+}
+
 }  // namespace lczero

--- a/src/neural/onnx/builder.h
+++ b/src/neural/onnx/builder.h
@@ -107,6 +107,18 @@ class OnnxBuilder {
                                  const std::string& input,
                                  const OnnxConst& scale, const OnnxConst& bias,
                                  int axis, float epsilon = 1e-6);
+  std::string Expand(const std::string& name, const std::string& input,
+                     const std::string& shape);
+  std::string Shape(const std::string& name, const std::string& input);
+  std::string Exp(const std::string& name, const std::string& input);
+  std::string Div(const std::string& name, const std::string& input1,
+                  const std::string& input2);
+  std::string Sub(const std::string& name, const std::string& input1,
+                  const std::string& input2);
+  std::string Greater(const std::string& name, const std::string& input1,
+                      const OnnxConst&);
+  std::string Where(const std::string& name, const std::string& input1,
+                    const std::string& input2, const std::string& input3);
   // Returns ONNX model as protobuf.
   const pblczero::ModelProto& as_proto() const { return model_; }
   // Returns serialized model.

--- a/src/neural/onnx/converter.cc
+++ b/src/neural/onnx/converter.cc
@@ -157,9 +157,28 @@ std::unique_ptr<OnnxConst> Converter::GetWeghtsConverter(
 
 std::string Converter::MakeMish(OnnxBuilder* builder, const std::string& input,
                                 const std::string& name) {
-  auto flow = builder->Softplus(name + "/softplus", input);
-  flow = builder->Tanh(name + "/tanh", flow);
-  return builder->Mul(name, flow, input);
+  if (!options_.alt_mish || options_.opset < 9 ||
+      options_.data_type_ !=
+          WeightsToOnnxConverterOptions::DataType::kFloat32) {
+    auto flow = builder->Softplus(name + "/softplus", input);
+    flow = builder->Tanh(name + "/tanh", flow);
+    return builder->Mul(name, flow, input);
+  } else {
+    const OnnxConst& two =
+        static_cast<const OnnxConst&>(FloatOnnxConst({2.0f}, {1}));
+    const OnnxConst& zero =
+        static_cast<const OnnxConst&>(FloatOnnxConst({0.0f}, {1}));
+    auto e = builder->Exp(name + "/exp", input);
+    auto flow = builder->Add(name + "/e+2", e, two);
+    auto n = builder->Mul(name + "/n", e, flow);
+    flow = builder->Add(name + "/n+2", n, two);
+    auto d = builder->Div(name + "/d", input, flow);
+    auto f = builder->Mul(name + "/n*d", n, d);
+    flow = builder->Mul(name + "/2*d", d, two);
+    auto t = builder->Sub(name + "/in-2*d", input, flow);
+    flow = builder->Greater(name + "/compare", input, zero);
+    return builder->Where(name, flow, t, f);
+  }
 }
 
 std::string Converter::MakeActivation(OnnxBuilder* builder,

--- a/src/neural/onnx/converter.h
+++ b/src/neural/onnx/converter.h
@@ -43,6 +43,7 @@ struct WeightsToOnnxConverterOptions {
   std::string output_mlh = "/output/mlh";
   int batch_size = -1;
   int opset = 17;
+  bool alt_mish = false;
 };
 
 // Converts "classical" weights file to weights file with embedded ONNX model.

--- a/src/neural/onnx/network_onnx.cc
+++ b/src/neural/onnx/network_onnx.cc
@@ -409,6 +409,8 @@ std::unique_ptr<Network> MakeOnnxNetwork(const std::optional<WeightsFile>& w,
     }
     WeightsToOnnxConverterOptions converter_options;
     converter_options.opset = opts.GetOrDefault<int>("opset", 17);
+    converter_options.alt_mish = opts.GetOrDefault<bool>(
+        "alt_mish", kProvider == OnnxProvider::CPU ? true : false);
     converter_options.data_type_ =
         fp16 ? WeightsToOnnxConverterOptions::DataType::kFloat16
              : WeightsToOnnxConverterOptions::DataType::kFloat32;


### PR DESCRIPTION
This is the onnx equivalent of the fast mish we already use, only in fp32 mode (fp16 breaks badly) and on by default for onnx-cpu where it is considerably faster.