### PR TITLE
Update build for C++17 minimum standard

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -510,7 +510,7 @@ if get_option('build_backends')
         cuda_arguments += ['-Xcompiler', '-MD']
       endif
     else
-      cuda_arguments += ['--std=c++14', '-Xcompiler', '-fPIC']
+      cuda_arguments += ['--std=c++17', '-Xcompiler', '-fPIC']
     endif
     if get_option('nvcc_ccbin') != ''
       cuda_arguments += ['-ccbin=' + get_option('nvcc_ccbin')]


### PR DESCRIPTION
Update build for C++17 minimum standard: CUDA std=c++17, remove C++14 compatibility