### PR TITLE
Issue 825

### DIFF
--- a/src/chess/bitboard.h
+++ b/src/chess/bitboard.h
@@ -87,7 +87,7 @@ class BoardSquare {
 
 // Represents a board as an array of 64 bits.
 // Bit enumeration goes from bottom to top, from left to right:
-// Square a1 is bit 0, square a8 is bit 7, square b1 is bit 8.
+// Square a1 is bit 0, square b1 is bit 7, square a8 is bit 8.
 class BitBoard {
  public:
   constexpr BitBoard(std::uint64_t board) : board_(board) {}

--- a/src/chess/bitboard.h
+++ b/src/chess/bitboard.h
@@ -87,7 +87,7 @@ class BoardSquare {
 
 // Represents a board as an array of 64 bits.
 // Bit enumeration goes from bottom to top, from left to right:
-// Square a1 is bit 0, square b1 is bit 7, square a8 is bit 8.
+// Square a1 is bit 0, square h1 is bit 7, square a2 is bit 8.
 class BitBoard {
  public:
   constexpr BitBoard(std::uint64_t board) : board_(board) {}


### PR DESCRIPTION
All bitboard methods (set, reset, get...) use std::uint64_t(1) << pos, moving the bit initiated at position 0 by 'pos' spaces. Making the bit position 0 + pos = pos. Pos is passed as argument to these methods as BoardSquare.as_int, a packed int representation of a boardsquare that follows horizontal indexing (a1=0, b1=1, ..., a2=8) which means bitboard bit location should follow a similar notation.