### PR TITLE
fixed size transposition table

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -226,6 +226,15 @@ if get_option('dag_classic')
     'src/search/dag_classic/wrapper.cc',
   ]
 
+  ## ~~~~~~~~~~
+  ## Transposition table
+  ## ~~~~~~~~~~
+  fix_tt = get_option('fixed_tt')
+  if fix_tt
+    # Change transposition table to a fixed size one.
+    add_project_arguments('-DFIX_TT', language : 'cpp')
+  endif
+
   deps += dependency('absl_flat_hash_map',
                      include_type: 'system',
                      fallback: ['abseil-cpp', 'absl_container_dep'],

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -258,3 +258,9 @@ option('dag_classic',
        type: 'boolean',
        value: true,
        description: 'Enable dag-classic search algorithm')
+
+option('fixed_tt',
+       type: 'boolean',
+       value: true,
+       description: 'Build dag using fixed size transposition table.')
+

--- a/src/search/dag_classic/node.h
+++ b/src/search/dag_classic/node.h
@@ -41,6 +41,7 @@
 #include "chess/gamestate.h"
 #include "chess/position.h"
 #include "neural/backend.h"
+#include "utils/cache.h"
 #include "utils/mutex.h"
 
 namespace lczero {
@@ -955,8 +956,12 @@ inline VisitedNode_Iterator<false> Node::VisitedNodes() {
 }
 
 // Transposition Table type for holding references to all low nodes in DAG.
+#ifndef FIX_TT
 typedef absl::flat_hash_map<uint64_t, std::weak_ptr<LowNode>>
     TranspositionTable;
+#else
+typedef HashKeyedCache<std::weak_ptr<LowNode>> TranspositionTable;
+#endif
 
 class NodeTree {
  public:

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -2245,32 +2245,30 @@ void SearchWorker::DoBackupUpdateSingleNode(
         node_to_process.hash, node_to_process.tt_low_node);
 #endif
     if (is_tt_miss) {
-#ifndef FIX_TT
-      assert(!tt_iter->second.expired());
-#endif
-      node_to_process.node->SetLowNode(node_to_process.tt_low_node);
 #ifdef FIX_TT
       search_->tt_->Insert(node_to_process.hash,
                            std::make_unique<std::weak_ptr<LowNode>>(
                                node_to_process.tt_low_node));
-#endif
-    } else {
-#ifndef FIX_TT
-      auto tt_low_node = tt_iter->second.lock();
 #else
+      assert(!tt_iter->second.expired());
+#endif
+      node_to_process.node->SetLowNode(node_to_process.tt_low_node);
+    } else {
+#ifdef FIX_TT
       auto tt_low_node = entry->lock();
       search_->tt_->Unpin(node_to_process.hash, entry);
+#else
+      auto tt_low_node = tt_iter->second.lock();
 #endif
       if (!tt_low_node) {
-#ifndef FIX_TT
-        tt_iter->second = node_to_process.tt_low_node;
-#endif
-        node_to_process.node->SetLowNode(node_to_process.tt_low_node);
 #ifdef FIX_TT
         search_->tt_->Insert(node_to_process.hash,
                              std::make_unique<std::weak_ptr<LowNode>>(
                                  node_to_process.tt_low_node));
+#else
+        tt_iter->second = node_to_process.tt_low_node;
 #endif
+        node_to_process.node->SetLowNode(node_to_process.tt_low_node);
       } else {
 #ifndef FIX_TT
         assert(!tt_iter->second.expired());

--- a/src/search/dag_classic/wrapper.cc
+++ b/src/search/dag_classic/wrapper.cc
@@ -50,7 +50,10 @@ const OptionId kClearTree{
      .visibility = OptionId::kProOnly}};
 
 #ifdef FIX_TT
-const OptionId kHashId{"hash", "Hash", "Size of the transposition table."};
+const OptionId kHashId{{.long_flag = "hash",
+                        .uci_option = "Hash",
+                        .help_text = "Size of the transposition table in MB.",
+                        .visibility = OptionId::kAlwaysVisible}};
 #endif
 
 class DagClassicSearch : public SearchBase {
@@ -122,7 +125,8 @@ void DagClassicSearch::SetPosition(const GameState& pos) {
   if (!is_same_game) time_manager_ = classic::MakeTimeManager(*options_);
 #ifdef FIX_TT
   // Transposition table size.
-  tt_.SetCapacity(options_->Get<int>(kHashId));
+  tt_.SetCapacity(options_->Get<int>(kHashId) * 1000000 /
+                  tt_.GetItemStructSize());
 #endif
 }
 
@@ -172,7 +176,7 @@ class DagClassicSearchFactory : public SearchFactory {
   void PopulateParams(OptionsParser* parser) const override {
     parser->Add<IntOption>(kThreadsOptionId, 0, 128) = 0;
 #ifdef FIX_TT
-    parser->Add<IntOption>(kHashId, 0, 999999999) = 2000000;
+    parser->Add<IntOption>(kHashId, 0, 2000) = 50;
 #endif
     SearchParams::Populate(parser);
     classic::PopulateTimeManagementOptions(classic::RunType::kUci, parser);


### PR DESCRIPTION
Can be enabled by the `FIX_TT` build option (on by default).
Introduces a new `Hash` uci option to control the size of the transposition table in MB (default 50).