### PR TITLE
fix build outside x86_64/aarch64

### DIFF
--- a/src/utils/mutex.h
+++ b/src/utils/mutex.h
@@ -32,8 +32,7 @@
 #include <shared_mutex>
 #include <thread>
 
-#if !defined(__arm__) && !defined(__aarch64__) && !defined(_M_ARM) && \
-    !defined(_M_ARM64)
+#if defined(__x86_64__)
 #include <emmintrin.h>
 #endif
 
@@ -126,8 +125,7 @@ class CAPABILITY("mutex") SharedMutex {
 };
 
 static inline void SpinloopPause() {
-#if !defined(__arm__) && !defined(__aarch64__) && !defined(_M_ARM) && \
-    !defined(_M_ARM64)
+#if defined(__x86_64__)
   _mm_pause();
 #endif
 }


### PR DESCRIPTION
the current logic includes the x86 simd header any time the platform is !arm, which is backwards