### PR TITLE
handle play contempt mode with infinite search

### DIFF
--- a/src/benchmark/benchmark.cc
+++ b/src/benchmark/benchmark.cc
@@ -106,8 +106,8 @@ void Benchmark::Run() {
           std::make_unique<CallbackUciResponder>(
               std::bind(&Benchmark::OnBestMove, this, std::placeholders::_1),
               std::bind(&Benchmark::OnInfo, this, std::placeholders::_1)),
-          MoveList(), start, std::move(stopper), false, option_dict, &cache,
-          nullptr);
+          MoveList(), start, std::move(stopper), false, false, option_dict,
+          &cache, nullptr);
       search->StartThreads(option_dict.Get<int>(kThreadsOptionId));
       search->Wait();
       const auto end = std::chrono::steady_clock::now();

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -298,7 +298,7 @@ void EngineController::Go(const GoParams& params) {
   search_ = std::make_unique<Search>(
       *tree_, network_.get(), std::move(responder),
       StringsToMovelist(params.searchmoves, tree_->HeadPosition().GetBoard()),
-      *move_start_time_, std::move(stopper), params.infinite || params.ponder,
+      *move_start_time_, std::move(stopper), params.infinite, params.ponder,
       options_, &cache_, syzygy_tb_.get());
 
   LOGFILE << "Timer started at "

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -238,6 +238,7 @@ class PonderResponseTransformer : public TransformingUciResponder {
         if (ponder_info.score) ponder_info.score = -*ponder_info.score;
         if (ponder_info.depth > 1) ponder_info.depth--;
         if (ponder_info.seldepth > 1) ponder_info.seldepth--;
+        if (ponder_info.wdl) std::swap(ponder_info.wdl->w, ponder_info.wdl->l);
         ponder_info.pv.clear();
       }
       if (!info.pv.empty() && info.pv[0].as_string() == ponder_move_) {

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -58,14 +58,6 @@ FillEmptyHistory EncodeHistoryFill(std::string history_fill) {
   return FillEmptyHistory::NO;
 }
 
-ContemptMode EncodeContemptMode(std::string mode) {
-  if (mode == "play") return ContemptMode::PLAY;
-  if (mode == "white_side_analysis") return ContemptMode::WHITE;
-  if (mode == "black_side_analysis") return ContemptMode::BLACK;
-  assert(mode == "disable");
-  return ContemptMode::NONE;
-}
-
 float GetContempt(std::string name, std::string contempt_str,
                   float uci_rating_adv) {
   float contempt = uci_rating_adv;
@@ -628,13 +620,9 @@ SearchParams::SearchParams(const OptionsDict& options)
       kDisplayCacheUsage(options.Get<bool>(kDisplayCacheUsageId)),
       kMaxConcurrentSearchers(options.Get<int>(kMaxConcurrentSearchersId)),
       kDrawScore(options.Get<float>(kDrawScoreId)),
-      kContemptMode(
-          EncodeContemptMode(options.Get<std::string>(kContemptModeId))),
-      kContempt(kContemptMode == ContemptMode::NONE
-                    ? 0
-                    : GetContempt(options.Get<std::string>(kUCIOpponentId),
-                                  options.Get<std::string>(kContemptId),
-                                  options.Get<float>(kUCIRatingAdvId))),
+      kContempt(GetContempt(options.Get<std::string>(kUCIOpponentId),
+                            options.Get<std::string>(kContemptId),
+                            options.Get<float>(kUCIRatingAdvId))),
       kWDLRescaleParams(
           options.Get<float>(kWDLCalibrationEloId) == 0
               ? AccurateWDLRescaleParams(
@@ -672,7 +660,6 @@ SearchParams::SearchParams(const OptionsDict& options)
           options.Get<int>(kMaxCollisionVisitsScalingEndId)),
       kMaxCollisionVisitsScalingPower(
           options.Get<float>(kMaxCollisionVisitsScalingPowerId)),
-      kSearchSpinBackoff(options_.Get<bool>(kSearchSpinBackoffId)) {
-}
+      kSearchSpinBackoff(options_.Get<bool>(kSearchSpinBackoffId)) {}
 
 }  // namespace lczero

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -117,7 +117,14 @@ class SearchParams {
   bool GetDisplayCacheUsage() const { return kDisplayCacheUsage; }
   int GetMaxConcurrentSearchers() const { return kMaxConcurrentSearchers; }
   float GetDrawScore() const { return kDrawScore; }
-  ContemptMode GetContemptMode() const { return kContemptMode; }
+  ContemptMode GetContemptMode() const {
+    std::string mode = options_.Get<std::string>(kContemptModeId);
+    if (mode == "play") return ContemptMode::PLAY;
+    if (mode == "white_side_analysis") return ContemptMode::WHITE;
+    if (mode == "black_side_analysis") return ContemptMode::BLACK;
+    assert(mode == "disable");
+    return ContemptMode::NONE;
+  }
   float GetWDLRescaleRatio() const { return kWDLRescaleParams.ratio; }
   float GetWDLRescaleDiff() const { return kWDLRescaleParams.diff; }
   float GetWDLEvalObjectivity() const { return kWDLEvalObjectivity; }
@@ -264,7 +271,6 @@ class SearchParams {
   const bool kDisplayCacheUsage;
   const int kMaxConcurrentSearchers;
   const float kDrawScore;
-  const ContemptMode kContemptMode;
   const float kContempt;
   const WDLRescaleParams kWDLRescaleParams;
   const float kWDLEvalObjectivity;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -302,7 +302,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
     auto wl = edge.GetWL(default_wl);
     auto d = edge.GetD(default_d);
     float mu_uci = 0.0f;
-    if (params_.GetWDLRescaleRatio() != 1.0f ||
+    if (score_type == "WDL_mu" || params_.GetWDLRescaleRatio() != 1.0f ||
         (params_.GetWDLRescaleDiff() != 0.0f &&
          contempt_mode_ != ContemptMode::NONE)) {
       auto sign = ((contempt_mode_ == ContemptMode::BLACK) ==

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -181,8 +181,8 @@ Search::Search(const NodeTree& tree, Network* network,
     if (infinite) {
       // For infinite search disable contempt, only "white"/"black" make sense.
       contempt_mode_ = ContemptMode::NONE;
-      if (params_.GetWDLRescaleRatio() != 1.0f ||
-          params_.GetWDLRescaleDiff() != 0.0f) {
+      // Issue a warning only if contempt mode would have an effect.
+      if (params_.GetWDLRescaleDiff() != 0.0f) {
         std::vector<ThinkingInfo> info(1);
         info.back().comment =
             "WARNING: Contempt mode set to 'disable' as 'play' not supported "
@@ -302,9 +302,8 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
     auto wl = edge.GetWL(default_wl);
     auto d = edge.GetD(default_d);
     float mu_uci = 0.0f;
-    if (score_type == "WDL_mu" || params_.GetWDLRescaleRatio() != 1.0f ||
-        (params_.GetWDLRescaleDiff() != 0.0f &&
-         contempt_mode_ != ContemptMode::NONE)) {
+    if (score_type == "WDL_mu" || (params_.GetWDLRescaleDiff() != 0.0f &&
+                                   contempt_mode_ != ContemptMode::NONE)) {
       auto sign = ((contempt_mode_ == ContemptMode::BLACK) ==
                    played_history_.IsBlackToMove())
                       ? 1.0f

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -53,7 +53,7 @@ class Search {
          std::unique_ptr<UciResponder> uci_responder,
          const MoveList& searchmoves,
          std::chrono::steady_clock::time_point start_time,
-         std::unique_ptr<SearchStopper> stopper, bool infinite,
+         std::unique_ptr<SearchStopper> stopper, bool infinite, bool ponder,
          const OptionsDict& options, NNCache* cache,
          SyzygyTablebase* syzygy_tb);
 
@@ -200,7 +200,7 @@ class Search {
       GUARDED_BY(nodes_mutex_);
 
   std::unique_ptr<UciResponder> uci_responder_;
-
+  ContemptMode contempt_mode_;
   friend class SearchWorker;
 };
 

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -182,9 +182,8 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
       search_ = std::make_unique<Search>(
           *tree_[idx], options_[idx].network, std::move(responder),
           /* searchmoves */ MoveList(), std::chrono::steady_clock::now(),
-          std::move(stoppers),
-          /* infinite */ false, *options_[idx].uci_options, options_[idx].cache,
-          syzygy_tb);
+          std::move(stoppers), /* infinite */ false, /* ponder */ false,
+          *options_[idx].uci_options, options_[idx].cache, syzygy_tb);
     }
 
     // Do search.


### PR DESCRIPTION
Makes sure play contempt mode is never used inside the search, it is switched to white/black depending on the first move side, same in normal searches, flipped when pondering or disabled in infinite search. For infinite search there is a warning if contempt would have an effect.
In addition there is a fix for a preexisting wdl display bug, w and l were swapped while pondering.
Also some cleanups.