### PR TITLE
Wait for search to finish before destructing Engine.

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -147,7 +147,7 @@ Engine::Engine(const SearchFactory& factory, const OptionsDict& opts)
   }
 }
 
-Engine::~Engine() = default;
+Engine::~Engine() { EnsureSearchStopped(); }
 
 void Engine::EnsureSearchStopped() {
   search_->AbortSearch();


### PR DESCRIPTION
`quit` while running search caused the engine to crash.