### PR TITLE
Initialized activation functions in blas backend

### DIFF
--- a/src/neural/backends/blas/network_blas.cc
+++ b/src/neural/backends/blas/network_blas.cc
@@ -205,9 +205,9 @@ class BlasNetwork : public Network {
   bool attn_policy_;
   bool attn_body_;
   bool is_pe_dense_embedding_;
-  ActivationFunction default_activation_;
-  ActivationFunction smolgen_activation_;
-  ActivationFunction ffn_activation_;
+  ActivationFunction default_activation_ = ACTIVATION_NONE;
+  ActivationFunction smolgen_activation_ = ACTIVATION_NONE;
+  ActivationFunction ffn_activation_ = ACTIVATION_NONE;
   std::string policy_head_;
   std::string value_head_;
   std::mutex buffers_lock_;


### PR DESCRIPTION
Undefined behavior sanitizer reports invalid enum value when BlasComputation copies activation functions from the network. Activation functions are uninitialized when network doesn't use them. BlasComputation copies them unconditionally. Initializing activation function avoids the error report.