### PR TITLE
add simple JS backend

### DIFF
--- a/cross-files/wasm32-emscripten
+++ b/cross-files/wasm32-emscripten
@@ -1,0 +1,24 @@
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm32'
+endian = 'little'
+
+[binaries]
+c = 'emcc'
+cpp = 'em++'
+ar = 'emar'
+strip = 'emstrip'
+
+[built-in options]
+cpp_args = ['-fexceptions', '-msse', '-msse2', '-msse3', '-msimd128']
+cpp_link_args = [
+		'-fexceptions',
+		'-sASYNCIFY', '-sASYNCIFY_STACK_SIZE=65536',
+		'-sMODULARIZE', '-sEXPORT_ES6',
+		'-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=$stringToNewUTF8',
+		'-sALLOW_MEMORY_GROWTH',
+		'-sWASM_BIGINT',
+		'-sENVIRONMENT=worker',
+	]

--- a/js/.gitignore
+++ b/js/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+package-lock.json
+dist
+build
+lc0.tar

--- a/js/README.md
+++ b/js/README.md
@@ -1,0 +1,21 @@
+<!-- TODO: improve documentation! -->
+
+Leela Chess Zero (Wasm)
+===
+
+Lc0 compiled to WebAssembly (running on WebGPU when supported).
+
+compiling
+---
+
+- Install [Emscripten].
+- Install [esbuild].
+- Install [npm].
+- Install [Meson].
+- Run `npm install`
+- Run `npm run build` (or `./build.sh`)
+
+[Emscripten]: <https://emscripten.org/docs/getting_started/downloads.html>
+[esbuild]: <https://esbuild.github.io/getting-started/>
+[npm]: <https://docs.npmjs.com/cli/configuring-npm/install>
+[Meson]: <https://mesonbuild.com/Getting-meson.html>

--- a/js/build.sh
+++ b/js/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+set -ex
+meson setup --buildtype=release -Ddefault_library=static --prefer-static --cross-file=../cross-files/wasm32-emscripten -Dblas=false build .. || :
+meson compile -C build lc0
+esbuild --minify --outdir=dist --format=esm main.js worker.js build/lc0.js build/lc0.worker.mjs
+mv dist/build/lc0.worker.js dist/build/lc0.worker.mjs
+cp build/lc0.wasm dist/build
+cat > dist/package.json << END
+{
+	"name": "lc0",
+	"description": "Leela Chess Zero",
+	"version": "0.0.0.1",
+	"license": "GPL",
+	"homepage": "https://lczero.org",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/LeelaChessZero/lc0"
+	},
+	"main": "./main.js",
+	"exports": {
+		".": {
+			"import": "./main.js"
+		}
+	},
+	"dependencies": {
+		"onnxruntime-web": "1.19.2"
+	}
+}
+END

--- a/js/example/.gitignore
+++ b/js/example/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+package-lock.json
+dist
+net.onnx
+.parcel-cache

--- a/js/example/README.md
+++ b/js/example/README.md
@@ -1,0 +1,20 @@
+<!-- TODO: improve documentation! -->
+
+Lc0 Web Example (Wasm)
+===
+
+First, convert an Lc0 network to ONNX format by using `lc0 leela2onnx` appropriately. Name the file `net.onnx` and place it on this directory.
+
+Then, run the following commands:
+
+- Install [Emscripten].
+- Install [esbuild].
+- Install [npm].
+- Install [Meson].
+- Run `npm install`
+- Run `npm run dev`
+
+[Emscripten]: <https://emscripten.org/docs/getting_started/downloads.html>
+[esbuild]: <https://esbuild.github.io/getting-started/>
+[npm]: <https://docs.npmjs.com/cli/configuring-npm/install>
+[Meson]: <https://mesonbuild.com/Getting-meson.html>

