### PR TITLE
Update meson.build and build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -57,7 +57,7 @@ if "%CUDA_PATH%"=="%CUDNN_PATH%" (
 
 if %CUDNN%==true set PATH=%CUDA_PATH%\bin;%PATH%
 
-meson build --backend %backend% --buildtype release -Ddx=%DX12% -Dcudnn=%CUDNN% -Dplain_cuda=%CUDA% ^
+meson setup build --backend %backend% --buildtype release -Ddx=%DX12% -Dcudnn=%CUDNN% -Dplain_cuda=%CUDA% ^
 -Dopencl=%OPENCL% -Dblas=%BLAS% -Dmkl=%MKL% -Dopenblas=%OPENBLAS% -Ddnnl=%DNNL% -Dgtest=%TEST% ^
 -Dcudnn_include="%CUDNN_INCLUDE_PATH%" -Dcudnn_libdirs="%CUDNN_LIB_PATH%" ^
 -Dmkl_include="%MKL_PATH%\include" -Dmkl_libdirs="%MKL_PATH%\lib\intel64" -Ddnnl_dir="%DNNL_PATH%" ^

--- a/meson.build
+++ b/meson.build
@@ -84,7 +84,7 @@ if run_command('scripts/checkdir.py', 'libs/lczero-common/proto', check : true).
       message('cloning lczero-common.git into libs/lczero-common')
       run_command(git, 'clone', '--depth=1',
                   'https://github.com/LeelaChessZero/lczero-common.git',
-                  'libs/lczero-common/', check : true)
+                  'libs/lczero-common/', check : false)
     endif
   else
     error('Please install git to automatically fetch submodules or download the archives manually from GitHub.')
@@ -101,12 +101,12 @@ common_files += pb_files
 # Extract git short revision.
 short_rev = 'unknown'
 if git.found()
-  r = run_command(git, 'rev-parse', '--short', 'HEAD', check : true)
+  r = run_command(git, 'rev-parse', '--short', 'HEAD', check : false)
   if r.returncode() == 0
     # Now let's check if the working directory is clean.
-    if run_command(git, 'diff-index', '--quiet', 'HEAD', check : true).returncode() == 0
+    if run_command(git, 'diff-index', '--quiet', 'HEAD', check : false).returncode() == 0
       short_rev = r.stdout().strip()
-      if run_command(git, 'describe', '--exact-match', '--tags', check : true).returncode() == 0
+      if run_command(git, 'describe', '--exact-match', '--tags', check : false).returncode() == 0
         short_rev = ''
       endif
     else

