### PR TITLE
Integration of CoreML Backend into Leela Chess Zero

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,4 +3,8 @@ Language: Cpp
 BasedOnStyle: Google
 DerivePointerAlignment: false
 ---
+Language: ObjC
+BasedOnStyle: Google
+DerivePointerAlignment: false
+---
 Language: Proto

--- a/meson.build
+++ b/meson.build
@@ -619,6 +619,29 @@ if get_option('build_backends')
     add_project_arguments('-fobjc-arc', language : 'objcpp')
   endif
 
+  ## ~~~~~~~~
+  ## CoreML
+  ## ~~~~~~~~
+  # CoreML backend only available on MacOS.
+  # Check for required frameworks - Foundation, CoreML.
+  coreml_frameworks = dependency('appleframeworks',
+                                 modules : ['Foundation', 'CoreML'],
+                                 required: get_option('coreml'))
+
+  if (coreml_frameworks.found() and add_languages('objc', 'objcpp'))
+    deps += coreml_frameworks
+
+    files += [
+      'src/neural/coreml/network_coreml.cc',
+      'src/neural/coreml/CoreML.mm',
+      'src/neural/coreml/CoreMLModel.mm',
+    ]
+
+    has_backends = true
+    add_project_arguments('-fobjc-arc', language : 'objc')
+    add_project_arguments('-fobjc-arc', language : 'objcpp')
+  endif
+
 
 
 endif # if get_option('build_backends')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -123,6 +123,11 @@ option('metal',
        value: 'auto',
        description: 'Enable Metal backend')
 
+option('coreml',
+       type: 'feature',
+       value: 'auto',
+       description: 'Enable CoreML backend')
+
 option('malloc',
        type : 'string',
        value: '',

--- a/src/neural/coreml/CoreML.h
+++ b/src/neural/coreml/CoreML.h
@@ -1,0 +1,44 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2024 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+#pragma once
+
+#include <vector>
+
+namespace lczero {
+namespace coreml_backend {
+
+class CoreML {
+ public:
+  CoreML(void);
+  ~CoreML(void);
+
+  void forwardEval(float* inputs, int batchSize,
+                   std::vector<float*> output_mems);
+};
+
+}  // namespace coreml_backend
+}  // namespace lczero

--- a/src/neural/coreml/CoreML.h
+++ b/src/neural/coreml/CoreML.h
@@ -36,8 +36,8 @@ class CoreML {
   CoreML(void);
   ~CoreML(void);
 
-  void forwardEval(float* inputs, int batchSize,
-                   std::vector<float*> output_mems);
+  void forwardEval(float* inputs, int batchSize, float* output_policy,
+                   float* output_value, float* output_moves_left);
 };
 
 }  // namespace coreml_backend

--- a/src/neural/coreml/CoreML.h
+++ b/src/neural/coreml/CoreML.h
@@ -33,11 +33,18 @@ namespace coreml_backend {
 
 class CoreML {
  public:
-  CoreML(void);
+  CoreML(bool wdl, bool moves_left);
   ~CoreML(void);
 
   void forwardEval(float* inputs, int batchSize, float* output_policy,
                    float* output_value, float* output_moves_left);
+
+  bool isWdl(void);
+  bool isMovesLeft(void);
+
+ private:
+  bool wdl_;
+  bool moves_left_;
 };
 
 }  // namespace coreml_backend

--- a/src/neural/coreml/CoreML.mm
+++ b/src/neural/coreml/CoreML.mm
@@ -26,8 +26,9 @@
 */
 
 #import "CoreML.h"
-#import <CoreML/CoreML.h>
 #import <Foundation/Foundation.h>
