### PR TITLE
A few improvements to the onxx 2 hlo converter.

### DIFF
--- a/src/neural/xla/onnx2hlo.cc
+++ b/src/neural/xla/onnx2hlo.cc
@@ -44,6 +44,18 @@
 namespace lczero {
 namespace {
 
+bool CanConvertConstant(const pblczero::XlaShapeProto::Type& type) {
+  switch (type) {
+    case pblczero::XlaShapeProto::F32:
+    case pblczero::XlaShapeProto::F64:
+    case pblczero::XlaShapeProto::S32:
+    case pblczero::XlaShapeProto::S64:
+      return true;
+    default:
+      return false;
+  }
+}
+
 template <typename T>
 void FetchConstForType(const pblczero::XlaLiteralProto& literal,
                        pblczero::XlaShapeProto::Type type, T&& func) {
@@ -222,6 +234,33 @@ pblczero::XlaLiteralProto ConstOpGather(
                        dst->push_back(inp[i]);
                      }
                    });
+  return result;
+}
+
+pblczero::XlaLiteralProto ConstOpMul(const pblczero::XlaLiteralProto& lhs,
+                                     const pblczero::XlaLiteralProto& rhs) {
+  pblczero::XlaLiteralProto result;
+  *result.mutable_shape() = lhs.shape();
+  LiteralOutInInOp(
+      &result, lhs, rhs, [](auto* dst, const auto& lhs, const auto& rhs) {
+        std::transform(lhs.begin(), lhs.end(), rhs.begin(),
+                       std::back_inserter(*dst), std::multiplies<>());
+      });
+  return result;
+}
+
+pblczero::XlaLiteralProto ConstOpMax(const pblczero::XlaLiteralProto& lhs,
+                                     const pblczero::XlaLiteralProto& rhs) {
+  pblczero::XlaLiteralProto result;
+  *result.mutable_shape() = lhs.shape();
+  LiteralOutInInOp(
+      &result, lhs, rhs, [](auto* dst, const auto& lhs, const auto& rhs) {
+        using T =
+            typename std::remove_reference<decltype(lhs)>::type::value_type;
+        std::transform(lhs.begin(), lhs.end(), rhs.begin(),
+                       std::back_inserter(*dst),
+                       [](T a, T b) { return std::max(a, b); });
+      });
   return result;
 }
 
