### PR TITLE
update circleci xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             ninja -j 4
   "mac":
     macos:
-      xcode: 13.4.1
+      xcode: 14.1.0
     steps:
       - checkout
       - run:
@@ -57,7 +57,7 @@ jobs:
           command: lipo -create -o /tmp/lc0 build/lc0 build-arm/lc0
       - store_artifacts:
           path: /tmp/lc0
-          destination: lc0-macos_12.3.1
+          destination: lc0-macos_12.5.1
 workflows:
   version: 2
   builds:


### PR DESCRIPTION
This is to test if an update fixes some circleci breakage on macos. This will become necessary in January when circleci phases out x86 mac builds (but will need other changes as well).