### PR TITLE
Remove Sycl dpct dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -651,26 +651,6 @@ if get_option('build_backends')
       add_project_arguments('-fsycl', language : 'cpp')
       add_project_link_arguments('-fsycl', language : 'cpp')
 
-      dpct_args = []
-      foreach onemkl_include : get_option('onemkl_include')
-        if run_command('scripts/checkdir.py', onemkl_include, check : false).returncode() == 0
-          includes += include_directories(onemkl_include, is_system: true)
-          dpct_args += '-I' + onemkl_include
-        endif
-      endforeach
-      # Check for oneMKL header which is used by DPC++ CT. It could also depend
-      # on oneMATH headers but L0 Sycl uses oneMKL kernels too.
-      cc.has_header('oneapi/mkl.hpp', required: true, args: dpct_args)
-
-      foreach dpct_include : get_option('dpct_include')
-        if run_command('scripts/checkdir.py', dpct_include, check : false).returncode() == 0
-          includes += include_directories(dpct_include, is_system: true)
-          dpct_args += '-I' + dpct_include
-        endif
-      endforeach
-      # Check for DPC++ Compatibility Tool header.
-      cc.has_header('dpct/dpct.hpp', required: true, args: dpct_args)
-
       files += 'src/neural/backends/sycl/layers.cc.dp.cpp'
       files += 'src/neural/backends/sycl/network_sycl.cc.dp.cpp'
       files += 'src/neural/backends/sycl/common_kernels.dp.cpp'
@@ -688,7 +668,7 @@ if get_option('build_backends')
         hip_libdirs = get_option('hip_libdirs')
         hip_args = []
         foreach hip_include : get_option('hip_include')
-          if run_command('scripts/checkdir.py', dpct_include, check : false).returncode() == 0
+          if run_command('scripts/checkdir.py', hip_include, check : false).returncode() == 0
             includes += include_directories(hip_include, is_system: true)
             hip_args += '-I' + hip_include
           endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -214,16 +214,6 @@ option('sycl',
        value: 'off',
        description: 'Enable SYCL backend')
 
