### PR TITLE
dag GetVerboseStats() fix and assorted cleanup.

### DIFF
--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -516,7 +516,9 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
     if (n && n->IsTerminal()) {
       v = n->GetQ(sign * draw_score);
     } else {
-      std::optional<EvalResult> nneval = GetCachedNNEval(n);
+      auto history = GetPositionHistoryAtNode(node);
+      std::optional<EvalResult> nneval = backend_->GetCachedEvaluation(
+          EvalPosition{history.GetPositions(), {}});
       if (nneval) v = -nneval->q;
     }
     if (v) {
@@ -607,13 +609,6 @@ PositionHistory Search::GetPositionHistoryAtNode(const Node* node) const {
     history.Append(*it);
   }
   return history;
-}
-
-std::optional<EvalResult> Search::GetCachedNNEval(const Node* node) const {
-  if (!node) return {};
-  PositionHistory history = GetPositionHistoryAtNode(node);
-  return backend_->GetCachedEvaluation(
-      EvalPosition{history.GetPositions(), {}});
 }
 
 void Search::MaybeTriggerStop(const IterationStats& stats,

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -609,28 +609,11 @@ PositionHistory Search::GetPositionHistoryAtNode(const Node* node) const {
   return history;
 }
 
-namespace {
-std::vector<Move> GetNodeLegalMoves(const Node* node, const ChessBoard& board) {
-  if (!node) return {};
-  std::vector<Move> moves;
-  if (node && node->HasChildren()) {
-    moves.reserve(node->GetNumEdges());
-    std::transform(node->Edges().begin(), node->Edges().end(),
-                   std::back_inserter(moves),
-                   [](const auto& edge) { return edge.GetMove(); });
-    return moves;
-  }
-  return board.GenerateLegalMoves();
-}
-}  // namespace
-
 std::optional<EvalResult> Search::GetCachedNNEval(const Node* node) const {
   if (!node) return {};
   PositionHistory history = GetPositionHistoryAtNode(node);
-  std::vector<Move> legal_moves =
-      GetNodeLegalMoves(node, history.Last().GetBoard());
   return backend_->GetCachedEvaluation(
-      EvalPosition{history.GetPositions(), legal_moves});
+      EvalPosition{history.GetPositions(), {}});
 }
 
 void Search::MaybeTriggerStop(const IterationStats& stats,

--- a/src/search/classic/search.h
+++ b/src/search/classic/search.h
@@ -94,9 +94,6 @@ class Search {
   // from temperature having been applied again.
   void ResetBestMove();
 
-  // Returns NN eval for a given node from cache, if that node is cached.
-  std::optional<EvalResult> GetCachedNNEval(const Node* node) const;
-
  private:
   // Computes the best move, maybe with temperature (according to the settings).
   void EnsureBestMoveKnown();

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -462,7 +462,7 @@ inline float ComputeCpuct(const SearchParams& params, uint32_t N,
 }  // namespace
 
 std::vector<std::string> Search::GetVerboseStats(
-    Node* node, std::optional<Move> best_move) const {
+    Node* node, std::optional<Move> move_to_node) const {
   const bool is_root = (node == root_node_);
   const bool is_odd_depth = !is_root;
   const bool is_black_to_move = (played_history_.IsBlackToMove() == is_root);
@@ -525,8 +525,8 @@ std::vector<std::string> Search::GetVerboseStats(
       v = n->GetQ(sign * draw_score);
     } else if (n) {
       auto history = played_history_;
-      if (best_move) {
-        history.Append(*best_move);
+      if (move_to_node) {
+        history.Append(*move_to_node);
       }
       if (is_edge) {
         history.Append(n->GetMove());

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -531,7 +531,8 @@ std::vector<std::string> Search::GetVerboseStats(
       if (is_edge) {
         history.Append(n->GetMove());
       }
-      std::optional<EvalResult> nneval = GetCachedNNEval(n, history);
+      std::optional<EvalResult> nneval = backend_->GetCachedEvaluation(
+          EvalPosition{history.GetPositions(), {}});
       if (nneval) v = -nneval->q;
     }
     if (v) {
@@ -610,13 +611,6 @@ void Search::SendMovesStats() const REQUIRES(counters_mutex_) {
       }
     }
   }
-}
-
-std::optional<EvalResult> Search::GetCachedNNEval(
-    const Node* node, PositionHistory& history) const {
-  if (!node) return {};
-  return backend_->GetCachedEvaluation(
-      EvalPosition{history.GetPositions(), {}});
 }
 
 void Search::MaybeTriggerStop(const IterationStats& stats,

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -461,7 +461,8 @@ inline float ComputeCpuct(const SearchParams& params, uint32_t N,
 }
 }  // namespace
 
-std::vector<std::string> Search::GetVerboseStats(Node* node) const {
+std::vector<std::string> Search::GetVerboseStats(
+    Node* node, std::optional<Move> best_move) const {
   const bool is_root = (node == root_node_);
   const bool is_odd_depth = !is_root;
   const bool is_black_to_move = (played_history_.IsBlackToMove() == is_root);
@@ -517,15 +518,18 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
       print(oss, "(Q: ", fpu, ") ", 8, 5);
     }
   };
-  auto print_tail = [&](auto* oss, const auto* n) {
+  auto print_tail = [&](auto* oss, const auto* n, bool is_edge) {
     const auto sign = n == node ? -1 : 1;
     std::optional<float> v;
     if (n && n->IsTerminal()) {
       v = n->GetQ(sign * draw_score);
     } else if (n) {
       auto history = played_history_;
-      if (!is_root) {
-        history.Append(node->GetMove());
+      if (best_move) {
+        history.Append(*best_move);
+      }
+      if (is_edge) {
+        history.Append(n->GetMove());
       }
       std::optional<EvalResult> nneval = GetCachedNNEval(n, history);
       if (nneval) v = -nneval->q;
@@ -565,7 +569,7 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
     print_stats(&oss, edge.node());
     print(&oss, "(U: ", edge.GetU(U_coeff), ") ", 6, 5);
     print(&oss, "(S: ", Q + edge.GetU(U_coeff) + M, ") ", 8, 5);
-    print_tail(&oss, edge.node());
+    print_tail(&oss, edge.node(), true);
     infos.emplace_back(oss.str());
   }
 
@@ -574,13 +578,13 @@ std::vector<std::string> Search::GetVerboseStats(Node* node) const {
   print_head(&oss, "node ", node->GetNumEdges(), node->GetN(),
              node->GetNInFlight(), node->GetVisitedPolicy());
   print_stats(&oss, node);
-  print_tail(&oss, node);
+  print_tail(&oss, node, false);
   infos.emplace_back(oss.str());
   return infos;
 }
 
 void Search::SendMovesStats() const REQUIRES(counters_mutex_) {
-  auto move_stats = GetVerboseStats(root_node_);
+  auto move_stats = GetVerboseStats(root_node_, std::nullopt);
 
   if (params_.GetVerboseStats()) {
     std::vector<ThinkingInfo> infos;
@@ -601,35 +605,18 @@ void Search::SendMovesStats() const REQUIRES(counters_mutex_) {
     }
     if (edge.HasNode()) {
       LOGFILE << "--- Opponent moves after: " << final_bestmove_.ToString(true);
-      for (const auto& line : GetVerboseStats(edge.node())) {
+      for (const auto& line : GetVerboseStats(edge.node(), edge.GetMove())) {
         LOGFILE << line;
       }
     }
   }
 }
 
-namespace {
-std::vector<Move> GetNodeLegalMoves(const Node* node, const ChessBoard& board) {
-  if (!node) return {};
-  std::vector<Move> moves;
-  if (node && node->HasChildren()) {
-    moves.reserve(node->GetNumEdges());
-    std::transform(node->Edges().begin(), node->Edges().end(),
-                   std::back_inserter(moves),
-                   [](const auto& edge) { return edge.GetMove(); });
-    return moves;
-  }
-  return board.GenerateLegalMoves();
-}
-}  // namespace
-
 std::optional<EvalResult> Search::GetCachedNNEval(
     const Node* node, PositionHistory& history) const {
   if (!node) return {};
-  std::vector<Move> legal_moves =
-      GetNodeLegalMoves(node, history.Last().GetBoard());
   return backend_->GetCachedEvaluation(
-      EvalPosition{history.GetPositions(), legal_moves});
+      EvalPosition{history.GetPositions(), {}});
 }
 
 void Search::MaybeTriggerStop(const IterationStats& stats,

--- a/src/search/dag_classic/search.h
+++ b/src/search/dag_classic/search.h
@@ -135,9 +135,10 @@ class Search {
   void PopulateCommonIterationStats(IterationStats* stats);
 
   // Returns verbose information about given node, as vector of strings.
-  // Node can only be root or ponder (depth 1).
-  std::vector<std::string> GetVerboseStats(Node* node,
-                                           std::optional<Move> best_move) const;
+  // Node can only be root or ponder (depth 1) and move_to_node is only given
+  // for the ponder node.
+  std::vector<std::string> GetVerboseStats(
+      Node* node, std::optional<Move> move_to_node) const;
 
   // Returns the draw score at the root of the search. At odd depth pass true to
   // the value of @is_odd_depth to change the sign of the draw score.

--- a/src/search/dag_classic/search.h
+++ b/src/search/dag_classic/search.h
@@ -136,7 +136,8 @@ class Search {
 
   // Returns verbose information about given node, as vector of strings.
   // Node can only be root or ponder (depth 1).
-  std::vector<std::string> GetVerboseStats(Node* node) const;
+  std::vector<std::string> GetVerboseStats(Node* node,
+                                           std::optional<Move> best_move) const;
 
   // Returns the draw score at the root of the search. At odd depth pass true to
   // the value of @is_odd_depth to change the sign of the draw score.

--- a/src/search/dag_classic/search.h
+++ b/src/search/dag_classic/search.h
@@ -100,10 +100,6 @@ class Search {
   // from temperature having been applied again.
   void ResetBestMove();
 
-  // Returns NN eval for a given node from cache, if that node is cached.
-  std::optional<EvalResult> GetCachedNNEval(const Node* node,
-                                            PositionHistory& history) const;
-
  private:
   // Computes the best move, maybe with temperature (according to the settings).
   void EnsureBestMoveKnown();


### PR DESCRIPTION
This is an old bug in dag's `GetVerboseStats()` that was missing the second to last move when making a cache lookup. It was not getting caught by the `ApplyMove()` assert so a cache lookup was done with the wrong moves and the copy in `GetCachedEvaluation()` was accessing out of bounds. Cache lookups before the new backend interface were more forgiving so this was never noticed.