### PR TITLE
Fix man page for onnx2leela

### DIFF
--- a/src/tools/onnx2leela.cc
+++ b/src/tools/onnx2leela.cc
@@ -61,9 +61,9 @@ T GetEnumValueFromString(const std::string& str_value,
 }
 
 const OptionId kInputFilenameId{"input", "InputFile",
-                                "Path of the input Lc0 weights file."};
+                                "Path of the input ONNX file."};
 const OptionId kOutputFilenameId{"output", "OutputFile",
-                                 "Path of the output ONNX file."};
+                                 "Path of the output Lc0 weights file."};
 
 const OptionId kInputFormatId(
     "input-format", "InputFormat",


### PR DESCRIPTION
In the description of 'input' and 'output' which place between 'Lc0 weights' and 'ONNX' in the documentation of onnx2leela