### PR TITLE
Use constant tensors for metal backend

### DIFF
--- a/src/neural/backends/metal/mps/NetworkGraph.mm
+++ b/src/neural/backends/metal/mps/NetworkGraph.mm
@@ -387,7 +387,8 @@ static const NSInteger kMinSubBatchSize = 20;
 
     MPSGraphTensor * convTensor = [self convolution2DWithSourceTensor:parent
                                                         weightsTensor:weightsTensor
-                                                           descriptor:convolution2DDescriptor];
+                                                           descriptor:convolution2DDescriptor
+                                                           name:[NSString stringWithFormat:@"%@/conv", label]];
 
     MPSGraphTensor * convBiasTensor = [self additionWithPrimaryTensor:convTensor
                                                       secondaryTensor:biasTensor


### PR DESCRIPTION
Replaced `[self variableWithData:...]` with `[self constantWithData:...]` allowing MPS to do more optimizations to the network.

I measured between a 12% (10 seconds on benchmark) and 26% (30 seconds) performance uplift. 