### PR TITLE
Improve windows build script

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -13,13 +13,37 @@ set EIGEN=false
 set TEST=false
 
 rem 2. Edit the paths for the build dependencies.
-set CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0
-set CUDNN_PATH=%CUDA_PATH%
+if "%CUDA%"=="false" (
+    echo CUDA build option is OFF. Skipping CUDA/cuDNN path setup.
+    rem Clear CUDA-related paths when CUDA backend is off
+    set "CUDA_PATH="
+    set "CUDNN_PATH="
+    set "OPENCL_LIB_PATH="
+    set "OPENCL_INCLUDE_PATH="
+) else (
+    echo CUDA build option is ON. Validating CUDA_PATH...
+    if defined CUDA_PATH (
+        echo CUDA_PATH found in system environment: "%CUDA_PATH%"
+        rem Proceed with derived paths as CUDA_PATH is defined
+    ) else (
+        echo.
+        echo ERROR: CUDA build option is ON, but CUDA_PATH environment variable is NOT set.
+        echo Please ensure CUDA is installed and CUDA_PATH is correctly defined
+        echo as a system or user environment variable, then restart your console/reboot.
+        echo For example: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.0
+        echo.
+        pause
+        exit /b 1
+    )
+
+    rem Set other derived paths if CUDA_PATH was successfully found
+    set CUDNN_PATH=%CUDA_PATH%
+    set OPENCL_LIB_PATH=%CUDA_PATH%\lib\x64
+    set OPENCL_INCLUDE_PATH=%CUDA_PATH%\include
+)
 set OPENBLAS_PATH=C:\OpenBLAS
 set MKL_PATH=C:\Program Files (x86)\IntelSWTools\compilers_and_libraries\windows\mkl
 set DNNL_PATH=C:\dnnl_win_1.1.1_cpu_vcomp
-set OPENCL_LIB_PATH=%CUDA_PATH%\lib\x64
-set OPENCL_INCLUDE_PATH=%CUDA_PATH%\include
 
 rem 3. In most cases you won't need to change anything further down.
 echo Deleting build directory:

--- a/build.cmd
+++ b/build.cmd
@@ -13,34 +13,33 @@ set EIGEN=false
 set TEST=false
 
 rem 2. Edit the paths for the build dependencies.
-if "%CUDA%"=="false" (
-    echo CUDA build option is OFF. Skipping CUDA/cuDNN path setup.
-    rem Clear CUDA-related paths when CUDA backend is off
-    set "CUDA_PATH="
+
+if not defined CUDA_PATH (
+    echo WARNING: CUDA_PATH environment variable not found.
+
+    rem Clear all paths that are derived from CUDA_PATH in this script.
     set "CUDNN_PATH="
     set "OPENCL_LIB_PATH="
     set "OPENCL_INCLUDE_PATH="
-) else (
-    echo CUDA build option is ON. Validating CUDA_PATH...
-    if defined CUDA_PATH (
-        echo CUDA_PATH found in system environment: "%CUDA_PATH%"
-        rem Proceed with derived paths as CUDA_PATH is defined
-    ) else (
+
+    rem If the user still intended to build with CUDA, exit.
+    if "%CUDA%"=="true" (
         echo.
         echo ERROR: CUDA build option is ON, but CUDA_PATH environment variable is NOT set.
-        echo Please ensure CUDA is installed and CUDA_PATH is correctly defined
-        echo as a system or user environment variable, then restart your console/reboot.
-        echo For example: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.0
+        echo Please ensure CUDA is installed and its PATH variable is configured.
         echo.
         pause
         exit /b 1
     )
+) else (
+    echo CUDA_PATH found in system environment: "%CUDA_PATH%"
 
-    rem Set other derived paths if CUDA_PATH was successfully found
+    rem Set all derived paths based on the found CUDA_PATH.
     set CUDNN_PATH=%CUDA_PATH%
     set OPENCL_LIB_PATH=%CUDA_PATH%\lib\x64
     set OPENCL_INCLUDE_PATH=%CUDA_PATH%\include
 )
+
 set OPENBLAS_PATH=C:\OpenBLAS
 set MKL_PATH=C:\Program Files (x86)\IntelSWTools\compilers_and_libraries\windows\mkl
 set DNNL_PATH=C:\dnnl_win_1.1.1_cpu_vcomp

--- a/build.cmd
+++ b/build.cmd
@@ -12,22 +12,19 @@ set OPENBLAS=false
 set EIGEN=false
 set TEST=false
 
-rem 2. Edit the paths for the build dependencies.
-
-if not defined CUDA_PATH (
-    echo WARNING: CUDA_PATH environment variable not found.
-    rem Clear all paths that are derived from CUDA_PATH in this script.
-    set "CUDNN_PATH="
-    set "OPENCL_LIB_PATH="
-    set "OPENCL_INCLUDE_PATH="
-) else (
+if "%CUDA%"=="true" (
+  if not defined CUDA_PATH (
+    echo WARNING: CUDA_PATH environment variable not found. Using default value.
+  ) else (
     echo CUDA_PATH found in system environment: "%CUDA_PATH%"
-    rem Set all derived paths based on the found CUDA_PATH.
-    set CUDNN_PATH=%CUDA_PATH%
-    set OPENCL_LIB_PATH=%CUDA_PATH%\lib\x64
-    set OPENCL_INCLUDE_PATH=%CUDA_PATH%\include
+  )
 )
 
+rem 2. Edit the paths for the build dependencies.
+if not defined CUDA_PATH set CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.9
+set CUDNN_PATH=%CUDA_PATH%
+set OPENCL_LIB_PATH=%CUDA_PATH%\lib\x64
+set OPENCL_INCLUDE_PATH=%CUDA_PATH%\include
 set OPENBLAS_PATH=C:\OpenBLAS
 set MKL_PATH=C:\Program Files (x86)\IntelSWTools\compilers_and_libraries\windows\mkl
 set DNNL_PATH=C:\dnnl_win_1.1.1_cpu_vcomp

--- a/build.cmd
+++ b/build.cmd
@@ -16,24 +16,12 @@ rem 2. Edit the paths for the build dependencies.
 
 if not defined CUDA_PATH (
     echo WARNING: CUDA_PATH environment variable not found.
-
     rem Clear all paths that are derived from CUDA_PATH in this script.
     set "CUDNN_PATH="
     set "OPENCL_LIB_PATH="
     set "OPENCL_INCLUDE_PATH="
-
-    rem If the user still intended to build with CUDA, exit.
-    if "%CUDA%"=="true" (
-        echo.
-        echo ERROR: CUDA build option is ON, but CUDA_PATH environment variable is NOT set.
-        echo Please ensure CUDA is installed and its PATH variable is configured.
-        echo.
-        pause
-        exit /b 1
-    )
 ) else (
     echo CUDA_PATH found in system environment: "%CUDA_PATH%"
-
     rem Set all derived paths based on the found CUDA_PATH.
     set CUDNN_PATH=%CUDA_PATH%
     set OPENCL_LIB_PATH=%CUDA_PATH%\lib\x64


### PR DESCRIPTION
Update build.cmd to use CUDA_PATH from the system variables automatically set by the installer instead of hard coding it. If it is not defined, clear the paths related to it to avoid setting up invalid paths. If cuda is enabled and CUDA_PATH is not defined, exit as it will not compile. As a bonus, the user can also set the CUDA_PATH variable before executing manually to point to another cuda installation. Any style/logic improvements are very welcome.