### PR TITLE
Issue 2003

### DIFF
--- a/src/mcts/stoppers/common.cc
+++ b/src/mcts/stoppers/common.cc
@@ -126,12 +126,12 @@ void PopulateCommonUciStoppers(ChainedSearchStopper* stopper,
 
   // "go nodes" stopper.
   int64_t node_limit = 0;
-  if (params.nodes) {
+  if (params.nodes.has_value()) {
     if (options.Get<bool>(kNodesAsPlayoutsId)) {
       stopper->AddStopper(std::make_unique<PlayoutsStopper>(
           *params.nodes, options.Get<float>(kSmartPruningFactorId) > 0.0f));
     } else {
-      node_limit = *params.nodes;
+      node_limit = 4000000000;
     }
   }
   // always limit nodes to avoid exceeding the limit 4000000000. That number is

--- a/src/mcts/stoppers/stoppers.h
+++ b/src/mcts/stoppers/stoppers.h
@@ -54,7 +54,7 @@ class ChainedSearchStopper : public SearchStopper {
 class VisitsStopper : public SearchStopper {
  public:
   VisitsStopper(int64_t limit, bool populate_remaining_playouts)
-    : nodes_limit_(limit ? limit : 4000000000ll),
+    : nodes_limit_(limit),
         populate_remaining_playouts_(populate_remaining_playouts) {}
   int64_t GetVisitsLimit() const { return nodes_limit_; }
   bool ShouldStop(const IterationStats&, StoppersHints*) override;


### PR DESCRIPTION
since GoParams.nodes is an std::optional, it's initialization status can be checked through params.nodes.has_value() instead of params.nodes, which returns false if params.nodes is set to 0 (source of the problem)