### PR TITLE
Drawscore simplification for Armageddon

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -360,18 +360,10 @@ const OptionId SearchParams::kMaxConcurrentSearchersId{
     "max-concurrent-searchers", "MaxConcurrentSearchers",
     "If not 0, at most this many search workers can be gathering minibatches "
     "at once."};
-const OptionId SearchParams::kDrawScoreSidetomoveId{
-    "draw-score-sidetomove", "DrawScoreSideToMove",
-    "Score of a drawn game, as seen by a player making the move."};
-const OptionId SearchParams::kDrawScoreOpponentId{
-    "draw-score-opponent", "DrawScoreOpponent",
-    "Score of a drawn game, as seen by the opponent."};
-const OptionId SearchParams::kDrawScoreWhiteId{
-    "draw-score-white", "DrawScoreWhite",
-    "Adjustment, added to a draw score of a white player."};
-const OptionId SearchParams::kDrawScoreBlackId{
-    "draw-score-black", "DrawScoreBlack",
-    "Adjustment, added to a draw score of a black player."};
+const OptionId SearchParams::kDrawScoreId{
+    "draw-score", "DrawScore",
+    "Adjustment of the draw score from white's perspective. For Armageddon, "
+    "use -100."};
 const OptionId SearchParams::kContemptPerspectiveId{
     "contempt-perspective", "ContemptPerspective",
     "Affects the way asymmetric WDL parameters are applied. Default is "
@@ -538,10 +530,7 @@ void SearchParams::Populate(OptionsParser* options) {
       -0.6521f;
   options->Add<BoolOption>(kDisplayCacheUsageId) = false;
   options->Add<IntOption>(kMaxConcurrentSearchersId, 0, 128) = 1;
-  options->Add<IntOption>(kDrawScoreSidetomoveId, -100, 100) = 0;
-  options->Add<IntOption>(kDrawScoreOpponentId, -100, 100) = 0;
-  options->Add<IntOption>(kDrawScoreWhiteId, -100, 100) = 0;
-  options->Add<IntOption>(kDrawScoreBlackId, -100, 100) = 0;
+  options->Add<IntOption>(kDrawScoreId, -100, 100) = 0;
   std::vector<std::string> perspective = {"sidetomove", "white", "black",
                                           "none"};
   options->Add<ChoiceOption>(kContemptPerspectiveId, perspective) =
@@ -639,10 +628,7 @@ SearchParams::SearchParams(const OptionsDict& options)
           options.Get<float>(kMovesLeftQuadraticFactorId)),
       kDisplayCacheUsage(options.Get<bool>(kDisplayCacheUsageId)),
       kMaxConcurrentSearchers(options.Get<int>(kMaxConcurrentSearchersId)),
-      kDrawScoreSidetomove{options.Get<int>(kDrawScoreSidetomoveId) / 100.0f},
-      kDrawScoreOpponent{options.Get<int>(kDrawScoreOpponentId) / 100.0f},
-      kDrawScoreWhite{options.Get<int>(kDrawScoreWhiteId) / 100.0f},
-      kDrawScoreBlack{options.Get<int>(kDrawScoreBlackId) / 100.0f},
+      kDrawScoreBlack{options.Get<int>(kDrawScoreId) / 100.0f},
       kContemptPerspective(EncodeContemptPerspective(
           options.Get<std::string>(kContemptPerspectiveId))),
       kContempt(GetContempt(options.Get<std::string>(kUCIOpponentId),
@@ -687,13 +673,6 @@ SearchParams::SearchParams(const OptionsDict& options)
           options.Get<float>(kMaxCollisionVisitsScalingPowerId)),
       kSearchSpinBackoff(
           options_.Get<bool>(kSearchSpinBackoffId)) {
-  if (std::max(std::abs(kDrawScoreSidetomove), std::abs(kDrawScoreOpponent)) +
-          std::max(std::abs(kDrawScoreWhite), std::abs(kDrawScoreBlack)) >
-      1.0f) {
-    throw Exception(
-        "max{|sidetomove|+|opponent|} + max{|white|+|black|} draw score must "
-        "be <= 100");
-  }
 }
 
 }  // namespace lczero

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -628,7 +628,7 @@ SearchParams::SearchParams(const OptionsDict& options)
           options.Get<float>(kMovesLeftQuadraticFactorId)),
       kDisplayCacheUsage(options.Get<bool>(kDisplayCacheUsageId)),
       kMaxConcurrentSearchers(options.Get<int>(kMaxConcurrentSearchersId)),
