### PR TITLE
Support network evaluations per second in uci info

### DIFF
--- a/src/chess/callbacks.h
+++ b/src/chess/callbacks.h
@@ -66,6 +66,8 @@ struct ThinkingInfo {
   int64_t nodes = -1;
   // Nodes per second.
   int nps = -1;
+  // Evaluations per second.
+  int eps = -1;
   // Hash fullness * 1000
   int hashfull = -1;
   // Moves to mate.

--- a/src/chess/uciloop.cc
+++ b/src/chess/uciloop.cc
@@ -54,6 +54,11 @@ const OptionId kShowWDL{{.long_flag = "show-wdl",
                          .uci_option = "UCI_ShowWDL",
                          .help_text = "Show win, draw and lose probability.",
                          .visibility = OptionId::kAlwaysVisible}};
+const OptionId kShowEPS{
+    {.long_flag = "show-eps",
+     .uci_option = "UCI_ShowEPS",
+     .help_text = "Show neural network evaluations per second.",
+     .visibility = OptionId::kAlwaysVisible}};
 const OptionId kShowMovesleft{{.long_flag = "show-movesleft",
                                .uci_option = "UCI_ShowMovesLeft",
                                .help_text = "Show estimated moves left.",
@@ -259,6 +264,7 @@ bool UciLoop::ProcessLine(const std::string& line) {
 void StringUciResponder::PopulateParams(OptionsParser* options) {
   options->Add<BoolOption>(kUciChess960) = false;
   options->Add<BoolOption>(kShowWDL) = false;
+  options->Add<BoolOption>(kShowEPS) = false;
   options->Add<BoolOption>(kShowMovesleft) = false;
   options_ = &options->GetOptionsDict();
 }
@@ -312,6 +318,9 @@ void StringUciResponder::OutputThinkingInfo(std::vector<ThinkingInfo>* infos) {
     }
     if (info.hashfull >= 0) res += " hashfull " + std::to_string(info.hashfull);
     if (info.nps >= 0) res += " nps " + std::to_string(info.nps);
+    if (info.eps >= 0 && options_ && options_->Get<bool>(kShowEPS)) {
+      res += " eps " + std::to_string(info.eps);
+    }
     if (info.tb_hits >= 0) res += " tbhits " + std::to_string(info.tb_hits);
     if (info.multipv >= 0) res += " multipv " + std::to_string(info.multipv);
 

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -281,6 +281,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
             .count();
     if (time_since_first_batch_ms > 0) {
       common_info.nps = total_playouts_ * 1000 / time_since_first_batch_ms;
+      common_info.eps = network_evaluations_ * 1000 / time_since_first_batch_ms;
     }
   }
   common_info.tb_hits = tb_hits_.load(std::memory_order_acquire);
@@ -2280,6 +2281,9 @@ void SearchWorker::DoBackupUpdateSingleNode(
     }
   }
   search_->total_playouts_ += node_to_process.multivisit;
+  if (node_to_process.nn_queried && !node_to_process.is_cache_hit) {
+    search_->network_evaluations_++;
+  }
   search_->cum_depth_ += node_to_process.depth * node_to_process.multivisit;
   search_->max_depth_ = std::max(search_->max_depth_, node_to_process.depth);
 }

--- a/src/search/classic/search.h
+++ b/src/search/classic/search.h
@@ -181,6 +181,7 @@ class Search {
   Edge* last_outputted_info_edge_ GUARDED_BY(nodes_mutex_) = nullptr;
   ThinkingInfo last_outputted_uci_info_ GUARDED_BY(nodes_mutex_);
   int64_t total_playouts_ GUARDED_BY(nodes_mutex_) = 0;
+  int64_t network_evaluations_ GUARDED_BY(nodes_mutex_) = 0;
   int64_t total_batches_ GUARDED_BY(nodes_mutex_) = 0;
   // Maximum search depth = length of longest path taken in PickNodetoExtend.
   uint16_t max_depth_ GUARDED_BY(nodes_mutex_) = 0;

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -329,6 +329,7 @@ void Search::SendUciInfo(const classic::IterationStats& stats)
     const auto time_since_first_batch_ms = stats.time_since_first_batch;
     if (time_since_first_batch_ms > 0) {
       common_info.nps = total_playouts_ * 1000 / time_since_first_batch_ms;
+      common_info.eps = network_evaluations_ * 1000 / time_since_first_batch_ms;
     }
   }
   common_info.tb_hits = tb_hits_.load(std::memory_order_acquire);
@@ -2369,6 +2370,9 @@ void SearchWorker::DoBackupUpdateSingleNode(
     nm = pm;
   }
   search_->total_playouts_ += node_to_process.multivisit;
+  if (node_to_process.nn_queried && !node_to_process.is_cache_hit) {
+    search_->network_evaluations_++;
+  }
   search_->cum_depth_ +=
       node_to_process.path.size() * node_to_process.multivisit;
   search_->max_depth_ =

--- a/src/search/dag_classic/search.h
+++ b/src/search/dag_classic/search.h
@@ -191,6 +191,7 @@ class Search {
   Edge* last_outputted_info_edge_ GUARDED_BY(nodes_mutex_) = nullptr;
   ThinkingInfo last_outputted_uci_info_ GUARDED_BY(nodes_mutex_);
   int64_t total_playouts_ GUARDED_BY(nodes_mutex_) = 0;
+  int64_t network_evaluations_ GUARDED_BY(nodes_mutex_) = 0;
   int64_t total_batches_ GUARDED_BY(nodes_mutex_) = 0;
   // Maximum search depth = length of longest path taken in PickNodetoExtend.
   uint16_t max_depth_ GUARDED_BY(nodes_mutex_) = 0;


### PR DESCRIPTION
This is based on @dje-dev 's proposal that we should report network evaluation numbers.

Example using `classic` search
```setoption name UCI_ShowEPS value true 
go
Loading weights file from: ./t3-512x15x16h-distill-swa-2767500.pb.gz
Switching to [cuda-fp16]...
info depth 1 seldepth 2 time 1305 nodes 2 score cp 8 nps 1000 eps 1000 tbhits 0 pv d2d4 d7d5
info depth 2 seldepth 3 time 1307 nodes 3 score cp 7 nps 750 eps 750 tbhits 0 pv d2d4 d7d5 c2c4
info depth 2 seldepth 4 time 1313 nodes 16 score cp 9 nps 1600 eps 600 tbhits 0 pv d2d4 d7d5 c2c4 c7c6
info depth 3 seldepth 5 time 1316 nodes 26 score cp 9 nps 2000 eps 1230 tbhits 0 pv d2d4 d7d5 c2c4 c7c6 c4d5

info depth 11 seldepth 46 time 12224 nodes 436658 score cp 12 nps 39983 eps 15751 tbhits 0 pv d2d4 d7d5 c2c4 c7c6 c4d5 c6d5 c1f4 g8f6 e2e3 b8c6 f1b5 c8g4 g1f3 a8c8 e1g1 g4f3 d1f3 e7e6 f1c1```