### PR TITLE
search-contempt implementation for classic search

### DIFF
--- a/src/neural/encoder.cc
+++ b/src/neural/encoder.cc
@@ -134,7 +134,7 @@ int TransformForPosition(pblczero::NetworkFormat::InputFormat input_format,
 InputPlanes EncodePositionForNN(
     pblczero::NetworkFormat::InputFormat input_format,
     std::span<const Position> history, int history_planes,
-    FillEmptyHistory fill_empty_history, int* transform_out) {
+    FillEmptyHistory fill_empty_history, int* transform_out, bool swap_colors) {
   InputPlanes result(kAuxPlaneBase + 8);
 
   int transform = 0;
@@ -147,7 +147,7 @@ InputPlanes EncodePositionForNN(
   ChessBoard::Castlings castlings;
   {
     const ChessBoard& board = history.back().GetBoard();
-    const bool we_are_black = board.flipped();
+    const bool we_are_black = (board.flipped() != swap_colors);
     if (IsCanonicalFormat(input_format)) {
       transform = ChooseTransform(board);
     }
@@ -332,7 +332,7 @@ InputPlanes EncodePositionForNN(
     const PositionHistory& history, int history_planes,
     FillEmptyHistory fill_empty_history, int* transform_out) {
   return EncodePositionForNN(input_format, history.GetPositions(),
-                             history_planes, fill_empty_history, transform_out);
+                             history_planes, fill_empty_history, transform_out, false);
 }
 
 namespace {

--- a/src/neural/encoder.h
+++ b/src/neural/encoder.h
@@ -54,7 +54,7 @@ InputPlanes EncodePositionForNN(
 InputPlanes EncodePositionForNN(
     pblczero::NetworkFormat::InputFormat input_format,
     std::span<const Position> positions, int history_planes,
-    FillEmptyHistory fill_empty_history, int* transform_out);
+    FillEmptyHistory fill_empty_history, int* transform_out, bool swap_colors);
 
 bool IsCanonicalFormat(pblczero::NetworkFormat::InputFormat input_format);
 bool IsCanonicalArmageddonFormat(

--- a/src/search/classic/node.cc
+++ b/src/search/classic/node.cc
@@ -167,9 +167,26 @@ void Edge::SetP(float p) {
   p_ = (tmp < 0) ? 0 : static_cast<uint16_t>(tmp >> 12);
 }
 
+void Edge::SetP_frozen(float p) {
+  assert(0.0f <= p && p <= 1.0f);
+  constexpr int32_t roundings = (1 << 11) - (3 << 28);
+  int32_t tmp;
+  std::memcpy(&tmp, &p, sizeof(float));
+  tmp += roundings;
+  p_frozen_ = (tmp < 0) ? 0 : static_cast<uint16_t>(tmp >> 12);
+}
+
 float Edge::GetP() const {
   // Reshift into place and set the assumed-set exponent bits.
   uint32_t tmp = (static_cast<uint32_t>(p_) << 12) | (3 << 28);
+  float ret;
+  std::memcpy(&ret, &tmp, sizeof(uint32_t));
+  return ret;
+}
+
+float Edge::GetP_frozen() const {
+  // Reshift into place and set the assumed-set exponent bits.
+  uint32_t tmp = (static_cast<uint32_t>(p_frozen_) << 12) | (3 << 28);
   float ret;
   std::memcpy(&ret, &tmp, sizeof(uint32_t));
   return ret;
@@ -314,6 +331,30 @@ void Node::MakeTerminal(GameResult result, float plies_left, Terminal type) {
     // comparable to another non-loss choice. Force this by clearing the policy.
     if (GetParent() != nullptr) GetOwnEdge()->SetP(0.0f);
   }
+}
+
+void Node::SetNodeLimitFrozen(bool value) {
+     node_limit_frozen_ = value;
+}
+
+void Node::SetNodeLimitFrozenLock(bool value) {
+     node_limit_frozen_lock_ = value;
+}
+
+bool Node::GetNodeLimitFrozen() {
+     return node_limit_frozen_;
+}
+
+bool Node::GetNodeLimitFrozenLock() {
+     return node_limit_frozen_lock_;
+}
+
+uint8_t Node::GetVisitedNumberOfEdges() {
+	return num_visited_edges_;
+}
+
+void Node::SetVisitedNumberOfEdges(int value) {
+	num_visited_edges_ = value;
 }
 
 void Node::MakeNotTerminal() {

--- a/src/search/classic/node.h
+++ b/src/search/classic/node.h
@@ -95,6 +95,8 @@ class Edge {
   // (but can be changed by adding Dirichlet noise). Must be in [0,1].
   float GetP() const;
   void SetP(float val);
+  void SetP_frozen(float val);
+  float GetP_frozen() const;  
 
   // Debug information about the edge.
   std::string DebugString() const;
@@ -108,6 +110,7 @@ class Edge {
   // Probability that this move will be made, from the policy head of the neural
   // network; compressed to a 16 bit format (5 bits exp, 11 bits significand).
   uint16_t p_ = 0;
+  uint16_t p_frozen_ = 0;  
   friend class Node;
 };
 
@@ -189,11 +192,25 @@ class Node {
     }
   }
 
+  void CopyPolicy_frozen(int max_needed, float* output) const {
+    if (!edges_) return;
+    int loops = std::min(static_cast<int>(num_edges_), max_needed);
+    for (int i = 0; i < loops; i++) {
+      output[i] = edges_[i].GetP_frozen();
+    }
+  }  
+
   // Makes the node terminal and sets it's score.
   void MakeTerminal(GameResult result, float plies_left = 0.0f,
                     Terminal type = Terminal::EndOfGame);
   // Makes the node not terminal and updates its visits.
   void MakeNotTerminal();
+  void SetNodeLimitFrozen(bool value);
+  void SetNodeLimitFrozenLock(bool value);
+  bool GetNodeLimitFrozen();
+  bool GetNodeLimitFrozenLock();
+  uint8_t GetVisitedNumberOfEdges();
+  void SetVisitedNumberOfEdges(int value);
   void SetBounds(GameResult lower, GameResult upper);
 
   // If this node is not in the process of being expanded by another thread
@@ -319,6 +336,7 @@ class Node {
   // 1 byte fields.
   // Number of edges in @edges_.
   uint8_t num_edges_ = 0;
+  uint8_t num_visited_edges_ = 0;  
 
   // Bit fields using parts of uint8_t fields initialized in the constructor.
   // Whether or not this node end game (with a winning of either sides or draw).
@@ -328,6 +346,8 @@ class Node {
   GameResult upper_bound_ : 2;
   // Whether the child_ is actually an array of equal length to edges.
   bool solid_children_ : 1;
+  bool node_limit_frozen_ = false;
+  bool node_limit_frozen_lock_ = false;  
 
   // TODO(mooskagh) Unfriend NodeTree.
   friend class NodeTree;

--- a/src/search/classic/params.cc
+++ b/src/search/classic/params.cc
@@ -287,6 +287,18 @@ const OptionId BaseSearchParams::kNoiseAlphaId{
                   "probabilities. Larger values result in flatter / more "
                   "evenly distributed values.",
      .visibility = OptionId::kProOnly}};
+const OptionId BaseSearchParams::kScLimitId{
+    {.long_flag = "search-contempt-node-limit",
+     .uci_option = "ScLimit",
+     .help_text = "UCT until this number of nodes "
+                  "thompson sampling beyond this limit.",
+     .visibility = OptionId::kProOnly}};
+const OptionId BaseSearchParams::kScTemperatureId{
+    {.long_flag = "search-contempt-temperature",
+     .uci_option = "ScTemperature",
+     .help_text = "Softmax temperature that is applied to visit distribution "
+                  "for thompson sampling after node is frozen. Default value is 1.",
+     .visibility = OptionId::kProOnly}};
 const OptionId BaseSearchParams::kVerboseStatsId{
     "verbose-move-stats", "VerboseMoveStats",
     "Display Q, V, N, U and P values of every move candidate after each move.",
@@ -558,6 +570,8 @@ void BaseSearchParams::Populate(OptionsParser* options) {
       0.0f;
   options->Add<FloatOption>(kNoiseEpsilonId, 0.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kNoiseAlphaId, 0.0f, 10000000.0f) = 0.3f;
+  options->Add<IntOption>(kScLimitId, -1000000000, 1000000000) = 1000000000;
+  options->Add<FloatOption>(kScTemperatureId, 0.0f, 1.0f) = 1.0f;
   options->Add<BoolOption>(kVerboseStatsId) = false;
   options->Add<BoolOption>(kLogLiveStatsId) = false;
   std::vector<std::string> fpu_strategy = {"reduction", "absolute"};

--- a/src/search/classic/params.h
+++ b/src/search/classic/params.h
@@ -83,6 +83,8 @@ class BaseSearchParams {
   }
   float GetNoiseEpsilon() const { return kNoiseEpsilon; }
   float GetNoiseAlpha() const { return kNoiseAlpha; }
+  int GetScLimit() const { return options_.Get<int>(kScLimitId); }
+  float GetScTemperature() const { return options_.Get<float>(kScTemperatureId); }
   bool GetVerboseStats() const { return options_.Get<bool>(kVerboseStatsId); }
   bool GetLogLiveStats() const { return options_.Get<bool>(kLogLiveStatsId); }
   bool GetFpuAbsolute(bool at_root) const {
@@ -178,6 +180,8 @@ class BaseSearchParams {
   static const OptionId kTemperatureVisitOffsetId;
   static const OptionId kNoiseEpsilonId;
   static const OptionId kNoiseAlphaId;
+  static const OptionId kScLimitId;
+  static const OptionId kScTemperatureId;
   static const OptionId kVerboseStatsId;
   static const OptionId kLogLiveStatsId;
   static const OptionId kFpuStrategyId;

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -35,6 +35,7 @@
 #include <iterator>
 #include <sstream>
 #include <thread>
+#include <random>
 
 #include "neural/encoder.h"
 #include "search/classic/node.h"
@@ -44,6 +45,40 @@
 
 namespace lczero {
 namespace classic {
+
+namespace {
+//binary search for Thompson Sampling (TS)
+int find_index (std::array<float,256> arr, int size, float val) {
+  int l1 = -1;
+  int l2 = size-1;
+  int l3;
+  float l1_val;
+  while (l2 - l1 >= 2) {
+    l3 = (l1 + l2)/2;
+    
+    if(l1 < 0) {
+      l1_val = -1;
+    } else {
+      l1_val = arr[l1];
+    }
+    
+    if (val < arr[l3]) {
+      l2 = l3;
+    } else if (val > arr[l3]) {
+      l1 = l3;
+    } else if (val == arr[l3]) {
+
+      if (val > l1_val) {
+        l2 = l3;
+      } else if (val < arr[l2]) {
+        l1 = l3;
+      }
+    }
+  }
+  return l2;
+}	
+
+}	
 
 namespace {
 // Maximum delay between outputting "uci info" when nothing interesting happens.
@@ -1586,6 +1621,7 @@ void SearchWorker::PickNodesToExtendTask(
 
   // These 2 are 'filled pre-emptively'.
   std::array<float, 256> current_pol;
+  std::array<float, 256> current_cumulative_pol_frozen;
   std::array<float, 256> current_util;
 
   // These 3 are 'filled on demand'.
@@ -1689,153 +1725,333 @@ void SearchWorker::PickNodesToExtendTask(
       const float draw_score = ((current_path.size() + base_depth) % 2 == 0)
                                    ? odd_draw_score
                                    : even_draw_score;
-      m_evaluator.SetParent(node);
-      float visited_pol = 0.0f;
-      for (Node* child : node->VisitedNodes()) {
-        int index = child->Index();
-        visited_pol += current_pol[index];
-        float q = child->GetQ(draw_score);
-        current_util[index] = q + m_evaluator.GetMUtility(child, q);
+
+      int opponent_node_limit_param = params_.GetScLimit();
+      int opponent_node_limit;
+      bool opponent_node_limit_param_positive;
+
+      if (opponent_node_limit_param > 0) {
+        opponent_node_limit = opponent_node_limit_param;
+        opponent_node_limit_param_positive = true;
+      } else if (opponent_node_limit_param < 0) {
+        opponent_node_limit = -opponent_node_limit_param;
+        opponent_node_limit_param_positive = false;
+      } else {
+        opponent_node_limit = 1;
+        opponent_node_limit_param_positive = true;
       }
-      const float fpu =
-          GetFpu(params_, node, is_root_node, draw_score, visited_pol);
-      for (int i = 0; i < max_needed; i++) {
-        if (current_util[i] == std::numeric_limits<float>::lowest()) {
-          current_util[i] = fpu + m_evaluator.GetDefaultMUtility();
+
+      bool root_stm = (search_->contempt_mode_ == ContemptMode::BLACK) ==
+                      search_->played_history_.Last().IsBlackToMove();
+      bool is_opponent_node;
+
+      if (opponent_node_limit_param_positive) {
+	// positive search-contempt      
+        is_opponent_node =
+        root_stm == ((current_path.size() + base_depth) % 2 == 0);
+      } else {
+	// negative search-contempt      
+        is_opponent_node =
+        root_stm == ((current_path.size() + base_depth) % 2 == 1);
+      }
+
+      // root node always uses PUCT
+      if (is_root_node) {
+        is_opponent_node = false;
+      }
+
+      int current_node_count = node->GetN();
+      bool node_limit_frozen = node->GetNodeLimitFrozen();
+      bool node_limit_frozen_lock = node->GetNodeLimitFrozenLock();      
+
+      // freeze policy distribution for opponent nodes with visits > ScLimit
+      if (is_opponent_node && current_node_count > opponent_node_limit) {
+        if( !(node_limit_frozen) ) {
+	  if ( !(node_limit_frozen_lock) ) {
+            node->SetNodeLimitFrozenLock(true);
+            float sum_n = 0;
+            float sum_p = 0;
+            int indchild = 0;
+            float sc_temperature = params_.GetScTemperature();
+            float sum_p_with_temp = 0;
+
+            for (Node* child : node->VisitedNodes()) {
+              sum_n = sum_n + child->GetN();
+              indchild++;
+            }
+
+            for (Node* child : node->VisitedNodes()) {
+              sum_p_with_temp = sum_p_with_temp + exp(log(child->GetN()/sum_n)/sc_temperature);
+            }
+
+            for (Node* child : node->VisitedNodes()) {
+              sum_p = sum_p + exp(log(child->GetN()/sum_n)/sc_temperature)/sum_p_with_temp;
+              if (sum_p > 1) { //avoid round-off error
+                sum_p = 1;
+              }
+              child->GetOwnEdge()->SetP_frozen(sum_p);
+            }
+
+            node->SetNodeLimitFrozen(true);
+            node->SetVisitedNumberOfEdges(indchild);
+            node->SetNodeLimitFrozenLock(false);
+          }
         }
       }
 
-      const float cpuct = ComputeCpuct(params_, node->GetN(), is_root_node);
-      const float puct_mult =
-          cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
-      int cache_filled_idx = -1;
-      while (cur_limit > 0) {
-        // Perform UCT for current node.
-        float best = std::numeric_limits<float>::lowest();
-        int best_idx = -1;
-        float best_without_u = std::numeric_limits<float>::lowest();
-        float second_best = std::numeric_limits<float>::lowest();
-        bool can_exit = false;
-        best_edge.Reset();
-        for (int idx = 0; idx < max_needed; ++idx) {
-          if (idx > cache_filled_idx) {
-            if (idx == 0) {
-              cur_iters[idx] = node->Edges();
+      node_limit_frozen = node->GetNodeLimitFrozen();
+      node_limit_frozen_lock = node->GetNodeLimitFrozenLock();
+
+      if (is_opponent_node && node_limit_frozen) { // Thompson sampling (TS) branch
+      
+        while (node_limit_frozen_lock) {
+          node_limit_frozen_lock = node->GetNodeLimitFrozenLock();
+        }
+        
+        std::mt19937_64 rng;
+        uint64_t timeSeed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+        std::seed_seq ss{uint32_t(timeSeed & 0xffffffff), uint32_t(timeSeed>>32)};
+        rng.seed(ss);
+        std::uniform_real_distribution<double> unif(0, 1);
+        node->CopyPolicy_frozen(max_needed, current_cumulative_pol_frozen.data());
+        int visited_num_nodes = int(node->GetVisitedNumberOfEdges());
+        std::array<int,256> tmp_visit_array;
+
+        for (int i = 0; i < visited_num_nodes; i++) {
+          tmp_visit_array[i] = 0;
+        }
+
+        for (int i = 0; i < cur_limit; i++) {
+          double currentRandomNumber = unif(rng);
+          float search_value = currentRandomNumber;
+          int number = find_index(current_cumulative_pol_frozen, visited_num_nodes, search_value);
+          tmp_visit_array[number] = tmp_visit_array[number] + 1;
+        }
+        
+	// This part of the TS is almost identical to the PUCT part
+        cur_limit=0;
+        int cache_filled_idx = -1;
+
+        for (int i = 0; i < visited_num_nodes; i++) {
+          bool can_exit = false;
+          best_edge.Reset();
+        
+          if (i > cache_filled_idx) {
+            if (i == 0) {
+              cur_iters[i] = node->Edges();
             } else {
-              cur_iters[idx] = cur_iters[idx - 1];
-              ++cur_iters[idx];
+              cur_iters[i] = cur_iters[i - 1];
+              ++cur_iters[i];
             }
-            current_nstarted[idx] = cur_iters[idx].GetNStarted();
+            current_nstarted[i] = cur_iters[i].GetNStarted();
           }
-          int nstarted = current_nstarted[idx];
-          const float util = current_util[idx];
-          if (idx > cache_filled_idx) {
-            current_score[idx] =
-                current_pol[idx] * puct_mult / (1 + nstarted) + util;
+        
+          if (i > cache_filled_idx) {
             cache_filled_idx++;
-          }
-          if (is_root_node) {
-            // If there's no chance to catch up to the current best node with
-            // remaining playouts, don't consider it.
-            // best_move_node_ could have changed since best_node_n was
-            // retrieved. To ensure we have at least one node to expand, always
-            // include current best node.
-            if (cur_iters[idx] != search_->current_best_edge_ &&
-                latest_time_manager_hints_.GetEstimatedRemainingPlayouts() <
-                    best_node_n - cur_iters[idx].GetN()) {
-              continue;
-            }
-            // If root move filter exists, make sure move is in the list.
-            if (!root_move_filter.empty() &&
-                std::find(root_move_filter.begin(), root_move_filter.end(),
-                          cur_iters[idx].GetMove()) == root_move_filter.end()) {
-              continue;
-            }
-          }
-
-          float score = current_score[idx];
-          if (score > best) {
-            second_best = best;
-            second_best_edge = best_edge;
-            best = score;
-            best_idx = idx;
-            best_without_u = util;
-            best_edge = cur_iters[idx];
-          } else if (score > second_best) {
-            second_best = score;
-            second_best_edge = cur_iters[idx];
-          }
+          }		       
+        
+          int new_visits = tmp_visit_array[i];
+          best_edge = cur_iters[i];
+        
           if (can_exit) break;
-          if (nstarted == 0) {
-            // One more loop will get 2 unvisited nodes, which is sufficient to
-            // ensure second best is correct. This relies upon the fact that
-            // edges are sorted in policy decreasing order.
-            can_exit = true;
-          }
-        }
-        int new_visits = 0;
-        if (second_best_edge) {
-          int estimated_visits_to_change_best = std::numeric_limits<int>::max();
-          if (best_without_u < second_best) {
-            const auto n1 = current_nstarted[best_idx] + 1;
-            estimated_visits_to_change_best = static_cast<int>(
-                std::max(1.0f, std::min(current_pol[best_idx] * puct_mult /
-                                                (second_best - best_without_u) -
-                                            n1 + 1,
-                                        1e9f)));
-          }
-          second_best_edge.Reset();
-          max_limit = std::min(max_limit, estimated_visits_to_change_best);
-          new_visits = std::min(cur_limit, estimated_visits_to_change_best);
-        } else {
-          // No second best - only one edge, so everything goes in here.
-          new_visits = cur_limit;
-        }
-        if (best_idx >= vtp_last_filled.back()) {
-          auto* vtp_array = visits_to_perform.back().get()->data();
-          std::fill(vtp_array + (vtp_last_filled.back() + 1),
-                    vtp_array + best_idx + 1, 0);
-        }
-        (*visits_to_perform.back())[best_idx] += new_visits;
-        cur_limit -= new_visits;
-        Node* child_node = best_edge.GetOrSpawnNode(/* parent */ node);
+        
+          if (new_visits > 0) { // This is added since some nodes may not get any visits in TS
+        
+            if (i >= vtp_last_filled.back()) {
+              auto* vtp_array = visits_to_perform.back().get()->data();
+              std::fill(vtp_array + (vtp_last_filled.back() + 1),
+                        vtp_array + i + 1, 0);
+            }
+            (*visits_to_perform.back())[i] += new_visits;
+            Node* child_node = best_edge.GetOrSpawnNode(/* parent */ node);
+          
+            // Probably best place to check for two-fold draws consistently.
+            // Depth starts with 1 at root, so real depth is depth - 1.
+            EnsureNodeTwoFoldCorrectForDepth(
+                child_node, current_path.size() + base_depth + 1 - 1);		       
+          
+            bool decremented = false;
+          
+            if (child_node->TryStartScoreUpdate()) {
+              current_nstarted[i]++;
+              new_visits -= 1;
+              decremented = true;
+              if (child_node->GetN() > 0 && !child_node->IsTerminal()) {
+                child_node->IncrementNInFlight(new_visits);
+                current_nstarted[i] += new_visits;
+              }
+            }
+          
+            if ((decremented &&
+                 (child_node->GetN() == 0 || child_node->IsTerminal()))) {
+              // Reduce 1 for the visits_to_perform to ensure the collision created
+              // doesn't include this visit.
+              (*visits_to_perform.back())[i] -= 1;
+              receiver->push_back(NodeToProcess::Visit(
+                  child_node,
+                  static_cast<uint16_t>(current_path.size() + 1 + base_depth)));
+              completed_visits++;
+              receiver->back().moves_to_visit.reserve(moves_to_path.size() + 1);
+              receiver->back().moves_to_visit = moves_to_path;
+              receiver->back().moves_to_visit.push_back(best_edge.GetMove());
+            }
+          
+            if (i > vtp_last_filled.back() &&
+                (*visits_to_perform.back())[i] > 0) {
+              vtp_last_filled.back() = i;
+            }
+          }		       
+        }	       
+      } else { // End of TS 'if' branch, begin the PUCT else branch
 
-        // Probably best place to check for two-fold draws consistently.
-        // Depth starts with 1 at root, so real depth is depth - 1.
-        EnsureNodeTwoFoldCorrectForDepth(
-            child_node, current_path.size() + base_depth + 1 - 1);
-
-        bool decremented = false;
-        if (child_node->TryStartScoreUpdate()) {
-          current_nstarted[best_idx]++;
-          new_visits -= 1;
-          decremented = true;
-          if (child_node->GetN() > 0 && !child_node->IsTerminal()) {
-            child_node->IncrementNInFlight(new_visits);
-            current_nstarted[best_idx] += new_visits;
+        m_evaluator.SetParent(node);
+        float visited_pol = 0.0f;
+        for (Node* child : node->VisitedNodes()) {
+          int index = child->Index();
+          visited_pol += current_pol[index];
+          float q = child->GetQ(draw_score);
+          current_util[index] = q + m_evaluator.GetMUtility(child, q);
+        }
+        const float fpu =
+            GetFpu(params_, node, is_root_node, draw_score, visited_pol);
+        for (int i = 0; i < max_needed; i++) {
+          if (current_util[i] == std::numeric_limits<float>::lowest()) {
+            current_util[i] = fpu + m_evaluator.GetDefaultMUtility();
           }
-          current_score[best_idx] = current_pol[best_idx] * puct_mult /
-                                        (1 + current_nstarted[best_idx]) +
-                                    current_util[best_idx];
         }
-        if ((decremented &&
-             (child_node->GetN() == 0 || child_node->IsTerminal()))) {
-          // Reduce 1 for the visits_to_perform to ensure the collision created
-          // doesn't include this visit.
-          (*visits_to_perform.back())[best_idx] -= 1;
-          receiver->push_back(NodeToProcess::Visit(
-              child_node,
-              static_cast<uint16_t>(current_path.size() + 1 + base_depth)));
-          completed_visits++;
-          receiver->back().moves_to_visit.reserve(moves_to_path.size() + 1);
-          receiver->back().moves_to_visit = moves_to_path;
-          receiver->back().moves_to_visit.push_back(best_edge.GetMove());
+  
+        const float cpuct = ComputeCpuct(params_, node->GetN(), is_root_node);
+        const float puct_mult =
+            cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
+        int cache_filled_idx = -1;
+        while (cur_limit > 0) {
+          // Perform UCT for current node.
+          float best = std::numeric_limits<float>::lowest();
+          int best_idx = -1;
+          float best_without_u = std::numeric_limits<float>::lowest();
+          float second_best = std::numeric_limits<float>::lowest();
+          bool can_exit = false;
+          best_edge.Reset();
+          for (int idx = 0; idx < max_needed; ++idx) {
+            if (idx > cache_filled_idx) {
+              if (idx == 0) {
+                cur_iters[idx] = node->Edges();
+              } else {
+                cur_iters[idx] = cur_iters[idx - 1];
+                ++cur_iters[idx];
+              }
+              current_nstarted[idx] = cur_iters[idx].GetNStarted();
+            }
+            int nstarted = current_nstarted[idx];
+            const float util = current_util[idx];
+            if (idx > cache_filled_idx) {
+              current_score[idx] =
+                  current_pol[idx] * puct_mult / (1 + nstarted) + util;
+              cache_filled_idx++;
+            }
+            if (is_root_node) {
+              // If there's no chance to catch up to the current best node with
+              // remaining playouts, don't consider it.
+              // best_move_node_ could have changed since best_node_n was
+              // retrieved. To ensure we have at least one node to expand, always
+              // include current best node.
+              if (cur_iters[idx] != search_->current_best_edge_ &&
+                  latest_time_manager_hints_.GetEstimatedRemainingPlayouts() <
+                      best_node_n - cur_iters[idx].GetN()) {
+                continue;
+              }
+              // If root move filter exists, make sure move is in the list.
+              if (!root_move_filter.empty() &&
+                  std::find(root_move_filter.begin(), root_move_filter.end(),
+                            cur_iters[idx].GetMove()) == root_move_filter.end()) {
+                continue;
+              }
+            }
+  
+            float score = current_score[idx];
+            if (score > best) {
+              second_best = best;
+              second_best_edge = best_edge;
+              best = score;
+              best_idx = idx;
+              best_without_u = util;
+              best_edge = cur_iters[idx];
+            } else if (score > second_best) {
+              second_best = score;
+              second_best_edge = cur_iters[idx];
+            }
+            if (can_exit) break;
+            if (nstarted == 0) {
+              // One more loop will get 2 unvisited nodes, which is sufficient to
+              // ensure second best is correct. This relies upon the fact that
+              // edges are sorted in policy decreasing order.
+              can_exit = true;
+            }
+          }
+          int new_visits = 0;
+          if (second_best_edge) {
+            int estimated_visits_to_change_best = std::numeric_limits<int>::max();
+            if (best_without_u < second_best) {
+              const auto n1 = current_nstarted[best_idx] + 1;
+              estimated_visits_to_change_best = static_cast<int>(
+                  std::max(1.0f, std::min(current_pol[best_idx] * puct_mult /
+                                                  (second_best - best_without_u) -
+                                              n1 + 1,
+                                          1e9f)));
+            }
+            second_best_edge.Reset();
+            max_limit = std::min(max_limit, estimated_visits_to_change_best);
+            new_visits = std::min(cur_limit, estimated_visits_to_change_best);
+          } else {
+            // No second best - only one edge, so everything goes in here.
+            new_visits = cur_limit;
+          }
+          if (best_idx >= vtp_last_filled.back()) {
+            auto* vtp_array = visits_to_perform.back().get()->data();
+            std::fill(vtp_array + (vtp_last_filled.back() + 1),
+                      vtp_array + best_idx + 1, 0);
+          }
+          (*visits_to_perform.back())[best_idx] += new_visits;
+          cur_limit -= new_visits;
+          Node* child_node = best_edge.GetOrSpawnNode(/* parent */ node);
+  
+          // Probably best place to check for two-fold draws consistently.
+          // Depth starts with 1 at root, so real depth is depth - 1.
+          EnsureNodeTwoFoldCorrectForDepth(
+              child_node, current_path.size() + base_depth + 1 - 1);
+  
+          bool decremented = false;
+          if (child_node->TryStartScoreUpdate()) {
+            current_nstarted[best_idx]++;
+            new_visits -= 1;
+            decremented = true;
+            if (child_node->GetN() > 0 && !child_node->IsTerminal()) {
+              child_node->IncrementNInFlight(new_visits);
+              current_nstarted[best_idx] += new_visits;
+            }
+            current_score[best_idx] = current_pol[best_idx] * puct_mult /
+                                          (1 + current_nstarted[best_idx]) +
+                                      current_util[best_idx];
+          }
+          if ((decremented &&
+               (child_node->GetN() == 0 || child_node->IsTerminal()))) {
+            // Reduce 1 for the visits_to_perform to ensure the collision created
+            // doesn't include this visit.
+            (*visits_to_perform.back())[best_idx] -= 1;
+            receiver->push_back(NodeToProcess::Visit(
+                child_node,
+                static_cast<uint16_t>(current_path.size() + 1 + base_depth)));
+            completed_visits++;
+            receiver->back().moves_to_visit.reserve(moves_to_path.size() + 1);
+            receiver->back().moves_to_visit = moves_to_path;
+            receiver->back().moves_to_visit.push_back(best_edge.GetMove());
+          }
+          if (best_idx > vtp_last_filled.back() &&
+              (*visits_to_perform.back())[best_idx] > 0) {
+            vtp_last_filled.back() = best_idx;
+          }
         }
-        if (best_idx > vtp_last_filled.back() &&
-            (*visits_to_perform.back())[best_idx] > 0) {
-          vtp_last_filled.back() = best_idx;
-        }
-      }
+      } // finish PUCT section of the 'if' branch 
       is_root_node = false;
       // Actively do any splits now rather than waiting for potentially long
       // tree walk to get there.


### PR DESCRIPTION
-search-contempt implementation on the current master branch
-added support for negative search-contempt, first suggested by Lucario6607 from discord
-added a new parameter ScTemperature, which does a softmax on the visit distribution of frozen nodes. This might mitigate some of the "blunders" observed in the odds bot, though it is recommended to leave it at the default value of 1
-no hit in nps observed with the default value of ScLimit which is 1000000000
-with lower values of ScLimit, nps actually improves