### PR TITLE
Make leela2onnx Conv-nodes compatible with onnx2pytorch

### DIFF
--- a/src/lc0ctl/leela2onnx.cc
+++ b/src/lc0ctl/leela2onnx.cc
@@ -53,6 +53,8 @@ const OptionId kOutputValue{
     "ONNX name to use for value policy head output node."};
 const OptionId kOutputMlh{"mlh-head-name", "MlhHeadName",
                           "ONNX name to use for the MLH head output node."};
+const OptionId kOnnxToPytorch{"onnx2pytorch", "Onnx2Pytorch",
+                          "Only use layer definitions supported by onnx2pytorch."};
 
 bool ProcessParameters(OptionsParser* options) {
   options->Add<StringOption>(kInputFilenameId);
@@ -63,6 +65,7 @@ bool ProcessParameters(OptionsParser* options) {
   options->Add<StringOption>(kOutputWdl) = "/output/wdl";
   options->Add<StringOption>(kOutputValue) = "/output/value";
   options->Add<StringOption>(kOutputMlh) = "/output/mlh";
+  options->Add<BoolOption>(kOnnxToPytorch) = false;
   if (!options->ProcessAllFlags()) return false;
 
   const OptionsDict& dict = options->GetOptionsDict();
@@ -94,6 +97,8 @@ void ConvertLeelaToOnnx() {
     onnx_options.output_wdl = dict.Get<std::string>(kOutputWdl);
     onnx_options.output_value = dict.Get<std::string>(kOutputValue);
     onnx_options.output_wdl = dict.Get<std::string>(kOutputWdl);
+    // onnx2pytorch only needs an alternate layernorm-implementation
+    onnx_options.alt_ln = dict.Get<bool>(kOnnxToPytorch);
     weights_file = ConvertWeightsToOnnx(weights_file, onnx_options);
   }
 

--- a/src/lc0ctl/leela2onnx.cc
+++ b/src/lc0ctl/leela2onnx.cc
@@ -97,8 +97,9 @@ void ConvertLeelaToOnnx() {
     onnx_options.output_wdl = dict.Get<std::string>(kOutputWdl);
     onnx_options.output_value = dict.Get<std::string>(kOutputValue);
     onnx_options.output_wdl = dict.Get<std::string>(kOutputWdl);
-    // onnx2pytorch only needs an alternate layernorm-implementation
-    onnx_options.alt_ln = dict.Get<bool>(kOnnxToPytorch);
+    // onnx2pytorch only needs an alternate layernorm-implementation, so it's currently
+    // only enables that. Might need to be extended in the future.
+    onnx_options.alternative_layer_normalization = dict.Get<bool>(kOnnxToPytorch);
     weights_file = ConvertWeightsToOnnx(weights_file, onnx_options);
   }
 

--- a/src/neural/onnx/builder.cc
+++ b/src/neural/onnx/builder.cc
@@ -440,4 +440,40 @@ std::string OnnxBuilder::Mish(const std::string& name,
   return PopulateStdNodeFields(node, name, input, "Mish");
 }
 
+std::string OnnxBuilder::Sqrt(const std::string& name,
+                              const std::string& input) {
+  auto* node = model_.mutable_graph()->add_node();
+  return PopulateStdNodeFields(node, name, input, "Sqrt");
+}
+
+std::string OnnxBuilder::Reciprocal(const std::string& name,
+                                    const std::string& input) {
+  auto* node = model_.mutable_graph()->add_node();
+  return PopulateStdNodeFields(node, name, input, "Reciprocal");
+}
+
+std::string OnnxBuilder::Cast(const std::string& name, const std::string& input,
+                              pblczero::TensorProto::DataType type) {
+  auto* node = model_.mutable_graph()->add_node();
+  auto out = PopulateStdNodeFields(node, name, input, "Cast");
+  AddIntAttribute(node, "to", type);
+  return out;
+}
+
+std::string OnnxBuilder::ReduceMean(const std::string& name,
+                                    const std::string& input,
+                                    std::initializer_list<int> axes) {
+  auto* node = model_.mutable_graph()->add_node();
+  auto out = PopulateStdNodeFields(node, name, input, "ReduceMean");
+  if (opset_ < 18) {
+    AddIntsAttribute(node, "axes", axes);
+  } else {
+    node->add_input(AddInitializer(
+        name + "/axes",
+        Int64OnnxConst(std::vector<int64_t>(begin(axes), end(axes)),
+                       {static_cast<int>(axes.size())})));
+  }
+  return out;
+}
+
 }  // namespace lczero

--- a/src/neural/onnx/builder.cc
+++ b/src/neural/onnx/builder.cc
@@ -362,6 +362,21 @@ std::string OnnxBuilder::Sigmoid(const std::string& name,
   return PopulateStdNodeFields(node, name, input, "Sigmoid");
 }
 
+// This is only defined in opset 17 but onnxruntime supports it from 1.
+std::string OnnxBuilder::LayerNormalization(const std::string& name,
+                                            const std::string& input,
+                                            const OnnxConst& scale,
+                                            const OnnxConst& bias, int axis,
+                                            float epsilon) {
+  auto* node = model_.mutable_graph()->add_node();
+  auto out = PopulateStdNodeFields(node, name, input, "LayerNormalization");
+  node->add_input(AddInitializer(name + "/w/scale", scale));
+  node->add_input(AddInitializer(name + "/w/bias", bias));
+  AddIntAttribute(node, "axis", axis);
+  AddFloatAttribute(node, "epsilon", epsilon);
+  return out;
+}
+
 std::string OnnxBuilder::Expand(const std::string& name,
                                 const std::string& input,
                                 const std::string& shape) {

--- a/src/neural/onnx/builder.cc
+++ b/src/neural/onnx/builder.cc
@@ -135,12 +135,15 @@ std::string PopulateStdNodeFields(pblczero::NodeProto* node,
 std::string OnnxBuilder::Conv(const std::string& name,
                               const std::string& input_name,
                               const OnnxConst& kernel_weights,
-                              const OnnxConst& bias_weights, int pads) {
+                              const OnnxConst& bias_weights, 
+                              int filters,
+                              int pads) {
   auto* node = model_.mutable_graph()->add_node();
   auto out = PopulateStdNodeFields(node, name, input_name, "Conv");
   node->add_input(AddInitializer(name + "/w/kernel", kernel_weights));
   node->add_input(AddInitializer(name + "/w/bias", bias_weights));
   AddIntsAttribute(node, "pads", {pads, pads, pads, pads});
+  AddIntsAttribute(node, "kernel_shape", {filters, filters});
   return out;
 }
 

--- a/src/neural/onnx/builder.cc
+++ b/src/neural/onnx/builder.cc
@@ -135,15 +135,14 @@ std::string PopulateStdNodeFields(pblczero::NodeProto* node,
 std::string OnnxBuilder::Conv(const std::string& name,
                               const std::string& input_name,
                               const OnnxConst& kernel_weights,
-                              const OnnxConst& bias_weights, 
-                              int filters,
-                              int pads) {
+                              const OnnxConst& bias_weights, int pads) {
   auto* node = model_.mutable_graph()->add_node();
+  auto shape = kernel_weights.GetDimensions().back();
   auto out = PopulateStdNodeFields(node, name, input_name, "Conv");
   node->add_input(AddInitializer(name + "/w/kernel", kernel_weights));
   node->add_input(AddInitializer(name + "/w/bias", bias_weights));
   AddIntsAttribute(node, "pads", {pads, pads, pads, pads});
-  AddIntsAttribute(node, "kernel_shape", {filters, filters});
+  AddIntsAttribute(node, "kernel_shape", {shape, shape});
   return out;
 }
 

--- a/src/neural/onnx/builder.cc
+++ b/src/neural/onnx/builder.cc
@@ -362,21 +362,6 @@ std::string OnnxBuilder::Sigmoid(const std::string& name,
   return PopulateStdNodeFields(node, name, input, "Sigmoid");
 }
 
-// This is only defined in opset 17 but onnxruntime supports it from 1.
-std::string OnnxBuilder::LayerNormalization(const std::string& name,
-                                            const std::string& input,
-                                            const OnnxConst& scale,
-                                            const OnnxConst& bias, int axis,
-                                            float epsilon) {
-  auto* node = model_.mutable_graph()->add_node();
-  auto out = PopulateStdNodeFields(node, name, input, "LayerNormalization");
-  node->add_input(AddInitializer(name + "/w/scale", scale));
-  node->add_input(AddInitializer(name + "/w/bias", bias));
-  AddIntAttribute(node, "axis", axis);
-  AddFloatAttribute(node, "epsilon", epsilon);
-  return out;
-}
-
 std::string OnnxBuilder::Expand(const std::string& name,
                                 const std::string& input,
                                 const std::string& shape) {

--- a/src/neural/onnx/builder.h
+++ b/src/neural/onnx/builder.h
@@ -65,7 +65,7 @@ class OnnxBuilder {
   std::string Add(const std::string& name, const std::string& input1,
                   const std::string& input2);
   std::string Add(const std::string& name, const std::string& input1,
-                  const OnnxConst&);
+                  const OnnxConst& input2);
   std::string GlobalAveragePool(const std::string& name,
                                 const std::string& input);
   std::string Squeeze(const std::string& name, const std::string& input,
@@ -120,6 +120,12 @@ class OnnxBuilder {
   std::string Where(const std::string& name, const std::string& input1,
                     const std::string& input2, const std::string& input3);
   std::string Mish(const std::string& name, const std::string& input);
+  std::string Sqrt(const std::string& name, const std::string& input);
+  std::string Reciprocal(const std::string& name, const std::string& input);
+  std::string Cast(const std::string& name, const std::string& input,
+                   pblczero::TensorProto::DataType type);
+  std::string ReduceMean(const std::string& name, const std::string& input,
+                         std::initializer_list<int> axes);
   // Returns ONNX model as protobuf.
   const pblczero::ModelProto& as_proto() const { return model_; }
   // Returns serialized model.

--- a/src/neural/onnx/builder.h
+++ b/src/neural/onnx/builder.h
@@ -103,6 +103,10 @@ class OnnxBuilder {
                     std::initializer_list<int> ends);
   std::string Concat(const std::string& name,
                      const std::vector<std::string>& input, int axis);
+  std::string LayerNormalization(const std::string& name,
+                                 const std::string& input,
+                                 const OnnxConst& scale, const OnnxConst& bias,
+                                 int axis, float epsilon = 1e-6);
   std::string Expand(const std::string& name, const std::string& input,
                      const std::string& shape);
   std::string Shape(const std::string& name, const std::string& input);

--- a/src/neural/onnx/builder.h
+++ b/src/neural/onnx/builder.h
@@ -61,7 +61,7 @@ class OnnxBuilder {
   // node name.
   std::string Conv(const std::string& name, const std::string& input_name,
                    const OnnxConst& kernel_weights,
-                   const OnnxConst& bias_weights, int filters, int pads = 1);
+                   const OnnxConst& bias_weights, int pads = 1);
   std::string Add(const std::string& name, const std::string& input1,
                   const std::string& input2);
   std::string Add(const std::string& name, const std::string& input1,

--- a/src/neural/onnx/builder.h
+++ b/src/neural/onnx/builder.h
@@ -61,7 +61,7 @@ class OnnxBuilder {
   // node name.
   std::string Conv(const std::string& name, const std::string& input_name,
                    const OnnxConst& kernel_weights,
-                   const OnnxConst& bias_weights, int pads = 1);
+                   const OnnxConst& bias_weights, int filters, int pads = 1);
   std::string Add(const std::string& name, const std::string& input1,
                   const std::string& input2);
   std::string Add(const std::string& name, const std::string& input1,

--- a/src/neural/onnx/builder.h
+++ b/src/neural/onnx/builder.h
@@ -103,10 +103,6 @@ class OnnxBuilder {
                     std::initializer_list<int> ends);
   std::string Concat(const std::string& name,
                      const std::vector<std::string>& input, int axis);
-  std::string LayerNormalization(const std::string& name,
-                                 const std::string& input,
-                                 const OnnxConst& scale, const OnnxConst& bias,
-                                 int axis, float epsilon = 1e-6);
   std::string Expand(const std::string& name, const std::string& input,
                      const std::string& shape);
   std::string Shape(const std::string& name, const std::string& input);

--- a/src/neural/onnx/converter.cc
+++ b/src/neural/onnx/converter.cc
@@ -268,7 +268,6 @@ std::string Converter::MakeConvBlock(
       *GetWeghtsConverter(weights.weights,
                           {output_channels, input_channels, filters, filters}),
       *GetWeghtsConverter(weights.biases, {output_channels}),
-      filters,
       (filters - 1) / 2);
 
   if (seunit) flow = MakeSqueezeAndExcite(builder, *seunit, flow, name + "/se");

--- a/src/neural/onnx/converter.cc
+++ b/src/neural/onnx/converter.cc
@@ -268,6 +268,7 @@ std::string Converter::MakeConvBlock(
       *GetWeghtsConverter(weights.weights,
                           {output_channels, input_channels, filters, filters}),
       *GetWeghtsConverter(weights.biases, {output_channels}),
+      filters,
       (filters - 1) / 2);
 
   if (seunit) flow = MakeSqueezeAndExcite(builder, *seunit, flow, name + "/se");

--- a/src/neural/onnx/converter.cc
+++ b/src/neural/onnx/converter.cc
@@ -364,6 +364,9 @@ std::string Converter::MakeLayerNorm(OnnxBuilder* builder,
                                      const lczero::OnnxConst& gammas,
                                      const lczero::OnnxConst& betas,
                                      float eps) {
+  if (!options_.alt_ln) {
+    return builder->LayerNormalization(name, input, gammas, betas, 1, eps);
+  }
   auto in =
       builder->Cast(name + "/to_float", input, pblczero::TensorProto::FLOAT);
   auto flow = builder->ReduceMean(name + "/mean", in, {1});

--- a/src/neural/onnx/converter.cc
+++ b/src/neural/onnx/converter.cc
@@ -364,9 +364,6 @@ std::string Converter::MakeLayerNorm(OnnxBuilder* builder,
                                      const lczero::OnnxConst& gammas,
                                      const lczero::OnnxConst& betas,
                                      float eps) {
-  if (!options_.alt_ln) {
-    return builder->LayerNormalization(name, input, gammas, betas, 1, eps);
-  }
   auto in =
       builder->Cast(name + "/to_float", input, pblczero::TensorProto::FLOAT);
   auto flow = builder->ReduceMean(name + "/mean", in, {1});

--- a/src/neural/onnx/converter.cc
+++ b/src/neural/onnx/converter.cc
@@ -364,7 +364,7 @@ std::string Converter::MakeLayerNorm(OnnxBuilder* builder,
                                      const lczero::OnnxConst& gammas,
                                      const lczero::OnnxConst& betas,
                                      float eps) {
-  if (!options_.alt_ln) {
+  if (!options_.alternative_layer_normalization) {
     return builder->LayerNormalization(name, input, gammas, betas, 1, eps);
   }
   auto in =

--- a/src/neural/onnx/converter.h
+++ b/src/neural/onnx/converter.h
@@ -44,6 +44,7 @@ struct WeightsToOnnxConverterOptions {
   int batch_size = -1;
   int opset = 17;
   bool alt_mish = false;
+  bool alt_ln = false;
 };
 
 // Converts "classical" weights file to weights file with embedded ONNX model.

--- a/src/neural/onnx/converter.h
+++ b/src/neural/onnx/converter.h
@@ -44,7 +44,7 @@ struct WeightsToOnnxConverterOptions {
   int batch_size = -1;
   int opset = 17;
   bool alt_mish = false;
-  bool alt_ln = false;
+  bool alternative_layer_normalization = false;
 };
 
 // Converts "classical" weights file to weights file with embedded ONNX model.

--- a/src/neural/onnx/network_onnx.cc
+++ b/src/neural/onnx/network_onnx.cc
@@ -442,7 +442,8 @@ std::unique_ptr<Network> MakeOnnxNetwork(const std::optional<WeightsFile>& w,
     converter_options.opset = opts.GetOrDefault<int>("opset", 17);
     converter_options.alt_mish = opts.GetOrDefault<bool>(
         "alt_mish", kProvider == OnnxProvider::CPU ? true : false);
-    converter_options.alt_ln = opts.GetOrDefault<bool>("alt_ln", true);
+    converter_options.alternative_layer_normalization =
+        opts.GetOrDefault<bool>("alternative_layer_normalization", true);
     converter_options.data_type_ =
         fp16 ? WeightsToOnnxConverterOptions::DataType::kFloat16
              : WeightsToOnnxConverterOptions::DataType::kFloat32;

--- a/src/neural/onnx/network_onnx.cc
+++ b/src/neural/onnx/network_onnx.cc
@@ -442,6 +442,7 @@ std::unique_ptr<Network> MakeOnnxNetwork(const std::optional<WeightsFile>& w,
     converter_options.opset = opts.GetOrDefault<int>("opset", 17);
     converter_options.alt_mish = opts.GetOrDefault<bool>(
         "alt_mish", kProvider == OnnxProvider::CPU ? true : false);
+    converter_options.alt_ln = opts.GetOrDefault<bool>("alt_ln", true);
     converter_options.data_type_ =
         fp16 ? WeightsToOnnxConverterOptions::DataType::kFloat16
              : WeightsToOnnxConverterOptions::DataType::kFloat32;


### PR DESCRIPTION
Adds `kernel_shape` as a property to all generated Conv-nodes for generated ONNX-networks, to partially address #1736 . This was specifically done for the onnx2pytorch-package requiring. [The ONNX-standard](https://onnx.ai/onnx/operators/onnx__Conv.html) states that this field is optional, and if not provided it should be inferred just looking at the dimensionality of the weights. These changes make _some_ networks generated by `leela2onnx` readable by `onnx2pytorch`. 

I verified that it works with the network that comes bundled with the latest lc0-release (791556) at least. However, many of the networks fail since `onnx2pytorch` hasn't implemented layer-normalisation, (as was the case with many of the networks I tried (mostly from https://lczero.org/play/networks/bestnets/). I also considered making a PR over there implementing that, [but it seems pretty dead](https://github.com/Talmaj/onnx2pytorch).

I'm not sure if it is correct that this project should add stuff like this to accomodate such requirements in other projects. It is practical that it works with other software that people are likely to use, especially in this case since it's quite a small change (and follows an optional part of the standard). I'm a big advocate for making the barrier as low as possible for other people to tinker with lc0-networks (and for that it's nice that conversion between pytorch and ONNX works as well as it could), but probably not at the cost of more bloat. I haven't done any large contributions, so that would be up to someone else to judge, but I wouldn't lose any sleep if this wasn't merged.