### PR TITLE
gaviota support for uci and selfplay

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
 
-project('lc0', 'cpp',
+project('lc0', ['c', 'cpp'],
         default_options : ['cpp_std=c++17', 'b_ndebug=if-release', 'warning_level=3', 'b_lto=true', 'b_vscrt=mt'],
         meson_version: '>=0.55')
 
@@ -691,6 +691,7 @@ endif
 
 if get_option('lc0')
   files += common_files
+  deps += subproject('gaviotatb').get_variable('gaviotatb_dep')
   executable('lc0', 'src/main.cc',
        files, include_directories: includes, dependencies: deps, install: true)
 endif

--- a/src/benchmark/benchmark.cc
+++ b/src/benchmark/benchmark.cc
@@ -101,13 +101,16 @@ void Benchmark::Run() {
       tree.ResetToPosition(position, {});
 
       const auto start = std::chrono::steady_clock::now();
+      std::unique_ptr<bool> gaviotaEnabled_;
+      gaviotaEnabled_ = std::make_unique<bool>(false);      
+      
       auto search = std::make_unique<Search>(
           tree, network.get(),
           std::make_unique<CallbackUciResponder>(
               std::bind(&Benchmark::OnBestMove, this, std::placeholders::_1),
               std::bind(&Benchmark::OnInfo, this, std::placeholders::_1)),
           MoveList(), start, std::move(stopper), false, false, option_dict,
-          &cache, nullptr);
+          &cache, nullptr, &gaviotaEnabled_);
       search->StartThreads(option_dict.Get<int>(kThreadsOptionId));
       search->Wait();
       const auto end = std::chrono::steady_clock::now();

--- a/src/engine.h
+++ b/src/engine.h
@@ -96,6 +96,7 @@ class EngineController {
   std::unique_ptr<Search> search_;
   std::unique_ptr<NodeTree> tree_;
   std::unique_ptr<SyzygyTablebase> syzygy_tb_;
+  std::unique_ptr<bool> gaviotaEnabled_ = nullptr;
   std::unique_ptr<Network> network_;
   NNCache cache_;
 

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -50,27 +50,192 @@ namespace {
 // Maximum delay between outputting "uci info" when nothing interesting happens.
 const int kUciInfoMinimumFrequencyMs = 5000;
 
+void gaviota_tb_probe_hard(const Position& pos, unsigned int& info,
+                           unsigned int& dtm) {
+  unsigned int wsq[17];
+  unsigned int bsq[17];
+  unsigned char wpc[17];
+  unsigned char bpc[17];
+
+  auto stm = pos.IsBlackToMove() ? tb_BLACK_TO_MOVE : tb_WHITE_TO_MOVE;
+  auto& board = pos.IsBlackToMove() ? pos.GetThemBoard() : pos.GetBoard();
+  auto epsq = tb_NOSQUARE;
+  for (auto sq : board.en_passant()) {
+    // Our internal representation stores en_passant 2 rows away
+    // from the actual sq.
+    if (sq.row() == 0) {
+      epsq = (TB_squares)(sq.as_int() + 16);
+    } else {
+      epsq = (TB_squares)(sq.as_int() - 16);
+    }
+  }
+  int idx = 0;
+  for (auto sq : (board.ours() & board.kings())) {
+    wsq[idx] = (TB_squares)sq.as_int();
+    wpc[idx] = tb_KING;
+    idx++;
+  }
+  for (auto sq : (board.ours() & board.knights())) {
+    wsq[idx] = (TB_squares)sq.as_int();
+    wpc[idx] = tb_KNIGHT;
+    idx++;
+  }
+  for (auto sq : (board.ours() & board.queens())) {
+    wsq[idx] = (TB_squares)sq.as_int();
+    wpc[idx] = tb_QUEEN;
+    idx++;
+  }
+  for (auto sq : (board.ours() & board.rooks())) {
+    wsq[idx] = (TB_squares)sq.as_int();
+    wpc[idx] = tb_ROOK;
+    idx++;
+  }
+  for (auto sq : (board.ours() & board.bishops())) {
+    wsq[idx] = (TB_squares)sq.as_int();
+    wpc[idx] = tb_BISHOP;
+    idx++;
+  }
+  for (auto sq : (board.ours() & board.pawns())) {
+    wsq[idx] = (TB_squares)sq.as_int();
+    wpc[idx] = tb_PAWN;
+    idx++;
+  }
+  wsq[idx] = tb_NOSQUARE;
+  wpc[idx] = tb_NOPIECE;
+
+  idx = 0;
+  for (auto sq : (board.theirs() & board.kings())) {
+    bsq[idx] = (TB_squares)sq.as_int();
+    bpc[idx] = tb_KING;
+    idx++;
+  }
+  for (auto sq : (board.theirs() & board.knights())) {
+    bsq[idx] = (TB_squares)sq.as_int();
+    bpc[idx] = tb_KNIGHT;
+    idx++;
+  }
+  for (auto sq : (board.theirs() & board.queens())) {
+    bsq[idx] = (TB_squares)sq.as_int();
+    bpc[idx] = tb_QUEEN;
+    idx++;
+  }
+  for (auto sq : (board.theirs() & board.rooks())) {
+    bsq[idx] = (TB_squares)sq.as_int();
+    bpc[idx] = tb_ROOK;
+    idx++;
+  }
+  for (auto sq : (board.theirs() & board.bishops())) {
+    bsq[idx] = (TB_squares)sq.as_int();
+    bpc[idx] = tb_BISHOP;
+    idx++;
+  }
+  for (auto sq : (board.theirs() & board.pawns())) {
+    bsq[idx] = (TB_squares)sq.as_int();
+    bpc[idx] = tb_PAWN;
+    idx++;
+  }
+  bsq[idx] = tb_NOSQUARE;
+  bpc[idx] = tb_NOPIECE;
+
+  tb_probe_hard(stm, epsq, tb_NOCASTLE, wsq, bsq, wpc, bpc, &info, &dtm);
+}
+
+bool root_probe_gaviota(const Position& pos, std::vector<Move>* safe_moves) {
+  // if the position is winning the strategy is trivial: shortest mate for the winning side, longest mate for the losing side.
+  // if the position is draw, all non-losing moves are equal. 
+
+  // Generate the list of legal moves.
+  auto root_moves = pos.GetBoard().GenerateLegalMoves();
+
+  // Create a vector to store dtm information in.
+  std::vector<unsigned int> dtms (root_moves.size());
+  // And a vector for info information.
+  std::vector<unsigned int> infos (root_moves.size());  
+  unsigned int minimum_dtm = 1000;
+  unsigned int maximum_dtm = 0;
+  unsigned int target_dtm;
+  int dtm_idx = 0;
+  bool winning = false;
+  bool drawing = false;
+    
+  // for all legal moves identify minimum and maximum dtm, if any.
+  for (auto& move : root_moves) {
+    Position next_pos = Position(pos, move);
+    unsigned int info;
+    unsigned int dtm;
+    gaviota_tb_probe_hard(next_pos, info, dtm);
+    // LOGFILE << "DTM for move: " << move.as_string() << " is " << dtm << " and info is " << info << "\n";
+    if (! winning && info == 2) winning = true; // set winning if it is not already set
+    if (! drawing && info == 0) drawing = true; // set drawing if it is not already set    
+    dtms[dtm_idx] = dtm;
+    infos[dtm_idx] = info;
+    dtm_idx++;    
+    if (dtm < minimum_dtm) minimum_dtm = dtm;
+    if (dtm > maximum_dtm) maximum_dtm = dtm;    
+  }
+
+  // Set a target DTM if the game is not drawn.
+  if (!winning && !drawing) {
+    target_dtm = maximum_dtm;
+  } else {
+    if (winning) {
+      target_dtm = minimum_dtm;
+    }
+  }
+  
+  if (winning || !drawing) {
+    dtm_idx = 0;
+    for (auto& move : root_moves) {
+      if (dtms[dtm_idx] == target_dtm) {
+	safe_moves->push_back(move);
+      }
+      dtm_idx++;
+    }
+  } else {
+    // Draw is the optimal outcome, but keep only drawing moves (info == 0 means draw).
+    dtm_idx = 0;
+    for (auto& move : root_moves) {
+      if (infos[dtm_idx] == 0) {
+	safe_moves->push_back(move);
+      }
+      dtm_idx++;
+    }
+  }
+  return true;
+}
+
 MoveList MakeRootMoveFilter(const MoveList& searchmoves,
                             SyzygyTablebase* syzygy_tb,
                             const PositionHistory& history, bool fast_play,
-                            std::atomic<int>* tb_hits, bool* dtz_success) {
+                            std::atomic<int>* tb_hits, bool* dtz_success,
+			    std::unique_ptr<bool>* gaviotaEnabled) {
   assert(tb_hits);
   assert(dtz_success);
   // Search moves overrides tablebase.
   if (!searchmoves.empty()) return searchmoves;
   const auto& board = history.Last().GetBoard();
   MoveList root_moves;
-  if (!syzygy_tb || !board.castlings().no_legal_castle() ||
-      (board.ours() | board.theirs()).count() > syzygy_tb->max_cardinality()) {
-    return root_moves;
-  }
-  if (syzygy_tb->root_probe(
+  
+  // Select TB to use.
+  // If gaviota is available and at most 5 pieces left, then use gaviota, else use syzygy.
+
+  if (gaviotaEnabled && (board.ours() | board.theirs()).count() <= 5 &&
+      root_probe_gaviota(history.Last(), &root_moves)){
+    tb_hits->fetch_add(1, std::memory_order_acq_rel);
+  } else {
+    // Try syzygy instead
+    if (!syzygy_tb || !board.castlings().no_legal_castle() ||
+	(board.ours() | board.theirs()).count() > syzygy_tb->max_cardinality()) {
+      return root_moves;
+    }
+    if (syzygy_tb->root_probe(
           history.Last(), fast_play || history.DidRepeatSinceLastZeroingMove(),
           false, &root_moves)) {
-    *dtz_success = true;
-    tb_hits->fetch_add(1, std::memory_order_acq_rel);
-  } else if (syzygy_tb->root_probe_wdl(history.Last(), &root_moves)) {
-    tb_hits->fetch_add(1, std::memory_order_acq_rel);
+      *dtz_success = true;
+      tb_hits->fetch_add(1, std::memory_order_acq_rel);
+    } else if (syzygy_tb->root_probe_wdl(history.Last(), &root_moves)) {
+      tb_hits->fetch_add(1, std::memory_order_acq_rel);
+    }
   }
   return root_moves;
 }
@@ -155,7 +320,7 @@ Search::Search(const NodeTree& tree, Network* network,
                std::chrono::steady_clock::time_point start_time,
                std::unique_ptr<SearchStopper> stopper, bool infinite,
                bool ponder, const OptionsDict& options, NNCache* cache,
-               SyzygyTablebase* syzygy_tb)
+               SyzygyTablebase* syzygy_tb, std::unique_ptr<bool>* gaviotaEnabled)
     : ok_to_respond_bestmove_(!infinite && !ponder),
       stopper_(std::move(stopper)),
       root_node_(tree.GetCurrentHead()),
@@ -169,7 +334,7 @@ Search::Search(const NodeTree& tree, Network* network,
       initial_visits_(root_node_->GetN()),
       root_move_filter_(MakeRootMoveFilter(
           searchmoves_, syzygy_tb_, played_history_,
-          params_.GetSyzygyFastPlay(), &tb_hits_, &root_is_in_dtz_)),
+          params_.GetSyzygyFastPlay(), &tb_hits_, &root_is_in_dtz_, gaviotaEnabled)),
       uci_responder_(std::move(uci_responder)) {
   if (params_.GetMaxConcurrentSearchers() != 0) {
     pending_searchers_.store(params_.GetMaxConcurrentSearchers(),

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -42,6 +42,7 @@
 #include "neural/cache.h"
 #include "neural/network.h"
 #include "syzygy/syzygy.h"
+#include "gtb-probe.h"
 #include "utils/logging.h"
 #include "utils/mutex.h"
 
@@ -55,7 +56,7 @@ class Search {
          std::chrono::steady_clock::time_point start_time,
          std::unique_ptr<SearchStopper> stopper, bool infinite, bool ponder,
          const OptionsDict& options, NNCache* cache,
-         SyzygyTablebase* syzygy_tb);
+         SyzygyTablebase* syzygy_tb, std::unique_ptr<bool>* gaviotaEnabled);
 
   ~Search();
 
@@ -166,6 +167,12 @@ class Search {
   SyzygyTablebase* syzygy_tb_;
   // Fixed positions which happened before the search.
   const PositionHistory& played_history_;
+
+  // Probes Gaviota tables to determine which moves are on the optimal play path.
+  // Thread safe.
+  // Returns false if the position is not in the tablebase.
+  // Safe moves are added to the safe_moves output paramater.
+  bool root_probe_gaviota(const Position& pos, std::vector<Move>* safe_moves);
 
   Network* const network_;
   const SearchParams params_;

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -128,7 +128,9 @@ SelfPlayGame::SelfPlayGame(PlayerOptions white, PlayerOptions black,
 }
 
 void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
-                        SyzygyTablebase* syzygy_tb, bool enable_resign) {
+                        SyzygyTablebase* syzygy_tb,
+			std::unique_ptr<bool>* gaviotaEnabled,
+			bool enable_resign) {
   bool blacks_move = tree_[0]->IsBlackToMove();
 
   // If we are training, verify that input formats are consistent.
@@ -182,7 +184,8 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
           *tree_[idx], options_[idx].network, std::move(responder),
           /* searchmoves */ MoveList(), std::chrono::steady_clock::now(),
           std::move(stoppers), /* infinite */ false, /* ponder */ false,
-          *options_[idx].uci_options, options_[idx].cache, syzygy_tb);
+          *options_[idx].uci_options, options_[idx].cache, syzygy_tb,
+	  /* gaviota */ gaviotaEnabled);
     }
 
     // Do search.

--- a/src/selfplay/game.h
+++ b/src/selfplay/game.h
@@ -80,7 +80,8 @@ class SelfPlayGame {
 
   // Starts the game and blocks until the game is finished.
   void Play(int white_threads, int black_threads, bool training,
-            SyzygyTablebase* syzygy_tb, bool enable_resign = true);
+            SyzygyTablebase* syzygy_tb, std::unique_ptr<bool>* gaviotaEnabled,
+	    bool enable_resign = true);
   // Aborts the game currently played, doesn't matter if it's synchronous or
   // not.
   void Abort();

--- a/src/selfplay/tournament.h
+++ b/src/selfplay/tournament.h
@@ -79,6 +79,7 @@ class SelfPlayTournament {
   // Whether first game will be black for player1.
   bool first_game_black_ GUARDED_BY(mutex_) = false;
   std::unique_ptr<SyzygyTablebase> syzygy_tb_ GUARDED_BY(mutex_);
+  std::unique_ptr<bool> gaviotaEnabled_ GUARDED_BY(mutex_) = nullptr;  
   std::vector<Opening> discard_pile_ GUARDED_BY(mutex_);
   // Number of games which already started.
   int games_count_ GUARDED_BY(mutex_) = 0;


### PR DESCRIPTION
This patch provides support for Gaviota endgame table databases in both `uci` mode and `selfplay` mode. The intended use case that motivated me writing it is to generate better training data, but since `uci` mode is covered, it can be used generally.

The implementation is inspired by the implementation of syzygy support, and much of the code is copied from `rescorer/rescorer.cc` which already supports Gaviota. Unlike the syzygy implementation it provides no new classes since Gaviota support only required two new functions, both located in `search.cc`.

The implementation is done via `Search::MakeRootFilter()` which deletes legal but sub-optimal moves from the root node before search is started. With syzygy, optimal included every move that did not worsen the game outcome, but with Gaviota support we can define optimal moves as moves "resulting in the shortest path to mate" (for the winning side) and "resulting in the longest path to mate" for the losing side. (For drawn positions both syzygy and Gaviota treats all non-losing moves as optimal).