### PR TITLE
setoption now throws an error if initiated without name or value

### DIFF
--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -156,9 +156,7 @@ bool UciLoop::DispatchCommand(
     if (GetOrEmpty(params, "name").empty()) {
       throw Exception("setoption requires name");
     }
-    else if (GetOrEmpty(params, "value").empty()) {
-      throw Exception("setoption requires value");
-    } else {
+    else {
     CmdSetOption(GetOrEmpty(params, "name"), GetOrEmpty(params, "value"),
                  GetOrEmpty(params, "context"));
     }

--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -153,8 +153,16 @@ bool UciLoop::DispatchCommand(
   } else if (command == "isready") {
     CmdIsReady();
   } else if (command == "setoption") {
+if (GetOrEmpty(params, "name").empty()) {
+      throw Exception("setoption requires name");
+    }
+    else if (GetOrEmpty(params, "value").empty()) {
+      throw Exception("setoption requires value");
+    }
+    else {
     CmdSetOption(GetOrEmpty(params, "name"), GetOrEmpty(params, "value"),
                  GetOrEmpty(params, "context"));
+    }
   } else if (command == "ucinewgame") {
     CmdUciNewGame();
   } else if (command == "position") {

--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -153,16 +153,8 @@ bool UciLoop::DispatchCommand(
   } else if (command == "isready") {
     CmdIsReady();
   } else if (command == "setoption") {
-if (GetOrEmpty(params, "name").empty()) {
-      throw Exception("setoption requires name");
-    }
-    else if (GetOrEmpty(params, "value").empty()) {
-      throw Exception("setoption requires value");
-    }
-    else {
     CmdSetOption(GetOrEmpty(params, "name"), GetOrEmpty(params, "value"),
                  GetOrEmpty(params, "context"));
-    }
   } else if (command == "ucinewgame") {
     CmdUciNewGame();
   } else if (command == "position") {

--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -153,8 +153,15 @@ bool UciLoop::DispatchCommand(
   } else if (command == "isready") {
     CmdIsReady();
   } else if (command == "setoption") {
+    if (GetOrEmpty(params, "name").empty()) {
+      throw Exception("setoption requires name");
+    }
+    else if (GetOrEmpty(params, "value").empty()) {
+      throw Exception("setoption requires value");
+    } else {
     CmdSetOption(GetOrEmpty(params, "name"), GetOrEmpty(params, "value"),
                  GetOrEmpty(params, "context"));
+    }
   } else if (command == "ucinewgame") {
     CmdUciNewGame();
   } else if (command == "position") {

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -1406,9 +1406,13 @@ class SyzygyTablebaseImpl {
       }
       idx = type != DTM ? encode_pawn_f(p, ei, be) : encode_pawn_r(p, ei, be);
     }
-
+    auto start = std::chrono::high_resolution_clock::now();
     uint8_t* w = decompress_pairs(ei->precomp, idx);
-
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+    if (duration.count() > 1) {
+      std::cout << "Time taken: " << duration.count() << " microseconds" << std::endl;
+    }
     if (type == WDL) return static_cast<int>(w[0]) - 2;
 
     int v = w[0] + ((w[1] & 0x0f) << 8);


### PR DESCRIPTION
added if statements in the setoption code block in dispatchcommand that checks if name and value are present in the command (and throw an error if not provided) before running CmdSetoption() 