### PR TITLE
Fix openbench-specific issues

### DIFF
--- a/OpenBench/Makefile
+++ b/OpenBench/Makefile
@@ -1,7 +1,6 @@
-
 ifndef EXE
 	EXE = $(CURDIR)/lc0
 endif
 
 all:
-	cd .. && sh ./build.sh && mv build/release/lc0 $(EXE)
+	../build.sh && mv ../build/release/lc0 $(EXE)

--- a/OpenBench/Makefile
+++ b/OpenBench/Makefile
@@ -3,4 +3,11 @@ ifndef EXE
 endif
 
 all:
+ifdef EVALFILE
+	../build.sh -Dembed=true && mv ../build/release/lc0 $(EXE)
+	cat $(EVALFILE) >> $(EXE)
+	perl -e "printf '%sLc0!', pack('V', -s '$(EVALFILE)')" >> $(EXE)
+else
 	../build.sh && mv ../build/release/lc0 $(EXE)
+endif
+	

--- a/src/main.cc
+++ b/src/main.cc
@@ -75,7 +75,8 @@ int main(int argc, const char** argv) {
       // Selfplay mode.
       SelfPlayLoop loop;
       loop.RunLoop();
-    } else if (CommandLine::ConsumeCommand("benchmark")) {
+    } else if (CommandLine::ConsumeCommand("benchmark") ||
+               CommandLine::ConsumeCommand("bench")) {
       // Benchmark mode.
       Benchmark benchmark;
       benchmark.Run();


### PR DESCRIPTION
* `EXE` parameter now creates binaries in the same directory as makefile (as it should)
* EVALFILE is now recognized
* `./lc0 bench` is now a synonim for `./lc0 benchmark`