### PR TITLE
change default values for v0.30 release

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -510,11 +510,11 @@ void SearchParams::Populate(OptionsParser* options) {
                                          "Q",
                                          "W-L",
                                          "WDL_mu"};
-  options->Add<ChoiceOption>(kScoreTypeId, score_type) = "centipawn";
+  options->Add<ChoiceOption>(kScoreTypeId, score_type) = "WDL_mu";
   std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
   options->Add<FloatOption>(kMovesLeftMaxEffectId, 0.0f, 1.0f) = 0.0345f;
-  options->Add<FloatOption>(kMovesLeftThresholdId, 0.0f, 1.0f) = 0.0f;
+  options->Add<FloatOption>(kMovesLeftThresholdId, 0.0f, 1.0f) = 0.8f;
   options->Add<FloatOption>(kMovesLeftSlopeId, 0.0f, 1.0f) = 0.0027f;
   options->Add<FloatOption>(kMovesLeftConstantFactorId, -1.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kMovesLeftScaledFactorId, -2.0f, 2.0f) = 1.6521f;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -337,7 +337,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
     } else if (score_type == "WDL_mu") {
       // Reports the WDL mu value whenever it is reasonable, and defaults to
       // centipawn otherwise.
-      const float centipawn_fallback_threshold = 0.99f;
+      const float centipawn_fallback_threshold = 0.996f;
       float centipawn_score = 90 * tan(1.5637541897 * wl);
       uci_info.score =
           mu_uci != 0.0f && std::abs(wl) + d < centipawn_fallback_threshold &&


### PR DESCRIPTION
Changed default values for v0.30 release:
- mlh-threshold to 0.8 as we now have a continuous behaviour. Training runs explicitly set threshold to 0, so no issues there.
- centipawn fallback for WDL_mu to only kick in if W or L < 0.2%, which should happen virtually never. Will still behave jumpy if around that threshold and needs a proper fix at some point, but eval at this point doesn't matter anyway anymore, 
- default scoretype to WDL_mu. Thanks to #1898, `WDL_mu` now is always calculated properly (even if contempt is disabled), and we use it everywhere anyway.