### PR TITLE
Attempt to Autocreate macOS Builds (Gemini)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,38 @@ jobs:
       - store_artifacts:
           path: /tmp/lc0
           destination: lc0-macos_12.6.1
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - lc0
+
+  "upload-github-release":
+    macos:
+      xcode: 14.1.0
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Install GitHub CLI
+          command: brew install gh
+      - run:
+          name: Upload to GitHub Release
+          command: |
+            gh release upload \
+              "$CIRCLE_TAG" \
+              /tmp/workspace/lc0 \
+              --clobber
 workflows:
   version: 2
   builds:
     jobs:
       - build
       - "mac"
+      - "upload-github-release":
+          requires:
+            - "mac"
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(\-.+)?/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
Just through the circleci examples and our config into Gemini, this is what it gave. It looks reasonable enough for this.

> [!NOTE]
> Make sure to set `GITHUB_TOKEN` as a private environmental variable on circleci with an access token so it will be able to upload.