### PR TITLE
Dag avoid float conversions and fix rare state transition bug

### DIFF
--- a/src/search/dag_classic/node.cc
+++ b/src/search/dag_classic/node.cc
@@ -343,7 +343,7 @@ void Node::CancelScoreUpdate(uint32_t multivisit) {
   n_in_flight_.fetch_sub(multivisit, std::memory_order_acq_rel);
 }
 
-void LowNode::FinalizeScoreUpdate(float v, float d, float m,
+void LowNode::FinalizeScoreUpdate(double v, double d, float m,
                                   uint32_t multivisit) {
   assert(edges_);
   // Recompute Q.
@@ -357,7 +357,7 @@ void LowNode::FinalizeScoreUpdate(float v, float d, float m,
   n_ += multivisit;
 }
 
-void LowNode::AdjustForTerminal(float v, float d, float m,
+void LowNode::AdjustForTerminal(double v, double d, float m,
                                 uint32_t multivisit) {
   assert(static_cast<uint32_t>(multivisit) <= n_);
 
@@ -369,7 +369,7 @@ void LowNode::AdjustForTerminal(float v, float d, float m,
   assert(WLDMInvariantsHold());
 }
 
-void Node::FinalizeScoreUpdate(float v, float d, float m, uint32_t multivisit) {
+void Node::FinalizeScoreUpdate(double v, double d, float m, uint32_t multivisit) {
   // Recompute Q.
   wl_ += multivisit * (v - wl_) / (n_ + multivisit);
   d_ += multivisit * (d - d_) / (n_ + multivisit);
@@ -384,7 +384,7 @@ void Node::FinalizeScoreUpdate(float v, float d, float m, uint32_t multivisit) {
   n_in_flight_.fetch_sub(multivisit, std::memory_order_acq_rel);
 }
 
-void Node::AdjustForTerminal(float v, float d, float m, uint32_t multivisit) {
+void Node::AdjustForTerminal(double v, double d, float m, uint32_t multivisit) {
   assert(static_cast<uint32_t>(multivisit) <= n_);
 
   // Recompute Q.
@@ -610,10 +610,10 @@ void Node::SortEdges() const {
   low_node_->SortEdges();
 }
 
-static constexpr float wld_tolerance = 0.000001f;
+static constexpr double wld_tolerance = 0.000001f;
 static constexpr float m_tolerance = 0.000001f;
 
-static bool WLDMInvariantsHold(float wl, float d, float m) {
+static bool WLDMInvariantsHold(double wl, double d, float m) {
   return -(1.0f + wld_tolerance) < wl && wl < (1.0f + wld_tolerance) &&  //
          -(0.0f + wld_tolerance) < d && d < (1.0f + wld_tolerance) &&    //
          -(0.0f + m_tolerance) < m &&                                    //

--- a/src/search/dag_classic/node.cc
+++ b/src/search/dag_classic/node.cc
@@ -343,54 +343,60 @@ void Node::CancelScoreUpdate(uint32_t multivisit) {
   n_in_flight_.fetch_sub(multivisit, std::memory_order_acq_rel);
 }
 
-void LowNode::FinalizeScoreUpdate(double v, double d, float m,
-                                  uint32_t multivisit) {
+float LowNode::FinalizeScoreUpdate(double v, double d, float m,
+                                   uint32_t multivisit) {
   assert(edges_);
-  // Recompute Q.
-  wl_ += multivisit * (v - wl_) / (n_ + multivisit);
-  d_ += multivisit * (d - d_) / (n_ + multivisit);
-  m_ += multivisit * (m - m_) / (n_ + multivisit);
-
-  assert(WLDMInvariantsHold());
-
   // Increment N.
   n_ += multivisit;
+
+  // Recompute Q.
+  float divisor = 1.0f / n_;
+  wl_ += multivisit * (v - wl_) * divisor;
+  d_ += multivisit * (d - d_) * divisor;
+  m_ += multivisit * (m - m_) * divisor;
+
+  assert(WLDMInvariantsHold());
+  return divisor;
 }
 
-void LowNode::AdjustForTerminal(double v, double d, float m,
+void LowNode::AdjustForTerminal(double v, double d, float m, float divisor,
                                 uint32_t multivisit) {
   assert(static_cast<uint32_t>(multivisit) <= n_);
 
   // Recompute Q.
-  wl_ += multivisit * v / n_;
-  d_ += multivisit * d / n_;
-  m_ += multivisit * m / n_;
+  wl_ += multivisit * v * divisor;
+  d_ += multivisit * d * divisor;
+  m_ += multivisit * m * divisor;
 
   assert(WLDMInvariantsHold());
 }
 
-void Node::FinalizeScoreUpdate(double v, double d, float m, uint32_t multivisit) {
-  // Recompute Q.
-  wl_ += multivisit * (v - wl_) / (n_ + multivisit);
-  d_ += multivisit * (d - d_) / (n_ + multivisit);
-  m_ += multivisit * (m - m_) / (n_ + multivisit);
-
-  assert(WLDMInvariantsHold());
-
+float Node::FinalizeScoreUpdate(double v, double d, float m,
+                                uint32_t multivisit) {
   // Increment N.
   n_ += multivisit;
+
+  // Recompute Q.
+  float divisor = 1.0f / n_;
+  wl_ += multivisit * (v - wl_) * divisor;
+  d_ += multivisit * (d - d_) * divisor;
+  m_ += multivisit * (m - m_) * divisor;
+
+  assert(WLDMInvariantsHold());
   // Decrement virtual loss.
   assert(GetNInFlight() >= (uint32_t)multivisit);
   n_in_flight_.fetch_sub(multivisit, std::memory_order_acq_rel);
+  return divisor;
 }
 
-void Node::AdjustForTerminal(double v, double d, float m, uint32_t multivisit) {
+void Node::AdjustForTerminal(double v, double d, float m, float divisor,
+                             uint32_t multivisit) {
   assert(static_cast<uint32_t>(multivisit) <= n_);
 
   // Recompute Q.
-  wl_ += multivisit * v / n_;
-  d_ += multivisit * d / n_;
-  m_ += multivisit * m / n_;
+  wl_ += multivisit * v * divisor;
+  d_ += multivisit * d * divisor;
+  m_ += multivisit * m * divisor;
 
   assert(WLDMInvariantsHold());
 }

--- a/src/search/dag_classic/node.cc
+++ b/src/search/dag_classic/node.cc
@@ -343,44 +343,44 @@ void Node::CancelScoreUpdate(uint32_t multivisit) {
   n_in_flight_.fetch_sub(multivisit, std::memory_order_acq_rel);
 }
 
-float LowNode::FinalizeScoreUpdate(double v, double d, float m,
+double LowNode::FinalizeScoreUpdate(double v, double d, float m,
                                    uint32_t multivisit) {
   assert(edges_);
   // Increment N.
   n_ += multivisit;
 
   // Recompute Q.
-  float divisor = 1.0f / n_;
+  double divisor = 1.0 / n_;
   wl_ += multivisit * (v - wl_) * divisor;
   d_ += multivisit * (d - d_) * divisor;
-  m_ += multivisit * (m - m_) * divisor;
+  m_ += multivisit * (m - m_) * static_cast<float>(divisor);
 
   assert(WLDMInvariantsHold());
   return divisor;
 }
 
-void LowNode::AdjustForTerminal(double v, double d, float m, float divisor,
+void LowNode::AdjustForTerminal(double v, double d, float m, double divisor,
                                 uint32_t multivisit) {
   assert(static_cast<uint32_t>(multivisit) <= n_);
 
   // Recompute Q.
   wl_ += multivisit * v * divisor;
   d_ += multivisit * d * divisor;
-  m_ += multivisit * m * divisor;
+  m_ += multivisit * m * static_cast<float>(divisor);
 
   assert(WLDMInvariantsHold());
 }
 
-float Node::FinalizeScoreUpdate(double v, double d, float m,
+double Node::FinalizeScoreUpdate(double v, double d, float m,
                                 uint32_t multivisit) {
   // Increment N.
   n_ += multivisit;
 
   // Recompute Q.
-  float divisor = 1.0f / n_;
+  double divisor = 1.0 / n_;
   wl_ += multivisit * (v - wl_) * divisor;
   d_ += multivisit * (d - d_) * divisor;
-  m_ += multivisit * (m - m_) * divisor;
+  m_ += multivisit * (m - m_) * static_cast<float>(divisor);
 
   assert(WLDMInvariantsHold());
   // Decrement virtual loss.
@@ -389,14 +389,14 @@ float Node::FinalizeScoreUpdate(double v, double d, float m,
   return divisor;
 }
 
-void Node::AdjustForTerminal(double v, double d, float m, float divisor,
+void Node::AdjustForTerminal(double v, double d, float m, double divisor,
                              uint32_t multivisit) {
   assert(static_cast<uint32_t>(multivisit) <= n_);
 
   // Recompute Q.
   wl_ += multivisit * v * divisor;
   d_ += multivisit * d * divisor;
-  m_ += multivisit * m * divisor;
+  m_ += multivisit * m * static_cast<float>(divisor);
 
   assert(WLDMInvariantsHold());
 }

--- a/src/search/dag_classic/node.h
+++ b/src/search/dag_classic/node.h
@@ -207,8 +207,8 @@ class Edge {
 };
 
 struct Eval {
-  float wl;
-  float d;
+  double wl;
+  double d;
   float ml;
 };
 
@@ -301,11 +301,11 @@ class Node {
   // Returns n + n_in_flight.
   int GetNStarted() const { return n_ + GetNInFlight(); }
 
-  float GetQ(float draw_score) const { return wl_ + draw_score * d_; }
+  double GetQ(double draw_score) const { return wl_ + draw_score * d_; }
   // Returns node eval, i.e. average subtree V for non-terminal node and -1/0/1
   // for terminal nodes.
-  float GetWL() const { return wl_; }
-  float GetD() const { return d_; }
+  double GetWL() const { return wl_; }
+  double GetD() const { return d_; }
   float GetM() const { return m_; }
 
   // Returns whether the node is known to be draw/lose/win.
@@ -335,9 +335,9 @@ class Node {
   // * Q (weighted average of all V in a subtree)
   // * N (+=multivisit)
   // * N-in-flight (-=multivisit)
-  void FinalizeScoreUpdate(float v, float d, float m, uint32_t multivisit);
+  void FinalizeScoreUpdate(double v, double d, float m, uint32_t multivisit);
   // Like FinalizeScoreUpdate, but it updates n existing visits by delta amount.
-  void AdjustForTerminal(float v, float d, float m, uint32_t multivisit);
+  void AdjustForTerminal(double v, double d, float m, uint32_t multivisit);
   // When search decides to treat one visit as several (in case of collisions
   // or visiting terminal nodes several times), it amplifies the visit by
   // incrementing n_in_flight.
@@ -546,8 +546,8 @@ class LowNode {
 
   // Returns node eval, i.e. average subtree V for non-terminal node and -1/0/1
   // for terminal nodes.
-  float GetWL() const { return wl_; }
-  float GetD() const { return d_; }
+  double GetWL() const { return wl_; }
+  double GetD() const { return d_; }
   float GetM() const { return m_; }
 
   // Returns whether the node is known to be draw/loss/win.
@@ -574,9 +574,9 @@ class LowNode {
   // * Q (weighted average of all V in a subtree)
   // * N (+=multivisit)
   // * N-in-flight (-=multivisit)
-  void FinalizeScoreUpdate(float v, float d, float m, uint32_t multivisit);
+  void FinalizeScoreUpdate(double v, double d, float m, uint32_t multivisit);
   // Like FinalizeScoreUpdate, but it updates n existing visits by delta amount.
-  void AdjustForTerminal(float v, float d, float m, uint32_t multivisit);
+  void AdjustForTerminal(double v, double d, float m, uint32_t multivisit);
 
   // Deletes all children.
   void ReleaseChildren();
@@ -691,13 +691,13 @@ class EdgeAndNode {
   Node* node() const { return node_; }
 
   // Proxy functions for easier access to node/edge.
-  float GetQ(float default_q, float draw_score) const {
+  double GetQ(double default_q, double draw_score) const {
     return (node_ && node_->GetN() > 0) ? node_->GetQ(draw_score) : default_q;
   }
-  float GetWL(float default_wl) const {
+  double GetWL(double default_wl) const {
     return (node_ && node_->GetN() > 0) ? node_->GetWL() : default_wl;
   }
-  float GetD(float default_d) const {
+  double GetD(double default_d) const {
     return (node_ && node_->GetN() > 0) ? node_->GetD() : default_d;
   }
   float GetM(float default_m) const {

--- a/src/search/dag_classic/node.h
+++ b/src/search/dag_classic/node.h
@@ -335,9 +335,9 @@ class Node {
   // * Q (weighted average of all V in a subtree)
   // * N (+=multivisit)
   // * N-in-flight (-=multivisit)
-  void FinalizeScoreUpdate(double v, double d, float m, uint32_t multivisit);
+  float FinalizeScoreUpdate(double v, double d, float m, uint32_t multivisit);
   // Like FinalizeScoreUpdate, but it updates n existing visits by delta amount.
-  void AdjustForTerminal(double v, double d, float m, uint32_t multivisit);
+  void AdjustForTerminal(double v, double d, float m, float divisor, uint32_t multivisit);
   // When search decides to treat one visit as several (in case of collisions
   // or visiting terminal nodes several times), it amplifies the visit by
   // incrementing n_in_flight.
@@ -574,9 +574,9 @@ class LowNode {
   // * Q (weighted average of all V in a subtree)
   // * N (+=multivisit)
   // * N-in-flight (-=multivisit)
-  void FinalizeScoreUpdate(double v, double d, float m, uint32_t multivisit);
+  float FinalizeScoreUpdate(double v, double d, float m, uint32_t multivisit);
   // Like FinalizeScoreUpdate, but it updates n existing visits by delta amount.
-  void AdjustForTerminal(double v, double d, float m, uint32_t multivisit);
+  void AdjustForTerminal(double v, double d, float m, float divisor, uint32_t multivisit);
 
   // Deletes all children.
   void ReleaseChildren();

--- a/src/search/dag_classic/node.h
+++ b/src/search/dag_classic/node.h
@@ -335,9 +335,9 @@ class Node {
   // * Q (weighted average of all V in a subtree)
   // * N (+=multivisit)
   // * N-in-flight (-=multivisit)
-  float FinalizeScoreUpdate(double v, double d, float m, uint32_t multivisit);
+  double FinalizeScoreUpdate(double v, double d, float m, uint32_t multivisit);
   // Like FinalizeScoreUpdate, but it updates n existing visits by delta amount.
-  void AdjustForTerminal(double v, double d, float m, float divisor, uint32_t multivisit);
+  void AdjustForTerminal(double v, double d, float m, double divisor, uint32_t multivisit);
   // When search decides to treat one visit as several (in case of collisions
   // or visiting terminal nodes several times), it amplifies the visit by
   // incrementing n_in_flight.
@@ -574,9 +574,9 @@ class LowNode {
   // * Q (weighted average of all V in a subtree)
   // * N (+=multivisit)
   // * N-in-flight (-=multivisit)
-  float FinalizeScoreUpdate(double v, double d, float m, uint32_t multivisit);
+  double FinalizeScoreUpdate(double v, double d, float m, uint32_t multivisit);
   // Like FinalizeScoreUpdate, but it updates n existing visits by delta amount.
-  void AdjustForTerminal(double v, double d, float m, float divisor, uint32_t multivisit);
+  void AdjustForTerminal(double v, double d, float m, double divisor, uint32_t multivisit);
 
   // Deletes all children.
   void ReleaseChildren();

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -271,7 +271,8 @@ void ApplyDirichletNoise(LowNode* node, float eps, double alpha) {
 
 namespace {
 // WDL conversion formula based on random walk model.
-inline double WDLRescale(float& v, float& d, float wdl_rescale_ratio,
+template <typename T>
+inline double WDLRescale(T& v, T& d, float wdl_rescale_ratio,
                          float wdl_rescale_diff, float sign, bool invert,
                          float max_reasonable_s) {
   if (invert) {
@@ -476,7 +477,7 @@ void Search::RecordNPSStartTime() {
 }
 
 // Root is depth 0, i.e. even depth.
-float Search::GetDrawScore(bool is_odd_depth) const {
+double Search::GetDrawScore(bool is_odd_depth) const {
   return (is_odd_depth == played_history_.IsBlackToMove()
               ? params_.GetDrawScore()
               : -params_.GetDrawScore());
@@ -2181,8 +2182,8 @@ void SearchWorker::DoBackupUpdate() {
 }
 
 bool SearchWorker::MaybeAdjustForTerminalOrTransposition(
-    Node* n, const std::shared_ptr<LowNode>& nl, float& v, float& d, float& m,
-    uint32_t& n_to_fix, float& v_delta, float& d_delta, float& m_delta,
+    Node* n, const std::shared_ptr<LowNode>& nl, double& v, double& d, float& m,
+    uint32_t& n_to_fix, double& v_delta, double& d_delta, float& m_delta,
     bool& update_parent_bounds) const {
   if (n->IsTerminal()) {
     v = n->GetWL();
@@ -2193,7 +2194,7 @@ bool SearchWorker::MaybeAdjustForTerminalOrTransposition(
   }
 
   // Use information from transposition or a new terminal.
-  if (nl->IsTransposition() || nl->IsTerminal() || n->GetN() < nl->GetN()) {
+  if (nl->IsTransposition() || nl->IsTerminal() || n->GetN() + 1 < nl->GetN()) {
     // Adapt information from low node to node by flipping Q sign, bounds,
     // result and incrementing m.
     v = -nl->GetWL();
@@ -2269,12 +2270,12 @@ void SearchWorker::DoBackupUpdateSingleNode(
   auto update_parent_bounds =
       params_.GetStickyEndgames() && n->IsTerminal() && !n->GetN();
   const auto& nl = n->GetLowNode();
-  float v = 0.0f;
-  float d = 0.0f;
+  double v = 0.0;
+  double d = 0.0;
   float m = 0.0f;
   uint32_t n_to_fix = 0;
-  float v_delta = 0.0f;
-  float d_delta = 0.0f;
+  double v_delta = 0.0;
+  double d_delta = 0.0;
   float m_delta = 0.0f;
 
   // Update the low node at the start of the backup path first, but only visit
@@ -2386,7 +2387,7 @@ void SearchWorker::DoBackupUpdateSingleNode(
 }
 
 bool SearchWorker::MaybeSetBounds(Node* p, float m, uint32_t* n_to_fix,
-                                  float* v_delta, float* d_delta,
+                                  double* v_delta, double* d_delta,
                                   float* m_delta) const {
   auto losing_m = 0.0f;
   auto prefer_tb = false;

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -1642,9 +1642,6 @@ bool SearchWorker::ShouldStopPickingHere(Node* node, bool is_root_node,
   auto low_node = node->GetLowNode().get();
   assert(low_node);
 
-  // Only known transpositions can differ.
-  if (!low_node->IsTransposition()) return false;
-
   // LowNode is terminal when Node is not.
   if (low_node->IsTerminal()) return true;
 

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -1642,6 +1642,9 @@ bool SearchWorker::ShouldStopPickingHere(Node* node, bool is_root_node,
   auto low_node = node->GetLowNode().get();
   assert(low_node);
 
+  // Only known transpositions can differ.
+  if (!low_node->IsTransposition()) return false;
+
   // LowNode is terminal when Node is not.
   if (low_node->IsTerminal()) return true;
 

--- a/src/search/dag_classic/search.h
+++ b/src/search/dag_classic/search.h
@@ -143,7 +143,7 @@ class Search {
   // Returns the draw score at the root of the search. At odd depth pass true to
   // the value of @is_odd_depth to change the sign of the draw score.
   // Depth of a root node is 0 (even number).
-  float GetDrawScore(bool is_odd_depth) const;
+  double GetDrawScore(bool is_odd_depth) const;
 
   mutable Mutex counters_mutex_ ACQUIRED_AFTER(nodes_mutex_);
   // Tells all threads to stop.
@@ -448,14 +448,14 @@ class SearchWorker {
   // Return true if adjustment happened.
   bool MaybeAdjustForTerminalOrTransposition(Node* n,
                                              const std::shared_ptr<LowNode>& nl,
-                                             float& v, float& d, float& m,
-                                             uint32_t& n_to_fix, float& v_delta,
-                                             float& d_delta, float& m_delta,
+                                             double& v, double& d, float& m,
+                                             uint32_t& n_to_fix, double& v_delta,
+                                             double& d_delta, float& m_delta,
                                              bool& update_parent_bounds) const;
   void DoBackupUpdateSingleNode(const NodeToProcess& node_to_process);
   // Returns whether a node's bounds were set based on its children.
-  bool MaybeSetBounds(Node* p, float m, uint32_t* n_to_fix, float* v_delta,
-                      float* d_delta, float* m_delta) const;
+  bool MaybeSetBounds(Node* p, float m, uint32_t* n_to_fix, double* v_delta,
+                      double* d_delta, float* m_delta) const;
   void PickNodesToExtend(int collision_limit);
   void PickNodesToExtendTask(const BackupPath& path, int collision_limit,
                              PositionHistory& history,


### PR DESCRIPTION
Small backup propagation improvements which might improve search slightly based on local testing. The difference is within error margin because I haven't run enough test games. Changes mainly aim to make backup propagation a little faster because single threaded code has relatively high impact to CPU bottleneck.

Rare picking node race condition was already fixed in PR #2318. It is still pending. This pull request includes a simplified workaround to avoid rare cases where n_in_flight underflows.