### PR TITLE
calculating neural network evaluation time and tablebase probing time, and log a warning message if any of the two > 1s

### DIFF
--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -153,8 +153,16 @@ bool UciLoop::DispatchCommand(
   } else if (command == "isready") {
     CmdIsReady();
   } else if (command == "setoption") {
+if (GetOrEmpty(params, "name").empty()) {
+      throw Exception("setoption requires name");
+    }
+    else if (GetOrEmpty(params, "value").empty()) {
+      throw Exception("setoption requires value");
+    }
+    else {
     CmdSetOption(GetOrEmpty(params, "name"), GetOrEmpty(params, "value"),
                  GetOrEmpty(params, "context"));
+    }
   } else if (command == "ucinewgame") {
     CmdUciNewGame();
   } else if (command == "position") {

--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -153,16 +153,8 @@ bool UciLoop::DispatchCommand(
   } else if (command == "isready") {
     CmdIsReady();
   } else if (command == "setoption") {
-if (GetOrEmpty(params, "name").empty()) {
-      throw Exception("setoption requires name");
-    }
-    else if (GetOrEmpty(params, "value").empty()) {
-      throw Exception("setoption requires value");
-    }
-    else {
     CmdSetOption(GetOrEmpty(params, "name"), GetOrEmpty(params, "value"),
                  GetOrEmpty(params, "context"));
-    }
   } else if (command == "ucinewgame") {
     CmdUciNewGame();
   } else if (command == "position") {

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -29,7 +29,6 @@
 
 #include <algorithm>
 #include <array>
-#include <chrono>
 #include <cmath>
 #include <iomanip>
 #include <iostream>

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -2189,7 +2189,16 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget, bool is_odd_depth) {
 
 // 4. Run NN computation.
 // ~~~~~~~~~~~~~~~~~~~~~~
-void SearchWorker::RunNNComputation() { computation_->ComputeBlocking(); }
+void SearchWorker::RunNNComputation() {
+    auto start_time = std::chrono::high_resolution_clock::now();
+    computation_->ComputeBlocking(); 
+    auto end_time = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = end_time - start_time;
+    if (elapsed.count() > 1.0) {
+        std::cout << "Warning: Computation took " << elapsed.count()  << " seconds, which is longer than expected." << std::endl;
+    }
+  
+}
 
 // 5. Retrieve NN computations (and terminal values) into nodes.
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <iomanip>
 #include <iostream>

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -1406,7 +1406,7 @@ class SyzygyTablebaseImpl {
       }
       idx = type != DTM ? encode_pawn_f(p, ei, be) : encode_pawn_r(p, ei, be);
     }
-    
+
     uint8_t* w = decompress_pairs(ei->precomp, idx);
 
     if (type == WDL) return static_cast<int>(w[0]) - 2;

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -1406,9 +1406,13 @@ class SyzygyTablebaseImpl {
       }
       idx = type != DTM ? encode_pawn_f(p, ei, be) : encode_pawn_r(p, ei, be);
     }
-
+    auto start = std::chrono::high_resolution_clock::now();
     uint8_t* w = decompress_pairs(ei->precomp, idx);
-
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+    if (duration.count() > 1) {
+      std::cout << "Time taken: " << duration.count() << " microseconds" << std::endl;
+    }
     if (type == WDL) return static_cast<int>(w[0]) - 2;
 
     int v = w[0] + ((w[1] & 0x0f) << 8);

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -33,6 +33,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -1407,7 +1408,13 @@ class SyzygyTablebaseImpl {
       idx = type != DTM ? encode_pawn_f(p, ei, be) : encode_pawn_r(p, ei, be);
     }
 
+    auto start = std::chrono::high_resolution_clock::now();
     uint8_t* w = decompress_pairs(ei->precomp, idx);
+    auto end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> duration = end - start;
+    if (duration.count() > 1) {
+    std::cout << "Warning: Computation took " << elapsed.count()  << " seconds, which is longer than expected." << std::endl;
+    }
 
     if (type == WDL) return static_cast<int>(w[0]) - 2;
 

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -1413,7 +1413,7 @@ class SyzygyTablebaseImpl {
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> duration = end - start;
     if (duration.count() > 1) {
-    std::cout << "Warning: Computation took " << elapsed.count()  << " seconds, which is longer than expected." << std::endl;
+    std::cout << "Warning: Tablebase probing took " << elapsed.count()  << " seconds, which is longer than expected." << std::endl;
     }
 
     if (type == WDL) return static_cast<int>(w[0]) - 2;

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -1406,13 +1406,9 @@ class SyzygyTablebaseImpl {
       }
       idx = type != DTM ? encode_pawn_f(p, ei, be) : encode_pawn_r(p, ei, be);
     }
-    auto start = std::chrono::high_resolution_clock::now();
+    
     uint8_t* w = decompress_pairs(ei->precomp, idx);
-    auto end = std::chrono::high_resolution_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-    if (duration.count() > 1) {
-      std::cout << "Time taken: " << duration.count() << " microseconds" << std::endl;
-    }
+
     if (type == WDL) return static_cast<int>(w[0]) - 2;
 
     int v = w[0] + ((w[1] & 0x0f) << 8);

--- a/src/syzygy/syzygy.cc
+++ b/src/syzygy/syzygy.cc
@@ -1413,7 +1413,7 @@ class SyzygyTablebaseImpl {
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> duration = end - start;
     if (duration.count() > 1) {
-    std::cout << "Warning: Tablebase probing took " << elapsed.count()  << " seconds, which is longer than expected." << std::endl;
+    std::cout << "Warning: Tablebase probing took " << duration.count()  << " seconds, which is longer than expected." << std::endl;
     }
 
     if (type == WDL) return static_cast<int>(w[0]) - 2;


### PR DESCRIPTION
utilizing chrono to calculate the time for NN evaluation and tablebase probing, logging a message if any of each exceeds 1s, as requested in issue #1768 