### PR TITLE
Move backend-specific options out of search params.cc

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -165,6 +165,7 @@ common_files += [
   'src/neural/decoder.cc',
   'src/neural/encoder.cc',
   'src/neural/register.cc',
+  'src/neural/shared_params.cc',
   'src/neural/wrapper.cc',
   'src/search/classic/node.cc',
   'src/syzygy/syzygy.cc',

--- a/src/engine_classic.cc
+++ b/src/engine_classic.cc
@@ -31,6 +31,7 @@
 #include <cmath>
 #include <functional>
 
+#include "neural/shared_params.h"
 #include "search/classic/search.h"
 #include "search/classic/stoppers/factory.h"
 #include "utils/commandline.h"
@@ -96,7 +97,6 @@ void EngineClassic::PopulateOptions(OptionsParser* options) {
   using namespace std::placeholders;
   const bool is_simple =
       CommandLine::BinaryName().find("simple") != std::string::npos;
-  NetworkFactory::PopulateOptions(options);
   options->Add<IntOption>(kThreadsOptionId, 0, 128) = 0;
   options->Add<IntOption>(classic::kNNCacheSizeId, 0, 999999999) = 2000000;
   classic::SearchParams::Populate(options);
@@ -105,7 +105,7 @@ void EngineClassic::PopulateOptions(OptionsParser* options) {
   if (is_simple) {
     options->HideAllOptions();
     options->UnhideOption(kThreadsOptionId);
-    options->UnhideOption(NetworkFactory::kWeightsId);
+    options->UnhideOption(SharedBackendParams::kWeightsId);
     options->UnhideOption(classic::SearchParams::kContemptId);
     options->UnhideOption(classic::SearchParams::kMultiPvId);
   }

--- a/src/engine_loop.cc
+++ b/src/engine_loop.cc
@@ -27,6 +27,7 @@
 
 #include "engine_loop.h"
 
+#include "neural/shared_params.h"
 #include "utils/configfile.h"
 
 namespace lczero {
@@ -52,6 +53,7 @@ EngineLoop::EngineLoop(std::unique_ptr<OptionsParser> options,
           options_->GetOptionsDict())) {
   options_->Add<StringOption>(kLogFileId);
   options_->Add<BoolOption>(kPreload) = false;
+  SharedBackendParams::Populate(options_.get());
 }
 
 void EngineLoop::RunLoop() {

--- a/src/neural/factory.cc
+++ b/src/neural/factory.cc
@@ -30,26 +30,11 @@
 #include <algorithm>
 
 #include "neural/loader.h"
+#include "neural/shared_params.h"
 #include "utils/commandline.h"
 #include "utils/logging.h"
 
 namespace lczero {
-
-const OptionId NetworkFactory::kWeightsId{
-    "weights", "WeightsFile",
-    "Path from which to load network weights.\nSetting it to <autodiscover> "
-    "makes it search in ./ and ./weights/ subdirectories for the latest (by "
-    "file date) file which looks like weights.",
-    'w'};
-const OptionId NetworkFactory::kBackendId{
-    "backend", "Backend", "Neural network computational backend to use.", 'b'};
-const OptionId NetworkFactory::kBackendOptionsId{
-    "backend-opts", "BackendOptions",
-    "Parameters of neural network backend. "
-    "Exact parameters differ per backend.",
-    'o'};
-const char* kAutoDiscover = "<autodiscover>";
-const char* kEmbed = "<built in>";
 
 NetworkFactory* NetworkFactory::Get() {
   static NetworkFactory factory;
@@ -59,18 +44,6 @@ NetworkFactory* NetworkFactory::Get() {
 NetworkFactory::Register::Register(const std::string& name, FactoryFunc factory,
                                    int priority) {
   NetworkFactory::Get()->RegisterNetwork(name, factory, priority);
-}
-
-void NetworkFactory::PopulateOptions(OptionsParser* options) {
-#if defined(EMBED)
-  options->Add<StringOption>(NetworkFactory::kWeightsId) = kEmbed;
-#else
-  options->Add<StringOption>(NetworkFactory::kWeightsId) = kAutoDiscover;
-#endif
-  const auto backends = NetworkFactory::Get()->GetBackendsList();
-  options->Add<ChoiceOption>(NetworkFactory::kBackendId, backends) =
-      backends.empty() ? "<none>" : backends[0];
-  options->Add<StringOption>(NetworkFactory::kBackendOptionsId);
 }
 
 void NetworkFactory::RegisterNetwork(const std::string& name,
@@ -99,9 +72,10 @@ std::unique_ptr<Network> NetworkFactory::Create(
 
 NetworkFactory::BackendConfiguration::BackendConfiguration(
     const OptionsDict& options)
-    : weights_path(options.Get<std::string>(kWeightsId)),
-      backend(options.Get<std::string>(kBackendId)),
-      backend_options(options.Get<std::string>(kBackendOptionsId)) {}
+    : weights_path(options.Get<std::string>(SharedBackendParams::kWeightsId)),
+      backend(options.Get<std::string>(SharedBackendParams::kBackendId)),
+      backend_options(
+          options.Get<std::string>(SharedBackendParams::kBackendOptionsId)) {}
 
 bool NetworkFactory::BackendConfiguration::operator==(
     const BackendConfiguration& other) const {
@@ -111,10 +85,15 @@ bool NetworkFactory::BackendConfiguration::operator==(
 
 std::unique_ptr<Network> NetworkFactory::LoadNetwork(
     const OptionsDict& options) {
-  std::string net_path = options.Get<std::string>(kWeightsId);
-  const std::string backend = options.Get<std::string>(kBackendId);
+  std::string net_path =
+      options.Get<std::string>(SharedBackendParams::kWeightsId);
+  const std::string backend =
+      options.Get<std::string>(SharedBackendParams::kBackendId);
   const std::string backend_options =
-      options.Get<std::string>(kBackendOptionsId);
+      options.Get<std::string>(SharedBackendParams::kBackendOptionsId);
+
+  constexpr char* kAutoDiscover = "<autodiscover>";
+  constexpr char* kEmbed = "<built in>";
 
   if (net_path == kAutoDiscover) {
     net_path = DiscoverWeightsFile();

--- a/src/neural/factory.cc
+++ b/src/neural/factory.cc
@@ -92,8 +92,8 @@ std::unique_ptr<Network> NetworkFactory::LoadNetwork(
   const std::string backend_options =
       options.Get<std::string>(SharedBackendParams::kBackendOptionsId);
 
-  constexpr char* kAutoDiscover = "<autodiscover>";
-  constexpr char* kEmbed = "<built in>";
+  constexpr const char* kAutoDiscover = "<autodiscover>";
+  constexpr const char* kEmbed = "<built in>";
 
   if (net_path == kAutoDiscover) {
     net_path = DiscoverWeightsFile();

--- a/src/neural/factory.h
+++ b/src/neural/factory.h
@@ -56,9 +56,6 @@ class NetworkFactory {
     Register(const std::string& name, FactoryFunc factory, int priority = 0);
   };
 
-  // Add the network/backend parameters to the options dictionary.
-  static void PopulateOptions(OptionsParser* options);
-
   // Returns list of backend names, sorted by priority (higher priority first).
   std::vector<std::string> GetBackendsList() const;
 
@@ -70,11 +67,6 @@ class NetworkFactory {
   // Helper function to load the network from the options. Returns nullptr
   // if no network options changed since the previous call.
   static std::unique_ptr<Network> LoadNetwork(const OptionsDict& options);
-
-  // Parameter IDs.
-  static const OptionId kWeightsId;
-  static const OptionId kBackendId;
-  static const OptionId kBackendOptionsId;
 
   struct BackendConfiguration {
     BackendConfiguration() = default;

--- a/src/neural/shared_params.cc
+++ b/src/neural/shared_params.cc
@@ -29,17 +29,13 @@
 
 #include "neural/factory.h"
 
-// TODO Remove the "NEW" prefixes when "classic" search goes off the old network
-// interface and these parameters are removes from there.
-
 namespace lczero {
 const OptionId SharedBackendParams::kPolicySoftmaxTemp{
-    "new-policy-softmax-temp", "NEWPolicyTemperature",
+    "policy-softmax-temp", "PolicyTemperature",
     "Policy softmax temperature. Higher values make priors of move candidates "
     "closer to each other, widening the search."};
-
 const OptionId SharedBackendParams::kHistoryFill{
-    "new-history-fill-new", "NEWHistoryFill",
+    "history-fill-new", "HistoryFill",
     "Neural network uses 7 previous board positions in addition to the current "
     "one. During the first moves of the game such historical positions don't "
     "exist, but they can be synthesized. This parameter defines when to "

--- a/src/neural/shared_params.cc
+++ b/src/neural/shared_params.cc
@@ -1,0 +1,52 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2024 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#include "neural/shared_params.h"
+
+// TODO Remove the "NEW" prefixes when "classic" search goes off the old network
+// interface and these parameters are removes from there.
+
+namespace lczero {
+const OptionId SharedBackendParams::kPolicySoftmaxTemp{
+    "new-policy-softmax-temp", "NEWPolicyTemperature",
+    "Policy softmax temperature. Higher values make priors of move candidates "
+    "closer to each other, widening the search."};
+
+const OptionId SharedBackendParams::kHistoryFill{
+    "new-history-fill-new", "NEWHistoryFill",
+    "Neural network uses 7 previous board positions in addition to the current "
+    "one. During the first moves of the game such historical positions don't "
+    "exist, but they can be synthesized. This parameter defines when to "
+    "synthesize them (always, never, or only at non-standard fen position)."};
+
+void SharedBackendParams::Populate(OptionsParser* options) {
+  options->Add<FloatOption>(kPolicySoftmaxTemp, 0.1f, 10.0f) = 1.359f;
+  std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};
+  options->Add<ChoiceOption>(kHistoryFill, history_fill_opt) = "fen_only";
+}
+
+}  // namespace lczero

--- a/src/neural/shared_params.h
+++ b/src/neural/shared_params.h
@@ -1,0 +1,46 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2024 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#pragma once
+
+#include "utils/optionsdict.h"
+#include "utils/optionsparser.h"
+
+namespace lczero {
+
+// Backend parameters that appear in UCI interface and are in use by most
+// backends.
+struct SharedBackendParams {
+  static const OptionId kPolicySoftmaxTemp;
+  static const OptionId kHistoryFill;
+  static void Populate(OptionsParser*);
+
+ private:
+  SharedBackendParams() = delete;
+};
+
+}  // namespace lczero

--- a/src/neural/shared_params.h
+++ b/src/neural/shared_params.h
@@ -37,6 +37,10 @@ namespace lczero {
 struct SharedBackendParams {
   static const OptionId kPolicySoftmaxTemp;
   static const OptionId kHistoryFill;
+  static const OptionId kWeightsId;
+  static const OptionId kBackendId;
+  static const OptionId kBackendOptionsId;
+
   static void Populate(OptionsParser*);
 
  private:

--- a/src/neural/wrapper.cc
+++ b/src/neural/wrapper.cc
@@ -31,6 +31,7 @@
 #include <numeric>
 
 #include "neural/encoder.h"
+#include "neural/shared_params.h"
 #include "utils/fastmath.h"
 
 namespace lczero {
@@ -140,8 +141,13 @@ NetworkAsBackendFactory::NetworkAsBackendFactory(const std::string& name,
 
 std::unique_ptr<Backend> NetworkAsBackendFactory::Create(
     const std::optional<WeightsFile>& weights, const OptionsDict& options) {
+  const std::string backend_options =
+      options.Get<std::string>(SharedBackendParams::kBackendOptionsId);
+  OptionsDict network_options;
+  network_options.AddSubdictFromString(backend_options);
+
   return std::make_unique<NetworkAsBackend>(
-      factory_(weights, options),
+      factory_(weights, network_options),
       options.GetOrDefault<float>("policy_temp", 1.359f));
 }
 

--- a/src/search/classic/params.h
+++ b/src/search/classic/params.h
@@ -191,7 +191,6 @@ class SearchParams {
   static const OptionId kFpuStrategyAtRootId;
   static const OptionId kFpuValueAtRootId;
   static const OptionId kCacheHistoryLengthId;
-  static const OptionId kPolicySoftmaxTempId;
   static const OptionId kMaxCollisionEventsId;
   static const OptionId kMaxCollisionVisitsId;
   static const OptionId kOutOfOrderEvalId;
@@ -200,7 +199,6 @@ class SearchParams {
   static const OptionId kMultiPvId;
   static const OptionId kPerPvCountersId;
   static const OptionId kScoreTypeId;
-  static const OptionId kHistoryFillId;
   static const OptionId kMovesLeftMaxEffectId;
   static const OptionId kMovesLeftThresholdId;
   static const OptionId kMovesLeftConstantFactorId;

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -143,7 +143,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   defaults->Set<int>(classic::SearchParams::kMiniBatchSizeId, 32);
   defaults->Set<float>(classic::SearchParams::kCpuctId, 1.2f);
   defaults->Set<float>(classic::SearchParams::kCpuctFactorId, 0.0f);
-  defaults->Set<float>(classic::SearchParams::kPolicySoftmaxTempId, 1.0f);
+  defaults->Set<float>(SharedBackendParams::kPolicySoftmaxTemp, 1.0f);
   defaults->Set<int>(classic::SearchParams::kMaxCollisionVisitsId, 1);
   defaults->Set<int>(classic::SearchParams::kMaxCollisionEventsId, 1);
   defaults->Set<int>(classic::SearchParams::kCacheHistoryLengthId, 7);
@@ -151,7 +151,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   defaults->Set<float>(classic::SearchParams::kTemperatureId, 1.0f);
   defaults->Set<float>(classic::SearchParams::kNoiseEpsilonId, 0.25f);
   defaults->Set<float>(classic::SearchParams::kFpuValueId, 0.0f);
-  defaults->Set<std::string>(classic::SearchParams::kHistoryFillId, "no");
+  defaults->Set<std::string>(SharedBackendParams::kHistoryFill, "no");
   defaults->Set<std::string>(SharedBackendParams::kBackendId, "multiplexing");
   defaults->Set<bool>(classic::SearchParams::kStickyEndgamesId, false);
   defaults->Set<bool>(classic::SearchParams::kTwoFoldDrawsId, false);

--- a/src/selfplay/tournament.cc
+++ b/src/selfplay/tournament.cc
@@ -31,6 +31,7 @@
 
 #include "chess/pgn.h"
 #include "neural/factory.h"
+#include "neural/shared_params.h"
 #include "search/classic/search.h"
 #include "search/classic/stoppers/factory.h"
 #include "selfplay/game.h"
@@ -110,7 +111,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
     dict->AddSubdict("black")->AddAliasDict(&options->GetOptionsDict("black"));
   }
 
-  NetworkFactory::PopulateOptions(options);
+  SharedBackendParams::Populate(options);
   options->Add<IntOption>(kThreadsId, 1, 8) = 1;
   options->Add<IntOption>(classic::kNNCacheSizeId, 0, 999999999) = 2000000;
   classic::SearchParams::Populate(options);
@@ -151,7 +152,7 @@ void SelfPlayTournament::PopulateOptions(OptionsParser* options) {
   defaults->Set<float>(classic::SearchParams::kNoiseEpsilonId, 0.25f);
   defaults->Set<float>(classic::SearchParams::kFpuValueId, 0.0f);
   defaults->Set<std::string>(classic::SearchParams::kHistoryFillId, "no");
-  defaults->Set<std::string>(NetworkFactory::kBackendId, "multiplexing");
+  defaults->Set<std::string>(SharedBackendParams::kBackendId, "multiplexing");
   defaults->Set<bool>(classic::SearchParams::kStickyEndgamesId, false);
   defaults->Set<bool>(classic::SearchParams::kTwoFoldDrawsId, false);
   defaults->Set<int>(classic::SearchParams::kTaskWorkersPerSearchWorkerId, 0);
@@ -658,9 +659,9 @@ void SelfPlayTournament::SaveResults() {
   if (kTournamentResultsFile.empty()) return;
   std::ofstream output(kTournamentResultsFile, std::ios_base::app);
   auto p1name =
-      player_options_[0][0].Get<std::string>(NetworkFactory::kWeightsId);
+      player_options_[0][0].Get<std::string>(SharedBackendParams::kWeightsId);
   auto p2name =
-      player_options_[1][0].Get<std::string>(NetworkFactory::kWeightsId);
+      player_options_[1][0].Get<std::string>(SharedBackendParams::kWeightsId);
 
   output << std::endl;
   output << "[White \"" << p1name << "\"]" << std::endl;

--- a/src/tools/backendbench.cc
+++ b/src/tools/backendbench.cc
@@ -29,6 +29,7 @@
 
 #include "chess/board.h"
 #include "neural/factory.h"
+#include "neural/shared_params.h"
 #include "search/classic/node.h"
 #include "utils/optionsparser.h"
 
@@ -76,7 +77,7 @@ void Clippy(std::string title, std::string msg3, std::string best3,
 
 void BackendBenchmark::Run() {
   OptionsParser options;
-  NetworkFactory::PopulateOptions(&options);
+  SharedBackendParams::Populate(&options);
   options.Add<IntOption>(kThreadsOptionId, 1, 128) = kDefaultThreads;
 
   options.Add<IntOption>(kBatchesId, 1, 999999999) = 100;

--- a/src/tools/benchmark.cc
+++ b/src/tools/benchmark.cc
@@ -29,6 +29,7 @@
 
 #include <numeric>
 
+#include "neural/shared_params.h"
 #include "search/classic/search.h"
 #include "search/classic/stoppers/factory.h"
 #include "search/classic/stoppers/stoppers.h"
@@ -49,7 +50,7 @@ const OptionId kNumPositionsId{"num-positions", "",
 
 void Benchmark::Run() {
   OptionsParser options;
-  NetworkFactory::PopulateOptions(&options);
+  SharedBackendParams::Populate(&options);
   options.Add<IntOption>(kThreadsOptionId, 1, 128) = kDefaultThreads;
   options.Add<IntOption>(classic::kNNCacheSizeId, 0, 999999999) = 200000;
   classic::SearchParams::Populate(&options);


### PR DESCRIPTION
* Have a separate file that defines backend options (that are likely used by all backends)
* Make Backend-to-Weights wrapper use these options.
* Move those options off params.cc (still accessible through that class because it will be changed anyway later)