### PR TITLE
Support updating backend parameters

### DIFF
--- a/src/engine.h
+++ b/src/engine.h
@@ -49,11 +49,12 @@ class Engine : public EngineControllerBase {
   void Stop() override;
 
  private:
-  void EnsureBackendCreated();
+  void UpdateBackendConfig();
   void EnsureSearchStopped();
 
   const OptionsDict& options_;
   std::unique_ptr<SearchBase> search_;
+  std::string backend_name_;
   std::unique_ptr<Backend> backend_;
   bool search_initialized_ = false;
 };

--- a/src/neural/backend.h
+++ b/src/neural/backend.h
@@ -100,6 +100,14 @@ class Backend {
   virtual std::optional<EvalResult> GetCachedEvaluation(const EvalPosition&) {
     return std::nullopt;
   }
+
+  // Updates the configuration of the backend. This is between searches.
+  // It's up to the backend to detect if the configuration has changed.
+  enum UpdateConfigurationResult {
+    UPDATE_OK = 0,     // Backend handled the update by itself (if needed).
+    NEED_RESTART = 1,  // Recreate the backend.
+  };
+  virtual UpdateConfigurationResult UpdateConfiguration(const OptionsDict&) = 0;
 };
 
 class BackendFactory {

--- a/src/neural/batchsplit.cc
+++ b/src/neural/batchsplit.cc
@@ -43,6 +43,11 @@ class BatchSplittingBackend : public Backend {
   }
   std::unique_ptr<BackendComputation> CreateComputation() override;
 
+  UpdateConfigurationResult UpdateConfiguration(
+      const OptionsDict& options) override {
+    return wrapped_backend_->UpdateConfiguration(options);
+  }
+
  private:
   Backend* wrapped_backend_;
 };

--- a/src/neural/memcache.cc
+++ b/src/neural/memcache.cc
@@ -73,6 +73,11 @@ class MemCache : public CachingBackend {
     cache_.SetCapacity(capacity);
   }
 
+  UpdateConfigurationResult UpdateConfiguration(
+      const OptionsDict& options) override {
+    return wrapped_backend_->UpdateConfiguration(options);
+  }
+
  private:
   std::unique_ptr<Backend> wrapped_backend_;
   HashKeyedCache<CachedValue> cache_;


### PR DESCRIPTION
Allow backend to update parameters and request reload if needed.  
Make (new) engine controller respect this flag.  
Make backend wrapper restart the backend on its own.

I'm currently adding tests for this few PRs later (not in this because that later PR has API change), you may want to wait for them to be ready (for the case they catch some bug), or not waiting and  finding bugs with your eyes is also fine.