### PR TITLE
Allow certain backends to run without network file.

### DIFF
--- a/src/engine_loop.cc
+++ b/src/engine_loop.cc
@@ -86,7 +86,7 @@ void RunEngineInternal(SearchFactory* factory) {
 }  // namespace
 
 void RunEngine(SearchFactory* factory) {
-  CERR << "Running engine with search algorithm=" << factory->GetName();
+  CERR << "Search algorithm: " << factory->GetName();
   RunEngineInternal<Engine>(factory);
 }
 void RunEngineClassic() { RunEngineInternal<EngineClassic>(nullptr); }

--- a/src/neural/loader.cc
+++ b/src/neural/loader.cc
@@ -218,7 +218,11 @@ std::optional<WeightsFile> LoadWeights(std::string_view location) {
     net_path = CommandLine::BinaryName();
   }
   if (net_path.empty()) return std::nullopt;
-  CERR << "Loading weights file from: " << net_path;
+  if (location == SharedBackendParams::kEmbed) {
+    CERR << "Using embedded weights from binary: " << net_path;
+  } else {
+    CERR << "Loading weights file from: " << net_path;
+  }
   return LoadWeightsFromFile(net_path);
 }
 

--- a/src/neural/loader.cc
+++ b/src/neural/loader.cc
@@ -210,20 +210,16 @@ WeightsFile LoadWeightsFromFile(const std::string& filename) {
   return ParseWeightsProto(buffer);
 }
 
-WeightsFile LoadWeights(std::string_view location) {
+std::optional<WeightsFile> LoadWeights(std::string_view location) {
   std::string net_path = std::string(location);
   if (net_path == SharedBackendParams::kAutoDiscover) {
     net_path = DiscoverWeightsFile();
   } else if (net_path == SharedBackendParams::kEmbed) {
     net_path = CommandLine::BinaryName();
-  } else {
-    CERR << "Loading weights file from: " << location;
   }
+  if (net_path.empty()) return std::nullopt;
+  CERR << "Loading weights file from: " << net_path;
   return LoadWeightsFromFile(net_path);
-}
-
-WeightsFile LoadWeightsFromOptions(const OptionsDict& options) {
-  return LoadWeights(options.Get<std::string>(SharedBackendParams::kWeightsId));
 }
 
 std::string DiscoverWeightsFile() {
@@ -264,24 +260,12 @@ std::string DiscoverWeightsFile() {
       gzclose(file);
       if (sz < 0) continue;
 
-      std::string str(buf, buf + sz);
-      std::istringstream data(str);
-      int val = 0;
-      data >> val;
-      if (!data.fail() && val == 2) {
-        CERR << "Found txt network file: " << candidate.second;
-        return candidate.second;
-      }
-
       // First byte of the protobuf stream is 0x0d for fixed32, so we ignore it
       // as our own magic should suffice.
       const auto magic = buf[1] | (static_cast<uint32_t>(buf[2]) << 8) |
                          (static_cast<uint32_t>(buf[3]) << 16) |
                          (static_cast<uint32_t>(buf[4]) << 24);
-      if (magic == kWeightMagic) {
-        CERR << "Found pb network file: " << candidate.second;
-        return candidate.second;
-      }
+      if (magic == kWeightMagic) return candidate.second;
     }
   }
   LOGFILE << "Network weights file not found.";

--- a/src/neural/loader.h
+++ b/src/neural/loader.h
@@ -50,10 +50,7 @@ WeightsFile LoadWeightsFromFile(const std::string& filename);
 // * "<autodiscover>" -- tries to find a file which looks like a weights file.
 // * "<embed>" -- weights are embedded in the binary.
 // * filename -- reads weights from the file.
-WeightsFile LoadWeights(std::string_view location);
-
-// Extracts location from the "backend" parameter of options, and loads weights.
-WeightsFile LoadWeightsFromOptions(const OptionsDict& options);
+std::optional<WeightsFile> LoadWeights(std::string_view location);
 
 // Tries to find a file which looks like a weights file, and located in
 // directory of binary_name or one of subdirectories. If there are several such

--- a/src/neural/loader.h
+++ b/src/neural/loader.h
@@ -50,6 +50,7 @@ WeightsFile LoadWeightsFromFile(const std::string& filename);
 // * "<autodiscover>" -- tries to find a file which looks like a weights file.
 // * "<embed>" -- weights are embedded in the binary.
 // * filename -- reads weights from the file.
+// Returns std::nullopt if no weights file was found in <autodiscover> mode.
 std::optional<WeightsFile> LoadWeights(std::string_view location);
 
 // Tries to find a file which looks like a weights file, and located in

--- a/src/neural/wrapper.cc
+++ b/src/neural/wrapper.cc
@@ -184,9 +184,7 @@ std::unique_ptr<Backend> NetworkAsBackendFactory::Create(
 
   std::string net_path =
       options.Get<std::string>(SharedBackendParams::kWeightsId);
-  std::optional<WeightsFile> weights;
-  if (!net_path.empty()) weights = LoadWeights(net_path);
-
+  std::optional<WeightsFile> weights = LoadWeights(net_path);
   std::unique_ptr<Network> network =
       factory_(std::move(weights), network_options);
   network_options.CheckAllOptionsRead(name_);


### PR DESCRIPTION
Discovered [in chat](https://discord.com/channels/425419482568196106/427066771627966466/1377092504935071904).

Also, remove autodiscovering of `.txt` weight files, we don't support them anymore.