### PR TITLE
Revised 'simple' TM

### DIFF
--- a/src/mcts/stoppers/simple.cc
+++ b/src/mcts/stoppers/simple.cc
@@ -1,6 +1,6 @@
 /*
   This file is part of Leela Chess Zero.
-  Copyright (C) 2022 The LCZero Authors
+  Copyright (C) 2023 The LCZero Authors
 
   Leela Chess is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -35,21 +35,17 @@ class SimpleTimeManager : public TimeManager {
  public:
   SimpleTimeManager(int64_t move_overhead, const OptionsDict& params)
       : move_overhead_(move_overhead),
-        basepct_(params.GetOrDefault<float>("base-pct", 1.83f)),
-        plypct_(params.GetOrDefault<float>("ply-pct", 0.0454f)),
-        timefactor_(params.GetOrDefault<float>("time-factor", 33.4f)),
-        opening_bonus_(params.GetOrDefault<float>("opening-bonus", 82.5f)) {
-    if (basepct_ <= 0.0f || basepct_ > 100.0f) {
+        base_pct_(params.GetOrDefault<float>("base-pct", 1.4f)),
+        ply_pct_(params.GetOrDefault<float>("ply-pct", 0.049f)),
+        time_factor_(params.GetOrDefault<float>("time-factor", 1.5f)) {
+    if (base_pct_ <= 0.0f || base_pct_ > 100.0f) {
       throw Exception("base-pct value to be in range [0.0, 100.0]");
     }
-    if (plypct_ < 0.0f || plypct_ > 1.0f) {
+    if (ply_pct_ < 0.0f || ply_pct_ > 1.0f) {
       throw Exception("ply-pct value to be in range [0.0, 1.0]");
     }
-    if (timefactor_ < 0.0f || timefactor_ > 100.0f) {
+    if (time_factor_ < 0.0f || time_factor_ > 100.0f) {
       throw Exception("time-factor value to be in range [0.0, 100.0]");
-    }
-    if (opening_bonus_ < 0.0f || opening_bonus_ > 1000.0f) {
-      throw Exception("opening-bonus value to be in range [0.0, 1000.0]");
     }
   }
   std::unique_ptr<SearchStopper> GetStopper(const GoParams& params,
@@ -57,13 +53,12 @@ class SimpleTimeManager : public TimeManager {
 
  private:
   const int64_t move_overhead_;
-  const float basepct_;
-  const float plypct_;
-  const float timefactor_;
-  const float opening_bonus_;
-  float prev_move_time = 0.0f;
-  float prev_total_moves_time = 0.0f;
-  bool bonus_applied = false;
+  const float base_pct_;
+  const float ply_pct_;
+  const float time_factor_;
+  float prev_time_budgeted_ = 0.0f;
+  float prev_time_available_ = 0.0f;
+  bool bonus_applied_ = false;
 };
 
 std::unique_ptr<SearchStopper> SimpleTimeManager::GetStopper(
@@ -71,57 +66,52 @@ std::unique_ptr<SearchStopper> SimpleTimeManager::GetStopper(
   const Position& position = tree.HeadPosition();
   const bool is_black = position.IsBlackToMove();
   const std::optional<int64_t>& time = (is_black ? params.btime : params.wtime);
-
+  
   // If no time limit is given, don't stop on this condition.
   if (params.infinite || params.ponder || !time) return nullptr;
 
   const std::optional<int64_t>& inc = is_black ? params.binc : params.winc;
   const int increment = inc ? std::max(int64_t(0), *inc) : 0;
 
-  const float total_moves_time =
+  const float time_available =
       static_cast<float>(*time) - static_cast<float>(move_overhead_);
 
+  const float time_ratio =
+      static_cast<float>(increment) / static_cast<float>(*time);
+
   // increase percentage as ply count increases
-  float pct = (basepct_ + position.GetGamePly() * plypct_) * 0.01f;
+  float pct = (base_pct_ + position.GetGamePly() * ply_pct_) * 0.01f;
 
-  // increase percentage as ratio of increment time to total time gets smaller
-  pct += pct * (static_cast<float>(increment) /
-                static_cast<float>(total_moves_time) * timefactor_);
+  // increase percentage as ratio of increment to total time reaches equality
+  pct += time_ratio * time_factor_;
 
-  float this_move_time = total_moves_time * pct;
+  float time_budgeted = time_available * pct;
 
   // immediately spend time saved from smart pruning during previous move
-  if (prev_move_time > 0.0f) {
+  if (prev_time_budgeted_ > 0.0f) {
     const float time_saved =
-        prev_move_time - (prev_total_moves_time -
-                          (total_moves_time - static_cast<float>(increment)));
+        prev_time_budgeted_ -
+        (prev_time_available_ - (time_available - static_cast<float>(increment)));
 
-    this_move_time += time_saved;
+    time_budgeted += std::max(time_saved, 0.0f);
   }
 
-  // apply any opening bonus and note the next move will also benefit
-  // from an increased time_saved as a result
-  if (!bonus_applied) {
-    this_move_time += this_move_time * opening_bonus_ * 0.01f;
-    bonus_applied = true;
-  }
+  time_budgeted = std::min(time_budgeted, time_available);
 
-  this_move_time = std::min(this_move_time, total_moves_time);
-
-  prev_move_time = this_move_time;
-  prev_total_moves_time = total_moves_time;
-
-  LOGFILE << "Budgeted time for the move: " << this_move_time << "ms"
+  LOGFILE << "Budgeted time for the move: " << time_budgeted << "ms "
           << "Remaining time " << *time << "ms(-" << move_overhead_
           << "ms overhead)";
 
-  return std::make_unique<TimeLimitStopper>(this_move_time);
+  prev_time_budgeted_ = time_budgeted;
+  prev_time_available_ = time_available;
+
+  return std::make_unique<TimeLimitStopper>(time_budgeted);
 }
 
 }  // namespace
 
-std::unique_ptr<TimeManager> MakeSimpleTimeManager(
-    int64_t move_overhead, const OptionsDict& params) {
+std::unique_ptr<TimeManager> MakeSimpleTimeManager(int64_t move_overhead,
+                                                   const OptionsDict& params) {
   return std::make_unique<SimpleTimeManager>(move_overhead, params);
 }
 }  // namespace lczero

--- a/src/mcts/stoppers/simple.cc
+++ b/src/mcts/stoppers/simple.cc
@@ -1,6 +1,6 @@
 /*
   This file is part of Leela Chess Zero.
-  Copyright (C) 2023 The LCZero Authors
+  Copyright (C) 2022-2023 The LCZero Authors
 
   Leela Chess is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -66,6 +66,7 @@ std::unique_ptr<SearchStopper> SimpleTimeManager::GetStopper(
   const Position& position = tree.HeadPosition();
   const bool is_black = position.IsBlackToMove();
   const std::optional<int64_t>& time = (is_black ? params.btime : params.wtime);
+  
   
   // If no time limit is given, don't stop on this condition.
   if (params.infinite || params.ponder || !time) return nullptr;


### PR DESCRIPTION
Wasnt happy with some of the calculations and variable names so I made some changes and ran new tests. I believe this version to be simpler, more intuitive, and better performing. Of course there is the possibility that it will need a different tune with more current nets.

Full test details in discord (https://discord.com/channels/425419482568196106/530486338236055583/1100426590824968243)

**SF Time control:** 1.66s+0.0277s
**LC0 Time control:** 10s+0.166s
```
   # PLAYER        :  RATING  ERROR  POINTS  PLAYED   (%)  CFS(%)    W     D    L  D(%)
   1 sf            :     0.0   ----  1657.5    3000    55     100  800  1715  485    57
   2 lc0-simple    :   -27.8   11.8   691.0    1500    46      99  255   872  373    58
   3 lc0-legacy    :   -46.6   11.2   651.5    1500    43     ---  230   843  427    56
```
**SF Time control:** 2s+0s
**LC0 Time control:** 10s+0s
```
   # PLAYER        :  RATING  ERROR  POINTS  PLAYED   (%)  CFS(%)     W     D    L  D(%)
   1 sf            :     0.0   ----  2115.0    4000    53     100  1148  1934  918    48
   2 lc0-simple    :   -16.4   10.8   953.5    2000    48      83   462   983  555    49
   3 lc0-legacy    :   -24.2   11.2   931.5    2000    47     ---   456   951  593    48
```