### PR TITLE
Introduce "openbench" build parameter

### DIFF
--- a/OpenBench/Makefile
+++ b/OpenBench/Makefile
@@ -5,10 +5,12 @@ endif
 all:
 	chmod +x ../build.sh
 ifdef EVALFILE
-	../build.sh -Dembed=true && mv ../build/release/lc0 $(EXE)
+	../build.sh -Dembed=true -Dopenbench=true
+	mv ../build/release/lc0 $(EXE)
 	cat $(EVALFILE) >> $(EXE)
 	perl -e "printf '%sLc0!', pack('V', -s '$(EVALFILE)')" >> $(EXE)
 else
-	../build.sh && mv ../build/release/lc0 $(EXE)
+	../build.sh -Dopenbench=true
+	mv ../build/release/lc0 $(EXE)
 endif
 	

--- a/meson.build
+++ b/meson.build
@@ -702,6 +702,10 @@ if get_option('embed')
   add_project_arguments('-DEMBED', language : 'cpp')
 endif
 
+if get_option('openbench')
+  add_project_arguments('-DOPENBENCH', language : 'cpp')
+endif
+
 if get_option('lc0')
   files += common_files
   executable('lc0', 'src/main.cc',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -202,3 +202,8 @@ option('rescorer',
        type: 'boolean',
        value: false,
        description: 'Build rescorer')
+
+option('openbench',
+       type: 'boolean',
+       value: false,
+       description: 'Build openbench-friendly version')

--- a/src/tools/benchmark.cc
+++ b/src/tools/benchmark.cc
@@ -57,9 +57,14 @@ void Benchmark::Run() {
   classic::SearchParams::Populate(&options);
 
   options.Add<IntOption>(kNodesId, -1, 999999999) = -1;
-  options.Add<IntOption>(kMovetimeId, -1, 999999999) = 500;
   options.Add<StringOption>(kFenId) = "";
+#if defined(OPENBENCH)
+  options.Add<IntOption>(kMovetimeId, -1, 999999999) = 500;
   options.Add<IntOption>(kNumPositionsId, 1, 34) = 10;
+#else
+  options.Add<IntOption>(kMovetimeId, -1, 999999999) = 10000;
+  options.Add<IntOption>(kNumPositionsId, 1, 34) = 34;
+#endif
 
   if (!options.ProcessAllFlags()) return;
 

--- a/src/utils/optionsparser.cc
+++ b/src/utils/optionsparser.cc
@@ -140,6 +140,9 @@ bool OptionsParser::ProcessAllFlags() {
 
 bool OptionsParser::ProcessFlags(const std::vector<std::string>& args) {
   auto show_help = false;
+#if defined(OPENBENCH)
+  ShowHidden();
+#endif
   if (CommandLine::BinaryName().find("pro") != std::string::npos) {
     ShowHidden();
   }


### PR DESCRIPTION
To use: `./build.sh -Dopenbench=true`

Builds Lc0 in the mode which is usable with Openbench:
* `bench` command runs 10 positions, half a second each (instead of running for 6 minutes)
* Options are unhidden, like in "pro" mode.
* Openbench Makefile uses that parameter now