### PR TITLE
Fixing has_wdl typo affecting no WDL_mu centipawn output

### DIFF
--- a/src/neural/network.h
+++ b/src/neural/network.h
@@ -109,7 +109,7 @@ struct NetworkCapabilities {
   }
 
   bool has_wdl() const {
-    return output_format != pblczero::NetworkFormat::OUTPUT_WDL;
+    return output_format == pblczero::NetworkFormat::OUTPUT_WDL;
   }
 };
 


### PR DESCRIPTION
v0.31 doesn't show the `WDL_mu` centipawn output because of a typo.