-      kDrawScoreBlack{options.Get<int>(kDrawScoreId) / 100.0f},
+      kDrawScore{options.Get<int>(kDrawScoreId) / 100.0f},
       kContemptPerspective(EncodeContemptPerspective(
           options.Get<std::string>(kContemptPerspectiveId))),
       kContempt(GetContempt(options.Get<std::string>(kUCIOpponentId),

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -362,8 +362,8 @@ const OptionId SearchParams::kMaxConcurrentSearchersId{
     "at once."};
 const OptionId SearchParams::kDrawScoreId{
     "draw-score", "DrawScore",
-    "Adjustment of the draw score from white's perspective. For Armageddon, "
-    "use -100."};
+    "Adjustment of the draw score from white's perspective. Value 0 gives "
+    "standard scoring, value -1 gives Armageddon scoring."};
 const OptionId SearchParams::kContemptPerspectiveId{
     "contempt-perspective", "ContemptPerspective",
     "Affects the way asymmetric WDL parameters are applied. Default is "
@@ -530,7 +530,7 @@ void SearchParams::Populate(OptionsParser* options) {
       -0.6521f;
   options->Add<BoolOption>(kDisplayCacheUsageId) = false;
   options->Add<IntOption>(kMaxConcurrentSearchersId, 0, 128) = 1;
-  options->Add<IntOption>(kDrawScoreId, -100, 100) = 0;
+  options->Add<FloatOption>(kDrawScoreId, -1.0f, 1.0f) = 0.0f;
   std::vector<std::string> perspective = {"sidetomove", "white", "black",
                                           "none"};
   options->Add<ChoiceOption>(kContemptPerspectiveId, perspective) =
@@ -628,7 +628,7 @@ SearchParams::SearchParams(const OptionsDict& options)
           options.Get<float>(kMovesLeftQuadraticFactorId)),
       kDisplayCacheUsage(options.Get<bool>(kDisplayCacheUsageId)),
       kMaxConcurrentSearchers(options.Get<int>(kMaxConcurrentSearchersId)),
-      kDrawScore{options.Get<int>(kDrawScoreId) / 100.0f},
+      kDrawScore(options.Get<float>(kDrawScoreId)),
       kContemptPerspective(EncodeContemptPerspective(
           options.Get<std::string>(kContemptPerspectiveId))),
       kContempt(GetContempt(options.Get<std::string>(kUCIOpponentId),

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -119,10 +119,7 @@ class SearchParams {
   ContemptPerspective GetContemptPerspective() const {
     return kContemptPerspective;
   }
-  float GetSidetomoveDrawScore() const { return kDrawScoreSidetomove; }
-  float GetOpponentDrawScore() const { return kDrawScoreOpponent; }
-  float GetWhiteDrawDelta() const { return kDrawScoreWhite; }
-  float GetBlackDrawDelta() const { return kDrawScoreBlack; }
+  float GetDrawScore() const { return kDrawScore; }
   float GetWDLRescaleRatio() const { return kWDLRescaleParams.ratio; }
   float GetWDLRescaleDiff() const { return kWDLRescaleParams.diff; }
   float GetWDLEvalObjectivity() const { return kWDLEvalObjectivity; }
@@ -206,10 +203,7 @@ class SearchParams {
   static const OptionId kDisplayCacheUsageId;
   static const OptionId kMaxConcurrentSearchersId;
   static const OptionId kContemptPerspectiveId;
-  static const OptionId kDrawScoreSidetomoveId;
-  static const OptionId kDrawScoreOpponentId;
-  static const OptionId kDrawScoreWhiteId;
-  static const OptionId kDrawScoreBlackId;
+  static const OptionId kDrawScoreId;
   static const OptionId kContemptId;
   static const OptionId kContemptMaxValueId;
   static const OptionId kWDLCalibrationEloId;
@@ -273,10 +267,7 @@ class SearchParams {
   const float kMovesLeftQuadraticFactor;
   const bool kDisplayCacheUsage;
   const int kMaxConcurrentSearchers;
-  const float kDrawScoreSidetomove;
-  const float kDrawScoreOpponent;
-  const float kDrawScoreWhite;
-  const float kDrawScoreBlack;
+  const float kDrawScore;
   const ContemptPerspective kContemptPerspective;
   const float kContempt;
   const WDLRescaleParams kWDLRescaleParams;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -402,11 +402,9 @@ int64_t Search::GetTimeSinceFirstBatch() const REQUIRES(counters_mutex_) {
 
 // Root is depth 0, i.e. even depth.
 float Search::GetDrawScore(bool is_odd_depth) const {
-  return (is_odd_depth ? params_.GetOpponentDrawScore()
-                       : params_.GetSidetomoveDrawScore()) +
-         (is_odd_depth == played_history_.IsBlackToMove()
-              ? params_.GetWhiteDrawDelta()
-              : params_.GetBlackDrawDelta());
+  return (is_odd_depth == played_history_.IsBlackToMove()
+              ? params_.GetDrawScore()
+              : -params_.GetDrawScore());
 }
 
 namespace {


### PR DESCRIPTION
Originally, the drawscore implementation #1066 was intended for both contempt/humbleness and Armageddon support. Since then it turned out however that
1. the parametrization doesn't even span all possible combinations
2. the effect on opening selection etc is very miniscule
3. we were using symmetric settings between white and black anyway
As we have a working contempt implementation now with #1791, we can reduce drawscore to the one remaining use case, where Armageddon is one extreme case, and we only need 1 parameter for that instead of 4.