### PR TITLE
fixed wrong nodes_limit for "go nodes 0" for issue #2003 

### DIFF
--- a/src/mcts/stoppers/stoppers.h
+++ b/src/mcts/stoppers/stoppers.h
@@ -54,7 +54,7 @@ class ChainedSearchStopper : public SearchStopper {
 class VisitsStopper : public SearchStopper {
  public:
   VisitsStopper(int64_t limit, bool populate_remaining_playouts)
-    : nodes_limit_(limit ? limit : 4000000000ll),
+    : nodes_limit_(limit),
         populate_remaining_playouts_(populate_remaining_playouts) {}
   int64_t GetVisitsLimit() const { return nodes_limit_; }
   bool ShouldStop(const IterationStats&, StoppersHints*) override;


### PR DESCRIPTION
I removed the condition on limit_nodes, making `go nodes 0` stop.