--- a/js/example/index.html
+++ b/js/example/index.html
@@ -1,0 +1,44 @@
+
+<!doctype html>
+<meta charset="utf-8">
+
+<title> Lc0 Web Test </title>
+
+<style> @import "@xterm/xterm/css/xterm.css"; </style>
+
+<script type="module">
+
+import {Lc0} from "lc0"
+import {Terminal} from "@xterm/xterm"
+
+let response = await fetch("net.onnx")
+let lc0 = Lc0(response.body)
+
+let terminal = new Terminal()
+terminal.open(document.querySelector("div"))
+
+let show = async out =>
+{
+	for await (let line of out) terminal.writeln(line)
+}
+
+show(lc0)
+show(lc0.stderr)
+
+let line = ""
+terminal.onData(data =>
+{
+	if (data === "\x7F") return
+	if (data === "\r") data = "\r\n"
+	terminal.write(data)
+	if (data === "\r\n") {
+		lc0.post(line)
+		line = ""
+		return
+	}
+	line += data
+})
+
+</script>
+
+<div></div>

--- a/js/example/package.json
+++ b/js/example/package.json
@@ -1,0 +1,11 @@
+{
+	"scripts": {
+		"pack": "cd .. && npm run pack",
+		"dev": "npm run pack && npm install && vite"
+	},
+	"dependencies": {
+		"@xterm/xterm": "5.5.0",
+		"lc0": "../lc0.tar",
+		"vite": "5.4.8"
+	}
+}

