### PR TITLE
set strict_uci_timing_ initially to true

### DIFF
--- a/src/engine.h
+++ b/src/engine.h
@@ -74,8 +74,9 @@ class Engine : public EngineControllerBase {
   std::unique_ptr<SyzygyTablebase> syzygy_tb_;  // absl_nullable
 
   // UCI parameters cache to be consistent between `position` and `go`.
+  // Defaults ensure corect operation even if `go` comes first.
   bool ponder_enabled_ = false;
-  bool strict_uci_timing_ = false;
+  bool strict_uci_timing_ = true;
   // Last position set for the search. Used to:
   // 1. Detect whether the position was ever set (to initialize to startpos).
   // 2. Remember the position for ponder go (removing the last ply).


### PR DESCRIPTION
If `go` is the first command then `strict_uci_timing_` is initialized late and the timer is never started. Setting it to `true` ensures the timer is started even in this case.