### PR TITLE
fix dml install script

### DIFF
--- a/dist/install-dml.cmd
+++ b/dist/install-dml.cmd
@@ -2,14 +2,7 @@
 where /q tar
 if errorlevel 1 goto error
 
-where /q lc0.exe
-if errorlevel 1 cd /d %~dp0
-where /q lc0.exe
-if errorlevel 1 (
-  echo This script must run in the lc0 folder.
-  pause
-  exit /b
-)
+cd /d %~dp0
 
 cls
 echo Installing the DirectML.dll version required by the Lc0 onnx-dml backend.


### PR DESCRIPTION
While testing #2009  I found a bug with the directml install script, probably some recent windows security change makes executables in the same directory unavailable when running it by double clicking, so I removed the lc0.exe check and it will directly install the dlls in the script's directory.