### PR TITLE
Wrapper for old search through new API

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -218,6 +218,7 @@ files += [
   'src/search/classic/stoppers/smooth.cc',
   'src/search/classic/stoppers/stoppers.cc',
   'src/search/classic/stoppers/timemgr.cc',
+  'src/search/classic/wrapper.cc',
   'src/search/register.cc',
   'src/selfplay/game.cc',
   'src/selfplay/loop.cc',

--- a/src/chess/position.cc
+++ b/src/chess/position.cc
@@ -119,6 +119,11 @@ void PositionHistory::Reset(const ChessBoard& board, int rule50_ply,
   positions_.emplace_back(board, rule50_ply, game_ply);
 }
 
+void PositionHistory::Reset(const Position& pos) {
+  positions_.clear();
+  positions_.push_back(pos);
+}
+
 void PositionHistory::Append(Move m) {
   // TODO(mooskagh) That should be emplace_back(Last(), m), but MSVS STL
   //                has a bug in implementation of emplace_back, when

--- a/src/chess/position.h
+++ b/src/chess/position.h
@@ -70,6 +70,9 @@ class Position {
   // Gets board from the point of view of player to move.
   const ChessBoard& GetBoard() const { return us_board_; }
 
+  bool operator==(const Position&) const = default;
+  bool operator!=(const Position&) const = default;
+
   std::string DebugString() const;
 
  private:
@@ -127,6 +130,7 @@ class PositionHistory {
 
   // Resets the position to a given state.
   void Reset(const ChessBoard& board, int rule50_ply, int game_ply);
+  void Reset(const Position& pos);
 
   // Appends a position to history.
   void Append(Move m);

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -128,7 +128,10 @@ void Engine::SetPosition(const std::string& fen,
   search_initialized_ = true;
 }
 
-void Engine::NewGame() { SetPosition(ChessBoard::kStartposFen, {}); }
+void Engine::NewGame() {
+  search_->NewGame();
+  SetPosition(ChessBoard::kStartposFen, {});
+}
 
 void Engine::Go(const GoParams& params) {
   if (!search_initialized_) NewGame();

--- a/src/engine_classic.cc
+++ b/src/engine_classic.cc
@@ -89,7 +89,6 @@ void EngineClassic::PopulateOptions(OptionsParser* options) {
   options->Add<IntOption>(kThreadsOptionId, 0, 128) = 0;
   classic::SearchParams::Populate(options);
 
-  ConfigFile::PopulateOptions(options);
   if (is_simple) {
     options->HideAllOptions();
     options->UnhideOption(kThreadsOptionId);

--- a/src/engine_loop.cc
+++ b/src/engine_loop.cc
@@ -48,6 +48,7 @@ void RunEngineInternal(SearchFactory* factory) {
   // Populate options from various sources.
   OptionsParser options_parser;
   options_parser.Add<StringOption>(kLogFileId);
+  ConfigFile::PopulateOptions(&options_parser);
   EngineType::PopulateOptions(&options_parser);
   if (factory) factory->PopulateParams(&options_parser);  // Search params.
   uci_responder.PopulateParams(&options_parser);          // UCI params.

--- a/src/search/classic/node.h
+++ b/src/search/classic/node.h
@@ -35,6 +35,7 @@
 
 #include "chess/board.h"
 #include "chess/callbacks.h"
+#include "chess/gamestate.h"
 #include "chess/position.h"
 #include "neural/cache.h"
 #include "neural/encoder.h"
@@ -649,6 +650,7 @@ class NodeTree {
   // or if it's shorter than before.
   bool ResetToPosition(const std::string& starting_fen,
                        const std::vector<std::string>& moves);
+  bool ResetToPosition(const GameState& pos);
   const Position& HeadPosition() const { return history_.Last(); }
   int GetPlyCount() const { return HeadPosition().GetGamePly(); }
   bool IsBlackToMove() const { return HeadPosition().IsBlackToMove(); }

--- a/src/search/classic/wrapper.cc
+++ b/src/search/classic/wrapper.cc
@@ -1,0 +1,134 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2025 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#include "chess/gamestate.h"
+#include "search/classic/search.h"
+#include "search/classic/stoppers/factory.h"
+#include "search/register.h"
+#include "search/search.h"
+
+namespace lczero {
+namespace classic {
+namespace {
+
+const OptionId kThreadsOptionId{
+    "threads", "Threads",
+    "Number of (CPU) worker threads to use, 0 for the backend default.", 't'};
+
+class ClassicSearch : public SearchBase {
+ public:
+  ClassicSearch(UciResponder* responder, const OptionsDict* options)
+      : SearchBase(responder), options_(options) {}
+
+ private:
+  void NewGame() override;
+  void SetPosition(const GameState& pos) override;
+  void StartSearch(const GoParams&) override;
+  void StartClock() override {
+    move_start_time_ = std::chrono::steady_clock::now();
+  }
+  void WaitSearch() override {
+    if (search_) search_->Wait();
+  }
+  void StopSearch() override {
+    if (search_) search_->Stop();
+  }
+  void AbortSearch() override {
+    if (search_) search_->Abort();
+  }
+
+  const OptionsDict* options_;
+  std::unique_ptr<classic::TimeManager> time_manager_;
+  std::unique_ptr<classic::Search> search_;
+  std::unique_ptr<classic::NodeTree> tree_;
+  std::optional<std::chrono::steady_clock::time_point> move_start_time_;
+};
+
+MoveList StringsToMovelist(const std::vector<std::string>& moves,
+                           const ChessBoard& board) {
+  MoveList result;
+  if (moves.size()) {
+    result.reserve(moves.size());
+    const auto legal_moves = board.GenerateLegalMoves();
+    for (const auto& move : moves) {
+      const Move m = board.ParseMove(move);
+      if (std::find(legal_moves.begin(), legal_moves.end(), m) !=
+          legal_moves.end()) {
+        result.emplace_back(m);
+      }
+    }
+    if (result.empty()) throw Exception("No legal searchmoves.");
+  }
+  return result;
+}
+
+void ClassicSearch::NewGame() {
+  search_.reset();
+  tree_.reset();
+  time_manager_ = classic::MakeTimeManager(*options_);
+}
+
+void ClassicSearch::SetPosition(const GameState& pos) {
+  if (!tree_) tree_ = std::make_unique<classic::NodeTree>();
+  const bool is_same_game = tree_->ResetToPosition(pos);
+  if (!is_same_game) time_manager_ = classic::MakeTimeManager(*options_);
+}
+
+void ClassicSearch::StartSearch(const GoParams& params) {
+  auto forwarder =
+      std::make_unique<NonOwningUciRespondForwarder>(uci_responder_);
+  auto stopper = time_manager_->GetStopper(params, *tree_.get());
+  search_ = std::make_unique<classic::Search>(
+      *tree_, backend_, std::move(forwarder),
+      StringsToMovelist(params.searchmoves, tree_->HeadPosition().GetBoard()),
+      *move_start_time_, std::move(stopper), params.infinite, params.ponder,
+      *options_, syzygy_tb_);
+
+  LOGFILE << "Timer started at "
+          << FormatTime(SteadyClockToSystemClock(*move_start_time_));
+  search_->StartThreads(options_->Get<int>(kThreadsOptionId));
+}
+
+class ClassicSearchFactory : public SearchFactory {
+  std::string_view GetName() const override { return "classic"; }
+  std::unique_ptr<SearchBase> CreateSearch(
+      UciResponder* responder, const OptionsDict* options) const override {
+    return std::make_unique<ClassicSearch>(responder, options);
+  }
+
+  void PopulateParams(OptionsParser* parser) const override {
+    parser->Add<IntOption>(kThreadsOptionId, 0, 128) = 0;
+    classic::SearchParams::Populate(parser);
+    PopulateTimeManagementOptions(classic::RunType::kUci, parser);
+  }
+};
+
+REGISTER_SEARCH(ClassicSearchFactory);
+
+}  // namespace
+}  // namespace classic
+}  // namespace lczero

--- a/src/search/classic/wrapper.cc
+++ b/src/search/classic/wrapper.cc
@@ -39,6 +39,9 @@ const OptionId kThreadsOptionId{
     "threads", "Threads",
     "Number of (CPU) worker threads to use, 0 for the backend default.", 't'};
 
+const OptionId kClearTree{"", "ClearTree",
+                          "Clear the tree before the next search."};
+
 class ClassicSearch : public SearchBase {
  public:
   ClassicSearch(UciResponder* responder, const OptionsDict* options)
@@ -101,6 +104,8 @@ void ClassicSearch::SetPosition(const GameState& pos) {
 void ClassicSearch::StartSearch(const GoParams& params) {
   auto forwarder =
       std::make_unique<NonOwningUciRespondForwarder>(uci_responder_);
+  if (options_->Get<Button>(kClearTree).TestAndReset()) tree_->TrimTreeAtHead();
+
   auto stopper = time_manager_->GetStopper(params, *tree_.get());
   search_ = std::make_unique<classic::Search>(
       *tree_, backend_, std::move(forwarder),
@@ -124,6 +129,9 @@ class ClassicSearchFactory : public SearchFactory {
     parser->Add<IntOption>(kThreadsOptionId, 0, 128) = 0;
     classic::SearchParams::Populate(parser);
     PopulateTimeManagementOptions(classic::RunType::kUci, parser);
+
+    parser->Add<ButtonOption>(kClearTree);
+    parser->HideOption(kClearTree);
   }
 };
 


### PR DESCRIPTION
Hopefully I didn't mess it up while rebasing to upstream/master

After this change `./lc0 classic` would start old search through new API (except that timer, ponder and syzygy parts are not merged yet)