### PR TITLE
Register UciResponder through observer pattern.

### DIFF
--- a/src/chess/callbacks.h
+++ b/src/chess/callbacks.h
@@ -35,6 +35,7 @@
 
 #include "chess/bitboard.h"
 #include "chess/position.h"
+#include "utils/exception.h"
 
 namespace lczero {
 
@@ -142,6 +143,34 @@ class UciResponder {
   virtual ~UciResponder() = default;
   virtual void OutputBestMove(BestMoveInfo* info) = 0;
   virtual void OutputThinkingInfo(std::vector<ThinkingInfo>* infos) = 0;
+};
+
+// The responder which forwards the output to another responder, with
+// observer-like subscription model.
+class UciResponderForwarder : public UciResponder {
+ public:
+  void OutputBestMove(BestMoveInfo* info) override {
+    if (wrapped_) wrapped_->OutputBestMove(info);
+  }
+  void OutputThinkingInfo(std::vector<ThinkingInfo>* infos) override {
+    if (wrapped_) wrapped_->OutputThinkingInfo(infos);
+  }
+  void Register(UciResponder* wrapped) {
+    if (wrapped_) {
+      throw Exception("UciResponderForwarder already has a wrapped responder");
+    }
+    wrapped_ = wrapped;
+  }
+  void Unregister(UciResponder* wrapped) {
+    if (wrapped_ != wrapped) {
+      throw Exception(
+          "UciResponderForwarder doesn't have this wrapped responder");
+    }
+    wrapped_ = nullptr;
+  }
+
+ private:
+  UciResponder* wrapped_ = nullptr;
 };
 
 // The responder which calls callbacks. Used for easier transition from old

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -38,10 +38,9 @@
 
 namespace lczero {
 
-Engine::Engine(std::unique_ptr<SearchBase> search, const OptionsDict& opts)
-    : options_(opts), search_(std::move(search)) {}
-
-Engine::~Engine() {}
+Engine::Engine(const SearchFactory& factory, const OptionsDict& opts)
+    : options_(opts),
+      search_(factory.CreateSearch(&uci_forwarder_, &options_)) {}
 
 namespace {
 GameState MakeGameState(const std::string& fen,
@@ -98,6 +97,14 @@ void Engine::Go(const GoParams& params) {
 
 void Engine::Stop() {
   if (search_) search_->StopSearch();
+}
+
+void Engine::RegisterUciResponder(UciResponder* responder) {
+  uci_forwarder_.Register(responder);
+}
+
+void Engine::UnregisterUciResponder(UciResponder* responder) {
+  uci_forwarder_.Unregister(responder);
 }
 
 }  // namespace lczero

--- a/src/engine.h
+++ b/src/engine.h
@@ -37,8 +37,7 @@ namespace lczero {
 
 class Engine : public EngineControllerBase {
  public:
-  Engine(std::unique_ptr<SearchBase>, const OptionsDict&);
-  ~Engine() override;
+  Engine(const SearchFactory&, const OptionsDict&);
 
  private:
   void EnsureReady() override {};
@@ -49,10 +48,14 @@ class Engine : public EngineControllerBase {
   void PonderHit() override {}
   void Stop() override;
 
+  void RegisterUciResponder(UciResponder*) override;
+  void UnregisterUciResponder(UciResponder*) override;
+
  private:
   void UpdateBackendConfig();
   void EnsureSearchStopped();
 
+  UciResponderForwarder uci_forwarder_;
   const OptionsDict& options_;
   std::unique_ptr<SearchBase> search_;
   std::string backend_name_;

--- a/src/engine_classic.cc
+++ b/src/engine_classic.cc
@@ -75,11 +75,8 @@ MoveList StringsToMovelist(const std::vector<std::string>& moves,
 
 }  // namespace
 
-EngineClassic::EngineClassic(UciResponder& uci_responder,
-                             const OptionsDict& options)
-    : options_(options),
-      uci_responder_(&uci_responder),
-      current_position_{ChessBoard::kStartposFen, {}} {}
+EngineClassic::EngineClassic(const OptionsDict& options)
+    : options_(options), current_position_{ChessBoard::kStartposFen, {}} {}
 
 void EngineClassic::PopulateOptions(OptionsParser* options) {
   using namespace std::placeholders;
@@ -242,7 +239,7 @@ void EngineClassic::Go(const GoParams& params) {
   go_params_ = params;
 
   std::unique_ptr<UciResponder> responder =
-      std::make_unique<NonOwningUciRespondForwarder>(uci_responder_);
+      std::make_unique<NonOwningUciRespondForwarder>(&uci_forwarder_);
 
   // Setting up current position, now that it's known whether it's ponder or
   // not.
@@ -283,6 +280,14 @@ void EngineClassic::PonderHit() {
 
 void EngineClassic::Stop() {
   if (search_) search_->Stop();
+}
+
+void EngineClassic::RegisterUciResponder(UciResponder* responder) {
+  uci_forwarder_.Register(responder);
+}
+
+void EngineClassic::UnregisterUciResponder(UciResponder* responder) {
+  uci_forwarder_.Unregister(responder);
 }
 
 }  // namespace lczero

--- a/src/engine_classic.h
+++ b/src/engine_classic.h
@@ -46,7 +46,7 @@ struct CurrentPosition {
 
 class EngineClassic : public EngineControllerBase {
  public:
-  EngineClassic(UciResponder& uci_responder, const OptionsDict& options);
+  EngineClassic(const OptionsDict& options);
 
   ~EngineClassic() {
     // Make sure search is destructed first, and it still may be running in
@@ -72,6 +72,9 @@ class EngineClassic : public EngineControllerBase {
   // Must not block.
   void Stop() override;
 
+  void RegisterUciResponder(UciResponder*) override;
+  void UnregisterUciResponder(UciResponder*) override;
+
  private:
   void UpdateFromUciOptions();
 
@@ -82,7 +85,7 @@ class EngineClassic : public EngineControllerBase {
 
   const OptionsDict& options_;
 
-  UciResponder* uci_responder_;
+  UciResponderForwarder uci_forwarder_;
 
   // Locked means that there is some work to wait before responding readyok.
   RpSharedMutex busy_mutex_;

--- a/src/engine_loop.h
+++ b/src/engine_loop.h
@@ -54,15 +54,17 @@ class EngineControllerBase {
   virtual void PonderHit() = 0;
   // Must not block.
   virtual void Stop() = 0;
+
+  // Register and unregister the UCI responder using observer pattern.
+  virtual void RegisterUciResponder(UciResponder*) = 0;
+  virtual void UnregisterUciResponder(UciResponder*) = 0;
 };
 
 class EngineLoop : public UciLoop {
  public:
-  EngineLoop(StringUciResponder* uci_responder,
-             std::unique_ptr<OptionsParser> options,
-             std::function<std::unique_ptr<EngineControllerBase>(
-                 UciResponder& uci_responder, const OptionsDict& options)>
-                 engine_factory);
+  EngineLoop(StringUciResponder* uci_responder, OptionsParser* options,
+             std::unique_ptr<EngineControllerBase> engine);
+  ~EngineLoop() override;
 
   void RunLoop() override;
   void CmdUci() override;
@@ -77,7 +79,7 @@ class EngineLoop : public UciLoop {
   void CmdStop() override;
 
  private:
-  std::unique_ptr<OptionsParser> options_;
+  OptionsParser* options_;
   std::unique_ptr<EngineControllerBase> engine_;
 };
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -107,13 +107,9 @@ int main(int argc, const char** argv) {
               SearchManager::Get()->GetFactoryByName(search_name);
           factory->PopulateParams(options_parser.get());
           StdoutUciResponder uci_responder;
-          EngineLoop loop(&uci_responder, std::move(options_parser),
-                          [factory](UciResponder& uci_responder,
-                                    const OptionsDict& options) {
-                            return std::make_unique<Engine>(
-                                factory->CreateSearch(&uci_responder, &options),
-                                options);
-                          });
+          EngineLoop loop(&uci_responder, options_parser.get(),
+                          std::make_unique<Engine>(
+                              *factory, options_parser->GetOptionsDict()));
           loop.RunLoop();
         }
       }
@@ -125,10 +121,8 @@ int main(int argc, const char** argv) {
         EngineClassic::PopulateOptions(options_parser.get());
         StdoutUciResponder uci_responder;
         EngineLoop loop(
-            &uci_responder, std::move(options_parser),
-            [](UciResponder& uci_responder, const OptionsDict& options) {
-              return std::make_unique<EngineClassic>(uci_responder, options);
-            });
+            &uci_responder, options_parser.get(),
+            std::make_unique<EngineClassic>(options_parser->GetOptionsDict()));
         loop.RunLoop();
       }
     }


### PR DESCRIPTION
Register UciResponder through observer pattern, rather than passing to constructor.