### PR TITLE
rename contempt perspective to contempt mode

### DIFF
--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -33,7 +33,7 @@
 
 namespace lczero {
 
-enum class ContemptPerspective { STM, WHITE, BLACK, NONE };
+enum class ContemptMode { PLAY, WHITE, BLACK, NONE };
 
 class SearchParams {
  public:
@@ -116,9 +116,7 @@ class SearchParams {
   }
   bool GetDisplayCacheUsage() const { return kDisplayCacheUsage; }
   int GetMaxConcurrentSearchers() const { return kMaxConcurrentSearchers; }
-  ContemptPerspective GetContemptPerspective() const {
-    return kContemptPerspective;
-  }
+  ContemptMode GetContemptMode() const { return kContemptMode; }
   float GetSidetomoveDrawScore() const { return kDrawScoreSidetomove; }
   float GetOpponentDrawScore() const { return kDrawScoreOpponent; }
   float GetWhiteDrawDelta() const { return kDrawScoreWhite; }
@@ -156,9 +154,7 @@ class SearchParams {
   float GetMaxCollisionVisitsScalingPower() const {
     return kMaxCollisionVisitsScalingPower;
   }
-  bool GetSearchSpinBackoff() const {
-    return kSearchSpinBackoff;
-  }
+  bool GetSearchSpinBackoff() const { return kSearchSpinBackoff; }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -205,7 +201,7 @@ class SearchParams {
   static const OptionId kMovesLeftSlopeId;
   static const OptionId kDisplayCacheUsageId;
   static const OptionId kMaxConcurrentSearchersId;
-  static const OptionId kContemptPerspectiveId;
+  static const OptionId kContemptModeId;
   static const OptionId kDrawScoreSidetomoveId;
   static const OptionId kDrawScoreOpponentId;
   static const OptionId kDrawScoreWhiteId;
@@ -277,7 +273,7 @@ class SearchParams {
   const float kDrawScoreOpponent;
   const float kDrawScoreWhite;
   const float kDrawScoreBlack;
-  const ContemptPerspective kContemptPerspective;
+  const ContemptMode kContemptMode;
   const float kContempt;
   const WDLRescaleParams kWDLRescaleParams;
   const float kWDLEvalObjectivity;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -40,9 +40,9 @@
 #include "mcts/node.h"
 #include "neural/cache.h"
 #include "neural/encoder.h"
-#include "utils/spinhelper.h"
 #include "utils/fastmath.h"
 #include "utils/random.h"
+#include "utils/spinhelper.h"
 
 namespace lczero {
 
@@ -282,13 +282,13 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
     auto d = edge.GetD(default_d);
     float mu_uci = 0.0f;
     // Only the diff effect is inverted, so we only need to call if diff != 0.
-    if (params_.GetContemptPerspective() != ContemptPerspective::NONE) {
-      auto sign =
-          ((params_.GetContemptPerspective() == ContemptPerspective::STM) ||
-           ((params_.GetContemptPerspective() == ContemptPerspective::BLACK) ==
-            played_history_.IsBlackToMove()))
-              ? 1.0f
-              : -1.0f;
+    if (params_.GetWDLRescaleDiff() != 0.0f) {
+      // For ContemptMode::NONE diff is 0, so value of sign is irrelevant.
+      auto sign = ((params_.GetContemptMode() == ContemptMode::PLAY) ||
+                   ((params_.GetContemptMode() == ContemptMode::BLACK) ==
+                    played_history_.IsBlackToMove()))
+                      ? 1.0f
+                      : -1.0f;
       WDLRescale(wl, d, &mu_uci, params_.GetWDLRescaleRatio(),
                  params_.GetWDLRescaleDiff() * params_.GetWDLEvalObjectivity(),
                  sign, true);
@@ -1284,8 +1284,9 @@ void SearchWorker::GatherMinibatch() {
     // massive nps drop.
     if (thread_count > 1 && minibatch_size > 0 &&
         computation_->GetCacheMisses() > params_.GetIdlingMinimumWork() &&
-        thread_count - search_->backend_waiting_counter_.load(
-                           std::memory_order_relaxed) >
+        thread_count -
+                search_->backend_waiting_counter_.load(
+                    std::memory_order_relaxed) >
             params_.GetThreadIdlingThreshold()) {
       return;
     }
@@ -2179,19 +2180,17 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
   auto v = -computation.GetQVal(idx_in_computation);
   auto d = computation.GetDVal(idx_in_computation);
   // Check whether root moves are from the set perspective.
-  if (params_.GetContemptPerspective() != ContemptPerspective::NONE) {
-    bool root_stm =
-        (params_.GetContemptPerspective() == ContemptPerspective::STM)
-            ? true
-            : ((params_.GetContemptPerspective() ==
-                ContemptPerspective::BLACK) ==
-               search_->played_history_.Last().IsBlackToMove());
+  if (params_.GetWDLRescaleRatio() != 1.0f ||
+      params_.GetWDLRescaleDiff() != 0.0f) {
+    // For ContemptMode::NONE diff is 0, so values of root_stm and sign are
+    // irrelevant.
+    bool root_stm = (params_.GetContemptMode() == ContemptMode::PLAY)
+                        ? true
+                        : ((params_.GetContemptMode() == ContemptMode::BLACK) ==
+                           search_->played_history_.Last().IsBlackToMove());
     auto sign = (root_stm ^ (node_to_process->depth & 1)) ? 1.0f : -1.0f;
-    if (params_.GetWDLRescaleRatio() != 1.0f ||
-        params_.GetWDLRescaleDiff() != 0.0f) {
-      WDLRescale(v, d, nullptr, params_.GetWDLRescaleRatio(),
-                 params_.GetWDLRescaleDiff(), sign, false);
-    }
+    WDLRescale(v, d, nullptr, params_.GetWDLRescaleRatio(),
+               params_.GetWDLRescaleDiff(), sign, false);
   }
   node_to_process->v = v;
   node_to_process->d = d;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -281,8 +281,8 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
     auto wl = edge.GetWL(default_wl);
     auto d = edge.GetD(default_d);
     float mu_uci = 0.0f;
-    // Only the diff effect is inverted, so we only need to call if diff != 0.
-    if (params_.GetWDLRescaleDiff() != 0.0f) {
+    if (params_.GetWDLRescaleRatio() != 1.0f ||
+        params_.GetWDLRescaleDiff() != 0.0f) {
       // For ContemptMode::NONE diff is 0, so value of sign is irrelevant.
       auto sign = ((params_.GetContemptMode() == ContemptMode::PLAY) ||
                    ((params_.GetContemptMode() == ContemptMode::BLACK) ==
@@ -2179,9 +2179,9 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
   // First the value...
   auto v = -computation.GetQVal(idx_in_computation);
   auto d = computation.GetDVal(idx_in_computation);
-  // Check whether root moves are from the set perspective.
   if (params_.GetWDLRescaleRatio() != 1.0f ||
       params_.GetWDLRescaleDiff() != 0.0f) {
+    // Check whether root moves are from the set perspective.
     // For ContemptMode::NONE diff is 0, so values of root_stm and sign are
     // irrelevant.
     bool root_stm = (params_.GetContemptMode() == ContemptMode::PLAY)


### PR DESCRIPTION
This renames the `ContemptPerspective` uci option to `ContemptMode` (and the command line option) with new option names:
* `play`
* `white_side_analysis`
* `black_side_analysis`
* `disable`

In contrast to the current version, `disable` only forces `Contempt` to zero, to keep `WDL_mu` score type and WDL sharpening working.