### PR TITLE
change onnx-dml default steps

### DIFF
--- a/src/neural/onnx/network_onnx.cc
+++ b/src/neural/onnx/network_onnx.cc
@@ -358,7 +358,7 @@ std::unique_ptr<Network> MakeOnnxNetwork(const std::optional<WeightsFile>& w,
       opts.GetOrDefault<int>("batch", kProvider == OnnxProvider::DML ? 16 : -1);
 
   int steps =
-      opts.GetOrDefault<int>("steps", kProvider == OnnxProvider::DML ? 8 : 1);
+      opts.GetOrDefault<int>("steps", kProvider == OnnxProvider::DML ? 4 : 1);
 
   int threads =
       opts.GetOrDefault<int>("threads", kProvider == OnnxProvider::CPU ? 1 : 0);


### PR DESCRIPTION
Changed the default steps to 4 from 8, limiting the number of onnxruntime sessions with different batch size (used to get decent performance from directml). This has a performance impact for smaller nets, but seems to solve out of memory issues with some gpus.