### PR TITLE
Fix unsigned int conversion from cpp to Python.

### DIFF
--- a/scripts/pybind/retval.py
+++ b/scripts/pybind/retval.py
@@ -185,7 +185,7 @@ class IntegralTupleRetVal(RetVal):
     def parse_tuple_format(self):
         return {
             'i': 'i',
-            'u64': 'k',
+            'u64': 'K',
             'f32': 'f',
         }[self.type]
 

--- a/scripts/pybind/retval.py
+++ b/scripts/pybind/retval.py
@@ -103,7 +103,7 @@ class NumericRetVal(RetVal):
     def parse_tuple_format(self):
         return {
             'i': 'i',
-            'u64': 'k',
+            'u64': 'K',
             'f32': 'f',
         }[self.type]
 


### PR DESCRIPTION
The custom `pybind` implementation for the Python binding has a bug when returning the masks for the input planes.

`Py_BuildValue()` takes a [format string](https://docs.python.org/3/c-api/arg.html) for converting C++ values to Python integers. Lowercase `k` is used for `unsigned long`, and uppercase `K` is used for `unsigned long long`. For `uint64_t`, we want to use the latter.

Previously, the bits were being stripped to 32 bits.
