### PR TITLE
Fix warnings in clang / macos compile process

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -646,6 +646,10 @@ if get_option('build_backends')
     has_backends = true
     add_project_arguments('-fobjc-arc', language : 'objc')
     add_project_arguments('-fobjc-arc', language : 'objcpp')
+
+    # Add new Acccelerate headers in MacOs >= 13.3. This may fail in older versions.
+    add_project_arguments('-DACCELERATE_NEW_LAPACK', language : 'cpp')
+    add_project_arguments('-DACCELERATE_LAPACK_ILP64', language : 'cpp')
   endif
 
   ## ~~~~~~~~

--- a/meson.build
+++ b/meson.build
@@ -647,9 +647,12 @@ if get_option('build_backends')
     add_project_arguments('-fobjc-arc', language : 'objc')
     add_project_arguments('-fobjc-arc', language : 'objcpp')
 
-    # Add new Acccelerate headers in MacOs >= 13.3. This may fail in older versions.
-    add_project_arguments('-DACCELERATE_NEW_LAPACK', language : 'cpp')
-    add_project_arguments('-DACCELERATE_LAPACK_ILP64', language : 'cpp')
+    # Minimum MacOS version = 12.6.1
+    macos_min_version = '12.6'
+    add_project_arguments(
+      '-mmacosx-version-min=' + macos_min_version,
+      language: ['c', 'cpp', 'objc', 'objcpp']
+    )
   endif
 
   ## ~~~~~~~~

--- a/src/neural/backends/metal/mps/MetalNetworkBuilder.mm
+++ b/src/neural/backends/metal/mps/MetalNetworkBuilder.mm
@@ -42,7 +42,7 @@ std::string MetalNetworkBuilder::init(int gpu_id)
     // All metal devices.
     NSArray<id<MTLDevice>> * devices = MTLCopyAllDevices();
 
