### PR TITLE
fix circleci macos build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,9 @@ jobs:
           command: |
             pip3 install meson==0.63
             pip3 install ninja
-            brew install ispc
+            curl -LJOs https://github.com/ispc/ispc/releases/download/v1.21.0/ispc-v1.21.0-macOS.universal.tar.gz
+            tar xf ispc-v1.21.0-macOS.universal.tar.gz
+            cp ispc-v1.21.0-macOS.universal/bin/ispc /usr/local/bin
       - run:
           name: Build lc0
           command: |


### PR DESCRIPTION
Apparently getting ispc through homebrew stopped working for the macos image we use, so we get it directly from github. As a bonus, this is also several minutes faster, as we skip the slow homebrew update.