### PR TITLE
Update logging.h

### DIFF
--- a/src/utils/logging.h
+++ b/src/utils/logging.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <deque>
 #include <fstream>
 #include <iomanip>


### PR DESCRIPTION
Update logging.h to include `#include <chrono>`, making it compatible with recent VS 2022 changes.

Doing this will allow for lc0 to be compiled.