### PR TITLE
XlaTensor refactoring, in preparation to variable i/o types.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -641,6 +641,7 @@ if get_option('build_backends')
         'src/neural/xla/network_xla.cc',
         'src/neural/xla/pjrt.cc',
         'src/neural/xla/xla_runner.cc',
+        'src/neural/xla/xla_tensor.cc',
       ]
       deps += cc.find_library('dl', required: false)
   endif

--- a/src/neural/xla/onnx2hlo.cc
+++ b/src/neural/xla/onnx2hlo.cc
@@ -1544,8 +1544,8 @@ Onnx2HloResult ConvertOnnxToHlo(const pblczero::ModelProto& onnx_model,
 std::unique_ptr<XlaTensor> OnnxTensorToXlaTensor(
     const pblczero::TensorProto& onnx_tensor) {
   return std::make_unique<XlaTensorNotOwned>(
-      onnx_tensor.dims(), onnx_tensor.raw_data(),
-      OnnxTypeToXlaType(onnx_tensor.data_type()));
+      OnnxTypeToXlaType(onnx_tensor.data_type()), onnx_tensor.dims(),
+      onnx_tensor.raw_data());
 }
 
 }  // namespace lczero

--- a/src/neural/xla/xla_runner.cc
+++ b/src/neural/xla/xla_runner.cc
@@ -210,7 +210,7 @@ std::vector<std::unique_ptr<XlaTensor>> XlaRunner::ExecuteBlocking(
   for (size_t i = 0; i < outputs.size(); ++i) {
     const auto& output = outputs[i];
     auto new_tensor = std::make_unique<XlaMutableTensor>(
-        output->GetDimensions(), PjrtTypeToXlaType(output->GetType()));
+        PjrtTypeToXlaType(output->GetType()), output->GetDimensions());
     done_events.push_back(
         output->DeviceToHost(new_tensor->mutable_data(), new_tensor->size()));
     result.push_back(std::move(new_tensor));

--- a/src/neural/xla/xla_runner.cc
+++ b/src/neural/xla/xla_runner.cc
@@ -209,7 +209,7 @@ std::vector<std::unique_ptr<XlaTensor>> XlaRunner::ExecuteBlocking(
   // Initialte transfers from device to host.
   for (size_t i = 0; i < outputs.size(); ++i) {
     const auto& output = outputs[i];
-    auto new_tensor = std::make_unique<XlaTensorOwned>(
+    auto new_tensor = std::make_unique<XlaMutableTensor>(
         output->GetDimensions(), PjrtTypeToXlaType(output->GetType()));
     done_events.push_back(
         output->DeviceToHost(new_tensor->mutable_data(), new_tensor->size()));

--- a/src/neural/xla/xla_runner.cc
+++ b/src/neural/xla/xla_runner.cc
@@ -120,44 +120,7 @@ PjrtType XlaTypeToPjrtType(pblczero::XlaShapeProto::Type type) {
                       pblczero::XlaShapeProto::Type_Name(type));
   }
 }
-
-std::string AsHexString(std::string_view buf) {
-  std::string result;
-  result.reserve(buf.size() * 2);
-  constexpr char hex[] = "0123456789abcdef";
-  for (unsigned char c : buf) {
-    result.push_back(hex[c >> 4]);
-    result.push_back(hex[c & 0xf]);
-  }
-  return result;
-}
-
 }  // namespace
-
-std::string XlaTensor::DebugString() {
-  constexpr size_t kMaxSize = 1000;
-  constexpr size_t kSuffixSize = 200;
-  std::string result = "XlaTensor(";
-  result += "shape=[";
-  for (size_t i = 0; i < shape().size(); ++i) {
-    if (i > 0) result += ", ";
-    result += std::to_string(shape()[i]);
-  }
-  result += "], type=";
-  result += pblczero::XlaShapeProto::Type_Name(type());
-  result += ") size=" + std::to_string(size());
-  result += " data=";
-  if (size() <= kMaxSize) {
-    result += AsHexString({static_cast<const char*>(data()), size()});
-  } else {
-    result += AsHexString(
-        {static_cast<const char*>(data()), kMaxSize - kSuffixSize - 2});
-    result += "....";
-    result += AsHexString(
-        {static_cast<const char*>(data()) + size() - kSuffixSize, kSuffixSize});
-  }
-  return result;
-}
 
 XlaRunner::XlaRunner(const char* library_path, int device)
     : pjrt_client_(Pjrt(library_path).CreateClient()), device_(device) {
@@ -273,7 +236,7 @@ std::vector<std::unique_ptr<XlaTensor>> XlaRunner::ExecuteBlocking(
   for (size_t i = 0; i < outputs.size(); ++i) {
     const auto& output = outputs[i];
     done_events[i]->Await();
-    result.push_back(std::make_unique<XlaTensorOwned>(
+    result.push_back(std::make_unique<XlaTensorStringBuf>(
         output->GetDimensions(), PjrtTypeToXlaType(output->GetType()),
         std::move(output_buffers[i])));
   }

--- a/src/neural/xla/xla_runner.h
+++ b/src/neural/xla/xla_runner.h
@@ -52,7 +52,7 @@ class XlaRunner {
   // the batch size. Only non-frozen inputs are passed as arguments.
   // Currnetly only single input is supported (just because we don't need more).
   std::vector<std::unique_ptr<XlaTensor>> ExecuteBlocking(
-      const std::vector<XlaTensor*>& inputs);
+      const std::vector<XlaMutableTensor*>& inputs);
   // Inputs that are shared between all calls (i.e. network weights passed as
   // parameters). These inputs are transferred to device immediately (and not
   // for each inference).

--- a/src/neural/xla/xla_runner.h
+++ b/src/neural/xla/xla_runner.h
@@ -35,64 +35,9 @@
 
 #include "neural/xla/hlo.pb.h"
 #include "neural/xla/pjrt.h"
+#include "neural/xla/xla_tensor.h"
 
 namespace lczero {
-
-// An interface for in-host-memory tensor in XLA format.
-class XlaTensor {
- public:
-  virtual ~XlaTensor() = default;
-  virtual const std::vector<int64_t>& shape() const = 0;
-  virtual const void* data() const = 0;
-  // Returns amount of valid data in bytes.
-  virtual size_t size() const = 0;
-  // Returns amount of memory that are allowed to address in bytes. This is
-  // useful when the size of the buffer has to be increased to match the
-  // supported batch size.
-  virtual size_t capacity() const = 0;
-  virtual pblczero::XlaShapeProto::Type type() const = 0;
-
-  std::string DebugString();
-};
-
-// Not-owned XLA tensor, used e.g. when ONNX buffer can be used directly, to
-// avoid unnecessary copy.
-class XlaTensorNotOwned : public XlaTensor {
- public:
-  XlaTensorNotOwned(const std::vector<int64_t>& shape, std::string_view data,
-                    pblczero::XlaShapeProto::Type type)
-      : shape_(&shape), data_(data), type_(type) {}
-
-  const std::vector<int64_t>& shape() const override { return *shape_; }
-  const void* data() const override { return data_.data(); }
-  size_t size() const override { return data_.size(); }
-  size_t capacity() const override { return data_.size(); }
-  pblczero::XlaShapeProto::Type type() const override { return type_; }
-
- private:
-  const std::vector<int64_t>* shape_;
-  std::string_view data_;
-  pblczero::XlaShapeProto::Type type_;
-};
-
-// Tensor that owns data, used e.g. for XLA output.
-class XlaTensorOwned : public XlaTensor {
- public:
-  XlaTensorOwned(const std::vector<int64_t>& shape,
-                 pblczero::XlaShapeProto::Type type, std::string data)
-      : shape_(shape), type_(type), data_(data) {}
-
-  const std::vector<int64_t>& shape() const override { return shape_; }
-  const void* data() const override { return data_.data(); }
-  size_t size() const override { return data_.size(); }
-  size_t capacity() const override { return data_.size(); }
-  pblczero::XlaShapeProto::Type type() const override { return type_; }
-
- private:
-  std::vector<int64_t> shape_;
-  pblczero::XlaShapeProto::Type type_;
-  std::string data_;
-};
 
 // A class that keeps several XLA executables (for different batch sizes),
 // manages common buffers among them, and chooses the right executable for a

--- a/src/neural/xla/xla_tensor.cc
+++ b/src/neural/xla/xla_tensor.cc
@@ -27,25 +27,7 @@
 
 #include "neural/xla/xla_tensor.h"
 
-#include "utils/exception.h"
-
 namespace lczero {
-size_t GetXlaTypeSize(pblczero::XlaShapeProto::Type type) {
-  switch (type) {
-    case pblczero::XlaShapeProto::F32:
-      return sizeof(float);
-    case pblczero::XlaShapeProto::F64:
-      return sizeof(double);
-    case pblczero::XlaShapeProto::S32:
-      return sizeof(int32_t);
-    case pblczero::XlaShapeProto::S64:
-      return sizeof(int64_t);
-    default:
-      throw Exception("Add size for type " +
-                      pblczero::XlaShapeProto::Type_Name(type));
-  }
-}
-
 namespace {
 std::string AsHexString(std::string_view buf) {
   std::string result;

--- a/src/neural/xla/xla_tensor.cc
+++ b/src/neural/xla/xla_tensor.cc
@@ -67,4 +67,14 @@ std::string XlaTensor::DebugString() {
   return result;
 }
 
+void XlaMutableTensor::Reshape(const std::vector<int64_t>& new_shape) {
+  const size_t new_size = GetBufferSize(type_, new_shape);
+  if (new_size > capacity_) {
+    // TODO Implement allocating of new buffer when needed.
+    throw Exception("Reshape to exceeds capacity.");
+  }
+  shape_ = new_shape;
+  size_ = new_size;
+}
+
 }  // namespace lczero

--- a/src/neural/xla/xla_tensor.cc
+++ b/src/neural/xla/xla_tensor.cc
@@ -1,0 +1,70 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2024 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#include "neural/xla/xla_tensor.h"
+
+namespace lczero {
+namespace {
+std::string AsHexString(std::string_view buf) {
+  std::string result;
+  result.reserve(buf.size() * 2);
+  constexpr char hex[] = "0123456789abcdef";
+  for (unsigned char c : buf) {
+    result.push_back(hex[c >> 4]);
+    result.push_back(hex[c & 0xf]);
+  }
+  return result;
+}
+
+}  // namespace
+
+std::string XlaTensor::DebugString() {
+  constexpr size_t kMaxSize = 1000;
+  constexpr size_t kSuffixSize = 200;
+  std::string result = "XlaTensor(";
+  result += "shape=[";
+  for (size_t i = 0; i < shape().size(); ++i) {
+    if (i > 0) result += ", ";
+    result += std::to_string(shape()[i]);
+  }
+  result += "], type=";
+  result += pblczero::XlaShapeProto::Type_Name(type());
+  result += ") size=" + std::to_string(size());
+  result += " data=";
+  if (size() <= kMaxSize) {
+    result += AsHexString({static_cast<const char*>(data()), size()});
+  } else {
+    result += AsHexString(
+        {static_cast<const char*>(data()), kMaxSize - kSuffixSize - 2});
+    result += "....";
+    result += AsHexString(
+        {static_cast<const char*>(data()) + size() - kSuffixSize, kSuffixSize});
+  }
+  return result;
+}
+
+}  // namespace lczero

--- a/src/neural/xla/xla_tensor.cc
+++ b/src/neural/xla/xla_tensor.cc
@@ -27,7 +27,25 @@
 
 #include "neural/xla/xla_tensor.h"
 
+#include "utils/exception.h"
+
 namespace lczero {
+size_t GetXlaTypeSize(pblczero::XlaShapeProto::Type type) {
+  switch (type) {
+    case pblczero::XlaShapeProto::F32:
+      return sizeof(float);
+    case pblczero::XlaShapeProto::F64:
+      return sizeof(double);
+    case pblczero::XlaShapeProto::S32:
+      return sizeof(int32_t);
+    case pblczero::XlaShapeProto::S64:
+      return sizeof(int64_t);
+    default:
+      throw Exception("Add size for type " +
+                      pblczero::XlaShapeProto::Type_Name(type));
+  }
+}
+
 namespace {
 std::string AsHexString(std::string_view buf) {
   std::string result;

--- a/src/neural/xla/xla_tensor.h
+++ b/src/neural/xla/xla_tensor.h
@@ -34,10 +34,25 @@
 #include <vector>
 
 #include "neural/xla/hlo.pb.h"
+#include "utils/exception.h"
 
 namespace lczero {
 
-size_t GetXlaTypeSize(pblczero::XlaShapeProto::Type type);
+constexpr size_t GetXlaTypeSize(pblczero::XlaShapeProto::Type type) {
+  switch (type) {
+    case pblczero::XlaShapeProto::F32:
+      return sizeof(float);
+    case pblczero::XlaShapeProto::F64:
+      return sizeof(double);
+    case pblczero::XlaShapeProto::S32:
+      return sizeof(int32_t);
+    case pblczero::XlaShapeProto::S64:
+      return sizeof(int64_t);
+    default:
+      throw Exception("Add size for type " +
+                      pblczero::XlaShapeProto::Type_Name(type));
+  }
+}
 
 // An interface for in-host-memory tensor in XLA format.
 class XlaTensor {
@@ -77,10 +92,10 @@ class XlaTensorNotOwned : public XlaTensor {
 };
 
 // Tensor that owns data, used e.g. for XLA output.
-class XlaTensorOwned : public XlaTensor {
+class XlaMutableTensor : public XlaTensor {
  public:
-  XlaTensorOwned(const std::vector<int64_t>& shape,
-                 pblczero::XlaShapeProto::Type type)
+  XlaMutableTensor(const std::vector<int64_t>& shape,
+                   pblczero::XlaShapeProto::Type type)
       : shape_(shape),
         type_(type),
         size_(GetBufferSize(shape, type)),

--- a/src/neural/xla/xla_tensor.h
+++ b/src/neural/xla/xla_tensor.h
@@ -1,0 +1,94 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2024 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "neural/xla/hlo.pb.h"
+
+namespace lczero {
+
+// An interface for in-host-memory tensor in XLA format.
+class XlaTensor {
+ public:
+  virtual ~XlaTensor() = default;
+  virtual const std::vector<int64_t>& shape() const = 0;
+  virtual const void* data() const = 0;
+  // Returns amount of valid data in bytes.
+  virtual size_t size() const = 0;
+  // Returns amount of memory that are allowed to address in bytes. This is
+  // useful when the size of the buffer has to be increased to match the
+  // supported batch size.
+  virtual size_t capacity() const = 0;
+  virtual pblczero::XlaShapeProto::Type type() const = 0;
+
+  std::string DebugString();
+};
+
+// Not-owned XLA tensor, used e.g. when ONNX buffer can be used directly, to
+// avoid unnecessary copy.
+class XlaTensorNotOwned : public XlaTensor {
+ public:
+  XlaTensorNotOwned(const std::vector<int64_t>& shape, std::string_view data,
+                    pblczero::XlaShapeProto::Type type)
+      : shape_(&shape), data_(data), type_(type) {}
+
+  const std::vector<int64_t>& shape() const override { return *shape_; }
+  const void* data() const override { return data_.data(); }
+  size_t size() const override { return data_.size(); }
+  size_t capacity() const override { return data_.size(); }
+  pblczero::XlaShapeProto::Type type() const override { return type_; }
+
+ private:
+  const std::vector<int64_t>* shape_;
+  std::string_view data_;
+  pblczero::XlaShapeProto::Type type_;
+};
+
+// Tensor that owns data, used e.g. for XLA output.
+class XlaTensorStringBuf : public XlaTensor {
+ public:
+  XlaTensorStringBuf(const std::vector<int64_t>& shape,
+                 pblczero::XlaShapeProto::Type type, std::string data)
+      : shape_(shape), type_(type), data_(data) {}
+
+  const std::vector<int64_t>& shape() const override { return shape_; }
+  const void* data() const override { return data_.data(); }
+  size_t size() const override { return data_.size(); }
+  size_t capacity() const override { return data_.size(); }
+  pblczero::XlaShapeProto::Type type() const override { return type_; }
+
+ private:
+  std::vector<int64_t> shape_;
+  pblczero::XlaShapeProto::Type type_;
+  std::string data_;
+};
+
+}  // namespace lczero

--- a/src/neural/xla/xla_tensor.h
+++ b/src/neural/xla/xla_tensor.h
@@ -111,6 +111,7 @@ class XlaMutableTensor : public XlaTensor {
   size_t size() const override { return size_; }
   size_t capacity() const override { return capacity_; }
   pblczero::XlaShapeProto::Type type() const override { return type_; }
+  void Reshape(const std::vector<int64_t>& new_shape);
 
   static size_t GetBufferSize(pblczero::XlaShapeProto::Type type,
                               const std::vector<int64_t>& shape) {

--- a/src/neural/xla/xla_tensor.h
+++ b/src/neural/xla/xla_tensor.h
@@ -95,14 +95,14 @@ class XlaTensorNotOwned : public XlaTensor {
 class XlaMutableTensor : public XlaTensor {
  public:
   XlaMutableTensor(pblczero::XlaShapeProto::Type type,
-                   const std::vector<int64_t>& shape)
+                   const std::vector<int64_t>& shape, size_t capacity = 0)
       : shape_(shape),
         type_(type),
-        size_(GetBufferSize(shape, type)),
-        capacity_(size_),
+        size_(GetBufferSize(type, shape)),
+        capacity_(std::max(size_, capacity)),
         // TODO replace with make_unique_for_overwrite() once C++20 is
         // available.
-        data_(new char[size_]) {}
+        data_(new char[capacity_]) {}
 
   const std::vector<int64_t>& shape() const override { return shape_; }
   const void* data() const override { return data_.get(); }
@@ -112,8 +112,8 @@ class XlaMutableTensor : public XlaTensor {
   size_t capacity() const override { return capacity_; }
   pblczero::XlaShapeProto::Type type() const override { return type_; }
 
-  static size_t GetBufferSize(const std::vector<int64_t>& shape,
-                              pblczero::XlaShapeProto::Type type) {
+  static size_t GetBufferSize(pblczero::XlaShapeProto::Type type,
+                              const std::vector<int64_t>& shape) {
     return GetXlaTypeSize(type) * std::accumulate(shape.begin(), shape.end(), 1,
                                                   std::multiplies<int64_t>());
   }

--- a/src/neural/xla/xla_tensor.h
+++ b/src/neural/xla/xla_tensor.h
@@ -38,7 +38,7 @@
 
 namespace lczero {
 
-constexpr size_t GetXlaTypeSize(pblczero::XlaShapeProto::Type type) {
+inline size_t GetXlaTypeSize(pblczero::XlaShapeProto::Type type) {
   switch (type) {
     case pblczero::XlaShapeProto::F32:
       return sizeof(float);
@@ -112,8 +112,8 @@ class XlaMutableTensor : public XlaTensor {
   size_t capacity() const override { return capacity_; }
   pblczero::XlaShapeProto::Type type() const override { return type_; }
 
-  static constexpr size_t GetBufferSize(const std::vector<int64_t>& shape,
-                                        pblczero::XlaShapeProto::Type type) {
+  static size_t GetBufferSize(const std::vector<int64_t>& shape,
+                              pblczero::XlaShapeProto::Type type) {
     return GetXlaTypeSize(type) * std::accumulate(shape.begin(), shape.end(), 1,
                                                   std::multiplies<int64_t>());
   }

--- a/src/neural/xla/xla_tensor.h
+++ b/src/neural/xla/xla_tensor.h
@@ -75,8 +75,8 @@ class XlaTensor {
 // avoid unnecessary copy.
 class XlaTensorNotOwned : public XlaTensor {
  public:
-  XlaTensorNotOwned(const std::vector<int64_t>& shape, std::string_view data,
-                    pblczero::XlaShapeProto::Type type)
+  XlaTensorNotOwned(pblczero::XlaShapeProto::Type type,
+                    const std::vector<int64_t>& shape, std::string_view data)
       : shape_(&shape), data_(data), type_(type) {}
 
   const std::vector<int64_t>& shape() const override { return *shape_; }
@@ -94,8 +94,8 @@ class XlaTensorNotOwned : public XlaTensor {
 // Tensor that owns data, used e.g. for XLA output.
 class XlaMutableTensor : public XlaTensor {
  public:
-  XlaMutableTensor(const std::vector<int64_t>& shape,
-                   pblczero::XlaShapeProto::Type type)
+  XlaMutableTensor(pblczero::XlaShapeProto::Type type,
+                   const std::vector<int64_t>& shape)
       : shape_(shape),
         type_(type),
         size_(GetBufferSize(shape, type)),


### PR DESCRIPTION
* Move XlaTensor to a separate file
* Remove string-based tensor buffer, only use heap-based `XlaMutableTensor` for all use cases.
* Remove special Lc0InputTensor, use "generic" `XlaMutableTensor` for it
* Both adding a sample to a tensor, and resizing the tensor to be accepted by PjRt Executable is done by the same `XlaMutableTensor::Reshape`