### PR TITLE
Refactor to use const refs and std::move for efficiency; 

### DIFF
--- a/src/neural/backends/network_mux.cc
+++ b/src/neural/backends/network_mux.cc
@@ -62,7 +62,7 @@ class MuxingComputation : public NetworkComputation {
     return parent_->GetPVal(sample + idx_in_parent_, move_id);
   }
 
-  void PopulateToParent(std::shared_ptr<NetworkComputation> parent) {
+  void PopulateToParent(const std::shared_ptr<NetworkComputation>& parent) {
     // Populate our batch into batch of batches.
     parent_ = parent;
     idx_in_parent_ = parent->GetBatchSize();

--- a/src/neural/factory.cc
+++ b/src/neural/factory.cc
@@ -28,6 +28,7 @@
 #include "neural/factory.h"
 
 #include <algorithm>
+#include <utility>
 
 #include "default_backend.h"
 #include "neural/loader.h"
@@ -44,7 +45,7 @@ NetworkFactory* NetworkFactory::Get() {
 
 NetworkFactory::Register::Register(const std::string& name, FactoryFunc factory,
                                    int priority) {
-  NetworkFactory::Get()->RegisterNetwork(name, factory, priority);
+  NetworkFactory::Get()->RegisterNetwork(name, std::move(factory), priority);
 }
 
 void NetworkFactory::RegisterNetwork(const std::string& name,

--- a/src/neural/onnx/adapters.cc
+++ b/src/neural/onnx/adapters.cc
@@ -37,7 +37,7 @@ namespace lczero {
 namespace {
 template <class T>
 std::string TransposeAndReturnRaw(const std::vector<int>& dims,
-                                  std::vector<int> order,
+                                  const std::vector<int>& order,
                                   const std::vector<T>& from) {
   if (order.empty()) {
     return {reinterpret_cast<const char*>(from.data()),

--- a/src/neural/onnx/converter.cc
+++ b/src/neural/onnx/converter.cc
@@ -169,10 +169,10 @@ class Converter {
   std::unique_ptr<OnnxConst> GetScalarConverter(float in);
 
   std::string StartOptionalBf16Fix(OnnxBuilder* builder, std::string flow,
-                                   std::string name);
+                                   const std::string& name);
 
   std::string EndOptionalBf16Fix(OnnxBuilder* builder, std::string flow,
-                                 std::string name);
+                                 const std::string& name);
 
   const pblczero::Net& src_;
   const WeightsToOnnxConverterOptions& options_;
@@ -228,7 +228,7 @@ std::unique_ptr<OnnxConst> Converter::GetScalarConverter(float in) {
 
 std::string Converter::StartOptionalBf16Fix(OnnxBuilder* builder,
                                             std::string flow,
-                                            std::string name) {
+                                            const std::string& name) {
   if (options_.opset >= 22 ||
       options_.data_type !=
           WeightsToOnnxConverterOptions::DataType::kBFloat16) {
@@ -238,7 +238,8 @@ std::string Converter::StartOptionalBf16Fix(OnnxBuilder* builder,
 }
 
 std::string Converter::EndOptionalBf16Fix(OnnxBuilder* builder,
-                                          std::string flow, std::string name) {
+                                          std::string flow, const std::string&
+                                          name) {
   if (options_.opset >= 22 ||
       options_.data_type !=
           WeightsToOnnxConverterOptions::DataType::kBFloat16) {

--- a/src/neural/wrapper.cc
+++ b/src/neural/wrapper.cc
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 #include <numeric>
+#include <utility>
 
 #include "neural/encoder.h"
 #include "neural/shared_params.h"
@@ -38,7 +39,7 @@
 namespace lczero {
 namespace {
 
-FillEmptyHistory EncodeHistoryFill(std::string history_fill) {
+FillEmptyHistory EncodeHistoryFill(const std::string& history_fill) {
   if (history_fill == "fen_only") return FillEmptyHistory::FEN_ONLY;
   if (history_fill == "always") return FillEmptyHistory::ALWAYS;
   assert(history_fill == "no");
@@ -174,7 +175,7 @@ std::unique_ptr<BackendComputation> NetworkAsBackend::CreateComputation() {
 NetworkAsBackendFactory::NetworkAsBackendFactory(const std::string& name,
                                                  FactoryFunc factory,
                                                  int priority)
-    : name_(name), factory_(factory), priority_(priority) {}
+    : name_(name), factory_(std::move(factory)), priority_(priority) {}
 
 std::unique_ptr<Backend> NetworkAsBackendFactory::Create(
     const OptionsDict& options) {

--- a/src/search/classic/params.cc
+++ b/src/search/classic/params.cc
@@ -47,14 +47,14 @@ namespace lczero {
 namespace classic {
 
 namespace {
-FillEmptyHistory EncodeHistoryFill(std::string history_fill) {
+FillEmptyHistory EncodeHistoryFill(const std::string& history_fill) {
   if (history_fill == "fen_only") return FillEmptyHistory::FEN_ONLY;
   if (history_fill == "always") return FillEmptyHistory::ALWAYS;
   assert(history_fill == "no");
   return FillEmptyHistory::NO;
 }
 
-float GetContempt(std::string name, std::string contempt_str,
+float GetContempt(std::string name, const std::string& contempt_str,
                   float uci_rating_adv) {
   float contempt = uci_rating_adv;
   for (auto& entry : StrSplit(contempt_str, ",")) {

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -35,6 +35,7 @@
 #include <iterator>
 #include <sstream>
 #include <thread>
+#include <utility>
 
 #include "neural/encoder.h"
 #include "search/classic/node.h"
@@ -474,12 +475,12 @@ std::vector<std::string> Search::GetVerboseStats(const Node* node) const {
   }
   std::sort(edges.begin(), edges.end());
 
-  auto print = [](auto* oss, auto pre, auto v, auto post, auto w, int p = 0) {
+  auto print = [](auto* oss, auto pre, const auto& v, auto post, auto w, int p = 0) {
     *oss << pre << std::setw(w) << std::setprecision(p) << v << post;
   };
   auto print_head = [&](auto* oss, auto label, int i, auto n, auto f, auto p) {
     *oss << std::fixed;
-    print(oss, "", label, " ", 5);
+    print(oss, "", std::move(label), " ", 5);
     print(oss, "(", i, ") ", 4);
     *oss << std::right;
     print(oss, "N: ", n, " ", 7);

--- a/src/tools/backendbench.cc
+++ b/src/tools/backendbench.cc
@@ -51,9 +51,11 @@ const OptionId kFenId{"fen", "", "Benchmark initial position FEN."};
 
 const OptionId kClippyId{"clippy", "", "Enable helpful assistant."};
 
-void Clippy(std::string title, std::string msg3, std::string best3,
-            std::string msg2, std::string best2, std::string msg,
-            std::string best) {
+void Clippy(const std::string& title, const std::string& msg3, const std::string
+            & best3,
+            const std::string& msg2, const std::string& best2, const std::string
+            & msg,
+            const std::string& best) {
   std::cout << "  __" << std::endl;
   std::cout << " /  \\" << std::endl;
   std::cout << " |  |    " << std::string(title.length() + 2, '_') << std::endl;

--- a/src/trainingdata/reader.cc
+++ b/src/trainingdata/reader.cc
@@ -25,6 +25,8 @@
   Program grant you additional permission to convey the resulting work.
 */
 
+#include <utility>
+
 #include "trainingdata/reader.h"
 
 namespace lczero {
@@ -118,7 +120,7 @@ InputPlanes PlanesFromTrainingData(const V6TrainingData& data) {
 }
 
 TrainingDataReader::TrainingDataReader(std::string filename)
-    : filename_(filename) {
+    : filename_(std::move(filename)) {
   fin_ = gzopen(filename_.c_str(), "rb");
   if (!fin_) {
     throw Exception("Cannot open gzip file " + filename_);

--- a/src/trainingdata/writer.cc
+++ b/src/trainingdata/writer.cc
@@ -25,6 +25,8 @@
   Program grant you additional permission to convey the resulting work.
 */
 
+#include <utility>
+
 #include "trainingdata/writer.h"
 
 #include "trainingdata/trainingdata.h"
@@ -61,7 +63,7 @@ TrainingDataWriter::TrainingDataWriter(int game_id) {
 }
 
 TrainingDataWriter::TrainingDataWriter(std::string filename)
-    : filename_(filename) {
+    : filename_(std::move(filename)) {
   fout_ = gzopen(filename_.c_str(), "wb");
   if (!fout_) throw Exception("Cannot create gzip file " + filename_);
 }


### PR DESCRIPTION
- Pass expensive-to-copy parameters as const references where possible
- Apply std::move to transfer ownership in constructors and factory registrations
- Update lambdas to take const refs for non-modified parameters
- Include <utility> in affected files to support std::move
ref: https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance/unnecessary-value-param.html