### PR TITLE
option for onnx threads

### DIFF
--- a/src/neural/onnx/network_onnx.cc
+++ b/src/neural/onnx/network_onnx.cc
@@ -82,8 +82,8 @@ class OnnxComputation : public NetworkComputation {
 class OnnxNetwork : public Network {
  public:
   OnnxNetwork(const WeightsFile& file, const OptionsDict& options,
-              OnnxProvider provider, int gpu, bool fp16, int batch_size,
-              int steps);
+              OnnxProvider provider, int gpu, int threads, bool fp16,
+              int batch_size, int steps);
   std::unique_ptr<NetworkComputation> NewComputation() override {
     if (fp16_) {
       return std::make_unique<OnnxComputation<Ort::Float16_t>>(this);
@@ -250,10 +250,11 @@ void OnnxComputation<DataType>::ComputeBlocking() {
   }
 }
 
-Ort::SessionOptions GetOptions(OnnxProvider provider, int gpu, int batch_size) {
+Ort::SessionOptions GetOptions(OnnxProvider provider, int gpu, int threads,
+                               int batch_size) {
   Ort::SessionOptions options;
   OrtCUDAProviderOptions cuda_options;
-  // options.SetIntraOpNumThreads(1);
+  options.SetIntraOpNumThreads(threads);
   options.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
 
   if (batch_size > 0) {
@@ -280,8 +281,6 @@ Ort::SessionOptions GetOptions(OnnxProvider provider, int gpu, int batch_size) {
       options.AppendExecutionProvider_CUDA(cuda_options);
       break;
     case OnnxProvider::CPU:
-      // Doesn't really work. :-( There are two execution providers (CUDA and
-      // CPU) already added, don't know how to force it to use CPU.
       auto status = OrtSessionOptionsAppendExecutionProvider_CPU(options, 0);
       if (status) {
         std::string error_message = Ort::GetApi().GetErrorMessage(status);
@@ -296,7 +295,7 @@ Ort::SessionOptions GetOptions(OnnxProvider provider, int gpu, int batch_size) {
 }
 
 OnnxNetwork::OnnxNetwork(const WeightsFile& file, const OptionsDict&,
-                         OnnxProvider provider, int gpu, bool fp16,
+                         OnnxProvider provider, int gpu, int threads, bool fp16,
                          int batch_size, int steps)
     : onnx_env_(ORT_LOGGING_LEVEL_WARNING, "lc0"),
       steps_(steps),
@@ -312,9 +311,10 @@ OnnxNetwork::OnnxNetwork(const WeightsFile& file, const OptionsDict&,
   }
 
   for (int step = 1; step <= steps_; step++)
-    session_.emplace_back(onnx_env_, file.onnx_model().model().data(),
-                          file.onnx_model().model().size(),
-                          GetOptions(provider, gpu, batch_size_ * step));
+    session_.emplace_back(
+        onnx_env_, file.onnx_model().model().data(),
+        file.onnx_model().model().size(),
+        GetOptions(provider, gpu, threads, batch_size_ * step));
 
   const auto& md = file.onnx_model();
   if (!md.has_input_planes()) {
@@ -360,14 +360,17 @@ std::unique_ptr<Network> MakeOnnxNetwork(const std::optional<WeightsFile>& w,
   int steps =
       opts.GetOrDefault<int>("steps", kProvider == OnnxProvider::DML ? 8 : 1);
 
+  int threads =
+      opts.GetOrDefault<int>("threads", kProvider == OnnxProvider::CPU ? 1 : 0);
+
   if (batch_size <= 0) batch_size = -1;  // Variable batch size.
 
   bool fp16 = opts.GetOrDefault<bool>(
       "fp16", kProvider == OnnxProvider::CPU ? false : true);
 
   if (w->has_onnx_model()) {
-    return std::make_unique<OnnxNetwork>(*w, opts, kProvider, gpu, false,
-                                         batch_size, steps);
+    return std::make_unique<OnnxNetwork>(*w, opts, kProvider, gpu, threads,
+                                         false, batch_size, steps);
   } else {
     if (w->format().network_format().network() !=
             pblczero::NetworkFormat::NETWORK_CLASSICAL_WITH_HEADFORMAT &&
@@ -415,8 +418,8 @@ std::unique_ptr<Network> MakeOnnxNetwork(const std::optional<WeightsFile>& w,
         fp16 ? WeightsToOnnxConverterOptions::DataType::kFloat16
              : WeightsToOnnxConverterOptions::DataType::kFloat32;
     auto converted = ConvertWeightsToOnnx(*w, converter_options);
-    return std::make_unique<OnnxNetwork>(converted, opts, kProvider, gpu, fp16,
-                                         batch_size, steps);
+    return std::make_unique<OnnxNetwork>(converted, opts, kProvider, gpu,
+                                         threads, fp16, batch_size, steps);
   }
 }
 


### PR DESCRIPTION
The onnxruntime thread usage is not playing well with our search threads, at least with onnx-cpu. Restricting each evaluation to a single thread seems to be a decent performance win for more that 2 search threads with onnxruntime 1.4.0, that uses threads more aggressively. Here I introduce a `threads` backend option that defaults to 1 for onnx-cpu and 0 (default) otherwise.