### PR TITLE
Save undecided games as draws

### DIFF
--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -155,6 +155,7 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
     if (game_result_ != GameResult::UNDECIDED) break;
     if (tree_[0]->GetPositionHistory().Last().GetGamePly() >= 450) {
       adjudicated_ = true;
+      game_result_ = GameResult::DRAW;
       break;
     }
     // Initialize search.


### PR DESCRIPTION
For context see https://discord.com/channels/425419482568196106/427066771627966466/1236740483091533825 but in short this patch makes sure that training games that are undecided after 450 are still saved (with game outcome DRAW). If that is a bad outcome, then the rescorer will likely be able to improve on it.

Without this patch, such long training games are not saved at all.