### PR TITLE
Make MemCache / Wrapper backends thread-safe

### DIFF
--- a/src/neural/memcache.cc
+++ b/src/neural/memcache.cc
@@ -141,8 +141,11 @@ std::optional<EvalResult> MemCache::GetCachedEvaluation(
   result.d = lock->d;
   result.q = lock->q;
   result.m = lock->m;
-  std::copy(lock->p.get(), lock->p.get() + pos.legal_moves.size(),
-            result.p.begin());
+  if (lock->p) {
+    result.p.reserve(pos.legal_moves.size());
+    std::copy(lock->p.get(), lock->p.get() + pos.legal_moves.size(),
+              std::back_inserter(result.p));
+  }
   return result;
 }
 

--- a/src/neural/wrapper.cc
+++ b/src/neural/wrapper.cc
@@ -87,10 +87,12 @@ class NetworkAsBackendComputation : public BackendComputation {
   AddInputResult AddInput(const EvalPosition& pos,
                           EvalResultPtr result) override {
     int transform;
-    const size_t idx = entries_.emplace_back(
-        EncodePositionForNN(backend_->input_format_, pos.pos, 8,
-                            backend_->fill_empty_history_, &transform),
-        MoveList(pos.legal_moves.begin(), pos.legal_moves.end()), result, 0);
+    const size_t idx = entries_.emplace_back(Entry{
+        .input = EncodePositionForNN(backend_->input_format_, pos.pos, 8,
+                                     backend_->fill_empty_history_, &transform),
+        .legal_moves = MoveList(pos.legal_moves.begin(), pos.legal_moves.end()),
+        .result = result,
+        .transform = 0});
     entries_[idx].transform = transform;
     return ENQUEUED_FOR_EVAL;
   }

--- a/src/neural/wrapper.cc
+++ b/src/neural/wrapper.cc
@@ -82,7 +82,7 @@ class NetworkAsBackendComputation : public BackendComputation {
         computation_(backend_->network_->NewComputation()),
         entries_(backend_->attrs_.maximum_batch_size) {}
 
-  size_t UsedBatchSize() const override { return computation_->GetBatchSize(); }
+  size_t UsedBatchSize() const override { return entries_.size(); }
 
   AddInputResult AddInput(const EvalPosition& pos,
                           EvalResultPtr result) override {

--- a/src/utils/atomic_vector.h
+++ b/src/utils/atomic_vector.h
@@ -1,0 +1,81 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2024 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#pragma once
+
+namespace lczero {
+
+template <typename T>
+class AtomicVector {
+ public:
+  explicit AtomicVector(size_t capacity) : capacity_(capacity), size_(0) {
+    data_ = new
+        typename std::aligned_storage<sizeof(T), alignof(T)>::type[capacity];
+  }
+
+  ~AtomicVector() {
+    clear();
+    delete[] data_;
+  }
+
+  // Thread safe, returns the index of the inserted element.
+  template <typename... Args>
+  size_t emplace_back(Args&&... args) {
+    size_t i = size_.fetch_add(1, std::memory_order_relaxed);
+    assert(i < capacity_);
+    new (&data_[i]) T(std::forward<Args>(args)...);
+    return i;
+  }
+
+  T& operator[](size_t i) {
+    assert(i < size());
+    return *reinterpret_cast<T*>(&data_[i]);
+  }
+
+  const T& operator[](size_t i) const {
+    assert(i < size());
+    return *reinterpret_cast<const T*>(&data_[i]);
+  }
+
+  size_t size() const { return size_.load(std::memory_order_relaxed); }
+  size_t capacity() const { return capacity_; }
+
+  // Not thread safe.
+  void clear() {
+    for (size_t i = size_.load(std::memory_order_relaxed); i-- > 0;) {
+      reinterpret_cast<T*>(&data_[i])->~T();
+    }
+    size_.store(0, std::memory_order_relaxed);
+  }
+
+ private:
+  const size_t capacity_;
+  std::atomic<size_t> size_;
+  typename std::aligned_storage<sizeof(T), alignof(T)>::type* data_;
+};
+
+}  // namespace lczero

--- a/src/utils/atomic_vector.h
+++ b/src/utils/atomic_vector.h
@@ -72,6 +72,11 @@ class AtomicVector {
     size_.store(0, std::memory_order_relaxed);
   }
 
+  T* begin() { return reinterpret_cast<T*>(data_); }
+  T* end() { return reinterpret_cast<T*>(data_) + size(); }
+  const T* begin() const { return reinterpret_cast<const T*>(data_); }
+  const T* end() const { return reinterpret_cast<const T*>(data_) + size(); }
+
  private:
   const size_t capacity_;
   std::atomic<size_t> size_;


### PR DESCRIPTION
Without mutex.  
Only `AddInput()` is thread-safe; others doesn't make sense to do thread safe.