### PR TITLE
circleci: build macos binaries on arm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,8 @@ jobs:
             ninja -j 4
   "mac":
     macos:
-      xcode: 13.4.1
+      xcode: 14.1.0
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - run:
@@ -41,13 +42,13 @@ jobs:
       - run:
           name: Build lc0
           command: |
-            meson build --buildtype=release -Dgtest=false -Dopencl=false
+            meson build --buildtype=release -Dgtest=false -Dopencl=false  --cross-file cross-files/x86_64-darwin
             cd build
             ninja
       - run:
           name: Build lc0 arm
           command: |
-            meson build-arm --buildtype=release -Dgtest=false -Dopencl=false --cross-file cross-files/aarch64-darwin
+            meson build-arm --buildtype=release -Dgtest=false -Dopencl=false
             cd build-arm
             ninja
       - run:
@@ -55,7 +56,7 @@ jobs:
           command: lipo -create -o /tmp/lc0 build/lc0 build-arm/lc0
       - store_artifacts:
           path: /tmp/lc0
-          destination: lc0-macos_12.3.1
+          destination: lc0-macos_12.6.1
 workflows:
   version: 2
   builds:

--- a/cross-files/x86_64-darwin
+++ b/cross-files/x86_64-darwin
@@ -1,0 +1,27 @@
+
+[host_machine]
+system = 'darwin'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+
+[properties]
+
+
+[binaries]
+c = 'clang'
+cpp = 'clang++'
+objc = 'clang'
+objcpp = 'clang++'
+ar = 'ar'
+ld = 'ld'
+
+[built-in options]
+c_args = ['-arch', 'x86_64']
+cpp_args = ['-arch', 'x86_64']
+objc_args = ['-arch', 'x86_64']
+objcpp_args = ['-arch', 'x86_64']
+c_link_args = ['-arch', 'x86_64']
+cpp_link_args = ['-arch', 'x86_64']
+objc_link_args = ['-arch', 'x86_64']
+objcpp_link_args = ['-arch', 'x86_64']


### PR DESCRIPTION
Circleci is phasing out their x86 mac build systems, so we have to migrate to the arm ones.