### PR TITLE
Support TF-generated ONNX files. Plus a few more ops added

### DIFF
--- a/src/neural/xla/hlo_builder.cc
+++ b/src/neural/xla/hlo_builder.cc
@@ -157,7 +157,11 @@ HloFlow HloBuilder::Broadcast(
     const std::vector<int64_t>& broadcast_dimensions) {
   auto flow = MakeInstruction("broadcast", target_shape.ToProto(), {input});
   if (broadcast_dimensions.size() != input->shape().dimensions_size()) {
-    throw Exception("Broadcast must have the same size as the input shape");
+    throw Exception(
+        "Broadcast must have the same size as the input shape: "
+        "broadcast_dimensions=" +
+            std::to_string(broadcast_dimensions.size()) +
+            ", input_shape=" + HloTensorType(input->shape()).ToString());
   }
   const auto& input_shape = input->shape();
   for (size_t i = 0; i < broadcast_dimensions.size(); ++i) {

--- a/src/neural/xla/hlo_builder.cc
+++ b/src/neural/xla/hlo_builder.cc
@@ -51,6 +51,7 @@ pblczero::XlaShapeProto HloTensorType::ToProto() const {
   pblczero::XlaShapeProto ret;
   ret.set_element_type(type_);
   *ret.mutable_dimensions() = dimensions_;
+  ret.mutable_layout();
   for (size_t i = 0; i < dimensions_.size(); ++i) {
     ret.add_is_dynamic_dimension(false);
     ret.mutable_layout()->add_minor_to_major(dimensions_.size() - i - 1);

--- a/src/neural/xla/hlo_builder.cc
+++ b/src/neural/xla/hlo_builder.cc
@@ -160,8 +160,8 @@ HloFlow HloBuilder::Broadcast(
     throw Exception(
         "Broadcast must have the same size as the input shape: "
         "broadcast_dimensions=" +
-            std::to_string(broadcast_dimensions.size()) +
-            ", input_shape=" + HloTensorType(input->shape()).ToString());
+        std::to_string(broadcast_dimensions.size()) +
+        ", input_shape=" + HloTensorType(input->shape()).ToString());
   }
   const auto& input_shape = input->shape();
   for (size_t i = 0; i < broadcast_dimensions.size(); ++i) {
@@ -427,7 +427,12 @@ HloFlow HloBuilder::Concatenate(const std::vector<HloFlow>& inputs,
         shape.SetDimension(
             j, shape.GetDimension(j) + inputs[i]->shape().dimensions(j));
       } else if (inputs[i]->shape().dimensions(j) != shape.GetDimension(j)) {
-        throw Exception("Concatenate operands must have the same shape");
+        std::string shapes;
+        for (const auto& input : inputs) {
+          shapes += HloTensorType(input->shape()).ToString() + ", ";
+        }
+        throw Exception("Concatenate operands must have the same shape, got " +
+                        shapes + "axis=" + std::to_string(dimension));
       }
     }
   }

--- a/src/neural/xla/hlo_builder.h
+++ b/src/neural/xla/hlo_builder.h
@@ -100,7 +100,6 @@ class HloBuilder {
   // HLO operations.
   HloFlow Parameter(const HloType& shape);
   HloFlow Constant(const pblczero::XlaLiteralProto& literal);
-  HloFlow Concatenate(const std::vector<HloFlow>& inputs, size_t dimension);
   HloFlow Convert(HloFlow input, const pblczero::XlaShapeProto::Type type);
   HloFlow Convolution(
       HloFlow input, HloFlow filter, const pblczero::XlaWindow& window,

--- a/src/neural/xla/onnx2hlo.cc
+++ b/src/neural/xla/onnx2hlo.cc
@@ -1281,7 +1281,7 @@ class Onnx2HloConverter {
     auto axes = *GetConstantInputAsVec<int64_t>(node, 1);
     HloTensorType input_shape(input->shape());
     HloTensorType new_shape(input->shape().element_type());
-    const size_t new_num_dims = input_shape.Rank() + new_shape.Rank();
+    const size_t new_num_dims = input_shape.Rank() + axes.size();
     size_t src_dim = 0;
     for (size_t i = 0; i < new_num_dims; ++i) {
       if (std::find(axes.begin(), axes.end(), i) != axes.end()) {

--- a/src/neural/xla/onnx2hlo.cc
+++ b/src/neural/xla/onnx2hlo.cc
@@ -373,6 +373,7 @@ class Onnx2HloConverter {
     onnx_op_to_builder_["Cast"] = &Onnx2HloConverter::OpCast;
     onnx_op_to_builder_["Concat"] = &Onnx2HloConverter::OpConcat;
     onnx_op_to_builder_["Conv"] = &Onnx2HloConverter::OpConv;
+    onnx_op_to_builder_["Div"] = &Onnx2HloConverter::OpDiv;
     onnx_op_to_builder_["Gather"] = &Onnx2HloConverter::OpGather;
     onnx_op_to_builder_["GlobalAveragePool"] =
         &Onnx2HloConverter::OpGlobalAveragePool;
@@ -946,6 +947,14 @@ class Onnx2HloConverter {
     auto* rhs = GetInput(node, 1);
     std::tie(lhs, rhs) = EqualizeShape(lhs, rhs);
     return {builder_.Add(lhs, rhs)};
+  }
+
+  std::vector<HloFlow> OpDiv(const pblczero::NodeProto& node) {
+    CheckKnownAttributes(node, 2, {});
+    auto* lhs = GetInput(node, 0);
+    auto* rhs = GetInput(node, 1);
+    std::tie(lhs, rhs) = EqualizeShape(lhs, rhs);
+    return {builder_.Divide(lhs, rhs)};
   }
 
   std::vector<HloFlow> OpSub(const pblczero::NodeProto& node) {

--- a/src/neural/xla/onnx2hlo.cc
+++ b/src/neural/xla/onnx2hlo.cc
@@ -1224,8 +1224,12 @@ class Onnx2HloConverter {
                                    sizeof(bf16));
         literal.set_bf16s(bf16_view);
       } break;
+      case pblczero::XlaShapeProto::S32:
+        literal.add_s32s(value);
+        break;
       default:
-        throw Exception("Unsupported type for a constant");
+        throw Exception("Unsupported type for a constant: " +
+                        pblczero::XlaShapeProto::Type_Name(type));
     }
     return builder_.Constant(literal);
   }

--- a/src/neural/xla/onnx2hlo.cc
+++ b/src/neural/xla/onnx2hlo.cc
@@ -1127,7 +1127,8 @@ class Onnx2HloConverter {
     if (axes_attr && axes_attr->size() != starts.size()) {
       throw Exception("Slice axes must have the same size as starts and ends");
     }
-    std::vector<int64_t> axes = axes_attr.value_or(std::vector<int64_t>());
+    std::vector<int64_t> axes =
+        axes_attr.value_or(std::vector<int64_t>(starts.size()));
     if (!axes_attr) std::iota(axes.begin(), axes.end(), 0);
 
     std::vector<pblczero::HloInstructionProto::SliceDimensions> slices;

--- a/src/neural/xla/onnx2hlo.cc
+++ b/src/neural/xla/onnx2hlo.cc
@@ -767,9 +767,10 @@ class Onnx2HloConverter {
   }
 
   std::vector<HloFlow> OpSoftmax(const pblczero::NodeProto& node) {
-    CheckKnownAttributes(node, 1, {"axis"});
-    const auto axis = GetAttributeAs<int>(node, "axis");
+    CheckKnownAttributes(node, 1, {""});
+    auto axis = GetOptionalAttributeAs<int>(node, "axis").value_or(-1);
     auto* input = GetInput(node, 0);
+    if (axis < 0) axis += input->shape().dimensions_size();
 
     // Normalize each batch by subtracting the maximum value.
     auto* max = builder_.Reduce(

--- a/src/neural/xla/onnx2hlo.cc
+++ b/src/neural/xla/onnx2hlo.cc
@@ -767,7 +767,7 @@ class Onnx2HloConverter {
   }
 
   std::vector<HloFlow> OpSoftmax(const pblczero::NodeProto& node) {
-    CheckKnownAttributes(node, 1, {""});
+    CheckKnownAttributes(node, 1, {"axis"});
     auto axis = GetOptionalAttributeAs<int>(node, "axis").value_or(-1);
     auto* input = GetInput(node, 0);
     if (axis < 0) axis += input->shape().dimensions_size();

--- a/src/neural/xla/onnx2hlo.cc
+++ b/src/neural/xla/onnx2hlo.cc
@@ -1236,8 +1236,8 @@ class Onnx2HloConverter {
       }
     }
     if (AllInputsConstant(node)) {
-      return {builder_.Constant(ConstReshape(*GetConstantInput(node, 0),
-                                            new_shape.ToProto()))};
+      return {builder_.Constant(
+          ConstReshape(*GetConstantInput(node, 0), new_shape.ToProto()))};
     }
     return {builder_.Reshape(input, new_shape)};
   }
@@ -1258,8 +1258,8 @@ class Onnx2HloConverter {
       }
     }
     if (AllInputsConstant(node)) {
-      return {builder_.Constant(ConstReshape(*GetConstantInput(node, 0),
-                                            new_shape.ToProto()))};
+      return {builder_.Constant(
+          ConstReshape(*GetConstantInput(node, 0), new_shape.ToProto()))};
     }
     return {builder_.Reshape(input, new_shape)};
   }
@@ -1427,8 +1427,15 @@ class Onnx2HloConverter {
   void DispatchNode(const pblczero::NodeProto& node) {
     auto iter = onnx_op_to_builder_.find(std::string(node.op_type()));
     if (iter == onnx_op_to_builder_.end()) {
+      std::string inputs;
+      for (const auto& input : node.input()) {
+        auto* flow = GetFlowByName(input);
+        inputs += "\ninput=[" + input + "]  shape=" +
+                  (flow ? flow->shape().OutputAsJson() : "(not found)");
+      }
       throw Exception("Unsupported ONNX op[" + std::string(node.op_type()) +
-                      "] name=[" + std::string(node.name()) + "]");
+                      "] name=[" + std::string(node.name()) + "] node=[" +
+                      node.OutputAsJson() + "]" + inputs);
     }
     try {
       auto outputs = (this->*iter->second)(node);

--- a/src/neural/xla/onnx2hlo.cc
+++ b/src/neural/xla/onnx2hlo.cc
@@ -189,7 +189,7 @@ HloTensorType OnnxShapeToHloTensorType(const pblczero::TypeProto& type,
       shape.AddDimension(dim.dim_value());
       continue;
     }
-    if (dim.dim_param() == "batch") {
+    if (dim.has_dim_param()) {
       if (batch_size.has_value()) {
         shape.AddDimension(batch_size.value());
         continue;

--- a/src/neural/xla/onnx2hlo.cc
+++ b/src/neural/xla/onnx2hlo.cc
@@ -760,7 +760,7 @@ class Onnx2HloConverter {
   std::vector<HloFlow> OpExpand(const pblczero::NodeProto& node) {
     CheckKnownAttributes(node, 2, {});
     auto* input = GetInput(node, 0);
-    const auto& shape = *GetConstantInputAsVec<int64_t>(node, 1);
+    const auto shape = *GetConstantInputAsVec<int64_t>(node, 1);
     return {DoBroadcast(input, shape)};
   }
 

--- a/src/neural/xla/onnx2hlo.cc
+++ b/src/neural/xla/onnx2hlo.cc
@@ -1245,6 +1245,9 @@ class Onnx2HloConverter {
       case pblczero::XlaShapeProto::S32:
         literal.add_s32s(value);
         break;
+      case pblczero::XlaShapeProto::S64:
+        literal.add_s64s(value);
+        break;
       default:
         throw Exception("Unsupported type for a constant: " +
                         pblczero::XlaShapeProto::Type_Name(type));


### PR DESCRIPTION
Added:
* Const versions for Cast, Gather
* Slice `axis` attr support.
* In Gather `axis` is optional
* ReduceProd
* ReduceSumSquare
* Unsqueeze
* Div
* BatchNormalization