### PR TITLE
onnx make alt_mish work with other data types

### DIFF
--- a/src/neural/xla/network_xla.cc
+++ b/src/neural/xla/network_xla.cc
@@ -303,6 +303,8 @@ std::unique_ptr<Network> MakeXlaNetwork(const std::optional<WeightsFile>& w,
         WeightsToOnnxConverterOptions::StringToDataType(
             opts.GetOrDefault<std::string>("datatype", "f32"));
     onnx_converter_options.opset = 22;  // For full onnx bfloat16 support.
+    onnx_converter_options.alt_mish =
+        opts.GetOrDefault<bool>("alt_mish", false);
     auto converted = ConvertWeightsToOnnx(*w, onnx_converter_options);
     options = FillXlaRunnerFromOnnx(converted.onnx_model(), runner.get(),
                                     max_batch_size, steps, io_type);


### PR DESCRIPTION
The onnx converter alt_mish option was restricted to fp32, since it was only seen to be useful with onnx-cpu (where it is the default). Recent tests show it may be a bit faster with xla over cuda in fp16 (but not with xla over tpu in bf16), so it is made optionally available everywhere, with the computation done in fp32.