### PR TITLE
node limit passed as 0 instead of a negative number to visits_stoppe if nn cache > memory limit (prevents unsigned int overflow)

### DIFF
--- a/src/mcts/stoppers/stoppers.cc
+++ b/src/mcts/stoppers/stoppers.cc
@@ -104,7 +104,8 @@ MemoryWatchingStopper::MemoryWatchingStopper(int cache_size, int ram_limit_mb,
                                              bool populate_remaining_playouts)
     : VisitsStopper(
           (ram_limit_mb * 1000000LL - cache_size * kAvgCacheItemSize) /
-              kAvgNodeSize,
+              kAvgNodeSize > 0 ? ram_limit_mb * 1000000LL - cache_size * kAvgCacheItemSize) /
+              kAvgNodeSize : 0,
           populate_remaining_playouts) {
   LOGFILE << "RAM limit " << ram_limit_mb << "MB. Cache takes "
           << cache_size * kAvgCacheItemSize / 1000000

--- a/src/mcts/stoppers/stoppers.cc
+++ b/src/mcts/stoppers/stoppers.cc
@@ -103,8 +103,8 @@ const size_t kAvgCacheItemSize =
 MemoryWatchingStopper::MemoryWatchingStopper(int cache_size, int ram_limit_mb,
                                              bool populate_remaining_playouts)
     : VisitsStopper(
-          (ram_limit_mb * 1000000LL - cache_size * kAvgCacheItemSize) /
-              kAvgNodeSize > 0 ? ram_limit_mb * 1000000LL - cache_size * kAvgCacheItemSize) /
+          ((ram_limit_mb * 1000000LL - cache_size * kAvgCacheItemSize) /
+              kAvgNodeSize > 0 ? (ram_limit_mb * 1000000LL - cache_size * kAvgCacheItemSize) /
               kAvgNodeSize : 0,
           populate_remaining_playouts) {
   LOGFILE << "RAM limit " << ram_limit_mb << "MB. Cache takes "


### PR DESCRIPTION
Visitstopper takes int64_t as node limit value. If cache size > ram limit, it causes node limit to overflow. Which is why passing 0 instead of ram_limit_mb * 1000000LL - cache_size * kAvgCacheItemSize/kAvgNodeSize if nn cache - memory limit < 0 is necessary.