### PR TITLE
Sycl for AMD build improvements

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -677,6 +677,26 @@ if get_option('build_backends')
       add_project_arguments('-fsycl', language : 'cpp')
       add_project_link_arguments('-fsycl', language : 'cpp')
 
+      dpct_args = []
+      foreach onemkl_include : get_option('onemkl_include')
+        if run_command('scripts/checkdir.py', onemkl_include, check : false).returncode() == 0
+          includes += include_directories(onemkl_include, is_system: true)
+          dpct_args += '-I' + onemkl_include
+        endif
+      endforeach
+      # Check for oneMKL header which is used by DPC++ CT. It could also depend
+      # on oneMATH headers but L0 Sycl uses oneMKL kernels too.
+      cc.has_header('oneapi/mkl.hpp', required: true, args: dpct_args)
+
+      foreach dpct_include : get_option('dpct_include')
+        if run_command('scripts/checkdir.py', dpct_include, check : false).returncode() == 0
+          includes += include_directories(dpct_include, is_system: true)
+          dpct_args += '-I' + dpct_include
+        endif
+      endforeach
+      # Check for DPC++ Compatibility Tool header.
+      cc.has_header('dpct/dpct.hpp', required: true, args: dpct_args)
+
       files += 'src/neural/backends/sycl/layers.cc.dp.cpp'
       files += 'src/neural/backends/sycl/network_sycl.cc.dp.cpp'
       files += 'src/neural/backends/sycl/common_kernels.dp.cpp'
@@ -691,8 +711,18 @@ if get_option('build_backends')
         deps += cc.find_library('mkl_core', required: true)
         deps += cc.find_library('OpenCL', required: true)
       elif get_option('sycl') == 'amd'
-        deps += cc.find_library('hipblas', required: true)
-        deps += cc.find_library('amdhip64', required: true)
+        hip_libdirs = get_option('hip_libdirs')
+        hip_args = []
+        foreach hip_include : get_option('hip_include')
+          if run_command('scripts/checkdir.py', dpct_include, check : false).returncode() == 0
+            includes += include_directories(hip_include, is_system: true)
+            hip_args += '-I' + hip_include
+          endif
+        endforeach
+        deps += cc.find_library('hipblas', dirs: hip_libdirs, required: true)
+        cc.has_header('hipblas/hipblas.h', required: true, args: hip_args)
+        deps += cc.find_library('amdhip64', dirs: hip_libdirs, required: true)
+        cc.has_header('hip/hip_runtime.h', required: true, args: hip_args)
         add_project_arguments('-DUSE_HIPBLAS=ON', language : 'cpp')
         add_project_arguments('-D__HIP_PLATFORM_AMD__', language : 'cpp')
         if get_option('amd_gfx') == ''

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -209,6 +209,26 @@ option('sycl',
        value: 'off',
        description: 'Enable SYCL backend')
 
+option('dpct_include',
+       type: 'array',
+       value: ['/opt/intel/oneapi/dpcpp-ct/latest/include'],
+       description: 'Path to DPC++ Compatibility Tool includes')
+
+option('onemkl_include',
+       type: 'array',
+       value: ['/opt/intel/oneapi/mkl/latest/include'],
+       description: 'Path to oneMKL includes')
+
+option('hip_libdirs',
+       type: 'array',
+       value: ['/opt/rocm/lib'],
+       description: 'Paths to AMD HIP libraries')
+
+option('hip_include',
+       type: 'array',
+       value: ['/opt/rocm/include'],
+       description: 'Path to AMD HIP includes')
+
 option('lc0',
        type: 'boolean',
        value: true,

--- a/src/neural/backends/sycl/cuBlasContext.h
+++ b/src/neural/backends/sycl/cuBlasContext.h
@@ -61,7 +61,7 @@ class cuBlasContextManager{
 
 
 #include "hip/hip_runtime.h" 
-#include "hipblas.h"
+#include "hipblas/hipblas.h"
 
 class hipBlasContextManager;
 static hipBlasContextManager *_hipBlasContextManager;

--- a/src/neural/backends/sycl/layers.cc.dp.cpp
+++ b/src/neural/backends/sycl/layers.cc.dp.cpp
@@ -28,7 +28,7 @@
 #include <vector>
 
 #ifdef USE_HIPBLAS 
-#include "hipblas.h"
+#include "hipblas/hipblas.h"
 #include "cuBlasContext.h"
 #elif defined(USE_CUBLAS)
 #include <sycl/backend/cuda.hpp>


### PR DESCRIPTION
I managed to compile Sycl for AMD. I used AMD provided ROCm packages for HIP support. I used Intel provided oneAPI packages for Sycl runtime and DPC++. Both install everything under /opt. Here are default paths to help others repeat the compile without manual paths. Path uses symlinks which point to the latest versioned path.