### PR TITLE
Spinlock warning fix

### DIFF
--- a/src/utils/mutex.h
+++ b/src/utils/mutex.h
@@ -127,6 +127,13 @@ class CAPABILITY("mutex") SharedMutex {
 static inline void SpinloopPause() {
 #if defined(__x86_64__)
   _mm_pause();
+#else
+// Fallback for non-x86_64 architectures - prevents optimization
+#ifdef _MSC_VER
+  __asm {}
+#else
+  asm volatile("");
+#endif
 #endif
 }
 

--- a/src/utils/mutex.h
+++ b/src/utils/mutex.h
@@ -125,15 +125,12 @@ class CAPABILITY("mutex") SharedMutex {
 };
 
 static inline void SpinloopPause() {
-#if defined(__x86_64__)
+#if defined(__x86_64__) || defined(_M_X64)
   _mm_pause();
-#else
-// Fallback for non-x86_64 architectures - prevents optimization
-#ifdef _MSC_VER
+#elif defined(_MSC_VER)
   __asm {}
 #else
   asm volatile("");
-#endif
 #endif
 }
 

--- a/src/utils/spinhelper.h
+++ b/src/utils/spinhelper.h
@@ -44,20 +44,17 @@ class SpinHelper {
 class ExponentialBackoffSpinHelper : public SpinHelper {
  public:
   ExponentialBackoffSpinHelper()
-    : backoff_iters_(kMinBackoffIters),
-      spin_to_sleep_iters_(0) {
-  }
+      : backoff_iters_(kMinBackoffIters), spin_to_sleep_iters_(0) {}
 
   virtual void Backoff() {
     thread_local std::uniform_int_distribution<size_t> distribution;
     thread_local std::minstd_rand generator(std::random_device{}());
-    const size_t spin_count = distribution(generator, decltype(distribution)::param_type{0, backoff_iters_});
+    const size_t spin_count = distribution(
+        generator, decltype(distribution)::param_type{0, backoff_iters_});
 
-    for (volatile size_t i=0; i<spin_count; i++) {
-      SpinloopPause();
-    }
+    for (size_t i = 0; i < spin_count; i++) SpinloopPause();
 
-    backoff_iters_ = std::min(2*backoff_iters_, kMaxBackoffIters);
+    backoff_iters_ = std::min(2 * backoff_iters_, kMaxBackoffIters);
     spin_to_sleep_iters_ = 0;
   }
 


### PR DESCRIPTION
++ for volatile variables is deprecated in C++20