### PR TITLE
 Improving the MUtility function

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -2,24 +2,28 @@
 setlocal
 
 rem 1. Set the following for the options you want to build.
-set CUDNN=true
-set CUDA=true
+set CUDNN=false
+set CUDA=false
 set DX12=false
-set OPENCL=false
+set OPENCL=true
 set MKL=false
-set DNNL=false
-set OPENBLAS=false
-set EIGEN=false
+set DNNL=true
+set OPENBLAS=true
+set EIGEN=true
 set TEST=false
+set ONNX=true
+
 
 rem 2. Edit the paths for the build dependencies.
-set CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0
-set CUDNN_PATH=%CUDA_PATH%
-set OPENBLAS_PATH=C:\OpenBLAS
-set MKL_PATH=C:\Program Files (x86)\IntelSWTools\compilers_and_libraries\windows\mkl
-set DNNL_PATH=C:\dnnl_win_1.1.1_cpu_vcomp
-set OPENCL_LIB_PATH=%CUDA_PATH%\lib\x64
-set OPENCL_INCLUDE_PATH=%CUDA_PATH%\include
+set CUDA_PATH=%CUDNN_PATH%
+set CUDNN_PATH=C:\cudnn-windows-x86_64-8.5.0.96_cuda10-archive\cudnn-windows-x86_64-8.5.0.96_cuda10-archive
+set OPENBLAS_PATH=C:\Users\cenam\Documents\Builds\OpenBLAS-0.3.3-win-oldthread\dist64
+set MKL_PATH=C:\Program Files (x86)\Intel\oneAPI\mkl\2023.1.0
+set DNNL_PATH=C:\Users\cenam\Documents\Builds\dnnl_win_2.6.0_cpu_vcomp_gpu_vcomp\dnnl_win_2.6.0_cpu_vcomp_gpu_vcomp
+setx OPENCL_LIBS=C:\Program Files (x86)\IntelSWTools\system_studio_2020\OpenCL\sdk\lib\x64
+setx OPENCL_INCS=C:\Program Files (x86)\IntelSWTools\system_studio_2020\OpenCL\sdk\include
+set ONNX_PATH=C:\Users\cenam\Documents\onnxruntime1.16custom
+set ISPC_PATH=C:\Users\cenam\Downloads\ispc-trunk-windows\ispc-trunk-windows\bin
 
 rem 3. In most cases you won't need to change anything further down.
 echo Deleting build directory:
@@ -34,15 +38,12 @@ if exist "C:\Program Files\Microsoft Visual Studio\2022" (
   where /q cl
   if errorlevel 1 call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
   set backend=vs2022
-) else if exist "C:\Program Files (x86)\Microsoft Visual Studio\2019" (
-  where /q cl
-  if errorlevel 1 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
-  set backend=vs2019
 ) else (
   where /q cl
   if errorlevel 1 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
   set backend=vs2017
 )
+
 
 set BLAS=true
 if %MKL%==false if %DNNL%==false if %OPENBLAS%==false if %EIGEN%==false set BLAS=false
