### PR TITLE
onnx-trt improvements

### DIFF
--- a/src/neural/backends/network_onnx.cc
+++ b/src/neural/backends/network_onnx.cc
@@ -407,12 +407,9 @@ OnnxNetwork::OnnxNetwork(const WeightsFile& file, const OptionsDict& opts,
       bf16_(file.onnx_model().data_type() == pblczero::OnnxModel::BFLOAT16),
       provider_(provider) {
   batch_size_ =
-      opts.GetOrDefault<int>("batch", provider == OnnxProvider::DML   ? 16
-                                      : provider == OnnxProvider::TRT ? 32
-                                                                      : -1);
-  steps_ = opts.GetOrDefault<int>(
-      "steps",
-      (provider == OnnxProvider::DML || provider == OnnxProvider::TRT) ? 4 : 1);
+      opts.GetOrDefault<int>("batch", provider == OnnxProvider::DML ? 16 : -1);
+  steps_ =
+      opts.GetOrDefault<int>("steps", provider == OnnxProvider::DML ? 4 : 1);
   min_batch_size_ = opts.GetOrDefault<int>(
       "min_batch", provider == OnnxProvider::TRT ? 4 : 1);
   int gpu = opts.GetOrDefault<int>("gpu", 0);

--- a/src/neural/backends/network_onnx.cc
+++ b/src/neural/backends/network_onnx.cc
@@ -330,8 +330,7 @@ Ort::SessionOptions OnnxNetwork::GetOptions(int gpu, int threads,
       trt_options["trt_min_subgraph_size"] = "1";
       trt_options["trt_engine_cache_enable"] = "1";
       trt_options["trt_engine_cache_prefix"] =
-          "Lc0_ONNX_TRT_batch_" + std::to_string(batch_size) + "_gpu_" +
-          std::to_string(gpu) + "_";
+          "Lc0_ONNX_TRT_batch_" + std::to_string(batch_size) + "_";
       trt_options["trt_timing_cache_enable"] = "1";
       trt_options["trt_layer_norm_fp32_fallback"] = "1";
       trt_options["trt_force_sequential_engine_build"] = "1";

--- a/src/neural/backends/network_onnx.cc
+++ b/src/neural/backends/network_onnx.cc
@@ -331,7 +331,9 @@ Ort::SessionOptions OnnxNetwork::GetOptions(int gpu, int threads,
       trt_options["trt_engine_cache_enable"] = "1";
       trt_options["trt_engine_cache_prefix"] =
           "Lc0_ONNX_TRT_batch_" + std::to_string(batch_size) + "_";
+      trt_options["trt_engine_cache_path"] = "./trt_cache";
       trt_options["trt_timing_cache_enable"] = "1";
+      trt_options["trt_timing_cache_path"] = "./trt_cache";
       trt_options["trt_layer_norm_fp32_fallback"] = "1";
       trt_options["trt_force_sequential_engine_build"] = "1";
       // Looks like we need I/O binding to enable this.

--- a/src/neural/backends/network_onnx.cc
+++ b/src/neural/backends/network_onnx.cc
@@ -330,6 +330,7 @@ Ort::SessionOptions OnnxNetwork::GetOptions(int gpu, int threads,
       trt_options["trt_max_partition_iterations"] = "1000";
       trt_options["trt_min_subgraph_size"] = "1";
       trt_options["trt_engine_cache_enable"] = "1";
+      trt_options["trt_engine_cache_prefix"] = "Lc0_ONNX_TRT";
       trt_options["trt_timing_cache_enable"] = "1";
       trt_options["trt_layer_norm_fp32_fallback"] = "1";
       // Looks like we need I/O binding to enable this.

--- a/src/neural/backends/network_onnx.cc
+++ b/src/neural/backends/network_onnx.cc
@@ -326,11 +326,11 @@ Ort::SessionOptions OnnxNetwork::GetOptions(int gpu, int threads,
       trt_options["device_id"] = std::to_string(gpu);
       trt_options["trt_fp16_enable"] = fp16_ ? "1" : "0";
       trt_options["trt_int8_enable"] = "0";
-      trt_options["trt_engine_cache_enable"] = "1";
       trt_options["trt_max_partition_iterations"] = "1000";
       trt_options["trt_min_subgraph_size"] = "1";
       trt_options["trt_engine_cache_enable"] = "1";
-      trt_options["trt_engine_cache_prefix"] = "Lc0_ONNX_TRT";
+      trt_options["trt_engine_cache_prefix"] =
+          "Lc0_ONNX_TRT_batch_" + std::to_string(batch_size) + "_";
       trt_options["trt_timing_cache_enable"] = "1";
       trt_options["trt_layer_norm_fp32_fallback"] = "1";
       trt_options["trt_force_sequential_engine_build"] = "1";

--- a/src/neural/backends/network_onnx.cc
+++ b/src/neural/backends/network_onnx.cc
@@ -330,7 +330,8 @@ Ort::SessionOptions OnnxNetwork::GetOptions(int gpu, int threads,
       trt_options["trt_min_subgraph_size"] = "1";
       trt_options["trt_engine_cache_enable"] = "1";
       trt_options["trt_engine_cache_prefix"] =
-          "Lc0_ONNX_TRT_batch_" + std::to_string(batch_size) + "_";
+          "Lc0_ONNX_TRT_batch_" + std::to_string(batch_size) + "_gpu_" +
+          std::to_string(gpu) + "_";
       trt_options["trt_timing_cache_enable"] = "1";
       trt_options["trt_layer_norm_fp32_fallback"] = "1";
       trt_options["trt_force_sequential_engine_build"] = "1";

--- a/src/neural/backends/network_onnx.cc
+++ b/src/neural/backends/network_onnx.cc
@@ -46,6 +46,7 @@
 #include "onnxruntime_cxx_api.h"
 #include "utils/bf16_utils.h"
 #include "utils/bititer.h"
+#include "utils/commandline.h"
 #include "utils/exception.h"
 #include "utils/fp16_utils.h"
 #include "utils/logging.h"
@@ -322,6 +323,7 @@ Ort::SessionOptions OnnxNetwork::GetOptions(int gpu, int threads,
     case OnnxProvider::TRT: {
       options.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
 
+      std::string cache_dir = CommandLine::BinaryDirectory() + "/trt_cache";
       std::map<std::string, std::string> trt_options;
       trt_options["device_id"] = std::to_string(gpu);
       trt_options["trt_fp16_enable"] = fp16_ ? "1" : "0";
@@ -331,9 +333,9 @@ Ort::SessionOptions OnnxNetwork::GetOptions(int gpu, int threads,
       trt_options["trt_engine_cache_enable"] = "1";
       trt_options["trt_engine_cache_prefix"] =
           "Lc0_ONNX_TRT_batch_" + std::to_string(batch_size) + "_";
-      trt_options["trt_engine_cache_path"] = "./trt_cache";
+      trt_options["trt_engine_cache_path"] = cache_dir;
       trt_options["trt_timing_cache_enable"] = "1";
-      trt_options["trt_timing_cache_path"] = "./trt_cache";
+      trt_options["trt_timing_cache_path"] = cache_dir;
       trt_options["trt_layer_norm_fp32_fallback"] = "1";
       trt_options["trt_force_sequential_engine_build"] = "1";
       // Looks like we need I/O binding to enable this.

--- a/src/neural/backends/network_onnx.cc
+++ b/src/neural/backends/network_onnx.cc
@@ -333,6 +333,7 @@ Ort::SessionOptions OnnxNetwork::GetOptions(int gpu, int threads,
       trt_options["trt_engine_cache_prefix"] = "Lc0_ONNX_TRT";
       trt_options["trt_timing_cache_enable"] = "1";
       trt_options["trt_layer_norm_fp32_fallback"] = "1";
+      trt_options["trt_force_sequential_engine_build"] = "1";
       // Looks like we need I/O binding to enable this.
       // trt_options["trt_cuda_graph_enable"] = "1";
       if (batch_size < 0) {


### PR DESCRIPTION
The main improvements here are:
1. The `min_batch` option to specify minimum batch size (normally 1, 4 for onnx-trt). Only used with variable batch size.
2. Prefix and directory for engine and timing files.
3. A different engine file per batch size (for fixed batch size).
4. A small cleanup.