### PR TITLE
auto setting of threads and task workers

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -39,10 +39,9 @@
 
 namespace lczero {
 namespace {
-const int kDefaultThreads = 2;
-
-const OptionId kThreadsOptionId{"threads", "Threads",
-                                "Number of (CPU) worker threads to use.", 't'};
+const OptionId kThreadsOptionId{
+    "threads", "Threads",
+    "Number of (CPU) worker threads to use, 0 for the backend default.", 't'};
 const OptionId kLogFileId{"logfile", "LogFile",
                           "Write log to that file. Special value <stderr> to "
                           "output the log to the console.",
@@ -97,7 +96,7 @@ void EngineController::PopulateOptions(OptionsParser* options) {
   const bool is_simple =
       CommandLine::BinaryName().find("simple") != std::string::npos;
   NetworkFactory::PopulateOptions(options);
-  options->Add<IntOption>(kThreadsOptionId, 1, 128) = kDefaultThreads;
+  options->Add<IntOption>(kThreadsOptionId, 0, 128) = 0;
   options->Add<IntOption>(kNNCacheSizeId, 0, 999999999) = 2000000;
   SearchParams::Populate(options);
 

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -405,7 +405,8 @@ const OptionId SearchParams::kSolidTreeThresholdId{
     "solidification for improved cache locality."};
 const OptionId SearchParams::kTaskWorkersPerSearchWorkerId{
     "task-workers", "TaskWorkers",
-    "The number of task workers to use to help the search worker."};
+    "The number of task workers to use to help the search worker. Setting to "
+    "-1 will use a heuristic value."};
 const OptionId SearchParams::kMinimumWorkSizeForProcessingId{
     "minimum-processing-work", "MinimumProcessingWork",
     "This many visits need to be gathered before tasks will be used to "
@@ -536,8 +537,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kWDLBookExitBiasId, -2.0f, 2.0f) = 0.65f;
   options->Add<FloatOption>(kNpsLimitId, 0.0f, 1e6f) = 0.0f;
   options->Add<IntOption>(kSolidTreeThresholdId, 1, 2000000000) = 100;
-  options->Add<IntOption>(kTaskWorkersPerSearchWorkerId, 0, 128) =
-      DEFAULT_TASK_WORKERS;
+  options->Add<IntOption>(kTaskWorkersPerSearchWorkerId, 0, 128) = -1;
   options->Add<IntOption>(kMinimumWorkSizeForProcessingId, 2, 100000) = 20;
   options->Add<IntOption>(kMinimumWorkSizeForPickingId, 1, 100000) = 1;
   options->Add<IntOption>(kMinimumRemainingWorkSizeForPickingId, 0, 100000) =

--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -167,9 +167,9 @@ class BlasNetwork : public Network {
     return capabilities_;
   }
 
-  int GetMiniBatchSize() const override {
-    return 7;
-  }
+  int GetMiniBatchSize() const override { return 7; }
+
+  bool IsCpu() const override { return true; }
 
   void InitThread(int id) override { Numa::BindThread(id); }
 

--- a/src/neural/cuda/network_cuda.cc
+++ b/src/neural/cuda/network_cuda.cc
@@ -901,6 +901,8 @@ class CudaNetwork : public Network {
     return 2 * sm_count_;
   }
 
+  int GetThreads() const override { return 1 + multi_stream_; }
+
   std::unique_ptr<NetworkComputation> NewComputation() override {
     // Set correct gpu id for this computation (as it might have been called
     // from a different thread).

--- a/src/neural/network.h
+++ b/src/neural/network.h
@@ -106,7 +106,9 @@ class Network {
  public:
   virtual const NetworkCapabilities& GetCapabilities() const = 0;
   virtual std::unique_ptr<NetworkComputation> NewComputation() = 0;
+  virtual int GetThreads() const { return 1; }
   virtual void InitThread(int /*id*/) {}
+  virtual bool IsCpu() const { return false; }
   virtual int GetMiniBatchSize() const { return 256; }
   virtual ~Network() = default;
 };

--- a/src/neural/network_demux.cc
+++ b/src/neural/network_demux.cc
@@ -121,11 +121,19 @@ class DemuxingNetwork : public Network {
   void AddBackend(const std::string& name,
                   const std::optional<WeightsFile>& weights,
                   const OptionsDict& opts) {
-    const int nn_threads = opts.GetOrDefault<int>("threads", 1);
     const std::string backend = opts.GetOrDefault<std::string>("backend", name);
 
     networks_.emplace_back(
         NetworkFactory::Get()->Create(backend, weights, opts));
+
+    int nn_threads = opts.GetOrDefault<int>("threads", 0);
+    if (nn_threads == 0) {
+      nn_threads = networks_.back()->GetThreads();
+    }
+
+    min_batch_size_ =
+        std::min(min_batch_size_, networks_.back()->GetMiniBatchSize());
+    is_cpu_ &= networks_.back()->IsCpu();
 
     if (networks_.size() == 1) {
       capabilities_ = networks_.back()->GetCapabilities();
@@ -145,6 +153,12 @@ class DemuxingNetwork : public Network {
   const NetworkCapabilities& GetCapabilities() const override {
     return capabilities_;
   }
+
+  int GetMiniBatchSize() const override {
+    return min_batch_size_ * threads_.size();
+  }
+
+  bool IsCpu() const override { return is_cpu_; }
 
   void Enqueue(DemuxingComputation* computation) {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -209,6 +223,8 @@ class DemuxingNetwork : public Network {
 
   std::vector<std::unique_ptr<Network>> networks_;
   NetworkCapabilities capabilities_;
+  int min_batch_size_ = std::numeric_limits<int>::max();
+  bool is_cpu_ = true;
   std::queue<DemuxingComputation*> queue_;
   int minimum_split_size_ = 0;
   std::atomic<long long> counter_;

--- a/src/neural/onednn/network_onednn.cc
+++ b/src/neural/onednn/network_onednn.cc
@@ -801,8 +801,10 @@ class OnednnNetwork : public Network {
     return capabilities_;
   }
 
-  int GetMiniBatchSize() const override {
-    return batch_size_ * steps_;
+  int GetMiniBatchSize() const override { return batch_size_ * steps_; }
+
+  bool IsCpu() const override {
+    return eng_.get_kind() == dnnl::engine::kind::cpu;
   }
 
   std::unique_ptr<NetworkComputation> NewComputation() override {

--- a/src/neural/onnx/network_onnx.cc
+++ b/src/neural/onnx/network_onnx.cc
@@ -98,6 +98,7 @@ class OnnxNetwork : public Network {
     return batch_size_ == -1 ? Network::GetMiniBatchSize()
                              : batch_size_ * steps_;
   }
+  bool IsCpu() const override { return provider_ == OnnxProvider::CPU; }
 
   Ort::Env onnx_env_;
   // Prepare sessions for this many multiples of the batch size;


### PR DESCRIPTION
This is the second part of the auto-configuration changes. It doesn't change the behavior for any explicitly set value, but the new defaults lead to the following:
1. Threads are set according to the backend specified value, plus 1 for non-cpu backends.
2. The backends request 1 thread except for cuda with multi-stream, multiplexing and round-robin.
3. The task workers are set to 0 for cpu backends, otherwise to cpu_cores/(threads-1) up to a max of 4.
4. The multiplexing and roundrobin backends suggest for minibatch the min of the values of the used backends. For the demux backend this is multiplied by the number of (backend) threads.

This is changing the default for cpu backends to 1 thread and may reduce task-workers (apparently this is generally expected of cpu engines). Multiplexing backends should now get a decent starting configuration. 