### PR TITLE
Remove EngineLoop class

### DIFF
--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -63,7 +63,6 @@ const std::unordered_map<std::string, std::unordered_set<std::string>>
         {{"go"},
          {"infinite", "wtime", "btime", "winc", "binc", "movestogo", "depth",
           "mate", "nodes", "movetime", "searchmoves", "ponder"}},
-        {{"start"}, {}},
         {{"stop"}, {}},
         {{"ponderhit"}, {}},
         {{"quit"}, {}},
@@ -137,41 +136,44 @@ bool ContainsKey(const std::unordered_map<std::string, std::string>& params,
 }
 }  // namespace
 
-void UciLoop::RunLoop() {
-  std::cout.setf(std::ios::unitbuf);
-  std::string line;
-  while (std::getline(std::cin, line)) {
-    LOGFILE << ">> " << line;
-    try {
-      auto command = ParseCommand(line);
-      // Ignore empty line.
-      if (command.first.empty()) continue;
-      if (!DispatchCommand(command.first, command.second)) break;
-    } catch (Exception& ex) {
-      uci_responder_->SendRawResponse(std::string("error ") + ex.what());
-    }
-  }
+UciLoop::UciLoop(StringUciResponder* uci_responder, OptionsParser* options,
+                 EngineControllerBase* engine)
+    : uci_responder_(uci_responder), options_(options), engine_(engine) {
+  engine_->RegisterUciResponder(uci_responder_);
 }
+
+UciLoop::~UciLoop() { engine_->UnregisterUciResponder(uci_responder_); }
 
 bool UciLoop::DispatchCommand(
     const std::string& command,
     const std::unordered_map<std::string, std::string>& params) {
   if (command == "uci") {
-    CmdUci();
+    uci_responder_->SendId();
+    for (const auto& option : options_->ListOptionsUci()) {
+      uci_responder_->SendRawResponse(option);
+    }
+    uci_responder_->SendRawResponse("uciok");
   } else if (command == "isready") {
-    CmdIsReady();
+    engine_->EnsureReady();
+    uci_responder_->SendRawResponse("readyok");
   } else if (command == "setoption") {
-    CmdSetOption(GetOrEmpty(params, "name"), GetOrEmpty(params, "value"),
-                 GetOrEmpty(params, "context"));
+    options_->SetUciOption(GetOrEmpty(params, "name"),
+                           GetOrEmpty(params, "value"),
+                           GetOrEmpty(params, "context"));
+    // Set the log filename for the case it was set in UCI option.
+    // DO NOT SUBMIT DECIDE WHAT TO DO WITH THIS.
+    // Logging::Get().SetFilename(
+    //     options_->GetOptionsDict().Get<std::string>(kLogFileId));
   } else if (command == "ucinewgame") {
-    CmdUciNewGame();
+    engine_->NewGame();
   } else if (command == "position") {
     if (ContainsKey(params, "fen") == ContainsKey(params, "startpos")) {
       throw Exception("Position requires either fen or startpos");
     }
     const std::vector<std::string> moves =
         StrSplitAtWhitespace(GetOrEmpty(params, "moves"));
-    CmdPosition(GetOrEmpty(params, "fen"), moves);
+    const std::string fen = GetOrEmpty(params, "fen");
+    engine_->SetPosition(fen.empty() ? ChessBoard::kStartposFen : fen, moves);
   } else if (command == "go") {
     GoParams go_params;
     if (ContainsKey(params, "infinite")) {
@@ -204,15 +206,11 @@ bool UciLoop::DispatchCommand(
     UCIGOOPTION(nodes);
     UCIGOOPTION(movetime);
 #undef UCIGOOPTION
-    CmdGo(go_params);
+    engine_->Go(go_params);
   } else if (command == "stop") {
-    CmdStop();
+    engine_->Stop();
   } else if (command == "ponderhit") {
-    CmdPonderHit();
-  } else if (command == "start") {
-    CmdStart();
-  } else if (command == "fen") {
-    CmdFen();
+    engine_->PonderHit();
   } else if (command == "xyzzy") {
     uci_responder_->SendRawResponse("Nothing happens.");
   } else if (command == "quit") {

--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -223,6 +223,13 @@ bool UciLoop::DispatchCommand(
   return true;
 }
 
+bool UciLoop::ProcessLine(const std::string& line) {
+  auto command = ParseCommand(line);
+  // Ignore empty line.
+  if (command.first.empty()) return true;
+  return DispatchCommand(command.first, command.second);
+}
+
 void StringUciResponder::PopulateParams(OptionsParser* options) {
   options->Add<BoolOption>(kUciChess960) = false;
   options->Add<BoolOption>(kShowWDL) = true;

--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -160,10 +160,6 @@ bool UciLoop::DispatchCommand(
     options_->SetUciOption(GetOrEmpty(params, "name"),
                            GetOrEmpty(params, "value"),
                            GetOrEmpty(params, "context"));
-    // Set the log filename for the case it was set in UCI option.
-    // DO NOT SUBMIT DECIDE WHAT TO DO WITH THIS.
-    // Logging::Get().SetFilename(
-    //     options_->GetOptionsDict().Get<std::string>(kLogFileId));
   } else if (command == "ucinewgame") {
     engine_->NewGame();
   } else if (command == "position") {

--- a/src/chess/uciloop.h
+++ b/src/chess/uciloop.h
@@ -77,6 +77,9 @@ class UciLoop {
  public:
   UciLoop(StringUciResponder* uci_responder) : uci_responder_(uci_responder) {}
 
+  // Returns false if the loop should stop.
+  bool ProcessLine(const std::string& line);
+
   virtual ~UciLoop() = default;
   virtual void RunLoop();
 

--- a/src/chess/uciloop.h
+++ b/src/chess/uciloop.h
@@ -73,36 +73,39 @@ class StringUciResponder : public UciResponder {
   const OptionsDict* options_ = nullptr;  // absl_nullable
 };
 
+class EngineControllerBase {
+ public:
+  virtual ~EngineControllerBase() = default;
+
+  // Blocks.
+  virtual void EnsureReady() = 0;
+
+  // Must not block.
+  virtual void NewGame() = 0;
+
+  // Blocks.
+  virtual void SetPosition(const std::string& fen,
+                           const std::vector<std::string>& moves) = 0;
+
+  // Must not block.
+  virtual void Go(const GoParams& params) = 0;
+  virtual void PonderHit() = 0;
+  // Must not block.
+  virtual void Stop() = 0;
+
+  // Register and unregister the UCI responder using observer pattern.
+  virtual void RegisterUciResponder(UciResponder*) = 0;
+  virtual void UnregisterUciResponder(UciResponder*) = 0;
+};
+
 class UciLoop {
  public:
-  UciLoop(StringUciResponder* uci_responder) : uci_responder_(uci_responder) {}
+  UciLoop(StringUciResponder* uci_responder, OptionsParser* options,
+          EngineControllerBase* engine);
+  virtual ~UciLoop();
 
   // Returns false if the loop should stop.
   bool ProcessLine(const std::string& line);
-
-  virtual ~UciLoop() = default;
-  virtual void RunLoop();
-
-  // Command handlers.
-  virtual void CmdUci() { throw Exception("Not supported"); }
-  virtual void CmdIsReady() { throw Exception("Not supported"); }
-  virtual void CmdSetOption(const std::string& /*name*/,
-                            const std::string& /*value*/,
-                            const std::string& /*context*/) {
-    throw Exception("Not supported");
-  }
-  virtual void CmdUciNewGame() { throw Exception("Not supported"); }
-  virtual void CmdPosition(const std::string& /*position*/,
-                           const std::vector<std::string>& /*moves*/) {
-    throw Exception("Not supported");
-  }
-  virtual void CmdFen() { throw Exception("Not supported"); }
-  virtual void CmdGo(const GoParams& /*params*/) {
-    throw Exception("Not supported");
-  }
-  virtual void CmdStop() { throw Exception("Not supported"); }
-  virtual void CmdPonderHit() { throw Exception("Not supported"); }
-  virtual void CmdStart() { throw Exception("Not supported"); }
 
  protected:
   bool DispatchCommand(
@@ -110,6 +113,8 @@ class UciLoop {
       const std::unordered_map<std::string, std::string>& params);
 
   StringUciResponder* uci_responder_;  // absl_nonnull
+  OptionsParser* options_;             // absl_notnull
+  EngineControllerBase* engine_;       // absl_notnull
 };
 
 class StdoutUciResponder : public StringUciResponder {

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -37,6 +37,21 @@
 #include "neural/shared_params.h"
 
 namespace lczero {
+namespace {
+const OptionId kPreload{"preload", "",
+                        "Initialize backend and load net on engine startup."};
+}  // namespace
+
+void Engine::PopulateOptions(OptionsParser* options) {
+  options->Add<BoolOption>(kPreload) = false;
+}
+
+void Engine::Initialize() {
+  if (options_.Get<bool>(kPreload)) {
+    UpdateBackendConfig();
+    // EnsureSyzygyTablebasesLoaded();
+  }
+}
 
 Engine::Engine(const SearchFactory& factory, const OptionsDict& opts)
     : options_(opts),

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -46,16 +46,14 @@ void Engine::PopulateOptions(OptionsParser* options) {
   options->Add<BoolOption>(kPreload) = false;
 }
 
-void Engine::Initialize() {
+Engine::Engine(const SearchFactory& factory, const OptionsDict& opts)
+    : options_(opts),
+      search_(factory.CreateSearch(&uci_forwarder_, &options_)) {
   if (options_.Get<bool>(kPreload)) {
     UpdateBackendConfig();
     // EnsureSyzygyTablebasesLoaded();
   }
 }
-
-Engine::Engine(const SearchFactory& factory, const OptionsDict& opts)
-    : options_(opts),
-      search_(factory.CreateSearch(&uci_forwarder_, &options_)) {}
 
 namespace {
 GameState MakeGameState(const std::string& fen,

--- a/src/engine.h
+++ b/src/engine.h
@@ -39,7 +39,10 @@ class Engine : public EngineControllerBase {
  public:
   Engine(const SearchFactory&, const OptionsDict&);
 
- private:
+  static void PopulateOptions(OptionsParser*);
+
+  void Initialize() override;
+
   void EnsureReady() override {};
   void NewGame() override;
   void SetPosition(const std::string& fen,

--- a/src/engine.h
+++ b/src/engine.h
@@ -41,8 +41,6 @@ class Engine : public EngineControllerBase {
 
   static void PopulateOptions(OptionsParser*);
 
-  void Initialize() override;
-
   void EnsureReady() override {};
   void NewGame() override;
   void SetPosition(const std::string& fen,

--- a/src/engine_classic.cc
+++ b/src/engine_classic.cc
@@ -78,7 +78,9 @@ MoveList StringsToMovelist(const std::vector<std::string>& moves,
 }  // namespace
 
 EngineClassic::EngineClassic(const OptionsDict& options)
-    : options_(options), current_position_{ChessBoard::kStartposFen, {}} {}
+    : options_(options), current_position_{ChessBoard::kStartposFen, {}} {
+  if (options_.Get<bool>(kPreload)) UpdateFromUciOptions();
+}
 
 void EngineClassic::PopulateOptions(OptionsParser* options) {
   using namespace std::placeholders;
@@ -111,10 +113,6 @@ void EngineClassic::PopulateOptions(OptionsParser* options) {
   options->HideOption(kClearTree);
 
   options->Add<BoolOption>(kPreload) = false;
-}
-
-void EngineClassic::Initialize() {
-  if (options_.Get<bool>(kPreload)) UpdateFromUciOptions();
 }
 
 void EngineClassic::ResetMoveTimer() {

--- a/src/engine_classic.cc
+++ b/src/engine_classic.cc
@@ -56,6 +56,8 @@ const OptionId kStrictUciTiming{"strict-uci-timing", "StrictTiming",
                                 "only then starts timing."};
 const OptionId kClearTree{"", "ClearTree",
                           "Clear the tree before the next search."};
+const OptionId kPreload{"preload", "",
+                        "Initialize backend and load net on engine startup."};
 
 MoveList StringsToMovelist(const std::vector<std::string>& moves,
                            const ChessBoard& board) {
@@ -107,6 +109,12 @@ void EngineClassic::PopulateOptions(OptionsParser* options) {
 
   options->Add<ButtonOption>(kClearTree);
   options->HideOption(kClearTree);
+
+  options->Add<BoolOption>(kPreload) = false;
+}
+
+void EngineClassic::Initialize() {
+  if (options_.Get<bool>(kPreload)) UpdateFromUciOptions();
 }
 
 void EngineClassic::ResetMoveTimer() {

--- a/src/engine_classic.h
+++ b/src/engine_classic.h
@@ -54,8 +54,6 @@ class EngineClassic : public EngineControllerBase {
     search_.reset();
   }
 
-  void Initialize() override;
-
   static void PopulateOptions(OptionsParser* options);
 
   // Blocks.

--- a/src/engine_classic.h
+++ b/src/engine_classic.h
@@ -54,6 +54,8 @@ class EngineClassic : public EngineControllerBase {
     search_.reset();
   }
 
+  void Initialize() override;
+
   static void PopulateOptions(OptionsParser* options);
 
   // Blocks.

--- a/src/engine_loop.cc
+++ b/src/engine_loop.cc
@@ -75,6 +75,8 @@ void RunEngineInternal(SearchFactory* factory) {
     LOGFILE << ">> " << line;
     try {
       if (!loop.ProcessLine(line)) break;
+      // Set the log filename for the case it was set in UCI option.
+      Logging::Get().SetFilename(options.Get<std::string>(kLogFileId));
     } catch (Exception& ex) {
       uci_responder.SendRawResponse(std::string("error ") + ex.what());
     }

--- a/src/engine_loop.cc
+++ b/src/engine_loop.cc
@@ -36,9 +36,6 @@ const OptionId kLogFileId{"logfile", "LogFile",
                           "Write log to that file. Special value <stderr> to "
                           "output the log to the console.",
                           'l'};
-const OptionId kPreload{"preload", "",
-                        "Initialize backend and load net on engine startup."};
-
 }  // namespace
 
 EngineLoop::EngineLoop(StringUciResponder* uci_responder,
@@ -47,20 +44,17 @@ EngineLoop::EngineLoop(StringUciResponder* uci_responder,
     : UciLoop(uci_responder), options_(options), engine_(std::move(engine)) {
   engine_->RegisterUciResponder(uci_responder_);
   options_->Add<StringOption>(kLogFileId);
-  options_->Add<BoolOption>(kPreload) = false;
   SharedBackendParams::Populate(options_);
   uci_responder_->PopulateParams(options_);
 }
 
-EngineLoop::~EngineLoop() {
-  engine_->UnregisterUciResponder(uci_responder_);
-}
+EngineLoop::~EngineLoop() { engine_->UnregisterUciResponder(uci_responder_); }
 
 void EngineLoop::RunLoop() {
   if (!ConfigFile::Init() || !options_->ProcessAllFlags()) return;
   const auto options = options_->GetOptionsDict();
   Logging::Get().SetFilename(options.Get<std::string>(kLogFileId));
-  if (options.Get<bool>(kPreload)) engine_->NewGame();
+  engine_->Initialize();
   UciLoop::RunLoop();
 }
 

--- a/src/engine_loop.cc
+++ b/src/engine_loop.cc
@@ -49,8 +49,8 @@ void RunEngineInternal(SearchFactory* factory) {
   OptionsParser options_parser;
   options_parser.Add<StringOption>(kLogFileId);
   EngineType::PopulateOptions(&options_parser);
-  factory->PopulateParams(&options_parser);       // Search params.
-  uci_responder.PopulateParams(&options_parser);  // UCI params.
+  if (factory) factory->PopulateParams(&options_parser);  // Search params.
+  uci_responder.PopulateParams(&options_parser);          // UCI params.
   SharedBackendParams::Populate(&options_parser);
 
   // Parse flags, show help, initialize logging, read config etc.

--- a/src/engine_loop.h
+++ b/src/engine_loop.h
@@ -1,6 +1,6 @@
 /*
   This file is part of Leela Chess Zero.
-  Copyright (C) 2018-2024 The LCZero Authors
+  Copyright (C) 2018-2025 The LCZero Authors
 
   Leela Chess is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -35,54 +35,6 @@
 #include "utils/optionsparser.h"
 
 namespace lczero {
-
-class EngineControllerBase {
- public:
-  virtual ~EngineControllerBase() = default;
-
-  // Blocks.
-  virtual void EnsureReady() = 0;
-
-  // Must not block.
-  virtual void NewGame() = 0;
-
-  // Blocks.
-  virtual void SetPosition(const std::string& fen,
-                           const std::vector<std::string>& moves) = 0;
-
-  // Must not block.
-  virtual void Go(const GoParams& params) = 0;
-  virtual void PonderHit() = 0;
-  // Must not block.
-  virtual void Stop() = 0;
-
-  // Register and unregister the UCI responder using observer pattern.
-  virtual void RegisterUciResponder(UciResponder*) = 0;
-  virtual void UnregisterUciResponder(UciResponder*) = 0;
-};
-
-class EngineLoop : public UciLoop {
- public:
-  EngineLoop(StringUciResponder* uci_responder, OptionsParser* options,
-             EngineControllerBase* engine);
-  ~EngineLoop() override;
-
-  void RunLoop() override;
-  void CmdUci() override;
-  void CmdIsReady() override;
-  void CmdSetOption(const std::string& name, const std::string& value,
-                    const std::string& context) override;
-  void CmdUciNewGame() override;
-  void CmdPosition(const std::string& position,
-                   const std::vector<std::string>& moves) override;
-  void CmdGo(const GoParams& params) override;
-  void CmdPonderHit() override;
-  void CmdStop() override;
-
- private:
-  OptionsParser* options_;        // absl_notnull
-  EngineControllerBase* engine_;  // absl_notnull
-};
 
 // Runs the stdin/stdout UCI loop for the engine.
 void RunEngine(SearchFactory* factory);

--- a/src/engine_loop.h
+++ b/src/engine_loop.h
@@ -31,6 +31,7 @@
 #include <string>
 
 #include "chess/uciloop.h"
+#include "search/search.h"
 #include "utils/optionsparser.h"
 
 namespace lczero {
@@ -38,9 +39,6 @@ namespace lczero {
 class EngineControllerBase {
  public:
   virtual ~EngineControllerBase() = default;
-
-  // Called once when the engine is created.
-  virtual void Initialize() = 0;
 
   // Blocks.
   virtual void EnsureReady() = 0;
@@ -66,7 +64,7 @@ class EngineControllerBase {
 class EngineLoop : public UciLoop {
  public:
   EngineLoop(StringUciResponder* uci_responder, OptionsParser* options,
-             std::unique_ptr<EngineControllerBase> engine);
+             EngineControllerBase* engine);
   ~EngineLoop() override;
 
   void RunLoop() override;
@@ -82,8 +80,14 @@ class EngineLoop : public UciLoop {
   void CmdStop() override;
 
  private:
-  OptionsParser* options_;
-  std::unique_ptr<EngineControllerBase> engine_;
+  OptionsParser* options_;        // absl_notnull
+  EngineControllerBase* engine_;  // absl_notnull
 };
+
+// Runs the stdin/stdout UCI loop for the engine.
+void RunEngine(SearchFactory* factory);
+
+// The same but through classic interface. To be gone soon.
+void RunEngineClassic();
 
 }  // namespace lczero

--- a/src/engine_loop.h
+++ b/src/engine_loop.h
@@ -39,6 +39,9 @@ class EngineControllerBase {
  public:
   virtual ~EngineControllerBase() = default;
 
+  // Called once when the engine is created.
+  virtual void Initialize() = 0;
+
   // Blocks.
   virtual void EnsureReady() = 0;
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -105,6 +105,7 @@ int main(int argc, const char** argv) {
           used_new_search = true;
           SearchFactory* factory =
               SearchManager::Get()->GetFactoryByName(search_name);
+          Engine::PopulateOptions(options_parser.get());
           factory->PopulateParams(options_parser.get());
           StdoutUciResponder uci_responder;
           EngineLoop loop(&uci_responder, options_parser.get(),

--- a/src/main.cc
+++ b/src/main.cc
@@ -105,13 +105,7 @@ int main(int argc, const char** argv) {
           used_new_search = true;
           SearchFactory* factory =
               SearchManager::Get()->GetFactoryByName(search_name);
-          Engine::PopulateOptions(options_parser.get());
-          factory->PopulateParams(options_parser.get());
-          StdoutUciResponder uci_responder;
-          EngineLoop loop(&uci_responder, options_parser.get(),
-                          std::make_unique<Engine>(
-                              *factory, options_parser->GetOptionsDict()));
-          loop.RunLoop();
+          RunEngine(factory);
         }
       }
 
@@ -119,12 +113,7 @@ int main(int argc, const char** argv) {
         // Consuming optional "uci" mode.
         CommandLine::ConsumeCommand("uci");
         // Ordinary UCI engine.
-        EngineClassic::PopulateOptions(options_parser.get());
-        StdoutUciResponder uci_responder;
-        EngineLoop loop(
-            &uci_responder, options_parser.get(),
-            std::make_unique<EngineClassic>(options_parser->GetOptionsDict()));
-        loop.RunLoop();
+        RunEngineClassic();
       }
     }
   } catch (std::exception& e) {


### PR DESCRIPTION
* Remove EngineLoop class (merge into UciLoop)
* UciLoop is no longer a class to override handlers
* Make reading from stdin outside of UciLoop
* Tidy up parameter initialization

Also includes changes from #2145 (can be merged either separately or together)