### PR TITLE
Update opencl.hpp

### DIFF
--- a/src/neural/backends/opencl/OpenCL.h
+++ b/src/neural/backends/opencl/OpenCL.h
@@ -36,7 +36,13 @@ using net_t = float;
 #include <string>
 #include <vector>
 
+#if __has_include("CL/opencl.hpp")
+#include "CL/opencl.hpp"
+#elif __has_include("OpenCL/opencl.hpp")
+#include "OpenCL/opencl.hpp"
+#else
 #include "opencl.hpp"
+#endif
 
 #include "neural/backends/opencl/OpenCLBuffers.h"
 #include "neural/backends/opencl/OpenCLParams.h"


### PR DESCRIPTION
There has been incompatible extension changes in opencl.h. My system opencl.h doesn't compile with old opencl.hpp because type names has changed. The new opencl.hpp adds version checks for incompatible extensions.
There was a typo in the last release which was fixed by KhronosGroup/OpenCL-CLHPP#321. Therefore choice is the latest version from KhronosGroup/OpenCL-CLHPP@2a60842