@@ -57,11 +58,12 @@ if "%CUDA_PATH%"=="%CUDNN_PATH%" (
 
 if %CUDNN%==true set PATH=%CUDA_PATH%\bin;%PATH%
 
-meson build --backend %backend% --buildtype release -Ddx=%DX12% -Dcudnn=%CUDNN% -Dplain_cuda=%CUDA% ^
--Dopencl=%OPENCL% -Dblas=%BLAS% -Dmkl=%MKL% -Dopenblas=%OPENBLAS% -Ddnnl=%DNNL% -Dgtest=%TEST% ^
--Dcudnn_include="%CUDNN_INCLUDE_PATH%" -Dcudnn_libdirs="%CUDNN_LIB_PATH%" ^
--Dmkl_include="%MKL_PATH%\include" -Dmkl_libdirs="%MKL_PATH%\lib\intel64" -Ddnnl_dir="%DNNL_PATH%" ^
--Dopencl_libdirs="%OPENCL_LIB_PATH%" -Dopencl_include="%OPENCL_INCLUDE_PATH%" ^
+meson build --backend %backend% --buildtype release -Ddx=%DX12% -Dcudnn=%CUDNN% -Dplain_cuda=%CUDA% -Dblas=%BLAS% -Dmkl=%MKL% ^
+-Dgtest=%TEST% -Donnx_libdir="%ONNX_PATH%\runtimes\win-x64\native" -Donnx_include="%ONNX_PATH%\build\native\include"  ^
+-Dopencl=%OPENCL% -Dcudnn_include="%CUDNN_INCLUDE_PATH%" -Dcudnn_libdirs="%CUDNN_LIB_PATH%" ^
+-Donednn=false -Dispc=true -Dispc_native_only=false -Ddnnl=true -Dmkl_include="%MKL_PATH%\include" ^
+-Dmkl_libdirs="%MKL_PATH%\lib\intel64" -Ddnnl_dir="%DNNL_PATH%" ^
+-Dopencl_libdirs="%OPENCL_LIBS%" -Dopencl_include="%OPENCL_INCS%" ^
 -Dopenblas_include="%OPENBLAS_PATH%\include" -Dopenblas_libdirs="%OPENBLAS_PATH%\lib" ^
 -Ddefault_library=static
 
@@ -71,5 +73,5 @@ pause
 
 cd build
 
-msbuild /m /p:Configuration=Release /p:Platform=x64 /p:WholeProgramOptimization=true ^
-/p:PreferredToolArchitecture=x64 lc0.sln /filelogger
+msbuild /m /p:Configuration=Release /p:Platform=x64 /p:WholeProgramOptimization=true  ^
+/p:PreferredToolArchitecture=x64 -p:Instruction_Set=AdvancedVectorExtensions2 lc0.sln /filelogger

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -319,32 +319,19 @@ const OptionId SearchParams::kHistoryFillId{
     "one. During the first moves of the game such historical positions don't "
     "exist, but they can be synthesized. This parameter defines when to "
     "synthesize them (always, never, or only at non-standard fen position)."};
-const OptionId SearchParams::kMovesLeftMaxEffectId{
-    "moves-left-max-effect", "MovesLeftMaxEffect",
-    "Maximum bonus to add to the score of a node based on how much "
-    "shorter/longer it makes the game when winning/losing."};
+const OptionId SearchParams::kMovesLeftMidpointMoveId{
+    "moves-left-midpoint-move", "MovesLeftMidpointMove",
+    "determines where the curve crosses the y-axis,"
+	"where the value of the calculation for m gets negative."};
 const OptionId SearchParams::kMovesLeftThresholdId{
     "moves-left-threshold", "MovesLeftThreshold",
     "Absolute value of node Q needs to exceed this value before shorter wins "
     "or longer losses are considered."};
-const OptionId SearchParams::kMovesLeftSlopeId{
-    "moves-left-slope", "MovesLeftSlope",
-    "Controls how the bonus for shorter wins or longer losses is adjusted "
-    "based on how many moves the move is estimated to shorten/lengthen the "
-    "game. The move difference is multiplied with the slope and capped at "
-    "MovesLeftMaxEffect."};
-const OptionId SearchParams::kMovesLeftConstantFactorId{
-    "moves-left-constant-factor", "MovesLeftConstantFactor",
-    "A simple multiplier to the moves left effect, can be set to 0 to only use "
-    "an effect scaled by Q."};
-const OptionId SearchParams::kMovesLeftScaledFactorId{
-    "moves-left-scaled-factor", "MovesLeftScaledFactor",
-    "A factor which is multiplied by the absolute Q of parent node and the "
-    "base moves left effect."};
-const OptionId SearchParams::kMovesLeftQuadraticFactorId{
-    "moves-left-quadratic-factor", "MovesLeftQuadraticFactor",
-    "A factor which is multiplied by the square of Q of parent node and the "
-    "base moves left effect."};
+const OptionId SearchParams::kMovesLeftSteepnessFactorId{
+    "moves-left-steepness-factor", "MovesLeftSteepnessFactor",
+    "This sets the steepness of the curve," 
+	"which is how quickly the Mutility value changes as the moves-left decrease."
+    "How high or low the curve of the sigmoid goes"};
 const OptionId SearchParams::kDisplayCacheUsageId{
     "display-cache-usage", "DisplayCacheUsage",
     "Display cache fullness through UCI info `hash` section."};
@@ -513,13 +500,9 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kScoreTypeId, score_type) = "WDL_mu";
   std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
