### PR TITLE
Fix TaskWorkers range

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -537,7 +537,7 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kWDLBookExitBiasId, -2.0f, 2.0f) = 0.65f;
   options->Add<FloatOption>(kNpsLimitId, 0.0f, 1e6f) = 0.0f;
   options->Add<IntOption>(kSolidTreeThresholdId, 1, 2000000000) = 100;
-  options->Add<IntOption>(kTaskWorkersPerSearchWorkerId, 0, 128) = -1;
+  options->Add<IntOption>(kTaskWorkersPerSearchWorkerId, -1, 128) = -1;
   options->Add<IntOption>(kMinimumWorkSizeForProcessingId, 2, 100000) = 20;
   options->Add<IntOption>(kMinimumWorkSizeForPickingId, 1, 100000) = 1;
   options->Add<IntOption>(kMinimumRemainingWorkSizeForPickingId, 0, 100000) =


### PR DESCRIPTION
Option TaskWorkers uses default value (-1) outside its range [0, 128]. Fix this by expanding the range to [-1, 128].

---

The out-of-bounds default broke python-chess for me:

```
DEBUG:chess.engine:<UciProtocol (pid=101352)>: Connection made
DEBUG:chess.engine:<UciProtocol (pid=101352)>: << uci
DEBUG:chess.engine:<UciProtocol (pid=101352)>: >> id name Lc0 v0.31.0-dev+git.3f4c157
DEBUG:chess.engine:<UciProtocol (pid=101352)>: >> id author The LCZero Authors.
...
DEBUG:chess.engine:<UciProtocol (pid=101352)>: >> option name TaskWorkers type spin default -1 min 0 max 128
...
DEBUG:chess.engine:<UciProtocol (pid=101352)>: >> uciok
/usr/lib/python3.11/asyncio/unix_events.py:940: RuntimeWarning: A loop is being detached from a child watcher with pending handlers
  warnings.warn(
Error: expected value for option 'TaskWorkers' to be at least 0, got: -1
Error: cannot access local variable 'engine' where it is not associated with a value
```

Extending the range to [-1, 128] fixed it.