### PR TITLE
Simplify task reading code

### DIFF
--- a/src/search/classic/search.h
+++ b/src/search/classic/search.h
@@ -441,7 +441,6 @@ class SearchWorker {
   Mutex picking_tasks_mutex_;
   std::vector<PickTask> picking_tasks_;
   std::atomic<int> task_count_ = -1;
-  std::atomic<int> task_taking_started_ = 0;
   std::atomic<int> tasks_taken_ = 0;
   std::atomic<int> completed_tasks_ = 0;
   std::condition_variable task_added_;

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -1098,25 +1098,22 @@ void SearchWorker::RunTasks(int tid) {
       while (true) {
         int nta = tasks_taken_.load(std::memory_order_acquire);
         int tc = task_count_.load(std::memory_order_acquire);
+
+        // Check if tasks are queued and try increment taken count.
+        while (nta < tc &&
+            !tasks_taken_.compare_exchange_weak(
+              nta, nta + 1, std::memory_order_acq_rel,
+              std::memory_order_acquire)) {
+          // Queue had tasks but another worker increment taken. We check
+          // if new work was added to the queue. Then we try to increment
+          // taken again.
+          tc = task_count_.load(std::memory_order_acquire);
+        }
+        // We incremented taken if nta and tc are different
         if (nta < tc) {
-          int val = 0;
-          if (task_taking_started_.compare_exchange_weak(
-                  val, 1, std::memory_order_acq_rel,
-                  std::memory_order_relaxed)) {
-            nta = tasks_taken_.load(std::memory_order_acquire);
-            tc = task_count_.load(std::memory_order_acquire);
-            // We got the spin lock, double check we're still in the clear.
-            if (nta < tc) {
-              id = tasks_taken_.fetch_add(1, std::memory_order_acq_rel);
-              task = &picking_tasks_[id];
-              task_taking_started_.store(0, std::memory_order_release);
-              break;
-            }
-            task_taking_started_.store(0, std::memory_order_release);
-          }
-          SpinloopPause();
-          spins = 0;
-          continue;
+          id = nta;
+          task = &picking_tasks_[id];
+          break;
         } else if (tc != -1) {
           spins++;
           if (spins >= 512) {

--- a/src/search/dag_classic/search.h
+++ b/src/search/dag_classic/search.h
@@ -496,7 +496,6 @@ class SearchWorker {
   Mutex picking_tasks_mutex_;
   std::vector<PickTask> picking_tasks_;
   std::atomic<int> task_count_ = -1;
-  std::atomic<int> task_taking_started_ = 0;
   std::atomic<int> tasks_taken_ = 0;
   std::atomic<int> completed_tasks_ = 0;
   std::condition_variable task_added_;


### PR DESCRIPTION
Atomic variables can be used without locks. We want an id from the shared taksks_taken_ counter. We want to increment the counter while staying less than or equal to the task_count_. This can be done using compare and exchange operation. We call compare exchange in a loop because it will either success soon or other thread increment counters to an equal value.

I have been learning the code base for a few days. I'm thinking about updating opencl backend to handle latest network files. I noticed potential for a minor simplification while reading the code. I decided to make the small changes to learn how pull request are handled.