### PR TITLE
add native_arch as a build option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -38,7 +38,9 @@ if cc.get_id() == 'clang'
 endif
 if cc.get_id() != 'msvc'
   if get_option('buildtype') == 'release'
-    add_project_arguments(cc.get_supported_arguments(['-march=native']), language : 'cpp')
+     if get_option('native_arch')
+       add_project_arguments(cc.get_supported_arguments(['-march=native']), language : 'cpp')
+     endif
   endif
 endif
 if cc.get_id() == 'msvc'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -68,6 +68,11 @@ option('native_cuda',
        value: true,
        description: 'build cuda code for native arch only (if supported)')
 
+option('native_arch',
+       type: 'boolean',
+       value: true, 
+       description: 'build code for native arch only')
+
 option('cudnn',
        type: 'boolean',
        value: false,


### PR DESCRIPTION
Make -march=native a build option so we can turn it off when building binaries to support multiple cpu architectures. Well without having to go into meson.build that is.