-option('dpct_include',
-       type: 'array',
-       value: ['/opt/intel/oneapi/dpcpp-ct/latest/include'],
-       description: 'Path to DPC++ Compatibility Tool includes')
-
-option('onemkl_include',
-       type: 'array',
-       value: ['/opt/intel/oneapi/mkl/latest/include'],
-       description: 'Path to oneMKL includes')
-
 option('hip_libdirs',
        type: 'array',
        value: ['/opt/rocm/lib'],

--- a/src/neural/backends/sycl/fp16_kernels.dp.cpp
+++ b/src/neural/backends/sycl/fp16_kernels.dp.cpp
@@ -20,14 +20,9 @@
 */
 
 #include <sycl/sycl.hpp>
-#include "dpct/dpct.hpp"
 #include "sycl_common.h"
 #include "neural/backends/shared/activation.h"
 
-// Allow building on an old architecture.
-#if DPCT_COMPATIBILITY_TEMP < 530
-#define SKIP_FP16_BITS 1
-#endif
 #include "winograd_helper.h"
 
 namespace lczero {

--- a/src/neural/backends/sycl/kernels.h
+++ b/src/neural/backends/sycl/kernels.h
@@ -20,7 +20,6 @@
 */
 
 #include <sycl/sycl.hpp>
-#include "dpct/dpct.hpp"
 #include "sycl_common.h"
 #include "neural/backends/shared/activation.h"
 

--- a/src/neural/backends/sycl/layers.cc.dp.cpp
+++ b/src/neural/backends/sycl/layers.cc.dp.cpp
@@ -20,7 +20,6 @@
 */
 
 #include <sycl/sycl.hpp>
-#include "dpct/dpct.hpp"
 #include "layers.h"
 
 #include <cassert>
@@ -46,7 +45,6 @@
 #include "neural/network.h"
 #include "neural/tables/attention_policy_map.h"
 #include "utils/fp16_utils.h"
-#include "dpct/lib_common_utils.hpp"
 
 #include <cmath>
 

--- a/src/neural/backends/sycl/layers.h
+++ b/src/neural/backends/sycl/layers.h
@@ -22,8 +22,6 @@
 #pragma once
 
 #include <sycl/sycl.hpp>
-#include "dpct/dpct.hpp"
-#include "dpct/blas_utils.hpp"
 
 #include <cstddef>
 

--- a/src/neural/backends/sycl/network_sycl.cc.dp.cpp
+++ b/src/neural/backends/sycl/network_sycl.cc.dp.cpp
@@ -22,7 +22,6 @@
 #define DPCT_COMPAT_RT_VERSION 12020
 
 #include <sycl/sycl.hpp>
-#include "dpct/dpct.hpp"
 #include <algorithm>
 #include <cassert>
 #include <functional>

--- a/src/neural/backends/sycl/sycl_common.h
+++ b/src/neural/backends/sycl/sycl_common.h
@@ -22,8 +22,6 @@
 #pragma once
 
 #include <sycl/sycl.hpp>
-#include "dpct/dpct.hpp"
-#include "dpct/blas_utils.hpp"
 
 #include "utils/exception.h"
 

--- a/src/neural/backends/sycl/winograd_helper.h
+++ b/src/neural/backends/sycl/winograd_helper.h
@@ -20,12 +20,12 @@
 */
 
 #include <sycl/sycl.hpp>
-#include "dpct/dpct.hpp"
 
 namespace lczero {
 namespace sycldnn_backend {
 
-__dpct_inline__ float mishActivate(float el) {
+[[gnu::always_inline]]
+inline float mishActivate(float el) {
   auto e = sycl::native::exp(el);
   auto n = e * e + 2.0f * e;
   auto d = el / (n + 2.0f);
@@ -35,7 +35,8 @@ __dpct_inline__ float mishActivate(float el) {
     return el - 2.0f * d;
   }
 }
-__dpct_inline__ float activate(float cVal, ActivationFunction activation) {
+[[gnu::always_inline]]
+inline float activate(float cVal, ActivationFunction activation) {
   switch (activation) {
     case ACTIVATION_RELU:
       if (cVal < 0) cVal = 0;
@@ -69,7 +70,8 @@ __dpct_inline__ float activate(float cVal, ActivationFunction activation) {
 }
 
 template <typename T, int M, int N, int K>
-__dpct_inline__ void matrixMul_gpu_serial(T* c, const T* a, const T* b) {
+[[gnu::always_inline]]
+inline void matrixMul_gpu_serial(T* c, const T* a, const T* b) {
 #ifndef SKIP_FP16_BITS
 #pragma unroll
   for (int i = 0; i < M; ++i)
@@ -84,7 +86,8 @@ __dpct_inline__ void matrixMul_gpu_serial(T* c, const T* a, const T* b) {
 }
 
 template <typename T>
-__dpct_inline__ void FilterTransform4x4(T* transformed_filter,
+[[gnu::always_inline]]
+inline void FilterTransform4x4(T* transformed_filter,
                                         const T* filter) {
   // transform applied to filter (of size 3x3)
   T G[6 * 3] = {1.0f / 4,  0,         0,         -1.0f / 6,  -1.0f / 6,
@@ -102,7 +105,8 @@ __dpct_inline__ void FilterTransform4x4(T* transformed_filter,
 }
 
 template <typename T>
-__dpct_inline__ void InputTransform4x4(T* transformedInput, const T* input) {
+[[gnu::always_inline]]
+inline void InputTransform4x4(T* transformedInput, const T* input) {
   // transform applied to input tile (of size 4x4)
   const T Bt[6 * 6] = {4, 0, -5, 0,  1, 0, 0, -4, -4, 1,  1, 0,
                        0, 4, -4, -1, 1, 0, 0, -2, -1, 2,  1, 0,
@@ -118,7 +122,8 @@ __dpct_inline__ void InputTransform4x4(T* transformedInput, const T* input) {
 }
 
 template <typename T>
-__dpct_inline__ void OutputTransform4x4(T* output, const T* transformedOutput) {
+[[gnu::always_inline]]
+inline void OutputTransform4x4(T* output, const T* transformedOutput) {
   // transform applied to result
   const T At[4 * 6] = {1, 1, 1, 1, 1, 0, 0, 1, -1, 2, -2, 0,
                        0, 1, 1, 4, 4, 0, 0, 1, -1, 8, -8, 1};
@@ -442,7 +447,8 @@ void OutputTransform_kernel(int N, int C, int se_K, T* output,
 }
 
 // fast reduction for the warp
-__dpct_inline__ float warpReduce(float x, const sycl::nd_item<3>& item_ct1) {
+[[gnu::always_inline]]
+inline float warpReduce(float x, const sycl::nd_item<3>& item_ct1) {
 #pragma unroll
   for (int mask = 16; mask > 0; mask >>= 1)
     /*
@@ -458,13 +464,14 @@ __dpct_inline__ float warpReduce(float x, const sycl::nd_item<3>& item_ct1) {
     device. Modify the size of the work-group to ensure that the value of the
     right-most dimension is a multiple of "32".
     */
-    x += dpct::permute_sub_group_by_xor(item_ct1.get_sub_group(), x, mask);
+    x += sycl::permute_group_by_xor(item_ct1.get_sub_group(), x, mask);
 
   return x;
 }
 
 // fast max reduction for the warp
-__dpct_inline__ float warpMax(float x, const sycl::nd_item<3>& item_ct1) {
+[[gnu::always_inline]]
+inline float warpMax(float x, const sycl::nd_item<3>& item_ct1) {
 #pragma unroll
   for (int mask = 16; mask > 0; mask >>= 1)
     /*
@@ -480,29 +487,16 @@ __dpct_inline__ float warpMax(float x, const sycl::nd_item<3>& item_ct1) {
     device. Modify the size of the work-group to ensure that the value of the
     right-most dimension is a multiple of "32".
     */
-    x = sycl::max(x, (float)(dpct::permute_sub_group_by_xor(
+    x = sycl::max(x, (float)(sycl::permute_group_by_xor(
                          item_ct1.get_sub_group(), x, mask)));
 
   return x;
 }
 
-// atomic max implementation for floats
-__dpct_inline__ float atomicMaxFloat(float* addr, float val) {
-  float max;
-  max = !sycl::signbit(val)
-            ? sycl::bit_cast<float>(dpct::atomic_fetch_max<
-                                    sycl::access::address_space::generic_space>(
-                  (int*)addr, sycl::bit_cast<int>(val)))
-            : sycl::bit_cast<float>(dpct::atomic_fetch_min<
-                                    sycl::access::address_space::generic_space>(
-                  (unsigned int*)addr, sycl::bit_cast<unsigned int>(val)));
-
-  return max;
-}
-
 // Helper fuction to do vector loads/stores
 template <typename T>
-__dpct_inline__ void copyAs(void* dst, const void* src) {
+[[gnu::always_inline]]
+inline void copyAs(void* dst, const void* src) {
   *((T*)(dst)) = *((const T*)(src));
 }
 


### PR DESCRIPTION
Nightly build of DPC++ renames some experimental functions. These functions are used by dpct tool. This forced me to finally remove the dpct dependency from sycl.

I'm not 100% sure if my sub group communication and atomic changes are correct. Sycl documentation makes me thing this should be correct. I may have missed some key details because I was reading it for the first time.