--- a/js/example/vite.config.js
+++ b/js/example/vite.config.js
@@ -1,0 +1,11 @@
+export default {
+	server: {
+		headers: {
+			"Cross-Origin-Embedder-Policy": "require-corp",
+			"Cross-Origin-Opener-Policy": "same-origin",
+		}
+	},
+	optimizeDeps: {
+		exclude: ["lc0"],
+	},
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,69 @@
+let Stream = (worker, type, finished) =>
+{
+	let gotLine
+	let lines = []
+	
+	worker.addEventListener("message", ({data}) =>
+	{
+		if (data.type !== type) return
+		if (!gotLine) {
+			lines.push(data.text)
+			return
+		}
+		gotLine(data.text)
+		gotLine = undefined
+	})
+	
+	let next = () =>
+	{
+		let value
+		if (lines.length !== 0) return lines.shift()
+		else return new Promise(resolve => gotLine = resolve)
+	}
+	
+	let it = {next: async () => finished() && lines.length === 0 ? {done: true} : {done: false, value: await next()}}
+	Object.freeze(it)
+	
+	let peek = () => lines[0]
+	
+	return {next, peek, [Symbol.asyncIterator]: () => it}
+}
+
+export let Lc0 = network =>
+{
+	let worker = new Worker(new URL("worker.js", import.meta.url), {type: "module"})
+	
+	let commands = []
+	let post0 = command => commands.push(command)
+	
+	worker.addEventListener("message", () =>
+	{
+		worker.postMessage({network}, [network])
+		for (let command of commands) worker.postMessage(command)
+		commands = undefined
+		post0 = command => worker.postMessage(command)
+	}, {once: true})
+	
+	let post = command =>
+	{
+		if (finished) throw new Error("Cannot post command to finished Lc0")
+		post0(String(command))
+	}
+	
+	let finished = false
+	
+	// todo: this should send a message to the worker instead
+	// so that it can end its pthread workers too
+	let finish = () =>
+	{
+		finished = true
+		worker.terminate()
+	}
+	
+	let stdout = Stream(worker, "stdout", () => finished)
+	let stderr = Stream(worker, "stderr", () => finished)
+	
+	let lc0 = {post, finish, ...stdout, stderr, get finished() { return finished }}
+	Object.freeze(lc0)
+	return lc0
+}

--- a/js/package.json
+++ b/js/package.json
@@ -1,0 +1,7 @@
+{
+	"scripts": {
+		"build": "npm install && ./build.sh",
+		"pack": "npm run build && tar cf lc0.tar dist"
+	}
+}
+

--- a/js/worker.js
+++ b/js/worker.js
@@ -1,0 +1,105 @@
+import Module from "./build/lc0.js"
+import {InferenceSession, Tensor} from "onnxruntime-web/all"
+
+let gotLine
+let lines = []
+
+addEventListener("message", ({data}) =>
+{
+	if (typeof data !== "string") return
+	if (!gotLine) {
+		lines.push(data)
+		return
+	}
+	gotLine(data)
+	gotLine = undefined
+})
+
+let {data: {network}} = await new Promise(resolve =>
+{
+	postMessage({type: "ready"})
+	addEventListener("message", resolve, {once: true})
+})
+
+let session = await InferenceSession.create(await new Response(network).arrayBuffer(), {executionProviders: ["webgpu", "wasm"]})
+let map = new Map()
+
+let lc0web_get_line = async () =>
+{
+	if (lines.length !== 0) return lines.shift()
+	return new Promise(resolve => gotLine = resolve)
+}
+
+let lc0web_is_cpu = () => true
+
+let id = 0
+let lc0web_id = () =>
+{
+	let i = id++
+	map.set(i, {input: []})
+	return i
+}
+
+let lc0web_batch_size = id => map.get(id).input.length
+
+let lc0web_remove = id => map.delete(id)
+
+let lc0web_q_val = (id, sample) =>
+{
+	let [w, d, l] = map.get(id).output["/output/wdl"].cpuData
+	return w - l
+}
+
+let lc0web_d_val = (id, sample) =>
+{
+	let [w, d, l] = map.get(id).output["/output/wdl"].cpuData
+	return d
+}
+
+let lc0web_p_val = (id, sample, moveID) =>
+	map.get(id).output["/output/policy"].cpuData[sample * 1858 + moveID]
+
+let lc0web_m_val = (id, sample) =>
+	map.get(id).output["/output/mlh"].cpuData[sample]
+
+let lc0web_add_input = id => map.get(id).input.push([])
+
+let lc0web_add_plane = (id, index, mask, value) =>
+{
+	let array = map.get(id).input[index]
+	for (let i = 0 ; i < 64 ; i++) {
+		if (mask & 1n) array.push(value)
+		else array.push(0)
+		mask >>= 1n
+	}
+}
+
+let lc0web_compute = async id =>
+{
+	let value = map.get(id)
+	let {input} = value
+	let array = new Float32Array(input.flat(Infinity))
+	let tensor = new Tensor("float32", array, [input.length, 112, 8, 8])
+	value.output = await session.run({"/input/planes": tensor})
+}
+
+Object.assign(globalThis, {
+	lc0web_get_line,
+	lc0web_is_cpu,
+	lc0web_id,
+	lc0web_batch_size,
+	lc0web_remove,
+	lc0web_q_val,
+	lc0web_d_val,
+	lc0web_p_val,
+	lc0web_m_val,
+	lc0web_add_input,
+	lc0web_add_plane,
+	lc0web_compute,
+})
+
+Module({
+	arguments: ["--preload"],
+	print: text => postMessage({type: "stdout", text}),
+	printErr: text => postMessage({type: "stderr", text}),
+})

--- a/meson.build
+++ b/meson.build
@@ -632,6 +632,11 @@ if get_option('build_backends')
       has_backends = true
   endif
 
+  if host_machine.system() == 'emscripten'
+      files += 'src/neural/js/network_js.cc'
+      has_backends = true
+  endif
+
 endif # if get_option('build_backends')
 
 if not has_backends and get_option('lc0') and get_option('build_backends')

--- a/src/mcts/node.h
+++ b/src/mcts/node.h
@@ -346,7 +346,7 @@ class Node {
 #endif
 
 // A basic sanity check. This must be adjusted when Node members are adjusted.
-#if defined(__i386__) || (defined(__arm__) && !defined(__aarch64__))
+#if defined(__i386__) || (defined(__arm__) && !defined(__aarch64__)) || defined(__EMSCRIPTEN__)
 static_assert(sizeof(Node) == 48, "Unexpected size of Node for 32bit compile");
 #else
 static_assert(sizeof(Node) == 64, "Unexpected size of Node");

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -899,6 +899,11 @@ EdgeAndNode Search::GetBestRootChildWithTemperature(float temperature) const {
 }
 
 void Search::StartThreads(size_t how_many) {
+#ifdef __EMSCRIPTEN__
+  (void) how_many;
+  SearchWorker worker(this, params_, 0);
+  worker.RunBlocking();
+#else
   Mutex::Lock lock(threads_mutex_);
   if (how_many == 0 && threads_.size() == 0) {
     how_many = network_->GetThreads() + !network_->IsCpu();
@@ -920,6 +925,7 @@ void Search::StartThreads(size_t how_many) {
                  std::chrono::steady_clock::now() - start_time_)
                  .count()
           << "ms already passed.";
+#endif
 }
 
 void Search::RunBlocking(size_t threads) {

--- a/src/neural/js/network_js.cc
+++ b/src/neural/js/network_js.cc
@@ -1,0 +1,115 @@
+#include <emscripten.h>
+#include <memory>
+
+#include "neural/factory.h"
+#include "neural/loader.h"
+#include "neural/network.h"
+
+namespace lczero {
+namespace {
+
+extern "C" {
+
+EM_JS(int, lc0web_is_cpu, (), { return globalThis.lc0web_is_cpu() });
+EM_JS(int, lc0web_id, (), { return globalThis.lc0web_id() });
+EM_JS(int, lc0web_q_val, (int id, int sample), { return globalThis.lc0web_q_val(id, sample) });
+EM_JS(int, lc0web_d_val, (int id, int sample), { return globalThis.lc0web_d_val(id, sample) });
+EM_JS(int, lc0web_p_val, (int id, int sample, int move_id), { return globalThis.lc0web_p_val(id, sample, move_id) });
+EM_JS(int, lc0web_m_val, (int id, int sample), { return globalThis.lc0web_m_val(id, sample) });
+EM_JS(int, lc0web_remove, (int id), { return globalThis.lc0web_remove(id) });
+EM_JS(void, lc0web_add_input, (int id), { return globalThis.lc0web_add_input(id) });
+EM_JS(void, lc0web_add_plane, (int id, int index, uint64_t mask, float value), { return globalThis.lc0web_add_plane(id, index,  mask, value) });
+EM_JS(int, lc0web_batch_size, (int id), { return globalThis.lc0web_batch_size(id) });
+EM_ASYNC_JS(void, lc0web_compute, (int id), { return globalThis.lc0web_compute(id) });
+
+}
+
+class JSComputation : public NetworkComputation {
+ public:
+  JSComputation();
+  ~JSComputation() override;
+  void AddInput(InputPlanes&& input) override;
+  int GetBatchSize() const override;
+  void ComputeBlocking() override;
+  float GetQVal(int sample) const override;
+  float GetDVal(int sample) const override;
+  float GetPVal(int sample, int move_id) const override;
+  float GetMVal(int sample) const override;
+ private:
+  int id;
+};
+
+class JSNetwork : public Network {
+ public:
+  const NetworkCapabilities& GetCapabilities() const override {
+    return capabilities;
+  };
+  std::unique_ptr<NetworkComputation> NewComputation() override;
+  bool IsCpu() const override;
+ private:
+  const NetworkCapabilities capabilities = {
+    pblczero::NetworkFormat_InputFormat_INPUT_CLASSICAL_112_PLANE,
+    pblczero::NetworkFormat_OutputFormat_OUTPUT_WDL,
+    pblczero::NetworkFormat_MovesLeftFormat_MOVES_LEFT_V1,
+  };
+};
+
+std::unique_ptr<Network> MakeJSNetwork(
+  const std::optional<WeightsFile>& w,
+  const OptionsDict& opts) {
+  (void) w;
+  (void) opts;
+  return std::make_unique<JSNetwork>();
+}
+
+bool JSNetwork::IsCpu() const {
+  return lc0web_is_cpu();
+}
+
+std::unique_ptr<NetworkComputation> JSNetwork::NewComputation() {
+  return std::make_unique<JSComputation>();
+}
+
+float JSComputation::GetQVal(int sample) const {
+  return lc0web_q_val(id, sample);
+}
+
+float JSComputation::GetDVal(int sample) const {
+  return lc0web_d_val(id, sample);
+}
+
+float JSComputation::GetPVal(int sample, int move_id) const {
+  return lc0web_p_val(id, sample, move_id);
+}
+
+float JSComputation::GetMVal(int sample) const {
+  return lc0web_m_val(id, sample);
+}
+
+void JSComputation::AddInput(InputPlanes&& input) {
+  int i = GetBatchSize();
+  lc0web_add_input(id);
+  for (auto& plane : input)
+    lc0web_add_plane(id, i, plane.mask, plane.value);
+}
+
+int JSComputation::GetBatchSize() const {
+  return lc0web_batch_size(id);
+}
+
+void JSComputation::ComputeBlocking() {
+  lc0web_compute(id);
+}
+
+JSComputation::JSComputation() {
+  id = lc0web_id();
+}
+
+JSComputation::~JSComputation() {
+  lc0web_remove(id);
+}
+
+REGISTER_NETWORK("js", MakeJSNetwork, 1000)
+
+}
+}

--- a/src/neural/onnx/builder.cc
+++ b/src/neural/onnx/builder.cc
@@ -143,6 +143,7 @@ std::string OnnxBuilder::Conv(const std::string& name,
   node->add_input(AddInitializer(name + "/w/bias", bias_weights));
   AddIntsAttribute(node, "pads", {pads, pads, pads, pads});
   AddIntsAttribute(node, "kernel_shape", {shape, shape});
+  AddIntsAttribute(node, "dilations", {1, 1});
   return out;
 }
 
@@ -289,7 +290,9 @@ std::string OnnxBuilder::Identity(const std::string& name,
 std::string OnnxBuilder::Selu(const std::string& name,
                               const std::string& input) {
   auto* node = model_.mutable_graph()->add_node();
-  return PopulateStdNodeFields(node, name, input, "Selu");
+  auto out = PopulateStdNodeFields(node, name + "/elu", input, "Elu");
+  AddFloatAttribute(node, "alpha", 1.0507);
+  return Mul(name, out, FloatOnnxConst({1.67326}, {1}));
 }
 
 std::vector<std::string> OnnxBuilder::Split(const std::string& name,

--- a/src/neural/onnx/converter.h
+++ b/src/neural/onnx/converter.h
@@ -45,7 +45,7 @@ struct WeightsToOnnxConverterOptions {
   std::string output_mlh = "/output/mlh";
   int batch_size = -1;
   int opset = 17;
-  bool alt_mish = false;       // Use "Mish" approximation (fp32 only).
+  bool alt_mish = true;        // Use "Mish" approximation (fp32 only).
   bool alt_layernorm = false;  // Discrete "LayerNormalization" implementation.
   bool relax_op_types = true;  // Use data_type even if unsuported by operator.
   bool no_shape = false;       // Avoid use of "Shape" operator.


### PR DESCRIPTION
I was told this might be desirable. A couple things to note:

- I wish to be able to publish this as a package to npm eventually. (I hope this can be allowed!)
- I have only tried this with Emscripten v3.1.57, see: emscripten-core/emscripten#22394
- If there is anything I can improve, I’d love to try to!
- I set this as a draft pull request because I think the documentation could be improved, and also because I have set up some ORT‐web compatibility changes very directly, whereas they should probably be conditional.
- This only works well in browsers with WebGPU enabled (and in computers with a decent GPU), so this is currently fairly niche.

If anyone has any thoughts on whether this is warranted, I’d love to know! (Do let me know what you think!)

Some more technical details: This works by converting an Lc0 network to ONNX format (with `leela2onnx`) and then using the ORT‐web APIs to allow Lc0 to interface with the network through JavaScript.