### PR TITLE
simple multi-gpu configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -124,6 +124,8 @@ before_build:
 - cmd: SET EXTRA=
 - cmd: IF %ANDROID%==false SET EXTRA=-Db_vscrt=md
 - cmd: IF %ONNX_DML%==true SET EXTRA=-Db_vscrt=md -Donnx_libdir=C:\cache\%ONNX_NAME%\lib -Donnx_include=C:\cache\%ONNX_NAME%\include
+- cmd: IF %BLAS%==true SET EXTRA=-Db_vscrt=md -Dgpus_opt=false
+- cmd: IF %ANDROID%==true SET EXTRA=-Dgpus_opt=false
 - cmd: IF %ANDROID%==false meson build --backend vs2017 --buildtype release -Dgtest=%GTEST% -Dopencl=%OPENCL% -Dblas=%BUILD_BLAS% -Ddnnl=true -Ddx=%DX% -Dcudnn=%CUDNN% -Donednn=%ONEDNN% -Dispc_native_only=false -Dnative_cuda=false -Dpopcnt=%POPCNT% -Df16c=%F16C% -Dcudnn_include="%CUDA_PATH%\include","%CUDA_PATH%\cuda\include" -Dcudnn_libdirs="%CUDA_PATH%\lib\x64","%CUDA_PATH%\cuda\lib\x64" -Dopenblas_include="%PKG_FOLDER%\OpenBLAS\dist64\include" -Dopenblas_libdirs="%PKG_FOLDER%\OpenBLAS\dist64\lib" -Ddnnl_dir="%PKG_FOLDER%\%DNNL_NAME%" -Dopencl_include="%PKG_FOLDER%\opencl-nug.0.777.77\build\native\include" -Dopencl_libdirs="%PKG_FOLDER%\opencl-nug.0.777.77\build\native\lib\x64" -Ddefault_library=static -Dmalloc=mimalloc -Dmimalloc_libdir="%MIMALLOC_PATH%"\out\msvc-x64\Release %EXTRA%
 - cmd: IF %ANDROID%==true meson arm64-v8a --buildtype release -Dgtest=false -Dopenblas_include="%PKG_FOLDER%\OpenBLAS\android-aarch64\include" -Dopenblas_libdirs="%PKG_FOLDER%\OpenBLAS\android-aarch64\lib" -Dembed=%EMBED% -Ddefault_library=static --cross-file crossfile-aarch64
 - cmd: IF %ANDROID%==true meson armeabi-v7a --buildtype release -Dgtest=false -Dopenblas_include="%PKG_FOLDER%\OpenBLAS\android-armv7a\include" -Dopenblas_libdirs="%PKG_FOLDER%\OpenBLAS\android-armv7a\lib" -Dembed=%EMBED% -Ddefault_library=static --cross-file crossfile-armv7a -Dispc=false -Dneon=false

--- a/meson.build
+++ b/meson.build
@@ -678,6 +678,10 @@ if get_option('embed')
   add_project_arguments('-DEMBED', language : 'cpp')
 endif
 
+if not get_option('gpus_opt')
+  add_project_arguments('-DNO_GPUS_OPT', language : 'cpp')
+endif
+
 executable('lc0', 'src/main.cc',
        files, include_directories: includes, dependencies: deps, install: true)
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -148,6 +148,11 @@ option('pext',
        value: false,
        description: 'Use the pext instruction')
 
+option('gpus_opt',
+       type: 'boolean',
+       value: true,
+       description: 'Add support for the --gpus command line option')
+
 option('neon',
        type: 'boolean',
        value: true,

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -105,6 +105,9 @@ void EngineController::PopulateOptions(OptionsParser* options) {
     options->HideAllOptions();
     options->UnhideOption(kThreadsOptionId);
     options->UnhideOption(NetworkFactory::kWeightsId);
+#if !defined(NO_GPUS_OPT)
+    options->UnhideOption(NetworkFactory::kGpusId);
+#endif
     options->UnhideOption(SearchParams::kContemptId);
     options->UnhideOption(SearchParams::kMultiPvId);
   }

--- a/src/neural/factory.h
+++ b/src/neural/factory.h
@@ -74,6 +74,7 @@ class NetworkFactory {
   static const OptionId kWeightsId;
   static const OptionId kBackendId;
   static const OptionId kBackendOptionsId;
+  static const OptionId kGpusId;
 
   struct BackendConfiguration {
     BackendConfiguration() = default;
@@ -81,6 +82,7 @@ class NetworkFactory {
     std::string weights_path;
     std::string backend;
     std::string backend_options;
+    int gpus = 0;
     bool operator==(const BackendConfiguration& other) const;
     bool operator!=(const BackendConfiguration& other) const {
       return !operator==(other);

--- a/src/neural/onednn/network_onednn.cc
+++ b/src/neural/onednn/network_onednn.cc
@@ -180,7 +180,12 @@ class OnednnNetwork : public Network {
     cpu_eng_ = dnnl::engine(dnnl::engine::kind::cpu, 0);
 
     if (!options.IsDefault<int>("gpu")) {
-      eng_ = dnnl::engine(dnnl::engine::kind::gpu, options.Get<int>("gpu"));
+      try {
+        eng_ = dnnl::engine(dnnl::engine::kind::gpu, options.Get<int>("gpu"));
+      } catch (dnnl::error &e) {
+        CERR << "OneDNN gpu engine unavailable, switching to cpu engine.";
+        eng_ = cpu_eng_;
+      }
     } else {
       eng_ = cpu_eng_;
     }


### PR DESCRIPTION
This adds a `--gpus=x` (0<=x<=8) to specify the number of gpus to use, which is ignored if `--backend-opts` is used. Calling meson build with `-Dgpus_opt=false` disables this option, and this is done for the blas and android appveyor builds. 

Using `--gpus=1` (default) is equivalent to `--backend-opts=gpu=0`, which is mainly affecting the onednn backend, making the gpu first choice, so I added a fallback to cpu there, if the gpu is not available. 

The old behavior is obtained by using `--gpus=0`, In practice this only makes sense with the onednn backend.

For a higher value of gpus, a backend options line of the form `(backend=X,gpu=0),(backend=X,gpu=1)` and so on is constructed, with X being either the backend specified with `--backend` (unless it is `multiplexing`, `demux` or `roundrobin`) or the default backend. The multiplexing backend is used, unless `demux` or `roundrobin` is specified with `--backend`.