### PR TITLE
build onnx on linux ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,11 @@ jobs:
             pip3 install meson==0.63
             pip3 install ninja
       - run:
+          name: Install onnxruntime
+          command: |
+            wget https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-linux-x64-1.22.0.tgz -P /tmp
+            tar xzf /tmp/onnxruntime-linux-x64-1.22.0.tgz -C /tmp
+      - run:
           name: "Pull Submodules"
           command: git submodule update --init
       - run:
@@ -20,13 +25,13 @@ jobs:
           environment:
             CC: gcc-10
             CXX: g++-10
-          command: meson build-gcc -Dgtest=false
+          command: meson build-gcc -Dgtest=false -Donnx_include=/tmp/onnxruntime-linux-x64-1.22.0/include -Donnx_libdir=/tmp/onnxruntime-linux-x64-1.22.0/lib
       - run:
           name: Meson Clang
           environment:
             CC: clang-12
             CXX: clang++-12
-          command: meson build-clang -Dgtest=false -Db_lto=false
+          command: meson build-clang -Dgtest=false -Db_lto=false -Donnx_include=/tmp/onnxruntime-linux-x64-1.22.0/include -Donnx_libdir=/tmp/onnxruntime-linux-x64-1.22.0/lib
       - run:
           name: Build GCC
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           name: Install build tools
           command: |
             apt-get update
-            apt-get -y install git python3-pip gcc-10 g++-10 clang-12 zlib1g zlib1g-dev
+            apt-get -y install git python3-pip gcc-10 g++-10 clang-12 zlib1g zlib1g-dev wget
             pip3 install meson==0.63
             pip3 install ninja
       - run:

--- a/src/neural/backends/network_onnx.cc
+++ b/src/neural/backends/network_onnx.cc
@@ -28,8 +28,10 @@
 #include <algorithm>
 #include <cassert>
 #include <fstream>
+#include <iomanip>
 #include <iterator>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -333,9 +335,11 @@ Ort::SessionOptions OnnxNetwork::GetOptions(int gpu, int threads,
       trt_options["trt_min_subgraph_size"] = "1";
       trt_options["trt_engine_cache_enable"] = "1";
       // We need the batch size as well as the hash, as it is set after loading.
+      std::ostringstream oss;
+      oss << std::hex << hash;
       trt_options["trt_engine_cache_prefix"] =
           "Lc0_ONNX_TRT_ORT_" + Ort::GetVersionString() + "_batch_" +
-          std::to_string(batch_size) + "_" + std::format("{:x}", hash) + "_";
+          std::to_string(batch_size) + "_" + oss.str() + "_";
       trt_options["trt_engine_cache_path"] = cache_dir;
       trt_options["trt_timing_cache_enable"] = "1";
       trt_options["trt_timing_cache_path"] = cache_dir;


### PR DESCRIPTION
Also replaces the call to `std::format()` that needs a newer c++ library