### PR TITLE
Compile error fix for rescorer on MSVC 2022  Windows11.

### DIFF
--- a/build_rescorer.cmd
+++ b/build_rescorer.cmd
@@ -23,7 +23,7 @@ if exist "C:\Program Files\Microsoft Visual Studio\2022" (
   set backend=vs2017
 )
 
-meson build --backend %backend% --buildtype release -Drescorer=true -Dlc0=false -Dgtest=false -Ddefault_library=static
+meson setup build --backend %backend% --buildtype release -Drescorer=true -Dlc0=false -Dgtest=false -Ddefault_library=static
 
 if errorlevel 1 exit /b
 
@@ -32,4 +32,4 @@ pause
 cd build
 
 msbuild /m /p:Configuration=Release /p:Platform=x64 /p:WholeProgramOptimization=true ^
-/p:PreferredToolArchitecture=x64 rescorer.sln /filelogger
+/p:PreferredToolArchitecture=x64 lc0.sln /filelogger

--- a/meson.build
+++ b/meson.build
@@ -666,12 +666,8 @@ endif
     deps += cc.find_library('libprofiler',
       dirs: ['/usr/local/lib'], required: false)
   endif
-
-  # Add libatomic dependency only when not using MSVC
-  if cc.get_id() != 'msvc'
-    deps += cc.find_library('libatomic', required: false)
-  endif
-  
+ 
+  deps += cc.find_library('libatomic', required: false)
 
 #############################################################################
 ## Main Executable

--- a/meson.build
+++ b/meson.build
@@ -44,9 +44,6 @@ endif
 if cc.get_id() == 'msvc'
   # Silence some zlib warnings.
   add_global_arguments('/wd4131', '/wd4267', '/wd4127', '/wd4244', '/wd4245', language : 'c')
-else
-  # Check libatomic only for non-MSVC compilers
-  add_project_link_arguments('-libatomic', language: 'cpp')
 endif
 if host_machine.system() == 'windows'
   add_project_arguments('-DNOMINMAX', language : 'cpp')
@@ -670,7 +667,11 @@ endif
       dirs: ['/usr/local/lib'], required: false)
   endif
 
-  deps += cc.find_library('libatomic', required: false)
+  # Add libatomic dependency only when not using MSVC
+  if cc.get_id() != 'msvc'
+    deps += cc.find_library('libatomic', required: false)
+  endif
+  
 
 #############################################################################
 ## Main Executable

--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
 
-project('lc0', 'cpp',
+project('lc0', ['cpp', 'c'],
         default_options : ['cpp_std=c++17', 'b_ndebug=if-release', 'warning_level=3', 'b_lto=true', 'b_vscrt=mt'],
         meson_version: '>=0.55')
 
@@ -44,6 +44,9 @@ endif
 if cc.get_id() == 'msvc'
   # Silence some zlib warnings.
   add_global_arguments('/wd4131', '/wd4267', '/wd4127', '/wd4244', '/wd4245', language : 'c')
+else
+  # Check libatomic only for non-MSVC compilers
+  add_project_link_arguments('-libatomic', language: 'cpp')
 endif
 if host_machine.system() == 'windows'
   add_project_arguments('-DNOMINMAX', language : 'cpp')

--- a/src/neural/writer.cc
+++ b/src/neural/writer.cc
@@ -1,0 +1,82 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018-2021 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#include "trainingdata/writer.h"
+
+#include "trainingdata/trainingdata.h"
+#include "utils/exception.h"
+#include "utils/filesystem.h"
+#include "utils/random.h"
+
+namespace lczero {
+namespace {
+std::string GetLc0CacheDirectory() {
+  std::string user_cache_path = GetUserCacheDirectory();
+  if (!user_cache_path.empty()) {
+    user_cache_path += "lc0/";
+    CreateDirectory(user_cache_path);
+  }
+  return user_cache_path;
+}
+
+}  // namespace
+
+TrainingDataWriter::TrainingDataWriter(int game_id) {
+  static std::string directory =
+      GetLc0CacheDirectory() + "data-" + Random::Get().GetString(12);
+  // It's fine if it already exists.
+  CreateDirectory(directory.c_str());
+
+  std::ostringstream oss;
+  oss << directory << '/' << "game_" << std::setfill('0') << std::setw(6)
+      << game_id << ".gz";
+
+  filename_ = oss.str();
+  fout_ = gzopen(filename_.c_str(), "wb");
+  if (!fout_) throw Exception("Cannot create gzip file " + filename_);
+}
+
+TrainingDataWriter::TrainingDataWriter(std::string filename)
+    : filename_(filename) {
+  fout_ = gzopen(filename_.c_str(), "wb");
+  if (!fout_) throw Exception("Cannot create gzip file " + filename_);
+}
+
+void TrainingDataWriter::WriteChunk(const V6TrainingData& data) {
+  auto bytes_written =
+      gzwrite(fout_, reinterpret_cast<const char*>(&data), sizeof(data));
+  if (bytes_written != sizeof(data)) {
+    throw Exception("Unable to write into " + filename_);
+  }
+}
+
+void TrainingDataWriter::Finalize() {
+  gzclose(fout_);
+  fout_ = nullptr;
+}
+
+}  // namespace lczero

--- a/src/neural/writer.h
+++ b/src/neural/writer.h
@@ -1,0 +1,62 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018-2021 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#pragma once
+
+#include <fstream>
+#include <zlib.h>
+
+namespace lczero {
+
+struct V6TrainingData;
+
+class TrainingDataWriter {
+ public:
+  // Creates a new file to write in data directory. It will has @game_id
+  // somewhere in the filename.
+  TrainingDataWriter(int game_id);
+  TrainingDataWriter(std::string filename);
+
+  ~TrainingDataWriter() {
+    if (fout_) Finalize();
+  }
+
+  // Writes a chunk.
+  void WriteChunk(const V6TrainingData& data);
+
+  // Flushes file and closes it.
+  void Finalize();
+
+  // Gets full filename of the file written.
+  std::string GetFileName() const { return filename_; }
+
+ private:
+  std::string filename_;
+  gzFile fout_;
+};
+
+}  // namespace lczero


### PR DESCRIPTION
This fixes the error:
```Executing subproject gaviotatb
gaviotatb| Project name: gaviotatb
gaviotatb| Project version: undefined
gaviotatb| C compiler for the host machine: cl (msvc 19.38.33130 "Microsoft (R) C/C++ Optimizing Compiler Version 19.38.33130 for x64")
gaviotatb| C linker for the host machine: link link 14.38.33130.0
gaviotatb| Build targets in project: 27
gaviotatb| Subproject gaviotatb finished.
meson.build:706:2: ERROR: No host machine compiler for 'subprojects/gaviotatb/gtb-probe.c'
```
The above was the output when running build_rescorer.cmd on Windows.