-  options->Add<FloatOption>(kMovesLeftMaxEffectId, 0.0f, 1.0f) = 0.0345f;
-  options->Add<FloatOption>(kMovesLeftThresholdId, 0.0f, 1.0f) = 0.8f;
-  options->Add<FloatOption>(kMovesLeftSlopeId, 0.0f, 1.0f) = 0.0027f;
-  options->Add<FloatOption>(kMovesLeftConstantFactorId, -1.0f, 1.0f) = 0.0f;
-  options->Add<FloatOption>(kMovesLeftScaledFactorId, -2.0f, 2.0f) = 1.6521f;
-  options->Add<FloatOption>(kMovesLeftQuadraticFactorId, -1.0f, 1.0f) =
-      -0.6521f;
+  options->Add<FloatOption>(kMovesLeftMidpointMoveId, 0.0f, 200.0f) = 100.0f;
+  options->Add<FloatOption>(kMovesLeftThresholdId, 0.0f, 1.0f) = 0.0f;
+  options->Add<FloatOption>(kMovesLeftSteepnessFactorId, -1.0f, 1.0f) = 0.0005f;
   options->Add<BoolOption>(kDisplayCacheUsageId) = false;
   options->Add<IntOption>(kMaxConcurrentSearchersId, 0, 128) = 1;
   options->Add<FloatOption>(kDrawScoreId, -1.0f, 1.0f) = 0.0f;
@@ -610,13 +593,9 @@ SearchParams::SearchParams(const OptionsDict& options)
       kSyzygyFastPlay(options.Get<bool>(kSyzygyFastPlayId)),
       kHistoryFill(EncodeHistoryFill(options.Get<std::string>(kHistoryFillId))),
       kMiniBatchSize(options.Get<int>(kMiniBatchSizeId)),
-      kMovesLeftMaxEffect(options.Get<float>(kMovesLeftMaxEffectId)),
+      kMovesLeftMidpointMove(options.Get<float>(kMovesLeftMidpointMoveId)),
       kMovesLeftThreshold(options.Get<float>(kMovesLeftThresholdId)),
-      kMovesLeftSlope(options.Get<float>(kMovesLeftSlopeId)),
-      kMovesLeftConstantFactor(options.Get<float>(kMovesLeftConstantFactorId)),
-      kMovesLeftScaledFactor(options.Get<float>(kMovesLeftScaledFactorId)),
-      kMovesLeftQuadraticFactor(
-          options.Get<float>(kMovesLeftQuadraticFactorId)),
+      kMovesLeftSteepnessFactor(options.Get<float>(kMovesLeftSteepnessFactorId)),
       kDisplayCacheUsage(options.Get<bool>(kDisplayCacheUsageId)),
       kMaxConcurrentSearchers(options.Get<int>(kMaxConcurrentSearchersId)),
       kDrawScore(options.Get<float>(kDrawScoreId)),

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -321,7 +321,7 @@ const OptionId SearchParams::kHistoryFillId{
     "synthesize them (always, never, or only at non-standard fen position)."};
 const OptionId SearchParams::kMovesLeftMidpointMoveId{
     "moves-left-midpoint-move", "MovesLeftMidpointMove",
-    "determines where the curve crosses the y-axis,"
+    "determines where the curve-value crosses the y-axis,"
 	"where the value of the calculation for m gets negative."};
 const OptionId SearchParams::kMovesLeftThresholdId{
     "moves-left-threshold", "MovesLeftThreshold",
@@ -331,7 +331,7 @@ const OptionId SearchParams::kMovesLeftSteepnessFactorId{
     "moves-left-steepness-factor", "MovesLeftSteepnessFactor",
     "This sets the steepness of the curve," 
 	"which is how quickly the Mutility value changes as the moves-left decrease."
-    "How high or low the curve of the sigmoid goes"};
+    "How high or low the curve-value goes"};
 const OptionId SearchParams::kDisplayCacheUsageId{
     "display-cache-usage", "DisplayCacheUsage",
     "Display cache fullness through UCI info `hash` section."};
