### PR TITLE
Fix ninja detection on some platforms.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,7 @@ fi
 
 cd ${BUILDDIR}
 
-NINJA=$(awk '/ninja/ {ninja=$4} END {print ninja}' meson-logs/meson-log.txt)
+NINJA=$(awk '/Found.*ninja/ {ninja=$4} END {print ninja}' meson-logs/meson-log.txt)
 
 if [ -n "${INSTALL_PREFIX}" ]
 then

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,8 @@ esac
 
 BUILDDIR=build/${BUILDTYPE}
 
-MESON=$(PATH="${PATH}:${HOME}/.local/bin" command -v meson)
+MESON=$(PATH="${PATH}:${HOME}/.local/bin" command -v meson || true)
+MESON=${MESON:?"Could not find meson. Is it installed and in PATH?"}
 
 if [ -f "${BUILDDIR}/build.ninja" ]
 then

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-pushd "$(dirname "$0")"
-
 set -e
 
 case $1 in
@@ -16,27 +14,14 @@ esac
 
 BUILDDIR=build/${BUILDTYPE}
 
-if ! hash meson 2>/dev/null && [ -x ${HOME}/.local/bin/meson ]
-then
-  export PATH=${PATH}:${HOME}/.local/bin
-fi
+MESON=$(PATH="${PATH}:${HOME}/.local/bin" command -v meson)
 
-if [ -f ${BUILDDIR}/build.ninja ]
+if [ -f "${BUILDDIR}/build.ninja" ]
 then
-  meson configure ${BUILDDIR} -Dbuildtype=${BUILDTYPE} -Dprefix=${INSTALL_PREFIX:-/usr/local} "$@"
+  "${MESON}" configure "${BUILDDIR}" -Dbuildtype="${BUILDTYPE}" -Dprefix="${INSTALL_PREFIX:-/usr/local}" "$@"
 else
-  meson ${BUILDDIR} --buildtype ${BUILDTYPE} --prefix ${INSTALL_PREFIX:-/usr/local} "$@"
+  "${MESON}" "${BUILDDIR}" --buildtype "${BUILDTYPE}" --prefix "${INSTALL_PREFIX:-/usr/local}" "$@"
 fi
 
-cd ${BUILDDIR}
-
-NINJA=$(awk '/Found.*ninja/ {ninja=$4} END {print ninja}' meson-logs/meson-log.txt)
-
-if [ -n "${INSTALL_PREFIX}" ]
-then
-  ${NINJA} install
-else
-  ${NINJA}
-fi
-
-popd
+"${MESON}" compile -C "${BUILDDIR}"
+[ -n "${INSTALL_PREFIX}" ] && "${MESON}" install -C "${BUILDDIR}"

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Move to this script's directory.
+cd "$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+
 case $1 in
   plain|debug|debugoptimized|release|minsize)
     BUILDTYPE=$1

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Move to this script's directory.
-cd "$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+CDPATH= cd -- "$(dirname -- "$0")"
 
 case $1 in
   plain|debug|debugoptimized|release|minsize)

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ esac
 
 BUILDDIR=build/${BUILDTYPE}
 
-MESON=$(PATH="${PATH}:${HOME}/.local/bin" command -v meson || true)
+MESON=$(PATH="${PATH}:${HOME}/.local/bin" command -v meson || :)
 MESON=${MESON:?"Could not find meson. Is it installed and in PATH?"}
 
 if [ -f "${BUILDDIR}/build.ninja" ]

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@
 
 project('lc0', 'cpp',
         default_options : ['cpp_std=c++17', 'b_ndebug=if-release', 'warning_level=3', 'b_lto=true', 'b_vscrt=mt'],
-        meson_version: '>=0.52')
+        meson_version: '>=0.54')
 
 cc = meson.get_compiler('cpp')
 


### PR DESCRIPTION
This fixes a build failure encountered on an Ubuntu Github cloud runner, where the meson logs contained the line `!meson_ci!/ci_include "/tmp/tmp.57HLIN4Fd8/lc0/build/release/build.ninja` that followed `Found ninja-1.11.1.git.kitware.jobserver-1 at /home/runner/work/lczero-onnx/lczero-onnx/build/venv/bin/ninja`. Here is a snippet of the log:

```
Found ninja-1.11.1.git.kitware.jobserver-1 at /home/runner/work/lczero-onnx/lczero-onnx/build/venv/bin/ninja
detecting CPU family based on trial='x86_64'
detecting CPU family based on trial='x86_64'
detecting CPU family based on trial='x86_64'
detecting CPU family based on trial='x86_64'
detecting CPU family based on trial='x86_64'
detecting CPU family based on trial='x86_64'
detecting CPU family based on trial='x86_64'
detecting CPU family based on trial='x86_64'
detecting CPU family based on trial='x86_64'
detecting CPU family based on trial='x86_64'
detecting CPU family based on trial='x86_64'
detecting CPU family based on trial='x86_64'
!meson_ci!/ci_include "/tmp/tmp.57HLIN4Fd8/lc0/build/release/build.ninja"
detecting CPU family based on trial='x86_64'
detecting CPU family based on trial='x86_64'
```

This led to `${NINJA}` being an empty string, and hence, nothing was built in the end.