### PR TITLE
do onnx wdl softmax on the cpu

### DIFF
--- a/src/neural/onnx/converter.cc
+++ b/src/neural/onnx/converter.cc
@@ -1033,9 +1033,11 @@ void Converter::MakeValueHead(pblczero::OnnxModel* onnx, OnnxBuilder* builder,
                         *GetWeghtsConverter(head.ip2_val_w, {128, 3}, {1, 0}));
     flow = builder->Add("/value/dense2/add", flow,
                         *GetWeghtsConverter(head.ip2_val_b, {3}));
-    auto output = builder->Softmax(options_.output_wdl, flow);
-    builder->AddOutput(output, {options_.batch_size, 3}, GetDataType());
-    onnx->set_output_wdl(output);
+    if (!options_.no_wdl_softmax) {
+      flow = builder->Softmax(options_.output_wdl, flow);
+    }
+    builder->AddOutput(flow, {options_.batch_size, 3}, GetDataType());
+    onnx->set_output_wdl(flow);
   } else {
     flow =
         builder->MatMul("/value/dense2/matmul", flow,

--- a/src/neural/onnx/converter.h
+++ b/src/neural/onnx/converter.h
@@ -49,6 +49,7 @@ struct WeightsToOnnxConverterOptions {
   bool alt_mish = false;       // Use "Mish" approximation (fp32 only).
   bool alt_layernorm = false;  // Discrete "LayerNormalization" implementation.
   bool no_shape = false;       // Avoid use of "Shape" operator.
+  bool no_wdl_softmax = false; // Skip wdl softmax.
   std::string policy_head = "vanilla";
   std::string value_head = "winner";
 


### PR DESCRIPTION
Fixes the `Unexpectedly large drift correction for d based on q` reports when generating training data.