+#import <CoreML/CoreML.h>
+#import "CoreMLModel.h"
 
 namespace lczero {
 namespace coreml_backend {
@@ -48,9 +49,10 @@ CoreML::CoreML() {
                NSLog(@"Initializing model with the compiled model URL...");
                NSError* modelInitError = nil;
                MLModelConfiguration* configuration = [[MLModelConfiguration alloc] init];
-               MLModel* model = [MLModel modelWithContentsOfURL:compiledModelURL
-                                                  configuration:configuration
-                                                          error:&modelInitError];
+               MLModel* mlmodel = [MLModel modelWithContentsOfURL:compiledModelURL
+                                                    configuration:configuration
+                                                            error:&modelInitError];
+              [CoreMLModel setMLModel:mlmodel];
 
                if (modelInitError) {
                  NSLog(@"Error initializing model: %@", modelInitError.localizedDescription);
@@ -69,7 +71,11 @@ CoreML::CoreML() {
 
 CoreML::~CoreML() {}
 
-void CoreML::forwardEval(float* inputs, int batchSize, std::vector<float*> output_mems) {}
+void CoreML::forwardEval(float* inputs, int batchSize, std::vector<float*> output_mems) {
+  NSLog(@">>> CoreML::forwardEval");
+  MLModel* mlmodel = [CoreMLModel getMLModel];
+  NSLog(@"<<< CoreML::forwardEval");
+}
 
 }  // namespace coreml_backend
 }  // namespace lczero

--- a/src/neural/coreml/CoreML.mm
+++ b/src/neural/coreml/CoreML.mm
@@ -1,0 +1,75 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2024 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#import "CoreML.h"
+#import <CoreML/CoreML.h>
+#import <Foundation/Foundation.h>
+
+namespace lczero {
+namespace coreml_backend {
+
+CoreML::CoreML() {
+  NSString* modelPath = @"lc0.mlpackage";
+  NSURL* modelURL = [NSURL fileURLWithPath:modelPath];
+  dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+  NSLog(@"Compiling model: %@", modelURL);
+
+  [MLModel compileModelAtURL:modelURL
+           completionHandler:^(NSURL* compiledModelURL, NSError* error) {
+             // Completion Handler
+             if (error) {
+               NSLog(@"Error compiling model: %@", error.localizedDescription);
+             } else {
+               NSLog(@"Compiled model URL: %@", compiledModelURL);
+               NSLog(@"Initializing model with the compiled model URL...");
+               NSError* modelInitError = nil;
+               MLModelConfiguration* configuration = [[MLModelConfiguration alloc] init];
+               MLModel* model = [MLModel modelWithContentsOfURL:compiledModelURL
+                                                  configuration:configuration
+                                                          error:&modelInitError];
+
+               if (modelInitError) {
+                 NSLog(@"Error initializing model: %@", modelInitError.localizedDescription);
+               } else {
+                 NSLog(@"Model successfully initialized");
+               }
+             }
+
+             // Signal the semaphore to indicate that the task is complete
+             dispatch_semaphore_signal(semaphore);
+           }];
+
+  // Wait for the semaphore
+  dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+}
+
+CoreML::~CoreML() {}
+
+void CoreML::forwardEval(float* inputs, int batchSize, std::vector<float*> output_mems) {}
+
+}  // namespace coreml_backend
+}  // namespace lczero

--- a/src/neural/coreml/CoreML.mm
+++ b/src/neural/coreml/CoreML.mm
@@ -76,42 +76,44 @@ CoreML::CoreML() {
 CoreML::~CoreML() {}
 
 NSMutableArray<CoreMLInput*>* setupInputArray(float* inputs, int batchSize) {
-    // Define the parameters for the input MLMultiArray
-    int inputChannels = 112;
-    int inputLength = 8;
-    int spatialSize = inputChannels * inputLength * inputLength;
-    NSArray<NSNumber*>* inputShape = @[ @1, @(inputChannels), @(inputLength), @(inputLength) ];
-    MLMultiArrayDataType inputDataType = MLMultiArrayDataTypeFloat;
-    NSArray<NSNumber*>* inputStrides = @[ @(spatialSize), @(inputLength * inputLength), @(inputLength), @1 ];
-    
-    // Initialize an array to hold CoreMLInput objects
-    NSMutableArray<CoreMLInput*>* inputArray = [NSMutableArray arrayWithCapacity:(NSUInteger)batchSize];
-    
-    for (int i = 0; i < batchSize; i++) {
-        NSError* arrayInitError = nil;
-        
-        // Calculate the pointer offset for the current batch item
-        float* inputPointer = inputs + (i * spatialSize);
-        
-        // Initialize an MLMultiArray with the input data
-        MLMultiArray* inputPlanes = [[MLMultiArray alloc] initWithDataPointer:inputPointer
-                                                                       shape:inputShape
-                                                                    dataType:inputDataType
-                                                                     strides:inputStrides
-                                                                 deallocator:nil
-                                                                       error:&arrayInitError];
-        
-        if (arrayInitError) {
-            NSLog(@"Error initializing MLMultiArray for input: %@", arrayInitError.localizedDescription);
-            return nil;
-        }
-        
-        // Wrap the MLMultiArray in a CoreMLInput object and add it to the inputArray
-        CoreMLInput* input = [[CoreMLInput alloc] initWithInput_planes:inputPlanes];
-        [inputArray addObject:input];
+  // Define the parameters for the input MLMultiArray
+  int inputChannels = 112;
+  int inputLength = 8;
+  int spatialSize = inputChannels * inputLength * inputLength;
+  NSArray<NSNumber*>* inputShape = @[ @1, @(inputChannels), @(inputLength), @(inputLength) ];
+  MLMultiArrayDataType inputDataType = MLMultiArrayDataTypeFloat;
+  NSArray<NSNumber*>* inputStrides =
+      @[ @(spatialSize), @(inputLength * inputLength), @(inputLength), @1 ];
+
+  // Initialize an array to hold CoreMLInput objects
+  NSMutableArray<CoreMLInput*>* inputArray =
+      [NSMutableArray arrayWithCapacity:(NSUInteger)batchSize];
+
+  for (int i = 0; i < batchSize; i++) {
+    NSError* arrayInitError = nil;
+
+    // Calculate the pointer offset for the current batch item
+    float* inputPointer = inputs + (i * spatialSize);
+
+    // Initialize an MLMultiArray with the input data
+    MLMultiArray* inputPlanes = [[MLMultiArray alloc] initWithDataPointer:inputPointer
+                                                                    shape:inputShape
+                                                                 dataType:inputDataType
+                                                                  strides:inputStrides
+                                                              deallocator:nil
+                                                                    error:&arrayInitError];
+
+    if (arrayInitError) {
+      NSLog(@"Error initializing MLMultiArray for input: %@", arrayInitError.localizedDescription);
+      return nil;
     }
-    
-    return inputArray;
+
+    // Wrap the MLMultiArray in a CoreMLInput object and add it to the inputArray
+    CoreMLInput* input = [[CoreMLInput alloc] initWithInput_planes:inputPlanes];
+    [inputArray addObject:input];
+  }
+
+  return inputArray;
 }
 
 NSArray<CoreMLOutput*>* performPredictions(NSMutableArray<CoreMLInput*>* inputArray) {
@@ -131,7 +133,8 @@ NSArray<CoreMLOutput*>* performPredictions(NSMutableArray<CoreMLInput*>* inputAr
   }
 }
 
-void processOutputs(NSArray<CoreMLOutput*>* results, int batchSize, float* output_policy, float* output_value, float* output_moves_left) {
+void processOutputs(NSArray<CoreMLOutput*>* results, int batchSize, float* output_policy,
+                    float* output_value, float* output_moves_left) {
   if (results) {
     for (int i = 0; i < batchSize; i++) {
       // Process policy output

--- a/src/neural/coreml/CoreMLModel.h
+++ b/src/neural/coreml/CoreMLModel.h
@@ -29,9 +29,47 @@
 #import <CoreML/CoreML.h>
 #import <Foundation/Foundation.h>
 
+/// Model Prediction Input Type
+API_AVAILABLE(macos(12.0), ios(15.0), watchos(8.0), tvos(15.0))
+__attribute__((visibility("hidden")))
+@interface CoreMLInput : NSObject<MLFeatureProvider>
+
+/// input_planes as 1 × 112 × 8 × 8 4-dimensional array of floats
+@property(readwrite, nonatomic, strong) MLMultiArray* _Nullable input_planes;
+- (instancetype _Nonnull)init NS_UNAVAILABLE;
+- (instancetype _Nonnull)initWithInput_planes:(MLMultiArray* _Nonnull)input_planes
+    NS_DESIGNATED_INITIALIZER;
+
+@end
+
+/// Model Prediction Output Type
+API_AVAILABLE(macos(12.0), ios(15.0), watchos(8.0), tvos(15.0))
+__attribute__((visibility("hidden")))
+@interface CoreMLOutput : NSObject<MLFeatureProvider>
+
+/// output_policy as 1 by 1858 matrix of floats
+@property(readwrite, nonatomic, strong) MLMultiArray* _Nullable output_policy;
+
+/// output_value as 1 by 3 matrix of floats
+@property(readwrite, nonatomic, strong) MLMultiArray* _Nullable output_value;
+
+/// output_moves_left as 1 by 1 matrix of floats
+@property(readwrite, nonatomic, strong) MLMultiArray* _Nullable output_moves_left;
+- (instancetype _Nonnull)init NS_UNAVAILABLE;
+- (instancetype _Nonnull)initWithOutput_policy:(MLMultiArray* _Nonnull)output_policy
+                                  output_value:(MLMultiArray* _Nonnull)output_value
+                             output_moves_left:(MLMultiArray* _Nonnull)output_moves_left
+    NS_DESIGNATED_INITIALIZER;
+
+@end
+
 @interface CoreMLModel : NSObject
 
 + (MLModel* _Nullable)getMLModel;
 + (void)setMLModel:(MLModel* _Nonnull)mlmodel;
++ (nullable NSArray<CoreMLOutput*>*)
+    predictionsFromInputs:(NSArray<CoreMLInput*>* _Nonnull)inputArray
+                  options:(MLPredictionOptions* _Nonnull)options
+                    error:(NSError* _Nullable __autoreleasing* _Nullable)error;
 
 @end

--- a/src/neural/coreml/CoreMLModel.h
+++ b/src/neural/coreml/CoreMLModel.h
@@ -1,0 +1,37 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2024 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+#pragma once
+
+#import <CoreML/CoreML.h>
+#import <Foundation/Foundation.h>
+
+@interface CoreMLModel : NSObject
+
++ (MLModel* _Nullable)getMLModel;
++ (void)setMLModel:(MLModel* _Nonnull)mlmodel;
+
+@end

--- a/src/neural/coreml/CoreMLModel.mm
+++ b/src/neural/coreml/CoreMLModel.mm
@@ -1,0 +1,46 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2024 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#import "CoreMLModel.h"
+
+@implementation CoreMLModel
+
+static MLModel* _Nullable sharedMLModel = nil;
+
++ (MLModel* _Nullable)getMLModel {
+  @synchronized(self) {
+    return sharedMLModel;
+  }
+}
+
++ (void)setMLModel:(MLModel* _Nonnull)mlmodel {
+  @synchronized(self) {
+    sharedMLModel = mlmodel;
+  }
+}
+
+@end

--- a/src/neural/coreml/network_coreml.cc
+++ b/src/neural/coreml/network_coreml.cc
@@ -1,0 +1,104 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2024 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#include "network_coreml.h"
+
+namespace lczero {
+namespace coreml_backend {
+
+CoreMLNetworkComputation::CoreMLNetworkComputation(CoreMLNetwork* network,
+                                                   bool wdl, bool moves_left)
+    : wdl_(wdl), moves_left_(moves_left), network_(network) {
+  batch_size_ = 0;
+  inputs_outputs_ = network_->GetInputsOutputs();
+}
+
+CoreMLNetworkComputation::~CoreMLNetworkComputation() {
+  network_->ReleaseInputsOutputs(std::move(inputs_outputs_));
+}
+
+void CoreMLNetworkComputation::ComputeBlocking() {
+  network_->forwardEval(inputs_outputs_.get(), GetBatchSize());
+}
+
+CoreMLNetwork::CoreMLNetwork(const WeightsFile& file,
+                             const OptionsDict& options)
+    : capabilities_{file.format().network_format().input(),
+                    file.format().network_format().moves_left()} {
+  LegacyWeights weights(file.weights());
+
+  max_batch_size_ = options.GetOrDefault<int>("max_batch", 1024);
+  batch_size_ = options.GetOrDefault<int>("batch", 64);
+
+  conv_policy_ = file.format().network_format().policy() ==
+                 pblczero::NetworkFormat::POLICY_CONVOLUTION;
+
+  attn_policy_ = file.format().network_format().policy() ==
+                 pblczero::NetworkFormat::POLICY_ATTENTION;
+
+  wdl_ = file.format().network_format().value() ==
+         pblczero::NetworkFormat::VALUE_WDL;
+
+  moves_left_ = (file.format().network_format().moves_left() ==
+                 pblczero::NetworkFormat::MOVES_LEFT_V1) &&
+                options.GetOrDefault<bool>("mlh", true);
+
+  coreml_ = std::make_unique<CoreML>();
+}
+
+void CoreMLNetwork::forwardEval(InputsOutputs* io, int batchSize) {
+  // Expand encoded input into N x 112 x 8 x 8.
+  float* dptr = &io->input_val_mem_expanded_[0];
+  for (int i = 0; i < batchSize; i++) {
+    for (int j = 0; j < kInputPlanes; j++) {
+      const float value = io->input_val_mem_[j + i * kInputPlanes];
+      const uint64_t mask = io->input_masks_mem_[j + i * kInputPlanes];
+      for (auto k = 0; k < 64; k++) {
+        *(dptr++) = (mask & (((uint64_t)1) << k)) != 0 ? value : 0;
+      }
+    }
+  }
+
+  lock_.lock();
+
+  coreml_->forwardEval(&io->input_val_mem_expanded_[0], batchSize,
+                       &io->op_policy_mem_[0], &io->op_value_mem_[0],
+                       &io->op_moves_left_mem_[0]);
+
+  lock_.unlock();
+}
+
+std::unique_ptr<Network> MakeCoreMLNetwork(const std::optional<WeightsFile>& w,
+                                           const OptionsDict& options) {
+  const WeightsFile& weights = *w;
+  return std::make_unique<CoreMLNetwork>(weights, options);
+}
+
+REGISTER_NETWORK("coreml", MakeCoreMLNetwork, 106)
+
+}  // namespace coreml_backend
+}  // namespace lczero

--- a/src/neural/coreml/network_coreml.cc
+++ b/src/neural/coreml/network_coreml.cc
@@ -67,7 +67,7 @@ CoreMLNetwork::CoreMLNetwork(const WeightsFile& file,
                  pblczero::NetworkFormat::MOVES_LEFT_V1) &&
                 options.GetOrDefault<bool>("mlh", true);
 
-  coreml_ = std::make_unique<CoreML>();
+  coreml_ = std::make_unique<CoreML>(wdl_, moves_left_);
 }
 
 void CoreMLNetwork::forwardEval(InputsOutputs* io, int batchSize) {

--- a/src/neural/coreml/network_coreml.cc
+++ b/src/neural/coreml/network_coreml.cc
@@ -98,7 +98,7 @@ std::unique_ptr<Network> MakeCoreMLNetwork(const std::optional<WeightsFile>& w,
   return std::make_unique<CoreMLNetwork>(weights, options);
 }
 
-REGISTER_NETWORK("coreml", MakeCoreMLNetwork, 106)
+REGISTER_NETWORK("coreml", MakeCoreMLNetwork, 104)
 
 }  // namespace coreml_backend
 }  // namespace lczero

--- a/src/neural/coreml/network_coreml.h
+++ b/src/neural/coreml/network_coreml.h
@@ -1,0 +1,180 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2024 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+#pragma once
+
+#include <list>
+
+#include "neural/coreml/CoreML.h"
+#include "neural/factory.h"
+#include "neural/network_legacy.h"
+
+namespace lczero {
+namespace coreml_backend {
+
+static int kNumOutputPolicy = 1858;
+static int kInputPlanes = 112;
+
+struct InputsOutputs {
+  InputsOutputs(int maxBatchSize, bool wdl, bool moves_left) {
+    input_masks_mem_.reserve(maxBatchSize * kInputPlanes);
+    input_val_mem_.reserve(maxBatchSize * kInputPlanes);
+    input_val_mem_expanded_.reserve(maxBatchSize * kInputPlanes * 64);
+    op_policy_mem_.reserve(maxBatchSize * kNumOutputPolicy);
+    op_value_mem_.reserve(maxBatchSize * (wdl ? 3 : 1));
+
+    if (moves_left) {
+      op_moves_left_mem_.reserve(maxBatchSize);
+    };
+  }
+  ~InputsOutputs() {}
+
+  std::vector<uint64_t> input_masks_mem_;
+  std::vector<float> input_val_mem_;
+  std::vector<float> input_val_mem_expanded_;
+  std::vector<float> op_policy_mem_;
+  std::vector<float> op_value_mem_;
+  std::vector<float> op_moves_left_mem_;
+};
+
+class CoreMLNetwork;
+
+class CoreMLNetworkComputation : public NetworkComputation {
+ public:
+  CoreMLNetworkComputation(CoreMLNetwork* network, bool wdl, bool moves_left);
+  ~CoreMLNetworkComputation();
+
+  void AddInput(InputPlanes&& input) override {
+    const auto iter_mask =
+        &inputs_outputs_->input_masks_mem_[batch_size_ * kInputPlanes];
+    const auto iter_val =
+        &inputs_outputs_->input_val_mem_[batch_size_ * kInputPlanes];
+
+    int i = 0;
+    for (const auto& plane : input) {
+      iter_mask[i] = plane.mask;
+      iter_val[i] = plane.value;
+      i++;
+    }
+
+    batch_size_++;
+  }
+
+  void ComputeBlocking() override;
+
+  int GetBatchSize() const override { return batch_size_; }
+
+  float GetQVal(int sample) const override {
+    if (wdl_) {
+      auto w = inputs_outputs_->op_value_mem_[3 * sample + 0];
+      auto l = inputs_outputs_->op_value_mem_[3 * sample + 2];
+      return w - l;
+    } else {
+      return inputs_outputs_->op_value_mem_[sample];
+    }
+  }
+
+  float GetDVal(int sample) const override {
+    if (wdl_) {
+      auto d = inputs_outputs_->op_value_mem_[3 * sample + 1];
+      return d;
+    } else {
+      return 0.0f;
+    }
+  }
+
+  float GetPVal(int sample, int move_id) const override {
+    return inputs_outputs_->op_policy_mem_[sample * kNumOutputPolicy + move_id];
+  }
+
+  float GetMVal(int sample) const override {
+    if (moves_left_) {
+      return inputs_outputs_->op_moves_left_mem_[sample];
+    }
+    return 0.0f;
+  }
+
+ private:
+  // Memory holding inputs, outputs.
+  std::unique_ptr<InputsOutputs> inputs_outputs_;
+  int batch_size_;
+  bool wdl_;
+  bool moves_left_;
+
+  CoreMLNetwork* network_;
+};
+
+class CoreMLNetwork : public Network {
+ public:
+  CoreMLNetwork(const WeightsFile& file, const OptionsDict& options);
+  ~CoreMLNetwork() {}
+
+  void forwardEval(InputsOutputs* io, int inputBatchSize);
+
+  std::unique_ptr<NetworkComputation> NewComputation() override {
+    return std::make_unique<CoreMLNetworkComputation>(this, wdl_, moves_left_);
+  }
+
+  std::unique_ptr<InputsOutputs> GetInputsOutputs() {
+    std::lock_guard<std::mutex> lock(inputs_outputs_lock_);
+    if (free_inputs_outputs_.empty()) {
+      return std::make_unique<InputsOutputs>(max_batch_size_, wdl_,
+                                             moves_left_);
+    } else {
+      std::unique_ptr<InputsOutputs> resource =
+          std::move(free_inputs_outputs_.front());
+      free_inputs_outputs_.pop_front();
+      return resource;
+    }
+  }
+
+  void ReleaseInputsOutputs(std::unique_ptr<InputsOutputs> resource) {
+    std::lock_guard<std::mutex> lock(inputs_outputs_lock_);
+    free_inputs_outputs_.push_back(std::move(resource));
+  }
+
+  const NetworkCapabilities& GetCapabilities() const override {
+    return capabilities_;
+  }
+
+ private:
+  NetworkCapabilities capabilities_{
+      pblczero::NetworkFormat::INPUT_CLASSICAL_112_PLANE,
+      pblczero::NetworkFormat::MOVES_LEFT_NONE};
+  int max_batch_size_;
+  int batch_size_;
+  bool wdl_;
+  bool moves_left_;
+  bool conv_policy_;
+  bool attn_policy_;
+  std::mutex inputs_outputs_lock_;
+  std::list<std::unique_ptr<InputsOutputs>> free_inputs_outputs_;
+  std::unique_ptr<coreml_backend::CoreML> coreml_;
+  mutable std::mutex lock_;
+};
+
+}  // namespace coreml_backend
+}  // namespace lczero


### PR DESCRIPTION
**Overview**
This pull request introduces a CoreML backend for Leela Chess Zero (lc0), capitalizing on Apple's [CoreML](https://developer.apple.com/documentation/coreml) framework to significantly enhance neural network computations on macOS devices. By integrating this backend, lc0 gains considerable performance optimizations and expanded computational capabilities tailored for Apple hardware.

**Implementation Highlights**
- **CoreML Backend Integration:** Initiated with the creation of a `coreml_backend` namespace, this phase includes the setup of essential CoreML header and source files, alongside the initialization of [MLModel](https://developer.apple.com/documentation/coreml/mlmodel) within this namespace.
- **CoreMLModel Class:** This newly developed class encapsulates the logic for CoreML model storage and retrieval, integrating tailored methods for handling inputs/outputs and predictions, thereby aligning with lc0's computational needs.
- **Model Initialization Enhancements:** The model initialization process has been refined to utilize [MLComputeUnits](https://developer.apple.com/documentation/coreml/mlcomputeunits?language=objc) across CPU, GPU, and Apple's [Neural Engine](https://www.apple.com/fi/newsroom/2020/11/apple-unleashes-m1/), ensuring optimal performance.
- **Comprehensive macOS Support:** This backend brings full-fledged support to macOS, incorporating all necessary frameworks and file inclusions to harness CoreML's capabilities on Apple devices efficiently.
- **Consistent Code Styling:** The project's `.clang-format` has been updated to ensure uniform coding styles across C++ and Objective-C++ languages, maintaining code clarity and consistency.

**Prerequisites and Setup**
Prior to the integration, it is imperative to build coremltools from a specific pull request (https://github.com/apple/coremltools/pull/2087) pending the release of coremltools 7.2. The conversion of networks into CoreML models necessitates the use of `net_to_coreml.py` from the [lczero-training](https://github.com/LeelaChessZero/lczero-training) repository, following the instructions delineated in https://github.com/LeelaChessZero/lczero-training/pull/222.

**Converting Networks to CoreML Models:**
1. Create a Python environment and install necessary packages:
```
conda create -n net-to-coreml-py39 python=3.9
conda activate net-to-coreml-py39
pip install numpy tensorflow tensorflow-metal protobuf==3.20.3 pyyaml coremltools
```
2. Clone the `lczero-training` repository and prepare the environment:
```
git clone --recurse-submodules https://github.com/LeelaChessZero/lczero-training.git
cd lczero-training
git fetch origin pull/222/head:net-to-coreml
git switch net-to-coreml
./init.sh
```
3. Download the network and configuration, then convert to CoreML model:
```
cd tf
wget -O 817580.lc0 "https://training.lczero.org/get_network?sha=7658338877bcf498b3329b9c196abfb123659dc16a5db298a2378cc4a5bb25ba"
wget https://gist.githubusercontent.com/ChinChangYang/948bc4f9114dfb512abff8e3b2392962/raw/7400327b759af7703aaa0052e0e837ebc25e1cc8/768x15x24h-t80.yaml
python net_to_coreml.py --cfg 768x15x24h-t80.yaml -e 817580.lc0
```
4. Transfer the CoreML model and network to lc0's directory:
```
cp -r dev1/networks/768x15x24h-t80/817580.lc0.mlpackage /path/to/lc0/build/release/lc0.mlpackage
cp 817580.lc0 /path/to/lc0/build/release/
```
**Benchmarking lc0 with CoreML Backend:**
Navigate to lc0's release directory and execute the benchmark command to evaluate performance:
```
% cd /path/to/lc0/build/release/
% ./lc0 benchmark -b coreml
[...]
===========================
Total time (ms) : 345668
Nodes searched  : 95896
Nodes/second    : 277
```

**Contribution and Review Request**
This pull request seeks a comprehensive review of the CoreML backend's integration, focusing on its compatibility, performance enhancements, and alignment with lc0's architectural standards. Feedback, suggestions, and further optimizations are highly encouraged to ensure this significant feature's robust integration into lc0, fostering a seamless user experience on macOS platforms.