### PR TITLE
fix test dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -839,7 +839,7 @@ endif
 if get_option('gtest')
   gtest = dependency('gtest', fallback: ['gtest', 'gtest_dep'])
   gmock = dependency('gmock', fallback: ['gtest', 'gmock_dep'])
-  lc0_lib = library('lc0_lib', files, include_directories: includes, dependencies: deps)
+  lc0_lib = library('lc0_lib', common_files, include_directories: includes, dependencies: deps)
 
   test('ChessBoard',
     executable('chessboard_test', 'src/chess/board_test.cc',
@@ -873,7 +873,8 @@ if get_option('gtest')
   ), args: '--gtest_output=xml:encoder.xml', timeout: 90)
 
   test('EngineTest',
-    executable('engine_test', 'src/engine_test.cc', pb_files,
+    executable('engine_test', 'src/engine_test.cc', 'src/engine.cc',
+               'src/neural/memcache.cc', pb_files,
     include_directories: includes, link_with: lc0_lib, dependencies: [gtest, gmock]),
     args: '--gtest_output=xml:engine_test.xml', timeout: 90)
 endif


### PR DESCRIPTION
Fixes building with `-Drescorer=true -Dlc0=false -Dtest=true`. Also removes about 50 files from a build with `-Dtest=true`