### PR TITLE
fix build error with newer cuda versions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -484,7 +484,7 @@ if get_option('build_backends')
     if cuda_cc != ''
       nvcc_extra_args = ['-arch=compute_' + cuda_cc, '-code=sm_' + cuda_cc]
     elif get_option('native_cuda') and nvcc_help.contains('-arch=native')
-      nvcc_extra_args = '-arch=native'
+      nvcc_extra_args = ['-arch=native']
     endif
     foreach x : get_option('cudnn_include')
       cuda_arguments += ['-I', x]


### PR DESCRIPTION
This fixes the error reported in https://github.com/LeelaChessZero/lc0/pull/1905#issuecomment-1656985747
The error is `meson.build:507:26: ERROR: The == operator of str does not accept objects of type list ([])`, this was not triggering in older meson versions.