### PR TITLE
fix rescorer build with newer meson

### DIFF
--- a/subprojects/packagefiles/gaviotatb/meson.build
+++ b/subprojects/packagefiles/gaviotatb/meson.build
@@ -27,8 +27,13 @@ gaviotatb_includes = [
   'compression/lzma'
 ]
 
+gaviota_lib = static_library('gaviota',
+  gaviotatb_src,
+  c_args : '-Dz_uLong=uLong',
+  include_directories : gaviotatb_includes)
+
+incdir = include_directories('.')
+
 gaviotatb_dep = declare_dependency(
-  sources: gaviotatb_src,
-  include_directories: gaviotatb_includes,
-  compile_args:'-Dz_uLong=uLong'
-)
+  link_with : gaviota_lib,
+  include_directories : gaviotatb_includes)


### PR DESCRIPTION
Newer meson versions can't build the rescorer because gaviota tb is written in c, but it will work fine if it is made into a static library.