### PR TITLE
update cuda/cudnn version warning

### DIFF
--- a/src/neural/backends/cuda/network_cuda.cc
+++ b/src/neural/backends/cuda/network_cuda.cc
@@ -997,9 +997,12 @@ class CudaNetwork : public Network {
       major = CUDART_VERSION / 1000;
       minor = (CUDART_VERSION - major * 1000) / 10;
       pl = CUDART_VERSION - major * 1000 - minor * 10;
-      CERR << "WARNING: CUDA Runtime version mismatch, was compiled with "
-              "version "
-           << major << "." << minor << "." << pl;
+      // After cuda 11, newer version with same major is OK.
+      if (major < 11 || (major != version / 1000) || version < CUDART_VERSION) {
+        CERR << "WARNING: CUDA Runtime version mismatch, was compiled with "
+                "version "
+             << major << "." << minor << "." << pl;
+      }
     }
     cudaDriverGetVersion(&version);
     major = version / 1000;

--- a/src/neural/backends/cuda/network_cudnn.cc
+++ b/src/neural/backends/cuda/network_cudnn.cc
@@ -1020,16 +1020,20 @@ class CudnnNetwork : public Network {
       major = CUDART_VERSION / 1000;
       minor = (CUDART_VERSION - major * 1000) / 10;
       pl = CUDART_VERSION - major * 1000 - minor * 10;
-      CERR << "WARNING: CUDA Runtime version mismatch, was compiled with "
-              "version "
-           << major << "." << minor << "." << pl;
+      // After cuda 11, newer version with same major is OK.
+      if (major < 11 || (major != version / 1000) || version < CUDART_VERSION) {
+        CERR << "WARNING: CUDA Runtime version mismatch, was compiled with "
+                "version "
+             << major << "." << minor << "." << pl;
+      }
     }
     version = (int)cudnnGetVersion();
     major = version / 1000;
     minor = (version - major * 1000) / 100;
     pl = version - major * 1000 - minor * 100;
     CERR << "Cudnn version: " << major << "." << minor << "." << pl;
-    if (version != CUDNN_VERSION) {
+    // Assuming CUDNN > 7.
+    if (major != CUDNN_MAJOR || minor < CUDNN_MINOR) {
       CERR << "WARNING: CUDNN Runtime version mismatch, was compiled with "
               "version "
            << CUDNN_MAJOR << "." << CUDNN_MINOR << "." << CUDNN_PATCHLEVEL;


### PR DESCRIPTION
We can relax the conditions for showing warnings about cuda/cudnn different compilation version. I'm thinking about offering a script to allow updating the dlls for cuda 11 to a later version, and showing a warning would be a bit embarrassing.