### PR TITLE
add support for fp16 encoded weights

### DIFF
--- a/src/utils/weights_adapter.h
+++ b/src/utils/weights_adapter.h
@@ -89,8 +89,10 @@ class LayerAdapter {
  private:
   const uint16_t* data_ = nullptr;
   const size_t size_ = 0;
+  const float max_;
   const float min_;
   const float range_;
+  const pblczero::Weights::Layer::Encoding encoding_;
 };
 
 }  // namespace lczero


### PR DESCRIPTION
Uses the `net.proto` from https://github.com/LeelaChessZero/lczero-common/pull/22