-    if ([devices count] <= gpu_id) {
+    if ((NSUInteger)gpu_id >= [devices count]) {
         // No GPU device matching ID.
         [NSException raise:@"Could not find device" format:@"Could not find a GPU or CPU compute device with specified id"];
         return "";

--- a/src/neural/backends/metal/mps/NetworkGraph.h
+++ b/src/neural/backends/metal/mps/NetworkGraph.h
@@ -55,7 +55,7 @@ static MPSImageFeatureChannelFormat fcFormat = MPSImageFeatureChannelFormatFloat
     NSArray<MPSGraphTensor *> * _resultTensors;
     NSArray<MPSGraphTensor *> * _targetTensors;
     NSMutableDictionary<NSNumber *, MPSGraphTensorDataDictionary *> * _resultDataDicts;
-    NSMutableDictionary<NSString *, NSObject *> * _readVariables;
+    NSMutableDictionary<NSString *, MPSGraphTensor *> * _readVariables;
 
     // Variables for triple buffering
     dispatch_semaphore_t _doubleBufferingSemaphore;

--- a/src/neural/backends/metal/mps/NetworkGraph.mm
+++ b/src/neural/backends/metal/mps/NetworkGraph.mm
@@ -191,8 +191,12 @@ static const NSInteger kMinSubBatchSize = 20;
 
     // Create execution descriptor with block to update results for each iteration.
     MPSGraphExecutionDescriptor * executionDescriptor = [[MPSGraphExecutionDescriptor alloc] init];
-    executionDescriptor.completionHandler = ^(MPSGraphTensorDataDictionary * resultDictionary, NSError * _) {
-        _resultDataDicts[@(subBatch)] = resultDictionary;
+    executionDescriptor.completionHandler = ^(MPSGraphTensorDataDictionary * resultDictionary, NSError * _Nullable error) {
+        if (error) {
+            NSLog(@"Error occurred during execution: %@", error);
+        } else {
+            _resultDataDicts[@(subBatch)] = resultDictionary;
+        }
 
         // Release double buffering semaphore for the next training iteration to be encoded.
         dispatch_semaphore_signal(_doubleBufferingSemaphore);

--- a/src/neural/backends/metal/network_metal.cc
+++ b/src/neural/backends/metal/network_metal.cc
@@ -168,8 +168,8 @@ MetalNetwork::MetalNetwork(const WeightsFile& file, const OptionsDict& options)
 void MetalNetwork::forwardEval(InputsOutputs* io, int batchSize) {
   // Expand encoded input into N x 112 x 8 x 8.
   float* dptr = &io->input_val_mem_expanded_[0];
-  for (size_t i = 0; i < batchSize; i++) {
-    for (size_t j = 0; j < kInputPlanes; j++) {
+  for (int i = 0; i < batchSize; i++) {
+    for (int j = 0; j < kInputPlanes; j++) {
       const float value = io->input_val_mem_[j + i * kInputPlanes];
       const uint64_t mask = io->input_masks_mem_[j + i * kInputPlanes];
       for (auto k = 0; k < 64; k++) {
@@ -203,7 +203,7 @@ void MetalNetwork::forwardEval(InputsOutputs* io, int batchSize) {
 
     if (attn_policy_) {
       // Promotion offset calculation.
-      for (size_t batch = 0; batch < batchSize; batch++) {
+      for (int batch = 0; batch < batchSize; batch++) {
         for (int k = 0; k < 8; k++) {      // y in cuda
           for (int j = 0; j < 8; j++) {    // w in cuda
             for (int i = 0; i < 3; i++) {  // c in cuda
@@ -218,9 +218,9 @@ void MetalNetwork::forwardEval(InputsOutputs* io, int batchSize) {
         }
       }
       // Mapping from attention policy to lc0 policy
-      for (size_t batch = 0; batch < batchSize; batch++) {
-        for (size_t i = 0; i < 64 * 64 + 8 * 24; i++) {
-          size_t j = kAttnPolicyMap[i];
+      for (int batch = 0; batch < batchSize; batch++) {
+        for (int i = 0; i < 64 * 64 + 8 * 24; i++) {
+          int j = kAttnPolicyMap[i];
           if (j >= 0) {
             io->op_policy_mem_[batch * 1858 + j] =
                 io->op_policy_raw_mem_[batch * (64 * 64 + 8 * 24) + i];
@@ -229,8 +229,8 @@ void MetalNetwork::forwardEval(InputsOutputs* io, int batchSize) {
       }
     } else if (conv_policy_) {
       // Mapping from convolutional policy to lc0 policy
-      for (size_t batch = 0; batch < batchSize; batch++) {
-        for (size_t i = 0; i < 73 * 64; i++) {
+      for (int batch = 0; batch < batchSize; batch++) {
+        for (int i = 0; i < 73 * 64; i++) {
           short j = kConvPolicyMap[i];
           if (j >= 0) {
             io->op_policy_mem_[batch * 1858 + j] =


### PR DESCRIPTION
A bunch of new warnings have cropped up due to lots of deprecations in MacOs after 13.0. This fixes a bunch of those as well as some pre-existing type warnings. Currently we have the following being addressed:

1.
```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/vecLib.framework/Headers/cblas.h:610:6: note: 'cblas_sgemm' has been explicitly marked deprecated here
  610 | void cblas_sgemm(const enum CBLAS_ORDER __Order,
```

2.
```
[377/387] Linking target lc0
ld: warning: -undefined error is deprecated
ld: warning: ignoring duplicate libraries: '-lc++'
[379/387] Linking target liblc0_lib.dylib
ld: warning: -undefined error is deprecated
ld: warning: ignoring duplicate libraries: '-lc++'
[381/387] Linking target hashcat_test
ld: warning: -undefined error is deprecated
ld: warning: ignoring duplicate libraries: '-lc++'
[382/387] Linking target position_test
ld: warning: -undefined error is deprecated
ld: warning: ignoring duplicate libraries: '-lc++'
[383/387] Linking target syzygy_test
ld: warning: -undefined error is deprecated
ld: warning: ignoring duplicate libraries: '-lc++'
[384/387] Linking target chessboard_test
ld: warning: -undefined error is deprecated
ld: warning: ignoring duplicate libraries: '-lc++'
[385/387] Linking target optionsparser_test
ld: warning: -undefined error is deprecated
ld: warning: ignoring duplicate libraries: '-lc++'
[386/387] Linking target encoder_test
ld: warning: -undefined error is deprecated
ld: warning: ignoring duplicate libraries: '-lc++'
[387/387] Linking target engine_test
ld: warning: -undefined error is deprecated
ld: warning: ignoring duplicate libraries: '-lc++'
```

fixes #2201 