### PR TITLE
auto setting for max prefetch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -109,8 +109,6 @@ cache:
   - C:\ndk\android-ndk-r19c\toolchains\llvm\prebuilt\windows-x86_64
 before_build:
 - cmd: git submodule update --init --recursive
-- cmd: IF %BLAS%==true (echo.#define DEFAULT_MAX_PREFETCH 0 & echo.#define DEFAULT_TASK_WORKERS 0) > params_override.h
-- cmd: IF %ANDROID%==true (echo.#define DEFAULT_MAX_PREFETCH 0 & echo.#define DEFAULT_TASK_WORKERS 0) > params_override.h
 - cmd: SET BUILD_BLAS=%BLAS%
 - cmd: IF %OPENCL%==true SET BUILD_BLAS=true
 - cmd: IF %DX%==true SET BUILD_BLAS=true

--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -34,17 +34,6 @@
 #include "utils/exception.h"
 #include "utils/string.h"
 
-#if __has_include("params_override.h")
-#include "params_override.h"
-#endif
-
-#ifndef DEFAULT_MAX_PREFETCH
-#define DEFAULT_MAX_PREFETCH 32
-#endif
-#ifndef DEFAULT_TASK_WORKERS
-#define DEFAULT_TASK_WORKERS 4
-#endif
-
 namespace lczero {
 
 namespace {
@@ -458,7 +447,7 @@ void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
   // Many of them are overridden with training specific values in tournament.cc.
   options->Add<IntOption>(kMiniBatchSizeId, 0, 1024) = 0;
-  options->Add<IntOption>(kMaxPrefetchBatchId, 0, 1024) = DEFAULT_MAX_PREFETCH;
+  options->Add<IntOption>(kMaxPrefetchBatchId, -1, 1024) = -1;
   options->Add<FloatOption>(kCpuctId, 0.0f, 100.0f) = 1.745f;
   options->Add<FloatOption>(kCpuctAtRootId, 0.0f, 100.0f) = 1.745f;
   options->Add<FloatOption>(kCpuctBaseId, 1.0f, 1000000000.0f) = 38739.0f;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -2079,12 +2079,12 @@ void SearchWorker::MaybePrefetchIntoCache() {
   // nodes which are likely useful in future.
   if (search_->stop_.load(std::memory_order_acquire)) return;
   if (computation_->GetCacheMisses() > 0 &&
-      computation_->GetCacheMisses() < params_.GetMaxPrefetchBatch()) {
+      computation_->GetCacheMisses() < max_prefetch_batch_) {
     history_.Trim(search_->played_history_.GetLength());
     SharedMutex::SharedLock lock(search_->nodes_mutex_);
-    PrefetchIntoCache(
-        search_->root_node_,
-        params_.GetMaxPrefetchBatch() - computation_->GetCacheMisses(), false);
+    PrefetchIntoCache(search_->root_node_,
+                      max_prefetch_batch_ - computation_->GetCacheMisses(),
+                      false);
   }
 }
 

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -240,6 +240,10 @@ class SearchWorker {
     max_out_of_order_ =
         std::max(1, static_cast<int>(params_.GetMaxOutOfOrderEvalsFactor() *
                                      target_minibatch_size_));
+    max_prefetch_batch_ = params.GetMaxPrefetchBatch();
+    if (max_prefetch_batch_ < 0) {
+      max_prefetch_batch_ = search_->network_->IsCpu() ? 0 : 32;
+    }
   }
 
   ~SearchWorker() {
@@ -473,6 +477,7 @@ class SearchWorker {
   int task_workers_;
   int target_minibatch_size_;
   int max_out_of_order_;
+  int max_prefetch_batch_;
   // History is reset and extended by PickNodeToExtend().
   PositionHistory history_;
   int number_out_of_order_ = 0;


### PR DESCRIPTION
This is the next in the auto-configure series, dealing with max-prefetch, 0 for cpu backends and 32 otherwise. It also removes the params_override.h mechanism as it isn't used any more.