### PR TITLE
Avoid sycl waits in forwardEval code paths

### DIFF
--- a/src/neural/backends/sycl/kernels.h
+++ b/src/neural/backends/sycl/kernels.h
@@ -146,5 +146,9 @@ void inputPreprocessForAttentionBody(T* output, const T* input,
 template <typename T>
 void applyInputGating(T* output, const T* input, const T* mult, const T* add,
                       int N, int HW, int C, sycl::queue &sycl_queue);
+
+template <typename T>
+void genOffsetPointers(T** offsets, int heads, int max_batch, int depth,
+                       int d_model, T* k, T* q, T* b1, T* v, T* b2, sycl::queue &sycl_queue);
 }  // namespace sycldnn_backend
 }  // namespace lczero

--- a/src/neural/backends/sycl/layers.cc.dp.cpp
+++ b/src/neural/backends/sycl/layers.cc.dp.cpp
@@ -2124,27 +2124,13 @@ void EncoderBlock<DataType>::Eval(int N, DataType* in_out_tensor,
   // matmul_qk = tf.matmul(q, k, transpose_b=True)
   {
     if (*offset_pointers == nullptr) {
-      std::vector<DataType*> offsets(encoder_heads_ * max_batch_size_ * 5);
-      for (int i = 0; i < encoder_heads_ * max_batch_size_; i++) {
-        int h = i % encoder_heads_;
-        int n = i / encoder_heads_;
-        offsets[i] = mha_k + h * depth + 64 * d_model * n;
-        offsets[i + encoder_heads_ * max_batch_size_] =
-            mha_q + h * depth + 64 * d_model * n;
-        offsets[i + 2 * encoder_heads_ * max_batch_size_] =
-            buffer1 + i * 64 * 64;
-        offsets[i + 3 * encoder_heads_ * max_batch_size_] =
-            mha_v + h * depth + 64 * d_model * n;
-        offsets[i + 4 * encoder_heads_ * max_batch_size_] =
-            buffer2 + h * depth + 64 * d_model * n;
-      }
       
       *offset_pointers = sycl::malloc_device<DataType*>(
                                encoder_heads_ * max_batch_size_ * 5,
                                sycl_queue_);
-
-      sycl_queue.memcpy(*offset_pointers, offsets.data(),
-                      encoder_heads_ * max_batch_size_ * 5 * sizeof(DataType*)).wait();
+      genOffsetPointers(*offset_pointers, encoder_heads_, max_batch_size_,
+                        depth, d_model, mha_k, mha_q, buffer1,
+                        mha_v, buffer2, sycl_queue_);
     }
 
     cublasXGemmBatched<DataType>(transpose_type_transpose, transpose_type_notranspose,

--- a/src/neural/backends/sycl/layers.cc.dp.cpp
+++ b/src/neural/backends/sycl/layers.cc.dp.cpp
@@ -241,16 +241,14 @@ void SELayer<float>::Eval(int N, float* output, const float* input,
   sycl_queue.submit([&](sycl::handler &cgh) {
         //auto d_A = b_A.get_access<sycl::access::mode::read_write>(cgh);
         
-        cgh.host_task([=](sycl::interop_handle ih) {
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
 
-        auto cudaStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+        auto cudaStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
         cublasSetStream(handle, cudaStreamHandle);  
 
         ReportCUBLASErrors(cublasSgemm(handle, transpose_type_transpose, transpose_type_notranspose, numFc1Out_,
                                  N, C, &alpha, w1_, C, op2, C, &beta, op1,
                                  numFc1Out_));
-
-        cudaStreamSynchronize(cudaStreamHandle);
 
         });
   });
@@ -260,16 +258,14 @@ void SELayer<float>::Eval(int N, float* output, const float* input,
   sycl_queue.submit([&](sycl::handler &cgh) {
         //auto d_A = b_A.get_access<sycl::access::mode::read_write>(cgh);
         
-        cgh.host_task([=](sycl::interop_handle ih) {
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+        auto hipStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
 
-        auto hipStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_hip>(sycl_queue);
         hipblasSetStream(handle, hipStreamHandle);  
 
         hipblasSgemm(handle, transpose_type_transpose, transpose_type_notranspose, numFc1Out_,
                                  N, C, &alpha, w1_, C, op2, C, &beta, op1,
                                  numFc1Out_);
-
-        hipStreamSynchronize(hipStreamHandle);
         });
   });  
   #else
@@ -288,33 +284,30 @@ void SELayer<float>::Eval(int N, float* output, const float* input,
   sycl_queue.submit([&](sycl::handler &cgh) {
         
         
-        cgh.host_task([=](sycl::interop_handle ih) {
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
 
-        auto cudaStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+        auto cudaStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
         cublasSetStream(handle, cudaStreamHandle);  
 
         ReportCUBLASErrors(cublasSgemm(handle, transpose_type_transpose, transpose_type_notranspose, 2 * C, N,
                                  numFc1Out_, &alpha, w2_, numFc1Out_, op1,
                                  numFc1Out_, &beta, op2, 2 * C));
 
-        cudaStreamSynchronize(cudaStreamHandle);
-        
         });
   });
 
   #elif defined(USE_HIPBLAS)
   sycl_queue.submit([&](sycl::handler &cgh) {
         
-        cgh.host_task([=](sycl::interop_handle ih) {
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+        auto hipStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
 
-        auto hipStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_hip>(sycl_queue);
         hipblasSetStream(handle, hipStreamHandle);  
 
         hipblasSgemm(handle, transpose_type_transpose, transpose_type_notranspose, 2 * C, N,
                                  numFc1Out_, &alpha, w2_, numFc1Out_, op1,
                                  numFc1Out_, &beta, op2, 2 * C);
 
-        hipStreamSynchronize(hipStreamHandle);
         
         });
   });
@@ -377,17 +370,15 @@ void SELayer<sycl::half>::Eval(int N, sycl::half* output, const sycl::half* inpu
 
     sycl_queue.submit([&](sycl::handler &cgh) {
        
-        cgh.host_task([=](sycl::interop_handle ih) {
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
 
-        auto cudaStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+        auto cudaStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
         cublasSetStream(handle, cudaStreamHandle);  
     
         ReportCUBLASErrors(cublasHgemm(handle, transpose_type_transpose, transpose_type_notranspose, numFc1Out_,
                                    N, C, &alpha, ((const half *)w1_), C, ((const half *)op2), C, &beta, ((half *)op1),
                                    numFc1Out_));
     
-        cudaStreamSynchronize(cudaStreamHandle);
-        
         });
     });
 
@@ -395,10 +386,9 @@ void SELayer<sycl::half>::Eval(int N, sycl::half* output, const sycl::half* inpu
     hipblasHandle_t handle = hipBlasContextManager::gethipBlasHandle_t();
 
     sycl_queue.submit([&](sycl::handler &cgh) {
-      cgh.host_task([=](sycl::interop_handle ih) {
+      cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+        auto hipStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
 
-        auto hipStreamHandle =
-            sycl::get_native<sycl::backend::ext_oneapi_hip>(sycl_queue);
         hipblasSetStream(handle, hipStreamHandle);
 
         hipblasHgemm(handle, transpose_type_transpose,
@@ -406,7 +396,6 @@ void SELayer<sycl::half>::Eval(int N, sycl::half* output, const sycl::half* inpu
                      ((const hipblasHalf *)w1_), C, ((const hipblasHalf *)op2), C,
                      &beta, ((hipblasHalf *)op1), numFc1Out_);
 
-        hipStreamSynchronize(hipStreamHandle);
       });
     });
 #else
@@ -422,9 +411,9 @@ void SELayer<sycl::half>::Eval(int N, sycl::half* output, const sycl::half* inpu
 
     sycl_queue_.submit([&](sycl::handler &cgh) {
         
-        cgh.host_task([=](sycl::interop_handle ih) {
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
 
-        auto cudaStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+        auto cudaStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
         cublasSetStream(handle, cudaStreamHandle);   
     
         // 3. Second fully connected layer.
@@ -432,16 +421,13 @@ void SELayer<sycl::half>::Eval(int N, sycl::half* output, const sycl::half* inpu
                                    numFc1Out_, &alpha, ((const half *)w2_), numFc1Out_, ((const half *)op1),
                                    numFc1Out_, &beta, ((half *)op2), 2 * C));
   
-        cudaStreamSynchronize(cudaStreamHandle);
-        
         });
     });  
     
 #elif defined(USE_HIPBLAS)
     sycl_queue.submit([&](sycl::handler &cgh) {
-      cgh.host_task([=](sycl::interop_handle ih) {
-        auto hipStreamHandle =
-            sycl::get_native<sycl::backend::ext_oneapi_hip>(sycl_queue);
+      cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+        auto hipStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
         hipblasSetStream(handle, hipStreamHandle);
 
         hipblasHgemm(
@@ -450,7 +436,6 @@ void SELayer<sycl::half>::Eval(int N, sycl::half* output, const sycl::half* inpu
             ((const hipblasHalf *)op1), numFc1Out_, &beta, ((hipblasHalf *)op2),
             2 * C);
 
-        hipStreamSynchronize(hipStreamHandle);
       });
     });
 #else
@@ -566,9 +551,9 @@ template <>
 
     sycl_queue.submit([&](sycl::handler &cgh) {
         
-         cgh.host_task([=](sycl::interop_handle ih) {
+         cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
 
-         auto cudaStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+         auto cudaStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
          cublasSetStream(handle, cudaStreamHandle);    
   
          ReportCUBLASErrors(cublasHgemm(handle, transpose_type_transpose, transpose_type_notranspose, num_outputs,
@@ -576,16 +561,13 @@ template <>
                                   ((const half *)input_tensor), num_inputs, &beta, ((half *)output_tensor),
                                   num_outputs));
 
-         cudaStreamSynchronize(cudaStreamHandle);
-        
        });
    });  
 #elif defined(USE_HIPBLAS)
   hipblasHandle_t handle = hipBlasContextManager::gethipBlasHandle_t();
   sycl_queue.submit([&](sycl::handler &cgh) {
-    cgh.host_task([=](sycl::interop_handle ih) {
-      auto hipStreamHandle =
-          sycl::get_native<sycl::backend::ext_oneapi_hip>(sycl_queue);
+    cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+      auto hipStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
       hipblasSetStream(handle, hipStreamHandle);
 
       hipblasHgemm(
@@ -594,7 +576,6 @@ template <>
           num_inputs, ((const hipblasHalf *)input_tensor), num_inputs, &beta,
           ((hipblasHalf *)output_tensor), num_outputs);
 
-        hipStreamSynchronize(hipStreamHandle);
       });
   });
 #else
@@ -629,9 +610,9 @@ void FCLayer<float>::Eval(int N, float* output_tensor,
 
   sycl_queue.submit([&](sycl::handler &cgh) {
         
-        cgh.host_task([=](sycl::interop_handle ih) {
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
 
-        auto cudaStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+        auto cudaStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
         cublasSetStream(handle, cudaStreamHandle);    
 
 
@@ -640,17 +621,14 @@ void FCLayer<float>::Eval(int N, float* output_tensor,
                                  input_tensor, num_inputs, &beta, output_tensor,
                                  num_outputs));
 
-        cudaStreamSynchronize(cudaStreamHandle);
-        
       });
   });  
   #elif defined(USE_HIPBLAS)
   hipblasHandle_t handle = hipBlasContextManager::gethipBlasHandle_t();
   sycl_queue.submit([&](sycl::handler &cgh) {
-        
-        cgh.host_task([=](sycl::interop_handle ih) {
+      cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+        auto hipStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
 
-        auto hipStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_hip>(sycl_queue);
         hipblasSetStream(handle, hipStreamHandle);    
 
 
@@ -659,7 +637,6 @@ void FCLayer<float>::Eval(int N, float* output_tensor,
                                  input_tensor, num_inputs, &beta, output_tensor,
                                  num_outputs);
 
-        hipStreamSynchronize(hipStreamHandle);
         
       });
   });
@@ -943,9 +920,9 @@ template <>
   
    sycl_queue.submit([&](sycl::handler &cgh) {
         //auto d_A = b_A.get_access<sycl::access::mode::read_write>(cgh);
-         cgh.host_task([=](sycl::interop_handle ih) {
+         cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
   
-          auto cudaStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+          auto cudaStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
           cublasSetStream(handle, cudaStreamHandle);
 
           ReportCUBLASErrors(cublasGemmStridedBatchedEx(
@@ -954,8 +931,6 @@ template <>
              batchSize, CUDA_R_16F, CUBLAS_GEMM_DEFAULT));
 
           
-           cudaStreamSynchronize(cudaStreamHandle);
-        
          });   
    });
   
@@ -963,9 +938,8 @@ template <>
   hipblasHandle_t handle = hipBlasContextManager::gethipBlasHandle_t();
 
   sycl_queue.submit([&](sycl::handler &cgh) {
-    cgh.host_task([=](sycl::interop_handle ih) {
-      auto hipStreamHandle =
-          sycl::get_native<sycl::backend::ext_oneapi_hip>(sycl_queue);
+    cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+      auto hipStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
       hipblasSetStream(handle, hipStreamHandle);
 
       hipblasGemmStridedBatchedEx(
@@ -974,7 +948,6 @@ template <>
           &beta, Out, HIPBLAS_R_16F, N, N * M, batchSize, HIPBLAS_COMPUTE_16F,
           HIPBLAS_GEMM_DEFAULT);
 
-      hipStreamSynchronize(hipStreamHandle);
     });
   });
 #else
@@ -1012,8 +985,8 @@ template <> void BaseLayer<float>::cublasRowMajorMatrixMul(const float* A, const
     #ifdef USE_CUBLAS
     sycl_queue.submit([&](sycl::handler &cgh) {
         //auto d_A = b_A.get_access<sycl::access::mode::read_write>(cgh);
-        cgh.host_task([=](sycl::interop_handle ih) {
-            auto cudaStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+            auto cudaStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
             cublasSetStream(handle, cudaStreamHandle);   
 
           ReportCUBLASErrors(cublasGemmStridedBatchedEx(
@@ -1022,15 +995,13 @@ template <> void BaseLayer<float>::cublasRowMajorMatrixMul(const float* A, const
           batchSize, CUDA_R_32F, CUBLAS_GEMM_DEFAULT));
 
           
-          cudaStreamSynchronize(cudaStreamHandle);
-
         });
     });
     #elif defined(USE_HIPBLAS)
     sycl_queue.submit([&](sycl::handler &cgh) {
         //auto d_A = b_A.get_access<sycl::access::mode::read_write>(cgh);
-        cgh.host_task([=](sycl::interop_handle ih) {
-            auto hipStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_hip>(sycl_queue);
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+            auto hipStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
             hipblasSetStream(handle, hipStreamHandle);   
 
           hipblasGemmStridedBatchedEx(
@@ -1039,8 +1010,6 @@ template <> void BaseLayer<float>::cublasRowMajorMatrixMul(const float* A, const
           batchSize, HIPBLAS_COMPUTE_32F, HIPBLAS_GEMM_DEFAULT);
 
           
-          hipStreamSynchronize(hipStreamHandle);
-
         });
     });  
     #else
@@ -1196,9 +1165,9 @@ template <>
 #ifdef USE_CUBLAS
     sycl_queue.submit([&](sycl::handler &cgh) {
          
-         cgh.host_task([=](sycl::interop_handle ih) {
+         cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
   
-          auto cudaStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+          auto cudaStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
           cublasSetStream(handle, cudaStreamHandle);
 
 
@@ -1207,22 +1176,18 @@ template <>
          N * K, A, CUDA_R_16F, K, 0, &zero_h, Out, CUDA_R_16F, N, N * M,
          batchSize, CUDA_R_16F, CUBLAS_GEMM_DEFAULT));
 
-         cudaStreamSynchronize(cudaStreamHandle);
-        
          });   
    });
 #elif defined(USE_HIPBLAS)
     sycl_queue.submit([&](sycl::handler &cgh) {
-      cgh.host_task([=](sycl::interop_handle ih) {
-         auto hipStreamHandle =
-             sycl::get_native<sycl::backend::ext_oneapi_hip>(sycl_queue);
+      cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+         auto hipStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
          hipblasSetStream(handle, hipStreamHandle);
          hipblasGemmStridedBatchedEx(
               handle, transpose_type_notranspose, transpose_type_notranspose,
               N, M, K, &alpha, B, HIPBLAS_R_16F, N, N * K, A, HIPBLAS_R_16F, K,
               0, &beta, Out, HIPBLAS_R_16F, N, N * M, batchSize, HIPBLAS_COMPUTE_16F,
               HIPBLAS_GEMM_DEFAULT);
-         hipStreamSynchronize(hipStreamHandle);
       });
     });
 #else
@@ -1261,9 +1226,9 @@ void Conv1Layer<float>::cublasSpecialMatrixMul(const float* A, const float* B,
     #ifdef USE_CUBLAS
     sycl_queue.submit([&](sycl::handler &cgh) {
         
-        cgh.host_task([=](sycl::interop_handle ih) {
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
   
-         auto cudaStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+         auto cudaStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
          cublasSetStream(handle, cudaStreamHandle);
 
 
@@ -1272,16 +1237,14 @@ void Conv1Layer<float>::cublasSpecialMatrixMul(const float* A, const float* B,
           N * K, A, CUDA_R_32F, K, 0, &floatZero, Out, CUDA_R_32F, N, N * M,
           batchSize, CUDA_R_32F, CUBLAS_GEMM_DEFAULT));
 
-         cudaStreamSynchronize(cudaStreamHandle);
-
         });   
     });
     #elif defined(USE_HIPBLAS)
     sycl_queue.submit([&](sycl::handler &cgh) {
         
-        cgh.host_task([=](sycl::interop_handle ih) {
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+         auto hipStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
   
-         auto hipStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_hip>(sycl_queue);
          hipblasSetStream(handle, hipStreamHandle);
 
 
@@ -1289,8 +1252,6 @@ void Conv1Layer<float>::cublasSpecialMatrixMul(const float* A, const float* B,
           handle, transpose_type_notranspose, transpose_type_notranspose, N, M, K, &floatOne, B, HIPBLAS_R_32F, N,
           N * K, A, HIPBLAS_R_32F, K, 0, &floatZero, Out, HIPBLAS_R_32F, N, N * M,
           batchSize, HIPBLAS_COMPUTE_32F, HIPBLAS_GEMM_DEFAULT);
-
-         hipStreamSynchronize(hipStreamHandle);
 
         });   
     });
@@ -1309,14 +1270,11 @@ void Conv1Layer<DataType>::Eval(int N, DataType* output, const DataType* input,
                                 size_t /*scratch_size*/,
                                 sycl::queue &sycl_queue, DataType***) {
 
-  sycl_queue.wait();
-  
   //CERR << "Conv1Layer<DataType>::Eval. ";
 
   cublasSpecialMatrixMul(weights_, input, output, C, H * W, c_input_, N, sycl_queue);
  // CERR << "cublasSpecialMatrixMul. ";
 
-  sycl_queue.wait();
   if (use_bias_){
   // CERR << "addBias. " << N << " " << C << " " << H << " " << W;
     addBias_NCHW(output, output, biases_, N, C, H, W, act_, sycl_queue);
@@ -1324,8 +1282,6 @@ void Conv1Layer<DataType>::Eval(int N, DataType* output, const DataType* input,
     addVectors(output, output, (DataType*)nullptr, N * C * H * W, N * C * H * W, 0, act_, sycl_queue);
   //  CERR << "addVectors. ";
   }
-
-  sycl_queue.wait();
 }
 
 template <typename DataType>
@@ -1796,24 +1752,22 @@ static void cublasXgemm(transpose_type transa,
     unsigned short alpha_h = FP32toFP16(alpha);
     unsigned short beta_h = FP32toFP16(beta);
     sycl_queue.submit([&](sycl::handler &cgh) {
-        cgh.host_task([=](sycl::interop_handle ih) {
-        auto cudaStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+        auto cudaStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
         cublasSetStream(handle, cudaStreamHandle);    
         ReportCUBLASErrors(cublasHgemm(
           handle, transa, transb, m, n, k, (const half*)&alpha_h, ((const half *)A),
           lda, ((const half *)B), ldb, (const half*)&beta_h, ((half *)C), ldc));
-        cudaStreamSynchronize(cudaStreamHandle);  
       });
     });
   } else { 
     sycl_queue.submit([&](sycl::handler &cgh) {
-        cgh.host_task([=](sycl::interop_handle ih) {  
-        auto cudaStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {  
+        auto cudaStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
         cublasSetStream(handle, cudaStreamHandle);  
         ReportCUBLASErrors(cublasSgemm(handle, transa, transb, m, n, k, &alpha,
                                    (const float*)A, lda, (const float*)B, ldb,
                                    &beta, (float*)C, ldc));
-        cudaStreamSynchronize(cudaStreamHandle);
 
         });
       });
@@ -1824,21 +1778,19 @@ static void cublasXgemm(transpose_type transa,
     unsigned short alpha_h = FP32toFP16(alpha);
     unsigned short beta_h = FP32toFP16(beta);
     sycl_queue.submit([&](sycl::handler &cgh) {
-      cgh.host_task([=](sycl::interop_handle ih) {
-        auto hipStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_hip>(sycl_queue);
+      cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+        auto hipStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
         hipblasSetStream(handle, hipStreamHandle);
         hipblasHgemm(handle, transa, transb, m, n, k, &alpha_h, (const hipblasHalf*)A,
           lda, (const hipblasHalf*)B, ldb, &beta_h, (hipblasHalf*)C, ldc);
-        hipStreamSynchronize(hipStreamHandle);
         });
       });
   } else {
     sycl_queue.submit([&](sycl::handler &cgh) {
-      cgh.host_task([=](sycl::interop_handle ih) {  
-        auto hipStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_hip>(sycl_queue);
+      cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {  
+        auto hipStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
         hipblasSetStream(handle, hipStreamHandle);  
         hipblasSgemm(handle, transa, transb, m, n, k, &alpha, (const float*)A, lda, (const float*)B, ldb, &beta, (float*)C, ldc);
-        hipStreamSynchronize(hipStreamHandle);
         });
       });
   }
@@ -1864,8 +1816,8 @@ static void cublasXGemmStridedBatched(transpose_type transa, transpose_type tran
     unsigned short beta_h = FP32toFP16(beta);
     
     sycl_queue.submit([&](sycl::handler &cgh) {
-        cgh.host_task([=](sycl::interop_handle ih) {
-        auto cudaStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+        auto cudaStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
         cublasSetStream(handle, cudaStreamHandle);    
 
         ReportCUBLASErrors(cublasGemmStridedBatchedEx(
@@ -1873,7 +1825,6 @@ static void cublasXGemmStridedBatched(transpose_type transa, transpose_type tran
           B, CUDA_R_16F, ldb, strideB, &beta_h, C, CUDA_R_16F, ldc, strideC,
           batchCount, CUDA_R_16F, CUBLAS_GEMM_DEFAULT));
         
-        cudaStreamSynchronize(cudaStreamHandle);
 
       });
 
@@ -1883,9 +1834,9 @@ static void cublasXGemmStridedBatched(transpose_type transa, transpose_type tran
     
     sycl_queue.submit([&](sycl::handler &cgh) {
         
-        cgh.host_task([=](sycl::interop_handle ih) {
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
     
-        auto cudaStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+        auto cudaStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
         cublasSetStream(handle, cudaStreamHandle);    
     
         ReportCUBLASErrors(cublasGemmStridedBatchedEx(
@@ -1893,7 +1844,6 @@ static void cublasXGemmStridedBatched(transpose_type transa, transpose_type tran
         CUDA_R_32F, ldb, strideB, &beta, C, CUDA_R_32F, ldc, strideC,
         batchCount, CUDA_R_32F, CUBLAS_GEMM_DEFAULT));
   
-        cudaStreamSynchronize(cudaStreamHandle);
   
       });
     });
@@ -1906,9 +1856,9 @@ static void cublasXGemmStridedBatched(transpose_type transa, transpose_type tran
 
     sycl_queue.submit([&](sycl::handler &cgh) {
 
-        cgh.host_task([=](sycl::interop_handle ih) {
+      cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+        auto hipStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
 
-        auto hipStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_hip>(sycl_queue);
         hipblasSetStream(handle, hipStreamHandle);
 
         hipblasGemmStridedBatchedEx(
@@ -1916,16 +1866,15 @@ static void cublasXGemmStridedBatched(transpose_type transa, transpose_type tran
         HIPBLAS_R_16F, ldb, strideB, &beta_h, C, HIPBLAS_R_16F, ldc, strideC,
         batchCount, HIPBLAS_COMPUTE_16F, HIPBLAS_GEMM_DEFAULT);
 
-        hipStreamSynchronize(hipStreamHandle);
 
       });
     });
   } else {
     sycl_queue.submit([&](sycl::handler &cgh) {
 
-        cgh.host_task([=](sycl::interop_handle ih) {
+      cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+        auto hipStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
     
-        auto hipStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_hip>(sycl_queue);
         hipblasSetStream(handle, hipStreamHandle);    
     
         hipblasGemmStridedBatchedEx(
@@ -1933,7 +1882,6 @@ static void cublasXGemmStridedBatched(transpose_type transa, transpose_type tran
         HIPBLAS_R_32F, ldb, strideB, &beta, C, HIPBLAS_R_32F, ldc, strideC,
         batchCount, HIPBLAS_COMPUTE_32F, HIPBLAS_GEMM_DEFAULT);
   
-        hipStreamSynchronize(hipStreamHandle);
   
       });
     });
@@ -1961,16 +1909,14 @@ static void cublasXGemmBatched(transpose_type transa,
 
 
     sycl_queue.submit([&](sycl::handler &cgh) {
-        cgh.host_task([=](sycl::interop_handle ih) {
-        auto cudaStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+        auto cudaStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
         cublasSetStream(handle, cudaStreamHandle);    
 
         ReportCUBLASErrors(cublasHgemmBatched(
         handle, transa, transb, m, n, k, (const half*)&alpha_h, (half**)A, lda,
         (half**)B, ldb, (const half*)&beta_h, (half**)C, ldc, batchCount));
         
-        cudaStreamSynchronize(cudaStreamHandle);
-
       });
 
     });
@@ -1978,16 +1924,14 @@ static void cublasXGemmBatched(transpose_type transa,
   } else {
     
     sycl_queue.submit([&](sycl::handler &cgh) {
-        cgh.host_task([=](sycl::interop_handle ih) {
-        auto cudaStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+        auto cudaStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
         cublasSetStream(handle, cudaStreamHandle);    
 
         ReportCUBLASErrors(cublasSgemmBatched(
         handle, transa, transb, m, n, k, &alpha, (float**)A, lda, (float**)B,
         ldb, &beta, (float**)C, ldc, batchCount));
         
-        cudaStreamSynchronize(cudaStreamHandle);
-
       });
 
     });
@@ -2003,17 +1947,15 @@ static void cublasXGemmBatched(transpose_type transa,
 
 
     sycl_queue.submit([&](sycl::handler &cgh) {
-        cgh.host_task([=](sycl::interop_handle ih) {
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+        auto hipStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
 
-        auto hipStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_hip>(sycl_queue);
         hipblasSetStream(handle, hipStreamHandle);       
 
         hipblasHgemmBatched(
         handle, transa, transb, m, n, k, (const hipblasHalf*)&alpha_h, (hipblasHalf**)A, lda,
         (hipblasHalf**)B, ldb, (const hipblasHalf*)&beta_h, (hipblasHalf**)C, ldc, batchCount);
         
-        hipStreamSynchronize(hipStreamHandle);
-
       });
 
     });
@@ -2021,16 +1963,15 @@ static void cublasXGemmBatched(transpose_type transa,
   } else {
     
     sycl_queue.submit([&](sycl::handler &cgh) {
-        cgh.host_task([=](sycl::interop_handle ih) {
+        cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
+        auto hipStreamHandle = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
 
-        auto hipStreamHandle = sycl::get_native<sycl::backend::ext_oneapi_hip>(sycl_queue);
         hipblasSetStream(handle, hipStreamHandle);        
 
         hipblasSgemmBatched(
         handle, transa, transb, m, n, k, &alpha, (float**)A, lda, (float**)B,
         ldb, &beta, (float**)C, ldc, batchCount);
         
-        hipStreamSynchronize(hipStreamHandle);
 
       });
 


### PR DESCRIPTION
I have been working on synchronizations changes for sycl backend. Whole change set will be touching many places. I decided to separate out high impact low risk changes which are already ready. I need to still improve rest of changes a little more.

These changes aim to improve performance by avoiding round trip synchronizations while submitting commands to the GPU. Round trip latency leaves GPU idle for a short moment when CPU is working to enqueue more commands. Worst case performance hit comes for one node evaluation. I decided to compare these changes to the current master using ./lc0 bench --nodes=1 --threads=1 --task-workers=0

I have tested hip on GPU and mkl on CPU

Cuda changes are untest.

Master managed:
Position: 1/10 rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
Benchmark time 132 ms, 1 nodes, -1 nps, move d2d4
bestmove d2d4

Position: 2/10 r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 10
Benchmark time 36 ms, 1 nodes, -1 nps, move e2a6
bestmove e2a6

Position: 3/10 8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 11
Benchmark time 35 ms, 1 nodes, -1 nps, move b4f4
bestmove b4f4

Position: 4/10 4rrk1/pp1n3p/3q2pQ/2p1pb2/2PP4/2P3N1/P2B2PP/4RRK1 b - - 7 19
Benchmark time 36 ms, 1 nodes, -1 nps, move f5d3
bestmove f5d3

Position: 5/10 rq3rk1/ppp2ppp/1bnpb3/3N2B1/3NP3/7P/PPPQ1PP1/2KR3R w - - 7 14 moves d4e6
Benchmark time 35 ms, 1 nodes, -1 nps, move f7e6
bestmove f7e6

Position: 6/10 r1bq1r1k/1pp1n1pp/1p1p4/4p2Q/4Pp2/1BNP4/PPP2PPP/3R1RK1 w - - 2 14 moves g2g4
Benchmark time 35 ms, 1 nodes, -1 nps, move f4f3
bestmove f4f3

Position: 7/10 r3r1k1/2p2ppp/p1p1bn2/8/1q2P3/2NPQN2/PPP3PP/R4RK1 b - - 2 15
Benchmark time 36 ms, 1 nodes, -1 nps, move b4b2
bestmove b4b2

Position: 8/10 r1bbk1nr/pp3p1p/2n5/1N4p1/2Np1B2/8/PPP2PPP/2KR1B1R w kq - 0 13
Benchmark time 35 ms, 1 nodes, -1 nps, move f4g3
bestmove f4g3

Position: 9/10 r1bq1rk1/ppp1nppp/4n3/3p3Q/3P4/1BP1B3/PP1N2PP/R4RK1 w - - 1 16
Benchmark time 37 ms, 1 nodes, -1 nps, move a1e1
bestmove a1e1

Position: 10/10 4r1k1/r1q2ppp/ppp2n2/4P3/5Rb1/1N1BQ3/PPP3PP/R5K1 w - - 1 17
Benchmark time 35 ms, 1 nodes, -1 nps, move e3g3
bestmove e3g3


Optimized version managed:
Position: 1/10 rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
Benchmark time 104 ms, 1 nodes, -1 nps, move b1c3
bestmove b1c3

Position: 2/10 r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 10
Benchmark time 13 ms, 1 nodes, -1 nps, move f3f6
bestmove f3f6

Position: 3/10 8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 11
Benchmark time 13 ms, 1 nodes, -1 nps, move e2e3
bestmove e2e3

Position: 4/10 4rrk1/pp1n3p/3q2pQ/2p1pb2/2PP4/2P3N1/P2B2PP/4RRK1 b - - 7 19
Benchmark time 12 ms, 1 nodes, -1 nps, move e8b8
bestmove e8b8

Position: 5/10 rq3rk1/ppp2ppp/1bnpb3/3N2B1/3NP3/7P/PPPQ1PP1/2KR3R w - - 7 14 moves d4e6
Benchmark time 11 ms, 1 nodes, -1 nps, move b8d8
bestmove b8d8

Position: 6/10 r1bq1r1k/1pp1n1pp/1p1p4/4p2Q/4Pp2/1BNP4/PPP2PPP/3R1RK1 w - - 2 14 moves g2g4
Benchmark time 10 ms, 1 nodes, -1 nps, move f8f6
bestmove f8f6

Position: 7/10 r3r1k1/2p2ppp/p1p1bn2/8/1q2P3/2NPQN2/PPP3PP/R4RK1 b - - 2 15
Benchmark time 9 ms, 1 nodes, -1 nps, move b4c4
bestmove b4c4

Position: 8/10 r1bbk1nr/pp3p1p/2n5/1N4p1/2Np1B2/8/PPP2PPP/2KR1B1R w kq - 0 13
Benchmark time 9 ms, 1 nodes, -1 nps, move f4g5
bestmove f4g5

Position: 9/10 r1bq1rk1/ppp1nppp/4n3/3p3Q/3P4/1BP1B3/PP1N2PP/R4RK1 w - - 1 16
Benchmark time 8 ms, 1 nodes, -1 nps, move h5h3
bestmove h5h3

Position: 10/10 4r1k1/r1q2ppp/ppp2n2/4P3/5Rb1/1N1BQ3/PPP3PP/R5K1 w - - 1 17
Benchmark time 8 ms, 1 nodes, -1 nps, move e3d2
bestmove e3d2