@@ -502,7 +502,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
   options->Add<FloatOption>(kMovesLeftMidpointMoveId, 0.0f, 200.0f) = 100.0f;
   options->Add<FloatOption>(kMovesLeftThresholdId, 0.0f, 1.0f) = 0.0f;
-  options->Add<FloatOption>(kMovesLeftSteepnessFactorId, -1.0f, 1.0f) = -1.0005f;
+  options->Add<FloatOption>(kMovesLeftSteepnessFactorId, -1.0f, 1.0f) = 0.5000f;
   options->Add<BoolOption>(kDisplayCacheUsageId) = false;
   options->Add<IntOption>(kMaxConcurrentSearchersId, 0, 128) = 1;
   options->Add<FloatOption>(kDrawScoreId, -1.0f, 1.0f) = 0.0f;

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -502,7 +502,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<ChoiceOption>(kHistoryFillId, history_fill_opt) = "fen_only";
   options->Add<FloatOption>(kMovesLeftMidpointMoveId, 0.0f, 200.0f) = 100.0f;
   options->Add<FloatOption>(kMovesLeftThresholdId, 0.0f, 1.0f) = 0.0f;
-  options->Add<FloatOption>(kMovesLeftSteepnessFactorId, -1.0f, 1.0f) = 0.0005f;
+  options->Add<FloatOption>(kMovesLeftSteepnessFactorId, -1.0f, 1.0f) = -1.0005f;
   options->Add<BoolOption>(kDisplayCacheUsageId) = false;
   options->Add<IntOption>(kMaxConcurrentSearchersId, 0, 128) = 1;
   options->Add<FloatOption>(kDrawScoreId, -1.0f, 1.0f) = 0.0f;

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -106,14 +106,9 @@ class SearchParams {
     return options_.Get<std::string>(kScoreTypeId);
   }
   FillEmptyHistory GetHistoryFill() const { return kHistoryFill; }
-  float GetMovesLeftMaxEffect() const { return kMovesLeftMaxEffect; }
   float GetMovesLeftThreshold() const { return kMovesLeftThreshold; }
-  float GetMovesLeftSlope() const { return kMovesLeftSlope; }
-  float GetMovesLeftConstantFactor() const { return kMovesLeftConstantFactor; }
-  float GetMovesLeftScaledFactor() const { return kMovesLeftScaledFactor; }
-  float GetMovesLeftQuadraticFactor() const {
-    return kMovesLeftQuadraticFactor;
-  }
+  float GetMovesLeftMidpointMove() const { return kMovesLeftMidpointMove; }
+  float GetMovesLeftSteepnessFactor() const { return kMovesLeftSteepnessFactor; }
   bool GetDisplayCacheUsage() const { return kDisplayCacheUsage; }
   int GetMaxConcurrentSearchers() const { return kMaxConcurrentSearchers; }
   float GetDrawScore() const { return kDrawScore; }
