### PR TITLE
adressing issue #825

### DIFF
--- a/src/chess/bitboard.h
+++ b/src/chess/bitboard.h
@@ -87,7 +87,7 @@ class BoardSquare {
 
 // Represents a board as an array of 64 bits.
 // Bit enumeration goes from bottom to top, from left to right:
-// Square a1 is bit 0, square a8 is bit 7, square b1 is bit 8.
+// Square a1 is bit 0, square b1 is bit 7, square a8 is bit 8.
 class BitBoard {
  public:
   constexpr BitBoard(std::uint64_t board) : board_(board) {}

--- a/src/chess/bitboard.h
+++ b/src/chess/bitboard.h
@@ -87,7 +87,7 @@ class BoardSquare {
 
 // Represents a board as an array of 64 bits.
 // Bit enumeration goes from bottom to top, from left to right:
-// Square a1 is bit 0, square b1 is bit 7, square a8 is bit 8.
+// Square a1 is bit 0, square h1 is bit 7, square a2 is bit 8.
 class BitBoard {
  public:
   constexpr BitBoard(std::uint64_t board) : board_(board) {}


### PR DESCRIPTION
The comment on the bitboard function previously stated that "a8 is bit 7, b1 is bit 8". 
All bitboard methods (set, get, reset...) use the following to set the position of the bit on the bitboard: std::uint64_t(1) << pos, with pos being the BoardSquare index that follows the horizontal indexing notation (a1=0, b1=1, c1=2...)
Meaning the bit's position on the bitboard is going to be 0 + pos which means the position of the bit should also follow the horizontal indexing notation.