### PR TITLE
Allow overriding the set of output nodes in ONNX2XLA

### DIFF
--- a/src/neural/xla/onnx2hlo.h
+++ b/src/neural/xla/onnx2hlo.h
@@ -46,6 +46,9 @@ struct Onnx2HloOptions {
   // If error occurs during conversion, return a partial result instead of
   // failing. Only to be used for debugging.
   bool debugging_allow_partial_result = false;
+  // If not empty, uses these nodes as outputs instead of the ones from the ONNX
+  // model.
+  std::vector<std::string> outputs_override;
 };
 
 struct Onnx2HloResult {


### PR DESCRIPTION
…d XLA, and only compute the heads that are needed in the XLA backend.

This is extracted from https://github.com/LeelaChessZero/lc0/pull/1986.