### PR TITLE
Skip proactively wake up TaskWorkers for cpu backend

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1517,12 +1517,6 @@ int SearchWorker::WaitForTasks() {
 
 void SearchWorker::PickNodesToExtend(int collision_limit) {
   ResetTasks();
-  {
-    // While nothing is ready yet - wake the task runners so they are ready to
-    // receive quickly.
-    Mutex::Lock lock(picking_tasks_mutex_);
-    task_added_.notify_all();
-  }
   std::vector<Move> empty_movelist;
   // This lock must be held until after the task_completed_ wait succeeds below.
   // Since the tasks perform work which assumes they have the lock, even though

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -1515,19 +1515,14 @@ int SearchWorker::WaitForTasks() {
   }
 }
 
-void SearchWorker::ProactivelyNotifyTaskWorkers() {
-  if (task_workers_ <= 0 || search_->network_->IsCpu())
-    return;
-
-  // While nothing is ready yet - wake the task runners so they are ready to
-  // receive quickly.
-  Mutex::Lock lock(picking_tasks_mutex_);
-  task_added_.notify_all();
-}
-
 void SearchWorker::PickNodesToExtend(int collision_limit) {
   ResetTasks();
-  ProactivelyNotifyTaskWorkers();
+  if (task_workers_ > 0 && !search_->network_->IsCpu()) {
+    // While nothing is ready yet - wake the task runners so they are ready to
+    // receive quickly.
+    Mutex::Lock lock(picking_tasks_mutex_);
+    task_added_.notify_all();
+  }
   std::vector<Move> empty_movelist;
   // This lock must be held until after the task_completed_ wait succeeds below.
   // Since the tasks perform work which assumes they have the lock, even though

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -446,6 +446,7 @@ class SearchWorker {
   // Returns whether a node's bounds were set based on its children.
   bool MaybeSetBounds(Node* p, float m, int* n_to_fix, float* v_delta,
                       float* d_delta, float* m_delta) const;
+  void ProactivelyNotifyTaskWorkers();
   void PickNodesToExtend(int collision_limit);
   void PickNodesToExtendTask(Node* starting_point, int collision_limit,
                              int base_depth,

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -446,7 +446,6 @@ class SearchWorker {
   // Returns whether a node's bounds were set based on its children.
   bool MaybeSetBounds(Node* p, float m, int* n_to_fix, float* v_delta,
                       float* d_delta, float* m_delta) const;
-  void ProactivelyNotifyTaskWorkers();
   void PickNodesToExtend(int collision_limit);
   void PickNodesToExtendTask(Node* starting_point, int collision_limit,
                              int base_depth,


### PR DESCRIPTION
This pr suggests to skip the proactively wake up TaskWorkers since it causes performance drop in CPU constraint moment.

### Environment:
**Hardware**:
Intel Icelake 2 sockets/80 physical cores/160 logical cores platform

**OS**:
CentOS 8 Stream with kernel version 6.2

**Benchmark**:
./lc0 benchmark -b eigen --threads=$num_threads -w b30e742bcfd905815e0e7dbd4e1bafb41ade748f85d006b8e28758f1a3107ae3 --num-positions=1

### Problems:
With latest lc0 code, it's observed sometimes the benchmark hit bad case in the moment CPU resource is constraint, and it's due to proactively wake up TaskWorkers.

When CPU resource is constraint, proactively wake up could make SearchWorker off CPU and TaskWorkers on CPU, unfortunately there is nothing in picking_tasks_, so that TaskWorkers will be busy waiting but actually starving. Even if they yield, TaskWorkers are probably picked up by OS scheduler than SearchWorker since they slept for a long time.

Here, to simulate the CPU constraint moment, we use taskset to specify core ids that the count is equal to num_threads, e.g.
taskset -c 0-7,80-87  -b eigen --threads=16 -w b30e742bcfd905815e0e7dbd4e1bafb41ade748f85d006b8e28758f1a3107ae3 --num-positions=1

The result is in Table 1, the bad case performance drop is 60% and 78% compare with normal case.

Table 1: Performance in CPU constraint moment
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/pdeng6/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/pdeng6/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding:0px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{vertical-align:middle;
	border:.5pt solid windowtext;
	white-space:normal;}
.xl66
	{mso-number-format:0%;
	vertical-align:middle;
	border:.5pt solid windowtext;
	white-space:normal;}
-->
</head>

<body link="#0563C1" vlink="#954F72" lang=EN-US style='tab-interval:.5in;
word-wrap:break-word'>


  | --threads=16 | --threads=60
-- | -- | --
Normal case | 1038 | 2129
Bad case | 417 | 476
Bad/Normal - 1 | -60% | -78%



</body>

</html>

*Bad case: many proactively wakeups cause TaskWorker busy waiting but staving
*Normal case: not so many proactively wakeups cause TaskWorker busy waiting but staving

### Solution in this Change:
Here we suggest to skip the proactively wake up, since there is thread notification when a Node is placed in picking_tasks_, the TaskWorker should be waked up soon after that.

With this solution, in the CPU resource constraint moment, the bad case is avoided, normal case is even improved, see @ Table 2.

Table 2: Performance in CPU constraint moment if skip proactively wakeup
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/pdeng6/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/pdeng6/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding:0px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{vertical-align:middle;
	border:.5pt solid windowtext;
	white-space:normal;}
.xl66
	{text-align:right;
	vertical-align:middle;
	border:.5pt solid windowtext;
	white-space:normal;}
.xl67
	{mso-number-format:0%;
	text-align:right;
	vertical-align:middle;
	border:.5pt solid windowtext;
	white-space:normal;}
-->
</head>

<body link="#0563C1" vlink="#954F72">


  | --threads=16 | --threads=16 | --threads=16 | --threads=60 | --threads=60 | --threads=60
-- | -- | -- | -- | -- | -- | --
  | Base | Skip | Skip/Base   - 1 | Base | Skip | Skip/Base   - 1
Normal case | 1038 | 1131 | 9% | 2129 | 2699 | 27%
Bad case | 417 | 1131 | 171% | 476 | 2699 | 467%



</body>

</html>


In the moment CPU resource is not constraint, this change doesn't introduce regression according to evaluation with thread# 16 and 60

Table 3: Performance in CPU not constraint moment if skip proactively wakeup
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/pdeng6/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/pdeng6/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding:0px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{text-align:right;
	vertical-align:middle;
	border:.5pt solid windowtext;
	white-space:normal;}
.xl66
	{vertical-align:middle;
	border:.5pt solid windowtext;
	white-space:normal;}
.xl67
	{mso-number-format:0%;
	text-align:right;
	vertical-align:middle;
	border:.5pt solid windowtext;
	white-space:normal;}
.xl68
	{border:.5pt solid windowtext;}
-->
</head>

<body link="#0563C1" vlink="#954F72">


  | --threads=16 | --threads=16 | --threads=16 | --threads=60 | --threads=60 | --threads=60
-- | -- | -- | -- | -- | -- | --
  | Base | Skip | Skip/Base   - 1 | Base | Skip | Skip/Base   - 1
Score | 2397 | 2413 | 1% | 5485 | 5487 | 0%



</body>

</html>

