### PR TITLE
backend to "switch" to a different net for the endgame

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -204,6 +204,7 @@ files += [
   'src/neural/network_random.cc',
   'src/neural/network_record.cc',
   'src/neural/network_rr.cc',
+  'src/neural/network_switch.cc',
   'src/neural/network_trivial.cc',
   'src/neural/onnx/adapters.cc',
   'src/neural/onnx/builder.cc',

--- a/src/neural/blas/network_blas.cc
+++ b/src/neural/blas/network_blas.cc
@@ -228,11 +228,7 @@ BlasComputation<use_eigen>::BlasComputation(
       ffn_activation_(ffn_activation),
       attn_policy_(attn_policy),
       attn_body_(attn_body),
-      network_(network) {
-#ifdef USE_DNNL
-  omp_set_num_threads(1);
-#endif
-}
+      network_(network) { }
 
 template <typename T>
 using EigenMatrixMap =
@@ -457,6 +453,9 @@ void BlasComputation<use_eigen>::MakeEncoderLayer(
 
 template <bool use_eigen>
 void BlasComputation<use_eigen>::ComputeBlocking() {
+#ifdef USE_DNNL
+  if (!use_eigen) omp_set_num_threads(1);
+#endif
   const auto& value_head = weights_.value_heads.at("winner");
   const auto& policy_head = weights_.policy_heads.at("vanilla");
   // Retrieve network key dimensions from the weights structure.
@@ -967,6 +966,7 @@ BlasNetwork<use_eigen>::BlasNetwork(const WeightsFile& file,
   }
 
   if (use_eigen) {
+    Eigen::setNbThreads(1);
     CERR << "Using Eigen version " << EIGEN_WORLD_VERSION << "."
          << EIGEN_MAJOR_VERSION << "." << EIGEN_MINOR_VERSION;
     CERR << "Eigen max batch size is " << max_batch_size_ << ".";

--- a/src/neural/network_blend.cc
+++ b/src/neural/network_blend.cc
@@ -1,0 +1,169 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2018-2021 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+ */
+
+#include "neural/factory.h"
+#include "neural/network.h"
+#include "utils/logging.h"
+
+namespace lczero {
+
+namespace {
+
+class BlendNetwork;
+
+class BlendComputation : public NetworkComputation {
+ public:
+  BlendComputation(std::unique_ptr<NetworkComputation> work_comp,
+                   std::unique_ptr<NetworkComputation> policy_comp)
+      : work_comp_(std::move(work_comp)),
+        policy_comp_(std::move(policy_comp)) {}
+
+  void AddInput(InputPlanes&& input) override {
+    InputPlanes x = input;
+    InputPlanes y = input;
+    work_comp_->AddInput(std::move(x));
+    policy_comp_->AddInput(std::move(y));
+  }
+
+  void ComputeBlocking() override {
+    work_comp_->ComputeBlocking();
+    policy_comp_->ComputeBlocking();
+  }
+
+  int GetBatchSize() const override {
+    return static_cast<int>(work_comp_->GetBatchSize());
+  }
+
+  float GetQVal(int sample) const override {
+    return work_comp_->GetQVal(sample);
+  }
+
+  float GetDVal(int sample) const override {
+    return work_comp_->GetDVal(sample);
+  }
+
+  float GetMVal(int sample) const override {
+    return work_comp_->GetMVal(sample);
+  }
+
+  float GetPVal(int sample, int move_id) const override {
+    return policy_comp_->GetPVal(sample, move_id);
+  }
+
+ private:
+  std::unique_ptr<NetworkComputation> work_comp_;
+  std::unique_ptr<NetworkComputation> policy_comp_;
+};
+
+class BlendNetwork : public Network {
+ public:
+  BlendNetwork(const std::optional<WeightsFile>& weights,
+               const OptionsDict& options) {
+    auto backends = NetworkFactory::Get()->GetBackendsList();
+
+    OptionsDict dict1;
+    std::string backendName1 = backends[0];
+    OptionsDict& backend1_dict = dict1;
+    std::string networkName1 = "<default>";
+
+    OptionsDict dict2;
+    std::string backendName2 = backends[0];
+    OptionsDict& backend2_dict = dict2;
+    std::string networkName2 = "<default>";
+
+    const auto parents = options.ListSubdicts();
+
+    if (parents.size() == 0) {
+      backendName1 = options.GetOrDefault<std::string>("backend", backendName1);
+      networkName1 = options.GetOrDefault<std::string>("weights", networkName1);
+    } else {
+      backend1_dict = options.GetSubdict(parents[0]);
+      backendName1 =
+          backend1_dict.GetOrDefault<std::string>("backend", backendName1);
+      networkName1 =
+          backend1_dict.GetOrDefault<std::string>("weights", networkName1);
+    }
+    if (parents.size() > 1) {
+      backend2_dict = options.GetSubdict(parents[1]);
+      backendName2 =
+          backend2_dict.GetOrDefault<std::string>("backend", backendName2);
+      networkName2 =
+          backend2_dict.GetOrDefault<std::string>("weights", networkName2);
+    }
+    if (parents.size() > 2) {
+      CERR << "Warning, cannot blend more than two backends";
+    }
+
+    if (networkName1 == "<default>") {
+      policy_net_ =
+          NetworkFactory::Get()->Create(backendName1, weights, backend1_dict);
+    } else {
+      CERR << "Policy net set to " << networkName1 << ".";
+      std::optional<WeightsFile> weights1;
+      weights1 = LoadWeightsFromFile(networkName1);
+      policy_net_ =
+          NetworkFactory::Get()->Create(backendName1, weights1, backend1_dict);
+    }
+
+    if (networkName2 == "<default>") {
+      work_net_ =
+          NetworkFactory::Get()->Create(backendName2, weights, backend2_dict);
+    } else {
+      CERR << "Working net set to " << networkName2 << ".";
+      std::optional<WeightsFile> weights2;
+      weights2 = LoadWeightsFromFile(networkName2);
+      work_net_ =
+          NetworkFactory::Get()->Create(backendName2, weights2, backend2_dict);
+    }
+  }
+
+  std::unique_ptr<NetworkComputation> NewComputation() override {
+    std::unique_ptr<NetworkComputation> work_comp = work_net_->NewComputation();
+    std::unique_ptr<NetworkComputation> policy_comp =
+        policy_net_->NewComputation();
+    return std::make_unique<BlendComputation>(std::move(work_comp),
+                                              std::move(policy_comp));
+  }
+
+  const NetworkCapabilities& GetCapabilities() const override {
+    return work_net_->GetCapabilities();
+  }
+
+ private:
+  std::unique_ptr<Network> work_net_;
+  std::unique_ptr<Network> policy_net_;
+};
+
+std::unique_ptr<Network> MakeBlendNetwork(
+    const std::optional<WeightsFile>& weights, const OptionsDict& options) {
+  return std::make_unique<BlendNetwork>(weights, options);
+}
+
+REGISTER_NETWORK("blend", MakeBlendNetwork, -800)
+
+}  // namespace
+}  // namespace lczero

--- a/src/neural/network_switch.cc
+++ b/src/neural/network_switch.cc
@@ -1,0 +1,152 @@
+/*
+ This file is part of Leela Chess Zero.
+ Copyright (C) 2024 The LCZero Authors
+
+ Leela Chess is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Leela Chess is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+ */
+
+#include "neural/network.h"
+#include "chess/bitboard.h"
+#include "neural/factory.h"
+#include "utils/logging.h"
+
+namespace lczero {
+
+namespace {
+
+class SwitchNetwork;
+
+class SwitchComputation : public NetworkComputation {
+ public:
+  SwitchComputation(std::unique_ptr<NetworkComputation> main_comp,
+                    std::unique_ptr<NetworkComputation> endgame_comp)
+      : main_comp_(std::move(main_comp)),
+        endgame_comp_(std::move(endgame_comp)) {}
+
+  void AddInput(InputPlanes&& input) override {
+    auto pieces = input[1].mask | input[2].mask | input[3].mask |
+                  input[4].mask | input[7].mask | input[8].mask |
+                  input[9].mask | input[10].mask;
+    if (BitBoard(pieces).count() > 6) {
+      is_endgame_.push_back(false);
+      rev_idx_.push_back(main_idx_.size());
+      main_idx_.push_back(main_idx_.size());
+      main_comp_->AddInput(std::move(input));
+    } else {
+      is_endgame_.push_back(true);
+      rev_idx_.push_back(endgame_idx_.size());
+      endgame_idx_.push_back(endgame_idx_.size());
+      endgame_comp_->AddInput(std::move(input));
+    }
+  }
+
+  void ComputeBlocking() override {
+    if (main_idx_.size() > 0) main_comp_->ComputeBlocking();
+    if (endgame_idx_.size() > 0) endgame_comp_->ComputeBlocking();
+  }
+
+  int GetBatchSize() const override {
+    return static_cast<int>(main_comp_->GetBatchSize() +
+                            endgame_comp_->GetBatchSize());
+  }
+
+  float GetQVal(int sample) const override {
+    if (is_endgame_[sample]) {
+      return endgame_comp_->GetQVal(rev_idx_[sample]);
+    }
+    return main_comp_->GetQVal(rev_idx_[sample]);
+  }
+
+  float GetDVal(int sample) const override {
+    if (is_endgame_[sample]) {
+      return endgame_comp_->GetDVal(rev_idx_[sample]);
+    }
+    return main_comp_->GetDVal(rev_idx_[sample]);
+  }
+
+  float GetMVal(int sample) const override {
+    if (is_endgame_[sample]) {
+      return endgame_comp_->GetMVal(rev_idx_[sample]);
+    }
+    return main_comp_->GetMVal(rev_idx_[sample]);
+  }
+
+  float GetPVal(int sample, int move_id) const override {
+    if (is_endgame_[sample]) {
+      return endgame_comp_->GetPVal(rev_idx_[sample], move_id);
+    }
+    return main_comp_->GetPVal(rev_idx_[sample], move_id);
+  }
+
+ private:
+  std::unique_ptr<NetworkComputation> main_comp_;
+  std::unique_ptr<NetworkComputation> endgame_comp_;
+  std::vector<size_t> main_idx_;
+  std::vector<size_t> endgame_idx_;
+  std::vector<size_t> rev_idx_;
+  std::vector<bool> is_endgame_;
+};
+
+class SwitchNetwork : public Network {
+ public:
+  SwitchNetwork(const std::optional<WeightsFile>& weights,
+                const OptionsDict& options) {
+    auto backends = NetworkFactory::Get()->GetBackendsList();
+    auto backend = options.GetOrDefault<std::string>("backend", backends[0]);
+    auto endgame_net = options.Get<std::string>("endgame_weights");
+
+    main_net_ = NetworkFactory::Get()->Create(backend, weights, options);
+
+    CERR << "Loading ensgame weights file from: " << endgame_net;
+    std::optional<WeightsFile> endgame_weights =
+        LoadWeightsFromFile(endgame_net);
+    endgame_net_ =
+        NetworkFactory::Get()->Create(backend, endgame_weights, options);
+  }
+
+  std::unique_ptr<NetworkComputation> NewComputation() override {
+    std::unique_ptr<NetworkComputation> main_comp = main_net_->NewComputation();
+    std::unique_ptr<NetworkComputation> endgame_comp =
+        endgame_net_->NewComputation();
+    return std::make_unique<SwitchComputation>(std::move(main_comp),
+                                               std::move(endgame_comp));
+  }
+
+  const NetworkCapabilities& GetCapabilities() const override {
+    return main_net_->GetCapabilities();
+  }
+
+ private:
+  std::unique_ptr<Network> main_net_;
+  std::unique_ptr<Network> endgame_net_;
+};
+
+std::unique_ptr<Network> MakeSwitchNetwork(
+    const std::optional<WeightsFile>& weights, const OptionsDict& options) {
+  return std::make_unique<SwitchNetwork>(weights, options);
+}
+
+REGISTER_NETWORK("switch", MakeSwitchNetwork, -800)
+
+}  // namespace
+}  // namespace lczero

--- a/src/utils/optionsdict.cc
+++ b/src/utils/optionsdict.cc
@@ -124,6 +124,13 @@ class Lexer {
     static const std::string kNumberChars = "0123456789-.";
     if (kNumberChars.find(str_[idx_]) != std::string::npos) {
       ReadNumber();
+      // If the next character isn't a separator, this is probably an identifier
+      // starting with a digit.
+      if (idx_ != str_.size() && !std::isspace(str_[idx_]) &&
+          str_[idx_] != ',' && str_[idx_] != ')') {
+        idx_ = last_offset_;
+        ReadIdentifier();
+      }
       return;
     }
 


### PR DESCRIPTION
The net is switched when the number of pieces on board, excluding pawns and kings, reaches a threshold, 6 by default. The net to switch to is selected using the `endgame_weights` backend option. Also two subdictionaries are accepted in the backend options, namely `main` and `endgame` to allow using different backend options with the respective net. Unsurprisingly, the threshold is set using the `threshold` backend option.