### PR TITLE
ms/lc0-2175: implement PolicyheadSearch

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -487,7 +487,25 @@ const OptionId SearchParams::kUCIRatingAdvId{
     "the current opponent, used as the default contempt value."};
 const OptionId SearchParams::kSearchSpinBackoffId{
     "search-spin-backoff", "SearchSpinBackoff",
-    "Enable backoff for the spin lock that acquires available searcher."};
+    "If enabled, search workers will use exponential backoff for their spin "
+    "lock waits. This reduces CPU usage but may hurt performance."};
+const OptionId SearchParams::kPolicyheadTemperatureId{
+    "policyhead-temperature", "PolicyheadTemperature",
+    "Temperature for move selection in policyhead mode. Higher values "
+    "increase randomness."};
+const OptionId SearchParams::kPolicyheadTempDecayId{
+    "policyhead-temp-decay", "PolicyheadTempDecay",
+    "Temperature decay per move in policyhead mode. Temperature reduces "
+    "linearly by this amount each move."};
+const OptionId SearchParams::kPolicyheadMultiPvId{
+    "policyhead-multipv", "PolicyheadMultiPv",
+    "Number of best moves to show in policyhead mode."};
+const OptionId SearchParams::kPolicyheadThinkTimeId{
+    "policyhead-think-time", "PolicyheadThinkTime",
+    "Artificial thinking time in milliseconds for policyhead mode."};
+const OptionId SearchParams::kPolicyheadVerboseId{
+    "policyhead-verbose", "PolicyheadVerbose",
+    "Show detailed move statistics in policyhead mode."};
 
 void SearchParams::Populate(OptionsParser* options) {
   // Here the uci optimized defaults" are set.
@@ -584,6 +602,11 @@ void SearchParams::Populate(OptionsParser* options) {
   options->Add<StringOption>(kUCIOpponentId);
   options->Add<FloatOption>(kUCIRatingAdvId, -10000.0f, 10000.0f) = 0.0f;
   options->Add<BoolOption>(kSearchSpinBackoffId) = false;
+  options->Add<FloatOption>(kPolicyheadTemperatureId, 0.0f, 10.0f) = 0.0f;
+  options->Add<FloatOption>(kPolicyheadTempDecayId, 0.0f, 1.0f) = 0.0f;
+  options->Add<IntOption>(kPolicyheadMultiPvId, 1, 500) = 1;
+  options->Add<IntOption>(kPolicyheadThinkTimeId, 0, 60000) = 0;
+  options->Add<BoolOption>(kPolicyheadVerboseId) = false;
 
   options->HideOption(kNoiseEpsilonId);
   options->HideOption(kNoiseAlphaId);

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -162,6 +162,21 @@ class SearchParams {
     return kMaxCollisionVisitsScalingPower;
   }
   bool GetSearchSpinBackoff() const { return kSearchSpinBackoff; }
+  float GetPolicyheadTemperature() const {
+    return options_.Get<float>(kPolicyheadTemperatureId);
+  }
+  float GetPolicyheadTempDecay() const {
+    return options_.Get<float>(kPolicyheadTempDecayId);
+  }
+  int GetPolicyheadMultiPv() const {
+    return options_.Get<int>(kPolicyheadMultiPvId);
+  }
+  int GetPolicyheadThinkTime() const {
+    return options_.Get<int>(kPolicyheadThinkTimeId);
+  }
+  bool GetPolicyheadVerbose() const {
+    return options_.Get<bool>(kPolicyheadVerboseId);
+  }
 
   // Search parameter IDs.
   static const OptionId kMiniBatchSizeId;
@@ -235,6 +250,11 @@ class SearchParams {
   static const OptionId kUCIOpponentId;
   static const OptionId kUCIRatingAdvId;
   static const OptionId kSearchSpinBackoffId;
+  static const OptionId kPolicyheadTemperatureId;
+  static const OptionId kPolicyheadTempDecayId;
+  static const OptionId kPolicyheadMultiPvId;
+  static const OptionId kPolicyheadThinkTimeId;
+  static const OptionId kPolicyheadVerboseId;
 
  private:
   const OptionsDict& options_;


### PR DESCRIPTION
#2175 - first time contributor, just giving back to the community.

# Files Modified
`lc0/src/mcts/params.h `- Added new parameter declarations for PolicyheadSearch
`lc0/src/mcts/params.cc `- Added parameter definitions and default values
`lc0/src/engine.cc `- Replaced ValueOnlyGo with comprehensive PolicyheadSearch class

# Features Implemented
1. Temperature Support
--policyhead-temperature: Controls move randomness (0.0 = deterministic, higher = more random)
--policyhead-temp-decay: Temperature reduces linearly by this amount each move
Uses exponential weighting with Boltzmann distribution for move selection
2. Syzygy Tablebase Integration
Automatically detects tablebase positions
Uses endgame knowledge when available
Properly handles WDL (Win/Draw/Loss) scores from tablebase
Marks tablebase moves with "TB" comment
3. Multi-PV Mode
--policyhead-multipv: Shows top N moves (default 1, max 500)
Displays detailed analysis for each candidate move
Sorts moves by evaluation score
4. Artificial Thinking Time
--policyhead-think-time: Delays move output by specified milliseconds
Simulates thinking by sending incremental UCI info updates
Provides more realistic experience for human players
5. Verbose Output
--policyhead-verbose: Shows detailed WDL probabilities and statistics
Enhanced UCI info output with complete move analysis
Clear indication of tablebase usage

# Usage Examples
**Basic enhanced policy search**
`./lc0 --value-only=true --backend=trivial
`
**With temperature for randomness**
`./lc0 --value-only=true --policyhead-temperature=0.5
`
**Multi-PV analysis with thinking time**
`./lc0 --value-only=true --policyhead-multipv=5 --policyhead-think-time=2000 --policyhead-verbose=true
`
**Temperature decay over time**
`./lc0 --value-only=true --policyhead-temperature=1.0 --policyhead-temp-decay=0.1`