### PR TITLE
Modify legacy TM to allow a bonus for first move if we expect shallow openings

### DIFF
--- a/src/mcts/stoppers/legacy.cc
+++ b/src/mcts/stoppers/legacy.cc
@@ -72,7 +72,7 @@ class LegacyTimeManager : public TimeManager {
             params.GetOrDefault<float>("midpoint-move", 51.5f)),
         time_curve_steepness_(params.GetOrDefault<float>("steepness", 7.0f)),
         spend_saved_time_(params.GetOrDefault<float>("immediate-use", 1.0f)),
-        first_move_bonus_(params.GetOrDefault<float>("first-move-bonus", 0.0f)),
+        first_move_bonus_(params.GetOrDefault<float>("first-move-bonus", 1.8f)),
         book_ply_bonus_(params.GetOrDefault<float>("book-ply-bonus", 0.25f)) {}
   std::unique_ptr<SearchStopper> GetStopper(const GoParams& params,
                                             const NodeTree& tree) override;

--- a/src/mcts/stoppers/legacy.cc
+++ b/src/mcts/stoppers/legacy.cc
@@ -72,6 +72,7 @@ class LegacyTimeManager : public TimeManager {
             params.GetOrDefault<float>("midpoint-move", 51.5f)),
         time_curve_steepness_(params.GetOrDefault<float>("steepness", 7.0f)),
         spend_saved_time_(params.GetOrDefault<float>("immediate-use", 1.0f)),
+        first_move_bonus_(params.GetOrDefault<float>("first-move-bonus", 0.0f)),
         book_ply_bonus_(params.GetOrDefault<float>("book-ply-bonus", 0.25f)) {}
   std::unique_ptr<SearchStopper> GetStopper(const GoParams& params,
                                             const NodeTree& tree) override;
@@ -83,6 +84,7 @@ class LegacyTimeManager : public TimeManager {
   const float time_curve_steepness_;
   const float spend_saved_time_;
   // When starting a game from a book, add bonus time per ply of the book.
+  const float first_move_bonus_;
   const float book_ply_bonus_;
   bool first_move_of_game_ = true;
   // No need to be atomic as only one thread will update it.
@@ -133,8 +135,8 @@ std::unique_ptr<SearchStopper> LegacyTimeManager::GetStopper(
   // Limit the bonus to max. 12 plies, which also prevents spending too much
   // time on the first move in resumed games.
   if (first_move_of_game_) {
-    this_move_time *= (1.0f + book_ply_bonus_ *
-                       std::min(12, position.GetGamePly()));
+    this_move_time *= (1.0f + first_move_bonus_ +
+                       book_ply_bonus_ * std::min(12, position.GetGamePly()));
     first_move_of_game_ = false;
   }
 


### PR DESCRIPTION
adds a first-move-bonus to legacy time manager to accompany book-ply-bonus for shallow openings especially in FRC and DFRC.

Reasoning: Due to high % of tree reuse and saved time from smart pruning, LTC games at TCEC without spending more time on the first move have nearly linearly increasing node counts for the first 8-12 moves (see #1493). When playing chess from regular startpos, this isn't an issue due to policy head agreeing with value head. However, we can't rely on policy in FRC and DFRC, so having an option which does the same without book exits would be required. Based on the 8-12 move observation which is (nearly) made equal for 12+ ply exits with `book-ply-bonus=0.4`, I recommend using `first-move-bonus=5.0`.