@@ -197,12 +192,9 @@ class SearchParams {
   static const OptionId kPerPvCountersId;
   static const OptionId kScoreTypeId;
   static const OptionId kHistoryFillId;
-  static const OptionId kMovesLeftMaxEffectId;
+  static const OptionId kMovesLeftMidpointMoveId;
   static const OptionId kMovesLeftThresholdId;
-  static const OptionId kMovesLeftConstantFactorId;
-  static const OptionId kMovesLeftScaledFactorId;
-  static const OptionId kMovesLeftQuadraticFactorId;
-  static const OptionId kMovesLeftSlopeId;
+  static const OptionId kMovesLeftSteepnessFactorId;
   static const OptionId kDisplayCacheUsageId;
   static const OptionId kMaxConcurrentSearchersId;
   static const OptionId kDrawScoreId;
@@ -262,12 +254,9 @@ class SearchParams {
   const bool kSyzygyFastPlay;
   const FillEmptyHistory kHistoryFill;
   const int kMiniBatchSize;
-  const float kMovesLeftMaxEffect;
+  const float kMovesLeftMidpointMove;
   const float kMovesLeftThreshold;
-  const float kMovesLeftSlope;
-  const float kMovesLeftConstantFactor;
-  const float kMovesLeftScaledFactor;
-  const float kMovesLeftQuadraticFactor;
+  const float kMovesLeftSteepnessFactor;
   const bool kDisplayCacheUsage;
   const int kMaxConcurrentSearchers;
   const float kDrawScore;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -540,6 +540,8 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
   for (const auto& edge : edges) {
     float Q = edge.GetQ(fpu, draw_score);
     float M = m_evaluator.GetMUtility(edge, Q);
+    LOGFILE <<  "Q: " << Q;
+    LOGFILE <<  "M: " << M;
     std::ostringstream oss;
     oss << std::left;
     // TODO: should this be displaying transformed index?

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -79,21 +79,15 @@ class MEvaluator {
  public:
   MEvaluator()
       : enabled_{false},
-        m_slope_{0.0f},
-        m_cap_{0.0f},
-        a_constant_{0.0f},
-        a_linear_{0.0f},
-        a_square_{0.0f},
+        move_midpoint_{0.0f},
+        steepness_factor_{0.0f},
         q_threshold_{0.0f},
         parent_m_{0.0f} {}
 
   MEvaluator(const SearchParams& params, const Node* parent = nullptr)
       : enabled_{true},
-        m_slope_{params.GetMovesLeftSlope()},
-        m_cap_{params.GetMovesLeftMaxEffect()},
-        a_constant_{params.GetMovesLeftConstantFactor()},
-        a_linear_{params.GetMovesLeftScaledFactor()},
-        a_square_{params.GetMovesLeftQuadraticFactor()},
+        move_midpoint_{params.GetMovesLeftMidpointMove()},
+        steepness_factor_{params.GetMovesLeftSteepnessFactor()},
         q_threshold_{params.GetMovesLeftThreshold()},
         parent_m_{parent ? parent->GetM() : 0.0f},
         parent_within_threshold_{parent ? WithinThreshold(parent, q_threshold_)
@@ -106,42 +100,43 @@ class MEvaluator {
       parent_within_threshold_ = WithinThreshold(parent, q_threshold_);
     }
   }
-
-  // Calculates the utility for favoring shorter wins and longer losses.
-  float GetMUtility(Node* child, float q) const {
-    if (!enabled_ || !parent_within_threshold_) return 0.0f;
-    const float child_m = child->GetM();
-    float m = std::clamp(m_slope_ * (child_m - parent_m_), -m_cap_, m_cap_);
-    m *= FastSign(-q);
-    if (q_threshold_ > 0.0f && q_threshold_ < 1.0f) {
-      // This allows a smooth M effect with higher q thresholds, which is
-      // necessary for using MLH together with contempt.
-      q = std::max(0.0f, (std::abs(q) - q_threshold_)) / (1.0f - q_threshold_);
-    }
-    m *= a_constant_ + a_linear_ * std::abs(q) + a_square_ * q * q;
+ 
+   // Calculates the utility for favoring shorter wins and longer losses.
+   float GetMUtility(Node* child, float q) const {
+    if (!enabled_ || !parent_within_threshold_) 
+        return GetDefaultMUtility();
+    if (child->GetN() == 0) 
+        return GetDefaultMUtility();
+    float sign = FastSign(q);
+    const float child_m = std::round(child->GetM() / 2.0f);
+    // Weighted average(w) of movesleft to give greater priority to
+    // shorter moves when winning and longer moves when losing.
+    float w = 1.0f / (1.0f + std::exp((sign * steepness_factor_) 
+              * ((move_midpoint_ - child_m) / 200.0f)));
+    float m = (move_midpoint_ - child_m) / 200.0f;
+    // Add 1 to the value of q before taking the logarithm,
+    // to avoid getting undefined values.
+    m *= (1.0f - w) * q + w * (q + std::log(q + 1.0f) + 0.5f * q);
     return m;
   }
 
+  // The M utility to use for unvisited nodes.
+  float GetDefaultMUtility() const { return 0.0f; }
+  
   float GetMUtility(const EdgeAndNode& child, float q) const {
     if (!enabled_ || !parent_within_threshold_) return 0.0f;
     if (child.GetN() == 0) return GetDefaultMUtility();
     return GetMUtility(child.node(), q);
   }
 
-  // The M utility to use for unvisited nodes.
-  float GetDefaultMUtility() const { return 0.0f; }
-
- private:
+  private:
   static bool WithinThreshold(const Node* parent, float q_threshold) {
     return std::abs(parent->GetQ(0.0f)) > q_threshold;
   }
 
   const bool enabled_;
-  const float m_slope_;
-  const float m_cap_;
-  const float a_constant_;
-  const float a_linear_;
-  const float a_square_;
+  const float move_midpoint_;
+  const float steepness_factor_;
   const float q_threshold_;
   float parent_m_ = 0.0f;
   bool parent_within_threshold_ = false;
@@ -540,8 +535,6 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
   for (const auto& edge : edges) {
     float Q = edge.GetQ(fpu, draw_score);
     float M = m_evaluator.GetMUtility(edge, Q);
-    LOGFILE <<  "Q: " << Q;
-    LOGFILE <<  "M: " << M;
     std::ostringstream oss;
     oss << std::left;
     // TODO: should this be displaying transformed index?
@@ -1625,7 +1618,6 @@ void SearchWorker::PickNodesToExtendTask(
   const float odd_draw_score = search_->GetDrawScore(true);
   const auto& root_move_filter = search_->root_move_filter_;
   auto m_evaluator = moves_left_support_ ? MEvaluator(params_) : MEvaluator();
-
   int max_limit = std::numeric_limits<int>::max();
 
   current_path.push_back(-1);
@@ -2209,6 +2201,7 @@ void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
   // First the value...
   auto v = -computation.GetQVal(idx_in_computation);
   auto d = computation.GetDVal(idx_in_computation);
+  
   if (params_.GetWDLRescaleRatio() != 1.0f ||
       (params_.GetWDLRescaleDiff() != 0.0f &&
        search_->contempt_mode_ != ContemptMode::NONE)) {


### PR DESCRIPTION
In this PR I'm introducing 2 new tune able parameters, only the MovesLeftThreshold parameter is left from the old MUtility function. What this PR will do is prioritize shorter wins and longer losses.
The first parameter is MovesLeftMidpointMove this controls where the m-value crosses the y-axis as in moves with greater value than this parameter will be negative. This is done so moves that have shorter movesleft-value than MovesLeftMidpointMove can be prioritized higher than moves with longer movesleft-value than MovesLeftMidpointMove I would recomend (100) for this parameter.
The second parameter is the MovesLeftSteepnessFactor this should be the more tune-able parameter to match hardware as this parameter will differ depending on the nps. This sets the steepness of the curve, which is how quickly the m-value changes as the moves-left decrease or how high or low the m-value goes in simple terms. The higher this value is the greater the m-effect on node Q will be which might cause aggressive play and missing some deeper tactic's that might cause losses. 

