### PR TITLE
Fix Metal backend bug with out of bounds vector access

### DIFF
--- a/src/neural/backends/metal/metal_common.h
+++ b/src/neural/backends/metal/metal_common.h
@@ -36,13 +36,13 @@ static int kInputPlanes = 112;
 struct InputsOutputs {
   InputsOutputs(int maxBatchSize, bool wdl, bool moves_left, bool conv_policy,
                 bool attn_policy) {
-    input_masks_mem_.reserve(maxBatchSize * kInputPlanes);
-    input_val_mem_.reserve(maxBatchSize * kInputPlanes);
-    op_policy_mem_.reserve(maxBatchSize * kNumOutputPolicy);
-    op_value_mem_.reserve(maxBatchSize * (wdl ? 3 : 1));
+    input_masks_mem_.resize(maxBatchSize * kInputPlanes);
+    input_val_mem_.resize(maxBatchSize * kInputPlanes);
+    op_policy_mem_.resize(maxBatchSize * kNumOutputPolicy);
+    op_value_mem_.resize(maxBatchSize * (wdl ? 3 : 1));
 
     if (moves_left) {
-      op_moves_left_mem_.reserve(maxBatchSize);
+      op_moves_left_mem_.resize(maxBatchSize);
     };
 
     /**
@@ -52,9 +52,9 @@ struct InputsOutputs {
      * Remove this op_policy_raw_mem_ memory allocation when bug is fixed.
      */
     if (attn_policy) {
-      op_policy_raw_mem_.reserve(maxBatchSize * (64 * 64 + 8 * 24));
+      op_policy_raw_mem_.resize(maxBatchSize * (64 * 64 + 8 * 24));
     } else if (conv_policy) {
-      op_policy_raw_mem_.reserve(maxBatchSize * 73 * 64);
+      op_policy_raw_mem_.resize(maxBatchSize * 73 * 64);
     }
   }
   ~InputsOutputs() {}


### PR DESCRIPTION
This issue only shows up in debug builds on macOS. The Metal backend immediately crashes when an input is added to the computation's batch: https://github.com/LeelaChessZero/lc0/blob/b8cc55ecf6e16d7583ba146ef82882b2fac6fb6f/src/neural/backends/metal/network_metal.h#L48