### PR TITLE
Avoid incrementing shared pointer when accessing low node

### DIFF
--- a/src/search/dag_classic/node.h
+++ b/src/search/dag_classic/node.h
@@ -287,7 +287,7 @@ class Node {
   float GetP() const { return edge_.GetP(); }
   void SetP(float val) { edge_.SetP(val); }
 
-  std::shared_ptr<LowNode> GetLowNode() const { return low_node_; }
+  const std::shared_ptr<LowNode>& GetLowNode() const { return low_node_; }
 
   void SetLowNode(std::shared_ptr<LowNode> low_node);
   void UnsetLowNode();

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -2191,7 +2191,7 @@ void SearchWorker::DoBackupUpdateSingleNode(
   // For the first visit to a terminal, maybe update parent bounds too.
   auto update_parent_bounds =
       params_.GetStickyEndgames() && n->IsTerminal() && !n->GetN();
-  auto nl = n->GetLowNode();
+  const auto& nl = n->GetLowNode();
   float v = 0.0f;
   float d = 0.0f;
   float m = 0.0f;
@@ -2245,7 +2245,7 @@ void SearchWorker::DoBackupUpdateSingleNode(
     // Nothing left to do without ancestors to update.
     if (++it == path.crend()) break;
     auto [p, pr, pm] = *it;
-    auto pl = p->GetLowNode();
+    const auto& pl = p->GetLowNode();
 
     assert(!p->IsTerminal() ||
            (p->IsTerminal() && pl->IsTerminal() && p->GetWL() == -pl->GetWL() &&
@@ -2347,7 +2347,7 @@ bool SearchWorker::MaybeSetBounds(Node* p, float m, uint32_t* n_to_fix,
   //        Win ( 1, 1) -> (-1,-1) Loss
 
   // Nothing left to do for ancestors if the parent would be a regular node.
-  auto pl = p->GetLowNode();
+  const auto& pl = p->GetLowNode();
   if (lower == GameResult::BLACK_WON && upper == GameResult::WHITE_WON) {
     return false;
   } else if (lower == upper) {

--- a/src/search/dag_classic/search.h
+++ b/src/search/dag_classic/search.h
@@ -361,7 +361,7 @@ class SearchWorker {
       for (auto it = path.cbegin(); it != path.cend(); ++it) {
         if (it != path.cbegin()) oss << "->";
         auto n = std::get<0>(*it);
-        auto nl = n->GetLowNode();
+        const auto& nl = n->GetLowNode();
         oss << n << ":" << n->GetNInFlight();
         if (nl) {
           oss << "(" << nl << ")";


### PR DESCRIPTION
A copy of shared ptr requires atomic increment and decrement operations. These use hardware level locking mechanism which have a small extra cost. The extra cost should be avoided in an inner loops when reading values from the node. The reference is only valid when holding nodes mutex.