### PR TITLE
Change centipawn fallback to account for sharper WDL with high WDLCalibrationElo

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -338,7 +338,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
       // Reports the WDL mu value whenever it is reasonable, and defaults to
       // centipawn otherwise.
       const float centipawn_fallback_threshold = 0.996f;
-      float centipawn_score = 90 * tan(1.5637541897 * wl);
+      float centipawn_score = 45 * tan(1.5637541897 * wl);
       uci_info.score =
           network_->GetCapabilities().has_wdl() && mu_uci != 0.0f &&
                   std::abs(wl) + d < centipawn_fallback_threshold &&

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -338,7 +338,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
       // Reports the WDL mu value whenever it is reasonable, and defaults to
       // centipawn otherwise.
       const float centipawn_fallback_threshold = 0.996f;
-      float centipawn_score = 45 * tan(1.5637541897 * wl);
+      float centipawn_score = 45 * tan(1.56728071628 * wl);
       uci_info.score =
           network_->GetCapabilities().has_wdl() && mu_uci != 0.0f &&
                   std::abs(wl) + d < centipawn_fallback_threshold &&


### PR DESCRIPTION
The previously used `centipawn` formula #1193 is also used as fallback for `WDL_mu` introduced in #1791 mostly to reproduce the extreme centipawn values in clearly decisive positions users are accustomed to. The formula however was calibrated with the raw (unsharpened) WDL NN output, which means that together with WDL sharpening due to high `WDLCalibrationElo` it climbs too quickly, which also means it takes over faster than intended. `WDL_mu` without the fallback usually produces meaningful evals up to around `+4.5`, which is roughly where the fallback formula should take over. However, in the described scenario with `WDLCalibrationElo: 3600` this already happens below +2, causing a discrepancy in behavior between Lc0 and SF eval roughly like [this](https://tcec-chess.com/#game=3&round=bz&season=cup14) between Lc0 and SF in the range between +2 and +5 for SF where Leela regularly shows about double the eval of SF.
![grafik](https://github.com/user-attachments/assets/ad8c846e-4472-4415-b0fc-8d6bfef3517c)

The fallback formula is therefore updated in two ways: 50% reduction in the scaling, while slightly increasing the constant to still meet +128 at `wl=1.0`.