### PR TITLE
fix incllude files

### DIFF
--- a/src/utils/filesystem.h
+++ b/src/utils/filesystem.h
@@ -27,7 +27,8 @@
 
 #pragma once
 
-#include <time.h>
+#include <cstdint>
+#include <ctime>
 #include <string>
 #include <vector>
 

--- a/src/version.h
+++ b/src/version.h
@@ -29,6 +29,7 @@
 // Versioning is performed according to the standard at <https://semver.org/>
 // Creating a new version should be performed using scripts/bumpversion.py.
 
+#include <cstdint>
 #include <string>
 #include "version.inc"
 #include "build_id.h"


### PR DESCRIPTION
It seems that some standard header file, most likely string, used to include cstdint, so it was omitted in some places. Fixes #1882.