### PR TITLE
Support outputting HLO in leela2onnx

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -623,12 +623,17 @@ if get_option('build_backends')
   ## ~~~~~~~~
   ## XLA
   ## ~~~~~~~~
-  if get_option('xla')
-      files += [
+  files += [
         'src/neural/xla/hlo_builder.cc',
-        'src/neural/xla/network_xla.cc',
         'src/neural/xla/onnx2hlo.cc',
         'src/neural/xla/print_hlo.cc',
+  ]
+  files += gen_proto_src.process('src/neural/xla/hlo.proto',
+      preserve_path_from : meson.current_source_dir() + '/src/')
+
+  if get_option('xla')
+      files += [
+        'src/neural/xla/network_xla.cc',
         'src/neural/xla/pjrt.cc',
         'src/neural/xla/xla_runner.cc',
       ]

--- a/meson.build
+++ b/meson.build
@@ -637,8 +637,6 @@ if get_option('build_backends')
         'src/neural/xla/pjrt.cc',
         'src/neural/xla/xla_runner.cc',
       ]
-      files += gen_proto_src.process('src/neural/xla/hlo.proto',
-          preserve_path_from : meson.current_source_dir() + '/src/')
       deps += cc.find_library('dl', required: false)
   endif
 

--- a/src/lc0ctl/leela2onnx.cc
+++ b/src/lc0ctl/leela2onnx.cc
@@ -39,35 +39,33 @@
 namespace lczero {
 namespace {
 
-const OptionId kInputFilenameId{"input", "InputFile",
+const OptionId kInputFilenameId{"input", "",
                                 "Path of the input Lc0 weights file."};
-const OptionId kOutputFilenameId{"output", "OutputFile",
-                                 "Path of the output ONNX file."};
-const OptionId kHloTextOutputFilenameId = {
-    "hlo-text-output", "HloTextOutputFile", "Path of the output HLO file."};
+const OptionId kOutputFilenameId{"output", "", "Path of the output ONNX file."};
+const OptionId kHloTextOutputFilenameId = {"hlo-text-output", "",
+                                           "Path of the output HLO file."};
 const OptionId kHloProtoOutputFilenameId = {
-    "hlo-proto-output", "HloProtoOutputFile",
-    "Path of the output HLO proto file."};
-const OptionId kHloBatchSizeId{"hlo-batch-size", "HloBatchSize",
+    "hlo-proto-output", "", "Path of the output HLO proto file."};
+const OptionId kHloBatchSizeId{"hlo-batch-size", "",
                                "Batch size to use for HLO conversion."};
 const OptionId kHloAllowPartialResultId = {
-    "hlo-allow-partial-result", "HloAllowPartialResult",
+    "hlo-allow-partial-result", "",
     "Allow partial result in case of HLO conversion failure (DEBUG ONLY!)."};
 
-const OptionId kInputPlanesName{"input-planes-name", "InputPlanesName",
+const OptionId kInputPlanesName{"input-planes-name", "",
                                 "ONNX name to use for the input planes node."};
 const OptionId kOutputPolicyHead{
-    "policy-head-name", "PolicyHeadName",
+    "policy-head-name", "",
     "ONNX name to use for the policy head output node."};
 const OptionId kOutputWdl{"wdl-head-name", "WdlHeadName",
                           "ONNX name to use for the WDL head output node."};
 const OptionId kOutputValue{
-    "value-head-name", "ValueHeadName",
+    "value-head-name", "",
     "ONNX name to use for value policy head output node."};
 const OptionId kOutputMlh{"mlh-head-name", "MlhHeadName",
                           "ONNX name to use for the MLH head output node."};
 const OptionId kOnnxToPytorch{
-    "onnx2pytorch", "Onnx2Pytorch",
+    "onnx2pytorch", "",
     "Only use layer definitions supported by onnx2pytorch."};
 
 bool ProcessParameters(OptionsParser* options) {
@@ -77,6 +75,7 @@ bool ProcessParameters(OptionsParser* options) {
   options->Add<StringOption>(kHloProtoOutputFilenameId);
   options->Add<IntOption>(kHloBatchSizeId, 1, 2048) = 333;
   options->Add<BoolOption>(kHloAllowPartialResultId);
+  options->HideOption(kHloAllowPartialResultId);
 
   options->Add<StringOption>(kInputPlanesName) = "/input/planes";
   options->Add<StringOption>(kOutputPolicyHead) = "/output/policy";

--- a/src/lc0ctl/leela2onnx.cc
+++ b/src/lc0ctl/leela2onnx.cc
@@ -26,12 +26,15 @@
 */
 
 #include <fstream>
+#include <iostream>
 
+#include "lc0ctl/describenet.h"
 #include "neural/loader.h"
 #include "neural/onnx/converter.h"
+#include "neural/xla/onnx2hlo.h"
+#include "neural/xla/print_hlo.h"
 #include "utils/files.h"
 #include "utils/optionsparser.h"
-#include "lc0ctl/describenet.h"
 
 namespace lczero {
 namespace {
@@ -40,6 +43,16 @@ const OptionId kInputFilenameId{"input", "InputFile",
                                 "Path of the input Lc0 weights file."};
 const OptionId kOutputFilenameId{"output", "OutputFile",
                                  "Path of the output ONNX file."};
+const OptionId kHloTextOutputFilenameId = {
+    "hlo-text-output", "HloTextOutputFile", "Path of the output HLO file."};
+const OptionId kHloProtoOutputFilenameId = {
+    "hlo-proto-output", "HloProtoOutputFile",
+    "Path of the output HLO proto file."};
+const OptionId kHloBatchSizeId{"hlo-batch-size", "HloBatchSize",
+                               "Batch size to use for HLO conversion."};
+const OptionId kHloAllowPartialResultId = {
+    "hlo-allow-partial-result", "HloAllowPartialResult",
+    "Allow partial result in case of HLO conversion failure (DEBUG ONLY!)."};
 
 const OptionId kInputPlanesName{"input-planes-name", "InputPlanesName",
                                 "ONNX name to use for the input planes node."};
@@ -53,12 +66,17 @@ const OptionId kOutputValue{
     "ONNX name to use for value policy head output node."};
 const OptionId kOutputMlh{"mlh-head-name", "MlhHeadName",
                           "ONNX name to use for the MLH head output node."};
-const OptionId kOnnxToPytorch{"onnx2pytorch", "Onnx2Pytorch",
-                          "Only use layer definitions supported by onnx2pytorch."};
+const OptionId kOnnxToPytorch{
+    "onnx2pytorch", "Onnx2Pytorch",
+    "Only use layer definitions supported by onnx2pytorch."};
 
 bool ProcessParameters(OptionsParser* options) {
   options->Add<StringOption>(kInputFilenameId);
   options->Add<StringOption>(kOutputFilenameId);
+  options->Add<StringOption>(kHloTextOutputFilenameId);
+  options->Add<StringOption>(kHloProtoOutputFilenameId);
+  options->Add<IntOption>(kHloBatchSizeId, 1, 2048) = 333;
+  options->Add<BoolOption>(kHloAllowPartialResultId);
 
   options->Add<StringOption>(kInputPlanesName) = "/input/planes";
   options->Add<StringOption>(kOutputPolicyHead) = "/output/policy";
@@ -70,8 +88,13 @@ bool ProcessParameters(OptionsParser* options) {
 
   const OptionsDict& dict = options->GetOptionsDict();
   dict.EnsureExists<std::string>(kInputFilenameId);
-  dict.EnsureExists<std::string>(kOutputFilenameId);
-
+  if (!dict.OwnExists<std::string>(kOutputFilenameId) &&
+      !dict.OwnExists<std::string>(kHloTextOutputFilenameId) &&
+      !dict.OwnExists<std::string>(kHloProtoOutputFilenameId)) {
+    throw Exception(
+        "At least one of --output, --hlo-output or --hlo-proto-output "
+        "must be specified.");
+  }
   return true;
 }
 
@@ -97,14 +120,40 @@ void ConvertLeelaToOnnx() {
     onnx_options.output_wdl = dict.Get<std::string>(kOutputWdl);
     onnx_options.output_value = dict.Get<std::string>(kOutputValue);
     onnx_options.output_wdl = dict.Get<std::string>(kOutputWdl);
-    // onnx2pytorch only needs an alternate layernorm-implementation, so it's currently
-    // only enables that. Might need to be extended in the future.
-    onnx_options.alternative_layer_normalization = dict.Get<bool>(kOnnxToPytorch);
+    // onnx2pytorch only needs an alternate layernorm-implementation, so it's
+    // currently only enables that. Might need to be extended in the future.
+    onnx_options.alternative_layer_normalization =
+        dict.Get<bool>(kOnnxToPytorch);
     weights_file = ConvertWeightsToOnnx(weights_file, onnx_options);
   }
 
   const auto& onnx = weights_file.onnx_model();
-  WriteStringToFile(dict.Get<std::string>(kOutputFilenameId), onnx.model());
+  if (dict.OwnExists<std::string>(kOutputFilenameId)) {
+    WriteStringToFile(dict.Get<std::string>(kOutputFilenameId), onnx.model());
+  }
+  if (dict.OwnExists<std::string>(kHloTextOutputFilenameId) ||
+      dict.OwnExists<std::string>(kHloProtoOutputFilenameId)) {
+    Onnx2HloOptions hlo_options;
+    hlo_options.debugging_allow_partial_result =
+        dict.Get<bool>(kHloAllowPartialResultId);
+    pblczero::ModelProto onnx_model;
+    onnx_model.ParseFromString(onnx.model());
+    auto hlo_result = ConvertOnnxToHlo(
+        onnx_model, dict.Get<int>(kHloBatchSizeId), hlo_options);
+    if (dict.OwnExists<std::string>(kHloTextOutputFilenameId)) {
+      std::string filename = dict.Get<std::string>(kHloTextOutputFilenameId);
+      if (filename == "-") {
+        PrettyPrintHlo(hlo_result.hlo_module, {}, std::cout);
+      } else {
+        std::ofstream file(filename.c_str());
+        PrettyPrintHlo(hlo_result.hlo_module, {}, file);
+      }
+    }
+    if (dict.OwnExists<std::string>(kHloProtoOutputFilenameId)) {
+      WriteStringToFile(dict.Get<std::string>(kHloProtoOutputFilenameId),
+                        hlo_result.hlo_module.OutputAsString());
+    }
+  }
   ShowNetworkOnnxInfo(weights_file, false);
   COUT << "Done.";
 }

--- a/src/neural/xla/hlo_builder.h
+++ b/src/neural/xla/hlo_builder.h
@@ -27,6 +27,7 @@
 
 #include <memory>
 #include <optional>
+#include <unordered_map>
 #include <vector>
 
 #include "neural/xla/hlo.pb.h"

--- a/src/neural/xla/onnx2hlo.h
+++ b/src/neural/xla/onnx2hlo.h
@@ -43,6 +43,9 @@ struct Onnx2HloOptions {
   // The types of input/output tensors (does not affect constants passed as
   // parameters).
   pblczero::XlaShapeProto::Type io_type = pblczero::XlaShapeProto::F32;
+  // If error occurs during conversion, return a partial result instead of
+  // failing. Only to be used for debugging.
+  bool debugging_allow_partial_result = false;
 };
 
 struct Onnx2HloResult {

--- a/src/neural/xla/print_hlo.cc
+++ b/src/neural/xla/print_hlo.cc
@@ -27,6 +27,8 @@
 
 #include "neural/xla/print_hlo.h"
 
+#include <cctype>
+
 namespace lczero {
 namespace {
 


### PR DESCRIPTION
In addition to (now optional) `--output=` parameter of `leela2onnx`,

* `--hlo-text-output=filename` to output as text HLO (or stdout if filename is `-`)
* `--hlo-proto-output=filename` to output to binary `HloModuleProto` file
* `--hlo-batch-size` -- for which batch size to generate HLO (333 is the default, to be noticeable in the output file)
* `--hlo-allow-partial-result` -- if conversion fails (i.e. due to ONNX op not being implemented), still output what was converted so far. Useful to look at the progress while implementing new ops.