### PR TITLE
Fix piece moves marked en passant

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -205,6 +205,11 @@ files += [
 
 includes += include_directories('src')
 
+deps += dependency('absl_flat_hash_map',
+                   include_type: 'system',
+                   fallback: ['abseil-cpp', 'absl_container_dep'],
+                   default_options : ['warning_level=0', 'cpp_std=c++20'])
+
 deps += dependency('threads')
 
 #############################################################################
@@ -225,11 +230,6 @@ if get_option('dag_classic')
     'src/search/dag_classic/search.cc',
     'src/search/dag_classic/wrapper.cc',
   ]
-
-  deps += dependency('absl_flat_hash_map',
-                     include_type: 'system',
-                     fallback: ['abseil-cpp', 'absl_container_dep'],
-                     default_options : ['warning_level=0', 'cpp_std=c++20'])
 endif
 
 #############################################################################

--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -598,6 +598,7 @@ bool ChessBoard::ApplyMove(Move move) {
   struct BoardValidate {
     const ChessBoard& board_;
     const Move move_;
+    BoardValidate(const ChessBoard& b, Move m) : board_(b), move_(m) {}
     ~BoardValidate() {
       assert(board_.IsValid(move_) && "after ChessBoard::ApplyMove");
     }

--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -573,8 +573,35 @@ MoveList ChessBoard::GeneratePseudolegalMoves() const {
   return result;
 }  // namespace lczero
 
+bool ChessBoard::IsValid(Move move) const {
+  const auto all = ours() | theirs();
+  auto check = all | pawns() | bishops() | rooks() | queens() | kings();
+  if (check != all ||
+      (pawns() & bishops()).as_int() ||
+      (pawns() & rooks()).as_int() ||
+      (pawns() & queens()).as_int() ||
+      (pawns() & kings()).as_int() ||
+      (bishops() & rooks()).as_int() ||
+      (bishops() & queens()).as_int() ||
+      (bishops() & kings()).as_int() ||
+      (rooks() & queens()).as_int() ||
+      (rooks() & kings()).as_int() ||
+      (queens() & kings()).as_int()) {
+    CERR << DebugString() << " " << move.ToString(false);
+    return false;
+  }
+  return true;
+}
+
 bool ChessBoard::ApplyMove(Move move) {
   assert(our_pieces_.intersects(BitBoard::FromSquare(move.from())));
+  struct BoardValidate {
+    const ChessBoard& board_;
+    const Move move_;
+    ~BoardValidate() {
+      assert(board_.IsValid(move_) && "after ChessBoard::ApplyMove");
+    }
+  } validator(*this, move);
   const Square& from = move.from();
   const Square& to = move.to();
   const Rank from_rank = from.rank();

--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -1160,7 +1160,7 @@ Move ChessBoard::ParseMove(std::string_view move_str) const {
     // Qeenside castling.
     return Move::WhiteCastling(from.file(), kFileA);
   }
-  if (from.file() != to.file() && pawns_.get(from) && !their_pieces_.get(to)) {
+  if (from.file() != to.file() && pawns().get(from) && !their_pieces_.get(to)) {
     // En passant.
     return Move::WhiteEnPassant(from, to);
   }

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -231,9 +231,8 @@ class ChessBoard {
  private:
   // Sets the piece on the square.
   void PutPiece(Square square, PieceType piece, bool is_theirs);
-  // Check internal state is consistent after state transformations. Move can be
-  // passed to provide context when transformation is related to making a move.
-  bool IsValid(Move move = Move()) const;
+  // Check internal state is consistent after state transformations.
+  bool IsValid() const;
 
   // All white pieces.
   BitBoard our_pieces_;

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -231,6 +231,7 @@ class ChessBoard {
  private:
   // Sets the piece on the square.
   void PutPiece(Square square, PieceType piece, bool is_theirs);
+  bool IsValid(Move move) const;
 
   // All white pieces.
   BitBoard our_pieces_;

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -231,7 +231,9 @@ class ChessBoard {
  private:
   // Sets the piece on the square.
   void PutPiece(Square square, PieceType piece, bool is_theirs);
-  bool IsValid(Move move) const;
+  // Check internal state is consistent after state transformations. Move can be
+  // passed to provide context when transformation is related to making a move.
+  bool IsValid(Move move = Move()) const;
 
   // All white pieces.
   BitBoard our_pieces_;

--- a/src/chess/board_test.cc
+++ b/src/chess/board_test.cc
@@ -2236,6 +2236,20 @@ TEST(ChessBoard, InvalidEnPassantFromKnightPromotion) {
   EXPECT_TRUE(board.en_passant().empty());
 }
 
+// Move from an en-passant flag square was mistakenly marked as en-passant.
+TEST(ChessBoard, QueenMoveFromEnPassantFlagBug) {
+  ChessBoard board;
+  board.SetFromFen("1Qnkr3/1p1b4/p2P2p1/P1q5/1NP3pP/1KN5/8/3R4 b - - 0 32");
+  board.ApplyMove(board.ParseMove("b7b5"));
+  board.Mirror();
+  auto m = board.ParseMove("b8c7");
+  EXPECT_FALSE(m.is_en_passant());
+  board.ApplyMove(m);
+  board.Mirror();
+  MoveList legal_moves = {board.ParseMove("c5c7")};
+  EXPECT_EQ(board.GenerateLegalMoves(), legal_moves);
+}
+
 }  // namespace lczero
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Fix a bug where a piece move starting from opponent's backrank was marked as en passant. This could eliminate one of opponents pieces from the board state.

```
position fen r1bqk1nr/pp1nbpp1/2pp3p/3Pp3/2P1P3/2N1B3/PP2NPPP/R2QKB1R w KQkq - 0 1 moves e2g3 g7g6 f1e2 c6c5 d1d2 e7g5 g3f1 d8e7 f2f3 g5e3 f1e3 d7b6 h2h4 g8f6 g2g4 c8d7 b2b3 h6h5 g4g5 f6h7 a2a4 f7f6 g5f6 e7f6 e1c1 b6c8 d1f1 c8e7 e3g2 e8c8 f3f4 h8f8 c1c2 a7a6 a4a5 d8e8 g2e1 e5f4 e1d3 f6g7 f1f4 h7f6 b3b4 c5b4 d3b4 f6g4 h1f1 f8f4 d2f4 g7d4 e2g4 h5g4 c2b3 c8c7 f1d1 d4c5 e4e5 d6e5 f4e5 c7d8 e5b8 e7c8 d5d6 b7b5 b8c7
go nodes 2
bestmove a1a1
```