@@ -425,6 +464,7 @@ class Onnx2HloConverter {
     onnx_op_to_builder_["Identity"] = &Onnx2HloConverter::OpIdentity;
     onnx_op_to_builder_["LayerNormalization"] =
         &Onnx2HloConverter::OpLayerNormalization;
+    onnx_op_to_builder_["Max"] = &Onnx2HloConverter::OpMax;
     onnx_op_to_builder_["MatMul"] = &Onnx2HloConverter::OpMatMul;
     onnx_op_to_builder_["Mish"] = &Onnx2HloConverter::OpMish;
     onnx_op_to_builder_["Mul"] = &Onnx2HloConverter::OpMul;
@@ -678,6 +718,12 @@ class Onnx2HloConverter {
     return GetOptionalAttributeAsVec<T>(node, name, false).value();
   }
 
+  std::vector<int64_t> GetIota(size_t size) {
+    std::vector<int64_t> result(size);
+    std::iota(result.begin(), result.end(), 0);
+    return result;
+  };
+
   /////////////////////////////////////////////////////////////////////////////
   // ONNX operations
   /////////////////////////////////////////////////////////////////////////////
@@ -880,18 +926,21 @@ class Onnx2HloConverter {
   std::vector<HloFlow> OpReduceProd(const pblczero::NodeProto& node) {
     CheckKnownAttributes(node, 1, {"axes", "keepdims"});
     auto* input = GetInput(node, 0);
-    auto axes = GetAttributeAsVec<int64_t>(node, "axes");
+    auto axes = GetOptionalAttributeAsVec<int64_t>(node, "axes")
+                    .value_or(GetIota(input->shape().dimensions_size()));
     bool keepdims =
         GetOptionalAttributeAs<bool>(node, "keepdims").value_or(true);
     HloFlow flow;
     if (AllInputsConstant(node)) {
-      flow = builder_.Constant(
-          ConstOpReduceProd(*GetConstantInput(node, 0), axes));
-    } else {
-      HloFlow one = MakeScalar(1, input->shape().element_type());
-      flow = builder_.Reduce(
-          input, one, MakeMulComputation(input->shape().element_type()), axes);
+      auto literal = ConstOpReduceProd(*GetConstantInput(node, 0), axes);
+      if (!keepdims) return {builder_.Constant(literal)};
+      HloTensorType target_shape(input->shape());
+      for (auto axis : axes) target_shape.SetDimension(axis, 1);
+      return {builder_.Constant(ConstReshape(literal, target_shape.ToProto()))};
     }
+    HloFlow one = MakeScalar(1, input->shape().element_type());
+    flow = builder_.Reduce(
+        input, one, MakeMulComputation(input->shape().element_type()), axes);
     if (!keepdims) return {flow};
     HloTensorType target_shape(input->shape());
     for (auto axis : axes) target_shape.SetDimension(axis, 1);
@@ -901,7 +950,8 @@ class Onnx2HloConverter {
   std::vector<HloFlow> OpReduceSumSquare(const pblczero::NodeProto& node) {
     CheckKnownAttributes(node, 1, {"axes", "keepdims"});
     auto* input = GetInput(node, 0);
-    auto axes = GetAttributeAsVec<int64_t>(node, "axes");
+    auto axes = GetOptionalAttributeAsVec<int64_t>(node, "axes")
+                    .value_or(GetIota(input->shape().dimensions_size()));
     bool keepdims =
         GetOptionalAttributeAs<bool>(node, "keepdims").value_or(true);
     auto flow = builder_.Multiply(input, input);
@@ -922,7 +972,8 @@ class Onnx2HloConverter {
     const auto hlo_type = OnnxTypeToXlaType(onnx_type);
     if (input->shape().element_type() == hlo_type) return {input};
     // Only convert constants of int64 to int32 as that's what TF does.
-    if (AllInputsConstant(node)) {
+    if (AllInputsConstant(node) && CanConvertConstant(hlo_type) &&
+        CanConvertConstant(input->shape().element_type())) {
       return {builder_.Constant(
           ConstOpConvert(*GetConstantInput(node, 0), hlo_type))};
     }
@@ -1070,8 +1121,37 @@ class Onnx2HloConverter {
     CheckKnownAttributes(node, 2, {});
     auto* lhs = GetInput(node, 0);
     auto* rhs = GetInput(node, 1);
+
+    if (AllInputsConstant(node)) {
+      const size_t num_elements = std::accumulate(
+          lhs->shape().dimensions().begin(), lhs->shape().dimensions().end(), 1,
+          std::multiplies<size_t>());
+      if (num_elements <= options_.max_inline_constant_size) {
+        return {builder_.Constant(ConstOpMul(*GetConstantInput(node, 0),
+                                             *GetConstantInput(node, 1)))};
+      }
+    }
+
     std::tie(lhs, rhs) = EqualizeShape(lhs, rhs);
     return {builder_.Multiply(lhs, rhs)};
+  }
+
+  std::vector<HloFlow> OpMax(const pblczero::NodeProto& node) {
+    CheckKnownAttributes(node, 2, {});
+    auto* lhs = GetInput(node, 0);
+    auto* rhs = GetInput(node, 1);
+
+    if (AllInputsConstant(node)) {
+      const size_t num_elements = std::accumulate(
+          lhs->shape().dimensions().begin(), lhs->shape().dimensions().end(), 1,
+          std::multiplies<size_t>());
+      if (num_elements <= options_.max_inline_constant_size) {
+        return {builder_.Constant(ConstOpMax(*GetConstantInput(node, 0),
+                                             *GetConstantInput(node, 1)))};
+      }
+    }
+    std::tie(lhs, rhs) = EqualizeShape(lhs, rhs);
+    return {builder_.Maximum(lhs, rhs)};
   }
 
   std::vector<HloFlow> OpSplit(const pblczero::NodeProto& node) {
@@ -1223,6 +1303,11 @@ class Onnx2HloConverter {
       new_shape.SetElementType(input->shape().element_type());
       new_shape.SetDimension(infer_dim.value(),
                              input_shape.NumElements() / num_elements);
+    }
+    if (AllInputsConstant(node) &&
+        new_shape.NumElements() <= options_.max_inline_constant_size) {
+      return {builder_.Constant(
+          ConstReshape(*GetConstantInput(node, 0), new_shape.ToProto()))};
     }
     return {builder_.Reshape(input, new_shape)};
   }


### PR DESCRIPTION
* In compile time, only cast from/to f32/f64/s32/s64.
* Constant evaluation of OpMul.
* Added support of Max op, also with constant evaluation.
* Const ReduceProd also does constant folding for the final reshape.
* OpReshape also handles constant evaluation now.