--- a/meson.build
+++ b/meson.build
@@ -75,11 +75,11 @@ gen = generator(compile_proto, output: ['@BASENAME@.pb.h'],
 
 # Handle submodules.
 git = find_program('git', required: false)
-if run_command('scripts/checkdir.py', 'libs/lczero-common/proto', check : true).returncode() != 0
+if run_command('scripts/checkdir.py', 'libs/lczero-common/proto', check : false).returncode() != 0
   if git.found()
-    if run_command(git, 'status', check : true).returncode() == 0
+    if run_command(git, 'status', check : false).returncode() == 0
       message('updating git submodule libs/lczero-common')
-      run_command(git, 'submodule', 'update', '--init', '--recursive', check : true)
+      run_command(git, 'submodule', 'update', '--init', '--recursive', check : false)
     else
       message('cloning lczero-common.git into libs/lczero-common')
       run_command(git, 'clone', '--depth=1',
@@ -272,7 +272,7 @@ if get_option('build_backends')
   if get_option('blas')
     if get_option('mkl') and mkl_lib.found()
       mkl_inc = get_option('mkl_include')
-      if run_command('scripts/checkdir.py', mkl_inc, check : true).returncode() == 0
+      if run_command('scripts/checkdir.py', mkl_inc, check : false).returncode() == 0
         includes += include_directories(mkl_inc)
       endif
       if cc.has_header('mkl.h')
@@ -459,7 +459,7 @@ if get_option('build_backends')
       cuda_files += 'src/neural/cuda/network_cuda.cc'
     endif
     foreach d : get_option('cudnn_include')
-      if run_command('scripts/checkdir.py', d, check : true).returncode() == 0
+      if run_command('scripts/checkdir.py', d, check : false).returncode() == 0
         includes += include_directories(d, is_system: true)
       endif
     endforeach
@@ -467,7 +467,7 @@ if get_option('build_backends')
 
     cuda_arguments = ['-c', '@INPUT@', '-o', '@OUTPUT@',
                       '-I', meson.current_source_dir() + '/src']
-    nvcc_help = run_command(nvcc, '-h', check : true).stdout()
+    nvcc_help = run_command(nvcc, '-h', check : false).stdout()
     if host_machine.system() == 'windows'
       if get_option('b_vscrt') == 'mt'
         cuda_arguments += ['-Xcompiler', '-MT']

--- a/meson.build
+++ b/meson.build
@@ -75,16 +75,16 @@ gen = generator(compile_proto, output: ['@BASENAME@.pb.h'],
 
 # Handle submodules.
 git = find_program('git', required: false)
-if run_command('scripts/checkdir.py', 'libs/lczero-common/proto').returncode() != 0
+if run_command('scripts/checkdir.py', 'libs/lczero-common/proto', check : true).returncode() != 0
   if git.found()
-    if run_command(git, 'status').returncode() == 0
+    if run_command(git, 'status', check : true).returncode() == 0
       message('updating git submodule libs/lczero-common')
-      run_command(git, 'submodule', 'update', '--init', '--recursive')
+      run_command(git, 'submodule', 'update', '--init', '--recursive', check : true)
     else
       message('cloning lczero-common.git into libs/lczero-common')
       run_command(git, 'clone', '--depth=1',
                   'https://github.com/LeelaChessZero/lczero-common.git',
-                  'libs/lczero-common/')
+                  'libs/lczero-common/', check : true)
     endif
   else
     error('Please install git to automatically fetch submodules or download the archives manually from GitHub.')
@@ -101,12 +101,12 @@ common_files += pb_files
 # Extract git short revision.
 short_rev = 'unknown'
 if git.found()
-  r = run_command(git, 'rev-parse', '--short', 'HEAD')
+  r = run_command(git, 'rev-parse', '--short', 'HEAD', check : true)
   if r.returncode() == 0
     # Now let's check if the working directory is clean.
-    if run_command(git, 'diff-index', '--quiet', 'HEAD').returncode() == 0
+    if run_command(git, 'diff-index', '--quiet', 'HEAD', check : true).returncode() == 0
       short_rev = r.stdout().strip()
-      if run_command(git, 'describe', '--exact-match', '--tags').returncode() == 0
+      if run_command(git, 'describe', '--exact-match', '--tags', check : true).returncode() == 0
         short_rev = ''
       endif
     else
@@ -272,7 +272,7 @@ if get_option('build_backends')
   if get_option('blas')
     if get_option('mkl') and mkl_lib.found()
       mkl_inc = get_option('mkl_include')
-      if run_command('scripts/checkdir.py', mkl_inc).returncode() == 0
+      if run_command('scripts/checkdir.py', mkl_inc, check : true).returncode() == 0
         includes += include_directories(mkl_inc)
       endif
       if cc.has_header('mkl.h')
@@ -459,7 +459,7 @@ if get_option('build_backends')
       cuda_files += 'src/neural/cuda/network_cuda.cc'
     endif
     foreach d : get_option('cudnn_include')
-      if run_command('scripts/checkdir.py', d).returncode() == 0
+      if run_command('scripts/checkdir.py', d, check : true).returncode() == 0
         includes += include_directories(d, is_system: true)
       endif
     endforeach
@@ -467,7 +467,7 @@ if get_option('build_backends')
 
     cuda_arguments = ['-c', '@INPUT@', '-o', '@OUTPUT@',
                       '-I', meson.current_source_dir() + '/src']
-    nvcc_help = run_command(nvcc, '-h').stdout()
+    nvcc_help = run_command(nvcc, '-h', check : true).stdout()
     if host_machine.system() == 'windows'
       if get_option('b_vscrt') == 'mt'
         cuda_arguments += ['-Xcompiler', '-MT']


### PR DESCRIPTION
Takes away meson warning for meson 1.1.0 or newer on windows builds.
```WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.```

Added meson kwarg warning fix, the ```run_command``` argument takes a check bool-argument so if check: true, is given and the command fails, meson will error out.

```WARNING: You should add the boolean check kwarg to the run_command call. It currently defaults to false, but it will default to true in future releases of meson.```