### PR TITLE
onnx-coreml backend

### DIFF
--- a/src/neural/backends/network_onnx.cc
+++ b/src/neural/backends/network_onnx.cc
@@ -928,6 +928,7 @@ std::unique_ptr<Network> MakeOnnxNetwork(const std::optional<WeightsFile>& w,
     } else {
       bool fp16 = kProvider == OnnxProvider::CPU ? false : true;
 #if ORT_API_VERSION < 24
+      CERR << "WARNING: CoreML with onnxruntime before v1.24 is very slow.";
       if (kProvider == OnnxProvider::COREML) fp16 = false;
 #endif
       fp16 = opts.GetOrDefault<bool>("fp16", fp16);

--- a/src/neural/backends/network_onnx.cc
+++ b/src/neural/backends/network_onnx.cc
@@ -351,6 +351,7 @@ Ort::SessionOptions OnnxNetwork::GetOptions(int gpu, int threads,
       std::unordered_map<std::string, std::string> provider_options;
       provider_options["ModelFormat"] = "MLProgram";
       provider_options["ProfileComputePlan"] = "1";
+      provider_options["AllowLowPrecisionAccumulationOnGPU"] = "1";
       options.AppendExecutionProvider("CoreML", provider_options);
       break;
     }

--- a/src/neural/backends/network_onnx.cc
+++ b/src/neural/backends/network_onnx.cc
@@ -439,7 +439,7 @@ Ort::SessionOptions OnnxNetwork::GetOptions(int gpu, int threads,
 
 OnnxNetwork::OnnxNetwork(const WeightsFile& file, const OptionsDict& opts,
                          OnnxProvider provider, bool cpu_wdl)
-    : onnx_env_(ORT_LOGGING_LEVEL_WARNING, "lc0"),
+    : onnx_env_(ORT_LOGGING_LEVEL_VERBOSE, "lc0"),
       capabilities_{file.format().network_format().input(),
                     file.format().network_format().output(),
                     file.format().network_format().moves_left()},

--- a/src/neural/backends/network_onnx.cc
+++ b/src/neural/backends/network_onnx.cc
@@ -56,7 +56,7 @@
 namespace lczero {
 namespace {
 
-enum class OnnxProvider { CPU, CUDA, DML, ROCM, TRT };
+enum class OnnxProvider { CPU, CUDA, DML, ROCM, TRT, COREML };
 
 class OnnxNetwork;
 
@@ -347,6 +347,13 @@ Ort::SessionOptions OnnxNetwork::GetOptions(int gpu, int threads,
       throw Exception("ONNX backend internal error.");
 #endif
       break;
+    case OnnxProvider::COREML: {
+      std::unordered_map<std::string, std::string> provider_options;
+      provider_options["ModelFormat"] = "MLProgram";
+      provider_options["ProfileComputePlan"] = "1";
+      options.AppendExecutionProvider("CoreML", provider_options);
+      break;
+    }
     case OnnxProvider::TRT: {
       options.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
 
@@ -544,6 +551,7 @@ REGISTER_NETWORK("onnx-rocm", MakeOnnxNetwork<OnnxProvider::ROCM>, 64)
 #ifdef USE_DML
 REGISTER_NETWORK("onnx-dml", MakeOnnxNetwork<OnnxProvider::DML>, 63)
 #endif
+REGISTER_NETWORK("onnx-coreml", MakeOnnxNetwork<OnnxProvider::COREML>, 59)
 REGISTER_NETWORK("onnx-trt", MakeOnnxNetwork<OnnxProvider::TRT>, 60)
 REGISTER_NETWORK("onnx-cuda", MakeOnnxNetwork<OnnxProvider::CUDA>, 61)
 REGISTER_NETWORK("onnx-cpu", MakeOnnxNetwork<OnnxProvider::CPU>, 62)

--- a/src/neural/backends/network_onnx.cc
+++ b/src/neural/backends/network_onnx.cc
@@ -537,6 +537,8 @@ std::unique_ptr<Network> MakeOnnxNetwork(const std::optional<WeightsFile>& w,
     converter_options.value_head =
         opts.GetOrDefault<std::string>("value_head", "winner");
     converter_options.no_wdl_softmax = true;
+    converter_options.alt_selu =
+        kProvider == OnnxProvider::COREML ? true : false;
 
     std::string datatype;
     if (opts.Exists<std::string>("datatype")) {

--- a/src/neural/backends/network_onnx.cc
+++ b/src/neural/backends/network_onnx.cc
@@ -449,10 +449,18 @@ OnnxNetwork::OnnxNetwork(const WeightsFile& file, const OptionsDict& opts,
       cpu_wdl_(cpu_wdl),
       provider_(provider) {
   onnx_env_.DisableTelemetryEvents();
-  batch_size_ =
-      opts.GetOrDefault<int>("batch", provider == OnnxProvider::DML ? 16 : -1);
-  steps_ =
-      opts.GetOrDefault<int>("steps", provider == OnnxProvider::DML ? 4 : 1);
+  switch (provider) {
+    case OnnxProvider::DML:
+    case OnnxProvider::COREML:
+      batch_size_ = 16;
+      steps_ = 4;
+      break;
+    default:
+      batch_size_ = -1;
+      steps_ = 1;
+  }
+  batch_size_ = opts.GetOrDefault<int>("batch", batch_size_);
+  steps_ = opts.GetOrDefault<int>("steps", steps_);
   min_batch_size_ = opts.GetOrDefault<int>(
       "min_batch", provider == OnnxProvider::TRT ? 4 : 1);
   int gpu = opts.GetOrDefault<int>("gpu", 0);

--- a/src/neural/backends/onnx/network_onnx.cc
+++ b/src/neural/backends/onnx/network_onnx.cc
@@ -928,8 +928,10 @@ std::unique_ptr<Network> MakeOnnxNetwork(const std::optional<WeightsFile>& w,
     } else {
       bool fp16 = kProvider == OnnxProvider::CPU ? false : true;
 #if ORT_API_VERSION < 24
-      CERR << "WARNING: CoreML with onnxruntime before v1.24 is very slow.";
-      if (kProvider == OnnxProvider::COREML) fp16 = false;
+      if (kProvider == OnnxProvider::COREML) {
+        CERR << "WARNING: CoreML with onnxruntime before v1.24 is very slow.";
+        fp16 = false;
+      }
 #endif
       fp16 = opts.GetOrDefault<bool>("fp16", fp16);
       datatype = fp16 ? "f16" : "f32";

--- a/src/neural/onnx/builder.cc
+++ b/src/neural/onnx/builder.cc
@@ -298,6 +298,16 @@ std::string OnnxBuilder::Selu(const std::string& name,
   return PopulateStdNodeFields(node, name, input, "Selu");
 }
 
+std::string OnnxBuilder::Elu(const std::string& name, const std::string& input,
+                             float alpha) {
+  auto* node = model_.mutable_graph()->add_node();
+  auto out = PopulateStdNodeFields(node, name, input, "Elu");
+  if (alpha != 1.0f) {
+    AddFloatAttribute(node, "alpha", alpha);
+  }
+  return out;
+}
+
 std::vector<std::string> OnnxBuilder::Split(const std::string& name,
                                             const std::string& input, int axis,
                                             std::initializer_list<int> split) {

--- a/src/neural/onnx/builder.h
+++ b/src/neural/onnx/builder.h
@@ -98,6 +98,8 @@ class OnnxBuilder {
   std::string Pad(const std::string& name, const std::string& input,
                   std::initializer_list<int> pads);
   std::string Selu(const std::string& name, const std::string& input);
+  std::string Elu(const std::string& name, const std::string& input,
+                  float alpha = 1.0);
   std::string Slice(const std::string& name, const std::string& input,
                     std::initializer_list<int> starts,
                     std::initializer_list<int> ends);

--- a/src/neural/onnx/converter.cc
+++ b/src/neural/onnx/converter.cc
@@ -266,22 +266,14 @@ std::string Converter::MakeMish(OnnxBuilder* builder, const std::string& input,
     return builder->Mul(name, flow, input);
   } else {
     auto in = input;
-    if (options_.data_type !=
-        WeightsToOnnxConverterOptions::DataType::kFloat32) {
-      in = builder->Cast(name + "/to_float", in, pblczero::TensorProto::FLOAT);
-    }
-    auto one = builder->AddInitializer(name + "/one", FloatOnnxConst({1}, {1}));
-    auto two = builder->AddInitializer(name + "/two", FloatOnnxConst({2}, {1}));
+    auto one = builder->AddInitializer(name + "/one", *GetScalarConverter(1));
+    auto two = builder->AddInitializer(name + "/two", *GetScalarConverter(2));
     auto e = builder->Exp(name + "/e", in);
     auto flow = builder->Add(name + "/e+2", e, two);
     flow = builder->Mul(name + "/e*e+2e", e, flow);
     flow = builder->Div(name + "/2/(e*e+2e)", two, flow);
     flow = builder->Add(name + "/1+2/(e*e+2e)", flow, one);
     flow = builder->Div(name + "/in/(1+2/(e*e+2e))", in, flow);
-    if (options_.data_type !=
-        WeightsToOnnxConverterOptions::DataType::kFloat32) {
-      flow = builder->Cast(name + "/to_data_type", flow, GetDataType());
-    }
     return flow;
   }
 }

--- a/src/neural/onnx/converter.h
+++ b/src/neural/onnx/converter.h
@@ -48,6 +48,7 @@ struct WeightsToOnnxConverterOptions {
   int ir = -1;                 // ONNX IR, -1 for auto.
   bool alt_mish = false;       // Use "Mish" approximation (fp32 only).
   bool alt_layernorm = false;  // Discrete "LayerNormalization" implementation.
+  bool alt_selu = false;       // Use discrete "Selu" implementation.
   bool no_shape = false;       // Avoid use of "Shape" operator.
   bool no_wdl_softmax = false; // Skip wdl softmax.
   std::string policy_head = "vanilla";


### PR DESCRIPTION
Currently the onnxruntime coreml provider doesn't support everything required, the following three patches are needed for both fp32 and fp16 with fixed batch size (default for now).
~~https://github.com/microsoft/onnxruntime/pull/26443~~ (merged)
~~https://github.com/microsoft/onnxruntime/pull/26442~~ (merged)
~~https://github.com/microsoft/onnxruntime/pull/26462~~ (merged)

For variable batch size, hopefully the fix for issue https://github.com/microsoft/onnxruntime/issues/26328 is simple.

If someone wants to try it out, the default onnxruntime branch should work. ~~The last outstanding patch is for `Gather` fp16 support, which is the last kernel before the policy output, so doing it on the cpu shouldn't cause a huge performance drop.~~