### PR TITLE
fix training data generation

### DIFF
--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -299,7 +299,8 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
       training_data_.Add(tree_[idx]->GetCurrentHead(),
                          tree_[idx]->GetPositionHistory(), best_eval,
                          played_eval, best_is_proof, best_move, move,
-                         legal_moves, nneval);
+                         legal_moves, nneval,
+                         search_->GetParams().GetPolicySoftmaxTemp());
     }
     // Must reset the search before mutating the tree.
     search_.reset();

--- a/src/trainingdata/trainingdata.h
+++ b/src/trainingdata/trainingdata.h
@@ -101,7 +101,7 @@ class V6TrainingDataArray {
            classic::Eval best_eval, classic::Eval played_eval,
            bool best_is_proven, Move best_move, Move played_move,
            std::span<Move> legal_moves,
-           const std::optional<EvalResult>& nneval);
+           const std::optional<EvalResult>& nneval, float policy_softmax_temp);
 
   // Writes training data to a file.
   void Write(TrainingDataWriter* writer, GameResult result,


### PR DESCRIPTION
There were two issues:
1. Indexing in the policy array was bad for black moves.
2. To calculate the KL divergence you need to revert any softmax temperature in the policy.