### PR TITLE
Use root utility offset to randomize move selection

### DIFF
--- a/src/search/classic/node.h
+++ b/src/search/classic/node.h
@@ -228,6 +228,7 @@ class Node {
   // Returns range for iterating over edges.
   ConstIterator Edges() const;
   Iterator Edges();
+  unsigned GetChildIndex(Edge* edge) const { return edge - edges_.get(); }
 
   // Returns range for iterating over child nodes with N > 0.
   VisitedNode_Iterator<true> VisitedNodes() const;

--- a/src/search/classic/params.cc
+++ b/src/search/classic/params.cc
@@ -225,10 +225,10 @@ const OptionId BaseSearchParams::kTwoFoldDrawsId{
     "in the search tree anymore."};
 const OptionId BaseSearchParams::kTempUtilityDeviationId{
     "temp-utility-deviation", "TempUtilityDeviation",
-    "When picking a move with temperature, add an offset to the utility of "
-    "each move, sampled from a normal distribution with mean 0 and this "
-    "standard deviation. This is an alternative way to add noise to the move "
-    "selection."};
+    "Add a random offset to the winning probability. It uses a normal "
+    "distribution with mean 0 and the specified standard deviation. The "
+    "maximum evaluation difference is capped at 5 times the standard "
+    "deviation."};
 const OptionId BaseSearchParams::kTempEndgameUtilityDeviationId{
     "temp-endgame-utility-deviation", "TempEndgameUtilityDeviation",
     "Temperature utility offset standard deviation used during endgame "
@@ -562,8 +562,9 @@ void BaseSearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctFactorAtRootId, 0.0f, 1000.0f) = 3.894f;
   options->Add<BoolOption>(kRootHasOwnCpuctParamsId) = false;
   options->Add<BoolOption>(kTwoFoldDrawsId) = true;
-  options->Add<FloatOption>(kTempUtilityDeviationId, 0.0f, 1.0f) = 0.0f;
-  options->Add<FloatOption>(kTempEndgameUtilityDeviationId, 0.0f, 1.0f) = 0.0f;
+  options->Add<FloatOption>(kTempUtilityDeviationId, 0.0f, 100.0f) = 0.0f;
+  options->Add<FloatOption>(kTempEndgameUtilityDeviationId, 0.0f, 100.0f) =
+      0.0f;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 640) = 0;
   options->Add<IntOption>(kTempDecayDelayMovesId, 0, 100) = 0;

--- a/src/search/classic/params.cc
+++ b/src/search/classic/params.cc
@@ -223,6 +223,15 @@ const OptionId BaseSearchParams::kTwoFoldDrawsId{
     "Evaluates twofold repetitions in the search tree as draws. Visits to "
     "these positions are reverted when the first occurrence is played and not "
     "in the search tree anymore."};
+const OptionId BaseSearchParams::kTempUtilityVarianceId{
+    "temp-utility-variance", "TempUtilityVariance",
+    "When picking a move with temperature, add an offset to the utility of "
+    "each move, sampled from a normal distribution with mean 0 and this "
+    "variance. This is an alternative way to add noise to the move selection."};
+const OptionId BaseSearchParams::kTempEndgameUtilityVarianceId{
+    "temp-endgame-utility-variance", "TempEndgameUtilityVariance",
+    "Temeperature utility offset variance used during endgame (starting from "
+    "cutoff move). There is no decay."};
 const OptionId BaseSearchParams::kTemperatureId{
     {.long_flag = "temperature",
      .uci_option = "Temperature",
@@ -552,6 +561,8 @@ void BaseSearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctFactorAtRootId, 0.0f, 1000.0f) = 3.894f;
   options->Add<BoolOption>(kRootHasOwnCpuctParamsId) = false;
   options->Add<BoolOption>(kTwoFoldDrawsId) = true;
+  options->Add<FloatOption>(kTempUtilityVarianceId, 0.0f, 1.0f) = 0.0f;
+  options->Add<FloatOption>(kTempEndgameUtilityVarianceId, 0.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 640) = 0;
   options->Add<IntOption>(kTempDecayDelayMovesId, 0, 100) = 0;

--- a/src/search/classic/params.cc
+++ b/src/search/classic/params.cc
@@ -223,15 +223,16 @@ const OptionId BaseSearchParams::kTwoFoldDrawsId{
     "Evaluates twofold repetitions in the search tree as draws. Visits to "
     "these positions are reverted when the first occurrence is played and not "
     "in the search tree anymore."};
-const OptionId BaseSearchParams::kTempUtilityVarianceId{
-    "temp-utility-variance", "TempUtilityVariance",
+const OptionId BaseSearchParams::kTempUtilityDeviationId{
+    "temp-utility-deviation", "TempUtilityDeviation",
     "When picking a move with temperature, add an offset to the utility of "
     "each move, sampled from a normal distribution with mean 0 and this "
-    "variance. This is an alternative way to add noise to the move selection."};
-const OptionId BaseSearchParams::kTempEndgameUtilityVarianceId{
-    "temp-endgame-utility-variance", "TempEndgameUtilityVariance",
-    "Temeperature utility offset variance used during endgame (starting from "
-    "cutoff move). There is no decay."};
+    "standard deviation. This is an alternative way to add noise to the move "
+    "selection."};
+const OptionId BaseSearchParams::kTempEndgameUtilityDeviationId{
+    "temp-endgame-utility-deviation", "TempEndgameUtilityDeviation",
+    "Temperature utility offset standard deviation used during endgame "
+    "(starting from cutoff move). There is no decay."};
 const OptionId BaseSearchParams::kTemperatureId{
     {.long_flag = "temperature",
      .uci_option = "Temperature",
@@ -561,8 +562,8 @@ void BaseSearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kCpuctFactorAtRootId, 0.0f, 1000.0f) = 3.894f;
   options->Add<BoolOption>(kRootHasOwnCpuctParamsId) = false;
   options->Add<BoolOption>(kTwoFoldDrawsId) = true;
-  options->Add<FloatOption>(kTempUtilityVarianceId, 0.0f, 1.0f) = 0.0f;
-  options->Add<FloatOption>(kTempEndgameUtilityVarianceId, 0.0f, 1.0f) = 0.0f;
+  options->Add<FloatOption>(kTempUtilityDeviationId, 0.0f, 1.0f) = 0.0f;
+  options->Add<FloatOption>(kTempEndgameUtilityDeviationId, 0.0f, 1.0f) = 0.0f;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 640) = 0;
   options->Add<IntOption>(kTempDecayDelayMovesId, 0, 100) = 0;

--- a/src/search/classic/params.cc
+++ b/src/search/classic/params.cc
@@ -227,12 +227,18 @@ const OptionId BaseSearchParams::kTempUtilityDeviationId{
     "temp-utility-deviation", "TempUtilityDeviation",
     "Add a random offset to the winning probability. It uses a normal "
     "distribution with mean 0 and the specified standard deviation. The "
-    "maximum evaluation difference is capped at 6 times the standard "
-    "deviation."};
+    "deviation is scaled down if evaluations claims advantage for either "
+    "side."};
 const OptionId BaseSearchParams::kTempEndgameUtilityDeviationId{
     "temp-endgame-utility-deviation", "TempEndgameUtilityDeviation",
     "Temperature utility offset standard deviation used during endgame "
-    "(starting from cutoff move). There is no decay."};
+    "(starting from cutoff move). ."};
+const OptionId BaseSearchParams::kTemperatureUtilityMaximumOffsetId{
+    "temp-utility-maximum-offset", "TempUtilityMaximumOffset",
+    "Sets the maximum multiple of standard deviation for the random offset. It "
+    "prevents extreme evaluation differences causing clear blunders when "
+    "randomizing move selection. Temperature decay affects standard deviation "
+    "which affects multiplicative maximum offset."};
 const OptionId BaseSearchParams::kTemperatureId{
     {.long_flag = "temperature",
      .uci_option = "Temperature",
@@ -565,6 +571,8 @@ void BaseSearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kTempUtilityDeviationId, 0.0f, 100.0f) = 0.0f;
   options->Add<FloatOption>(kTempEndgameUtilityDeviationId, 0.0f, 100.0f) =
       0.0f;
+  options->Add<FloatOption>(kTemperatureUtilityMaximumOffsetId, 0.0f, 100.0f) =
+      2.5f;
   options->Add<FloatOption>(kTemperatureId, 0.0f, 100.0f) = 0.0f;
   options->Add<IntOption>(kTempDecayMovesId, 0, 640) = 0;
   options->Add<IntOption>(kTempDecayDelayMovesId, 0, 100) = 0;

--- a/src/search/classic/params.cc
+++ b/src/search/classic/params.cc
@@ -227,7 +227,7 @@ const OptionId BaseSearchParams::kTempUtilityDeviationId{
     "temp-utility-deviation", "TempUtilityDeviation",
     "Add a random offset to the winning probability. It uses a normal "
     "distribution with mean 0 and the specified standard deviation. The "
-    "maximum evaluation difference is capped at 5 times the standard "
+    "maximum evaluation difference is capped at 6 times the standard "
     "deviation."};
 const OptionId BaseSearchParams::kTempEndgameUtilityDeviationId{
     "temp-endgame-utility-deviation", "TempEndgameUtilityDeviation",

--- a/src/search/classic/params.h
+++ b/src/search/classic/params.h
@@ -64,11 +64,11 @@ class BaseSearchParams {
     return at_root ? kCpuctFactorAtRoot : kCpuctFactor;
   }
   bool GetTwoFoldDraws() const { return kTwoFoldDraws; }
-  float GetTemperatureUtilityVariance() const {
-    return options_.Get<float>(kTempUtilityVarianceId);
+  float GetTemperatureUtilityDeviation() const {
+    return options_.Get<float>(kTempUtilityDeviationId);
   }
-  float GetTemperatureEndgameUtilityVariance() const {
-    return options_.Get<float>(kTempEndgameUtilityVarianceId);
+  float GetTemperatureEndgameUtilityDeviation() const {
+    return options_.Get<float>(kTempEndgameUtilityDeviationId);
   }
   float GetTemperature() const { return options_.Get<float>(kTemperatureId); }
   float GetTemperatureVisitOffset() const {
@@ -179,8 +179,8 @@ class BaseSearchParams {
   static const OptionId kCpuctFactorAtRootId;
   static const OptionId kRootHasOwnCpuctParamsId;
   static const OptionId kTwoFoldDrawsId;
-  static const OptionId kTempUtilityVarianceId;
-  static const OptionId kTempEndgameUtilityVarianceId;
+  static const OptionId kTempUtilityDeviationId;
+  static const OptionId kTempEndgameUtilityDeviationId;
   static const OptionId kTemperatureId;
   static const OptionId kTempDecayMovesId;
   static const OptionId kTempDecayDelayMovesId;

--- a/src/search/classic/params.h
+++ b/src/search/classic/params.h
@@ -64,6 +64,12 @@ class BaseSearchParams {
     return at_root ? kCpuctFactorAtRoot : kCpuctFactor;
   }
   bool GetTwoFoldDraws() const { return kTwoFoldDraws; }
+  float GetTemperatureUtilityVariance() const {
+    return options_.Get<float>(kTempUtilityVarianceId);
+  }
+  float GetTemperatureEndgameUtilityVariance() const {
+    return options_.Get<float>(kTempEndgameUtilityVarianceId);
+  }
   float GetTemperature() const { return options_.Get<float>(kTemperatureId); }
   float GetTemperatureVisitOffset() const {
     return options_.Get<float>(kTemperatureVisitOffsetId);
@@ -173,6 +179,8 @@ class BaseSearchParams {
   static const OptionId kCpuctFactorAtRootId;
   static const OptionId kRootHasOwnCpuctParamsId;
   static const OptionId kTwoFoldDrawsId;
+  static const OptionId kTempUtilityVarianceId;
+  static const OptionId kTempEndgameUtilityVarianceId;
   static const OptionId kTemperatureId;
   static const OptionId kTempDecayMovesId;
   static const OptionId kTempDecayDelayMovesId;

--- a/src/search/classic/params.h
+++ b/src/search/classic/params.h
@@ -70,6 +70,9 @@ class BaseSearchParams {
   float GetTemperatureEndgameUtilityDeviation() const {
     return options_.Get<float>(kTempEndgameUtilityDeviationId);
   }
+  float GetTemperatureUtilityMaximumOffset() const {
+    return options_.Get<float>(kTemperatureUtilityMaximumOffsetId);
+  }
   float GetTemperature() const { return options_.Get<float>(kTemperatureId); }
   float GetTemperatureVisitOffset() const {
     return options_.Get<float>(kTemperatureVisitOffsetId);
@@ -181,6 +184,7 @@ class BaseSearchParams {
   static const OptionId kTwoFoldDrawsId;
   static const OptionId kTempUtilityDeviationId;
   static const OptionId kTempEndgameUtilityDeviationId;
+  static const OptionId kTemperatureUtilityMaximumOffsetId;
   static const OptionId kTemperatureId;
   static const OptionId kTempDecayMovesId;
   static const OptionId kTempDecayDelayMovesId;

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -222,15 +222,15 @@ Search::Search(const NodeTree& tree, Backend* backend,
     }
   }
 
-  float root_variance = params_.GetTemperatureUtilityVariance();
-  float root_endgame_variance = params_.GetTemperatureEndgameUtilityVariance();
-  root_variance = TemperatureDecay(root_variance, root_endgame_variance,
+  float root_deviation = params_.GetTemperatureUtilityDeviation();
+  float root_endgame_deviation = params_.GetTemperatureEndgameUtilityDeviation();
+  root_deviation = TemperatureDecay(root_deviation, root_endgame_deviation,
                                     played_history_, params_);
 
-  if (root_variance) {
-    const float max_offset = root_variance * 2.5f;
+  if (root_deviation) {
+    const float max_offset = root_deviation * 2.5f;
     const float min_offset = -max_offset;
-    std::normal_distribution<float> dist(0.0f, root_variance);
+    std::normal_distribution<float> dist(0.0f, root_deviation);
     const int legal_moves =
         root_node_->GetN() > 0
             ? root_node_->GetNumEdges()

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -228,6 +228,7 @@ Search::Search(const NodeTree& tree, Backend* backend,
                                     played_history_, params_);
 
   if (root_deviation) {
+    root_deviation /= 50.0f;
     const float max_offset = root_deviation * 2.5f;
     const float min_offset = -max_offset;
     std::normal_distribution<float> dist(0.0f, root_deviation);

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -2460,5 +2460,9 @@ void SearchWorker::UpdateCounters() {
   }
 }
 
+void SearchCachedState::UciNewGame() {
+  temperature_offset_decay_ = 0;
+}
+
 }  // namespace classic
 }  // namespace lczero

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -189,7 +189,7 @@ float UpdateTemperatureOffsetDecay(const Node* root, const SearchParams& params,
   }
   float div = 50.0f * 0.5f /
               std::max(kTemperatureOffsetDecayCuttoff *
-                           (1.0f - std::abs(root->GetWL())),
+                           (1.0f - std::abs(root->GetQ(draw_score))),
                        0.00001f);
   return (best_q - selected_q) * div;
 }
@@ -219,7 +219,7 @@ void GenerateRootUtilityOffsets(const Node* root, const SearchParams& params,
   auto& rng = Random::Get();
   for (int i = 0; i < legal_moves; i++) {
     float offset = std::clamp(dist(rng), min_offset, max_offset);
-    offsets.push_back(offset * (1.0f - std::abs(root->GetWL())));
+    offsets.push_back(offset);
   }
 }
 
@@ -640,7 +640,8 @@ std::vector<std::string> Search::GetVerboseStats(const Node* node) const {
     float O = 0;
     if (node == root_node_ && !root_utility_offsets_.empty()) {
       unsigned index = node->GetChildIndex(edge.edge());
-      O = root_utility_offsets_[index];
+      O = root_utility_offsets_[index] *
+          std::max(0.0f, 1.0f - std::abs(node->GetQ(draw_score)));
       print(&oss, "(O: ", O, ") ", 8, 5);
     }
     print(&oss, "(S: ", Q + edge.GetU(U_coeff) + M + O, ") ", 8, 5);
@@ -1781,7 +1782,10 @@ void SearchWorker::PickNodesToExtendTask(
         visited_pol += current_pol[index];
         float q = child->GetQ(draw_score);
         float o =
-            use_utility_offset ? search_->root_utility_offsets_[index] : 0.0f;
+            use_utility_offset
+                ? search_->root_utility_offsets_[index] *
+                      std::max(0.0f, 1.0f - std::abs(node->GetQ(draw_score)))
+                : 0.0f;
         current_util[index] = q + m_evaluator.GetMUtility(child, q) + o;
       }
       const float fpu =

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -149,8 +149,8 @@ class MEvaluator {
 };
 
 float TemperatureDecay(float temp, float endgame,
-                        const PositionHistory& history,
-                        const SearchParams& params) {
+                       const PositionHistory& history,
+                       const SearchParams& params) {
   const int cutoff_move = params.GetTemperatureCutoffMove();
   const int decay_moves = params.GetTempDecayMoves();
   const int decay_delay_moves = params.GetTempDecayDelayMoves();
@@ -172,16 +172,36 @@ float TemperatureDecay(float temp, float endgame,
   return temp;
 }
 
+constexpr float kTemperatureOffsetDecayCuttoff = 3.0f;
+
+float UpdateTemperatureOffsetDecay(const Node* root, Move bestmove,
+                                   float draw_score) {
+  float best_q = -1.0f;
+  float selected_q = -1.0f;
+  if (root->GetN() <= 1) return 0.0f;
+  for (const auto& edge : root->Edges()) {
+    if (!edge.HasNode()) continue;
+    float q = edge.GetQ(0.0, draw_score);
+    best_q = std::max(best_q, q);
+    if (edge.GetMove(false) == bestmove) {
+      selected_q = q;
+    }
+  }
+  float div = 50.0f * 0.5f / kTemperatureOffsetDecayCuttoff;
+  return (best_q - selected_q) * div;
+}
+
 }  // namespace
 
-Search::Search(const NodeTree& tree, Backend* backend,
+Search::Search(SearchCachedState& state, const NodeTree& tree, Backend* backend,
                std::unique_ptr<UciResponder> uci_responder,
                const MoveList& searchmoves,
                std::chrono::steady_clock::time_point start_time,
                std::unique_ptr<SearchStopper> stopper, bool infinite,
                bool ponder, const OptionsDict& options,
                SyzygyTablebase* syzygy_tb)
-    : ok_to_respond_bestmove_(!infinite && !ponder),
+    : state_(state),
+      ok_to_respond_bestmove_(!infinite && !ponder),
       stopper_(std::move(stopper)),
       root_node_(tree.GetCurrentHead()),
       syzygy_tb_(syzygy_tb),
@@ -223,13 +243,16 @@ Search::Search(const NodeTree& tree, Backend* backend,
   }
 
   float root_deviation = params_.GetTemperatureUtilityDeviation();
-  float root_endgame_deviation = params_.GetTemperatureEndgameUtilityDeviation();
+  float root_endgame_deviation =
+      params_.GetTemperatureEndgameUtilityDeviation();
+  root_deviation =
+      std::max(0.0f, root_deviation - state_.temperature_offset_decay_);
   root_deviation = TemperatureDecay(root_deviation, root_endgame_deviation,
                                     played_history_, params_);
 
   if (root_deviation) {
     root_deviation /= 50.0f;
-    const float max_offset = root_deviation * 2.5f;
+    const float max_offset = root_deviation * kTemperatureOffsetDecayCuttoff;
     const float min_offset = -max_offset;
     std::normal_distribution<float> dist(0.0f, root_deviation);
     const int legal_moves =
@@ -689,6 +712,10 @@ void Search::MaybeTriggerStop(const IterationStats& stats,
       !bestmove_is_sent_) {
     SendUciInfo();
     EnsureBestMoveKnown();
+    auto bestmove = final_bestmove_;
+    if (played_history_.IsBlackToMove()) bestmove.Flip();
+    state_.temperature_offset_decay_ += UpdateTemperatureOffsetDecay(
+        root_node_, bestmove, GetDrawScore(played_history_.IsBlackToMove()));
     SendMovesStats();
     BestMoveInfo info(final_bestmove_, final_pondermove_);
     uci_responder_->OutputBestMove(&info);

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -172,12 +172,12 @@ float TemperatureDecay(float temp, float endgame,
   return temp;
 }
 
-constexpr float kTemperatureOffsetDecayCuttoff = 3.0f;
-
-float UpdateTemperatureOffsetDecay(const Node* root, Move bestmove,
-                                   float draw_score) {
+float UpdateTemperatureOffsetDecay(const Node* root, const SearchParams& params,
+                                   Move bestmove, float draw_score) {
   float best_q = -1.0f;
   float selected_q = -1.0f;
+  const float kTemperatureOffsetDecayCuttoff =
+      params.GetTemperatureUtilityMaximumOffset();
   if (root->GetN() <= 1) return 0.0f;
   for (const auto& edge : root->Edges()) {
     if (!edge.HasNode()) continue;
@@ -187,8 +187,40 @@ float UpdateTemperatureOffsetDecay(const Node* root, Move bestmove,
       selected_q = q;
     }
   }
-  float div = 50.0f * 0.5f / kTemperatureOffsetDecayCuttoff;
+  float div = 50.0f * 0.5f /
+              std::max(kTemperatureOffsetDecayCuttoff *
+                           (1.0f - std::abs(root->GetWL())),
+                       0.00001f);
   return (best_q - selected_q) * div;
+}
+
+void GenerateRootUtilityOffsets(const Node* root, const SearchParams& params,
+                                const SearchCachedState& state,
+                                const PositionHistory& history,
+                                std::vector<float>& offsets) {
+  if (!offsets.empty() || root->GetN() == 0) return;
+
+  float root_deviation = params.GetTemperatureUtilityDeviation();
+  float root_endgame_deviation = params.GetTemperatureEndgameUtilityDeviation();
+  root_deviation =
+      std::max(0.0f, root_deviation - state.GetTemperatureOffsetDecay());
+  root_deviation =
+      TemperatureDecay(root_deviation, root_endgame_deviation, history, params);
+
+  if (!root_deviation) return;
+  root_deviation /= 50.0f;
+  const float kTemperatureOffsetDecayCuttoff =
+      params.GetTemperatureUtilityMaximumOffset();
+  const float max_offset = root_deviation * kTemperatureOffsetDecayCuttoff;
+  const float min_offset = -max_offset;
+  std::normal_distribution<float> dist(0.0f, root_deviation);
+  const int legal_moves = root->GetNumEdges();
+  offsets.reserve(legal_moves);
+  auto& rng = Random::Get();
+  for (int i = 0; i < legal_moves; i++) {
+    float offset = std::clamp(dist(rng), min_offset, max_offset);
+    offsets.push_back(offset * (1.0f - std::abs(root->GetWL())));
+  }
 }
 
 }  // namespace
@@ -241,31 +273,8 @@ Search::Search(SearchCachedState& state, const NodeTree& tree, Backend* backend,
                            : ContemptMode::WHITE;
     }
   }
-
-  float root_deviation = params_.GetTemperatureUtilityDeviation();
-  float root_endgame_deviation =
-      params_.GetTemperatureEndgameUtilityDeviation();
-  root_deviation =
-      std::max(0.0f, root_deviation - state_.temperature_offset_decay_);
-  root_deviation = TemperatureDecay(root_deviation, root_endgame_deviation,
-                                    played_history_, params_);
-
-  if (root_deviation) {
-    root_deviation /= 50.0f;
-    const float max_offset = root_deviation * kTemperatureOffsetDecayCuttoff;
-    const float min_offset = -max_offset;
-    std::normal_distribution<float> dist(0.0f, root_deviation);
-    const int legal_moves =
-        root_node_->GetN() > 0
-            ? root_node_->GetNumEdges()
-            : played_history_.Last().GetBoard().GenerateLegalMoves().size();
-    root_utility_offsets_.reserve(legal_moves);
-    auto& rng = Random::Get();
-    for (int i = 0; i < legal_moves; i++) {
-      float offset = std::clamp(dist(rng), min_offset, max_offset);
-      root_utility_offsets_.push_back(offset);
-    }
-  }
+  GenerateRootUtilityOffsets(root_node_, params_, state_, played_history_,
+                             root_utility_offsets_);
 }
 
 namespace {
@@ -715,7 +724,8 @@ void Search::MaybeTriggerStop(const IterationStats& stats,
     auto bestmove = final_bestmove_;
     if (played_history_.IsBlackToMove()) bestmove.Flip();
     state_.temperature_offset_decay_ += UpdateTemperatureOffsetDecay(
-        root_node_, bestmove, GetDrawScore(played_history_.IsBlackToMove()));
+        root_node_, params_, bestmove,
+        GetDrawScore(played_history_.IsBlackToMove()));
     SendMovesStats();
     BestMoveInfo info(final_bestmove_, final_pondermove_);
     uci_responder_->OutputBestMove(&info);
@@ -2276,6 +2286,9 @@ void SearchWorker::DoBackupUpdate() {
       work_done = true;
     }
   }
+  GenerateRootUtilityOffsets(search_->root_node_, params_, search_->state_,
+                             search_->played_history_,
+                             search_->root_utility_offsets_);
   if (!work_done) return;
   search_->CancelSharedCollisions();
   search_->total_batches_ += 1;
@@ -2460,9 +2473,7 @@ void SearchWorker::UpdateCounters() {
   }
 }
 
-void SearchCachedState::UciNewGame() {
-  temperature_offset_decay_ = 0;
-}
+void SearchCachedState::UciNewGame() { temperature_offset_decay_ = 0; }
 
 }  // namespace classic
 }  // namespace lczero

--- a/src/search/classic/search.h
+++ b/src/search/classic/search.h
@@ -200,6 +200,7 @@ class Search {
 
   std::unique_ptr<UciResponder> uci_responder_;
   ContemptMode contempt_mode_;
+  std::vector<float> root_utility_offsets_;
   friend class SearchWorker;
 };
 

--- a/src/search/classic/search.h
+++ b/src/search/classic/search.h
@@ -459,6 +459,8 @@ class SearchCachedState {
   public:
     SearchCachedState() {}
 
+    void UciNewGame();
+
     friend class Search;
     friend class SearchWorker;
   private:

--- a/src/search/classic/search.h
+++ b/src/search/classic/search.h
@@ -461,6 +461,8 @@ class SearchCachedState {
 
     void UciNewGame();
 
+    float GetTemperatureOffsetDecay() const { return temperature_offset_decay_; }
+
     friend class Search;
     friend class SearchWorker;
   private:

--- a/src/search/classic/search.h
+++ b/src/search/classic/search.h
@@ -47,9 +47,11 @@
 namespace lczero {
 namespace classic {
 
+class SearchCachedState;
+
 class Search {
  public:
-  Search(const NodeTree& tree, Backend* network,
+  Search(SearchCachedState& state, const NodeTree& tree, Backend* network,
          std::unique_ptr<UciResponder> uci_responder,
          const MoveList& searchmoves,
          std::chrono::steady_clock::time_point start_time,
@@ -138,6 +140,7 @@ class Search {
 
   PositionHistory GetPositionHistoryAtNode(const Node* node) const;
 
+  SearchCachedState& state_;
   mutable Mutex counters_mutex_ ACQUIRED_AFTER(nodes_mutex_);
   // Tells all threads to stop.
   std::atomic<bool> stop_{false};
@@ -450,6 +453,16 @@ class SearchWorker {
   std::vector<TaskWorkspace> task_workspaces_;
   TaskWorkspace main_workspace_;
   bool exiting_ = false;
+};
+
+class SearchCachedState {
+  public:
+    SearchCachedState() {}
+
+    friend class Search;
+    friend class SearchWorker;
+  private:
+    float temperature_offset_decay_ = 0.0f;
 };
 
 }  // namespace classic

--- a/src/search/classic/wrapper.cc
+++ b/src/search/classic/wrapper.cc
@@ -102,6 +102,7 @@ void ClassicSearch::NewGame() {
   LCTRACE_FUNCTION_SCOPE;
   search_.reset();
   tree_.reset();
+  search_cached_state_.UciNewGame();
   time_manager_ = MakeTimeManager(*options_);
 }
 

--- a/src/search/classic/wrapper.cc
+++ b/src/search/classic/wrapper.cc
@@ -77,6 +77,7 @@ class ClassicSearch : public SearchBase {
   std::unique_ptr<Search> search_;
   std::unique_ptr<NodeTree> tree_;
   std::optional<std::chrono::steady_clock::time_point> move_start_time_;
+  SearchCachedState search_cached_state_;
 };
 
 MoveList StringsToMovelist(const std::vector<std::string>& moves,
@@ -130,7 +131,7 @@ void ClassicSearch::StartSearch(const GoParams& params) {
       params, tree_.get()->HeadPosition(), total_memory, kAvgNodeSize,
       tree_.get()->GetCurrentHead()->GetN());
   search_ = std::make_unique<Search>(
-      *tree_, backend_, std::move(forwarder),
+      search_cached_state_, *tree_, backend_, std::move(forwarder),
       StringsToMovelist(params.searchmoves, tree_->HeadPosition().GetBoard()),
       *move_start_time_, std::move(stopper), params.infinite, params.ponder,
       *options_, syzygy_tb_);

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -269,15 +269,15 @@ Search::Search(const NodeTree& tree, Backend* backend,
     }
   }
 
-  float root_variance = params_.GetTemperatureUtilityVariance();
-  float root_endgame_variance = params_.GetTemperatureEndgameUtilityVariance();
-  root_variance = TemperatureDecay(root_variance, root_endgame_variance,
+  float root_deviation = params_.GetTemperatureUtilityDeviation();
+  float root_endgame_deviation = params_.GetTemperatureEndgameUtilityDeviation();
+  root_deviation = TemperatureDecay(root_deviation, root_endgame_deviation,
                                    played_history_, params_);
 
-  if (root_variance) {
-    const float max_offset = root_variance * 2.5f;
+  if (root_deviation) {
+    const float max_offset = root_deviation * 2.5f;
     const float min_offset = -max_offset;
-    std::normal_distribution<float> dist(0.0f, root_variance);
+    std::normal_distribution<float> dist(0.0f, root_deviation);
     const int legal_moves =
         root_node_->GetN() > 0
             ? root_node_->GetNumEdges()

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -275,6 +275,7 @@ Search::Search(const NodeTree& tree, Backend* backend,
                                    played_history_, params_);
 
   if (root_deviation) {
+    root_deviation /= 50.0f;
     const float max_offset = root_deviation * 2.5f;
     const float min_offset = -max_offset;
     std::normal_distribution<float> dist(0.0f, root_deviation);

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -2546,5 +2546,9 @@ void SearchWorker::UpdateCounters() {
   }
 }
 
+void SearchCachedState::UciNewGame() {
+  temperature_offset_decay_ = 0;
+}
+
 }  // namespace dag_classic
 }  // namespace lczero

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -228,7 +228,7 @@ float UpdateTemperatureOffsetDecay(const Node* root, const SearchParams& params,
   }
   float div = 50.0f * 0.5f /
               std::max(kTemperatureOffsetDecayCuttoff *
-                           (1.0f - std::abs(root->GetWL())),
+                           (1.0f - std::abs(root->GetQ(draw_score))),
                        0.00001f);
   return (best_q - selected_q) * div;
 }
@@ -258,7 +258,7 @@ void GenerateRootUtilityOffsets(const Node* root, const SearchParams& params,
   auto& rng = Random::Get();
   for (int i = 0; i < legal_moves; i++) {
     float offset = std::clamp(dist(rng), min_offset, max_offset);
-    offsets.push_back(offset * (1.0f - std::abs(root->GetWL())));
+    offsets.push_back(offset);
   }
 }
 
@@ -701,7 +701,8 @@ std::vector<std::string> Search::GetVerboseStats(
     float O = 0;
     if (node == root_node_ && !root_utility_offsets_.empty()) {
       unsigned index = edge.edge() - node->GetLowNode()->GetEdges();
-      O = root_utility_offsets_[index];
+      O = root_utility_offsets_[index] *
+          std::max(0.0f, 1.0f - std::abs(node->GetQ(draw_score)));
       print(&oss, "(O: ", O, ") ", 8, 5);
     }
     print(&oss, "(S: ", Q + edge.GetU(U_coeff) + M + O, ") ", 8, 5);
@@ -1874,7 +1875,10 @@ void SearchWorker::PickNodesToExtendTask(
         visited_pol += child->GetP();
         float q = child->GetQ(draw_score);
         float o =
-            use_utility_offset ? search_->root_utility_offsets_[index] : 0.0f;
+            use_utility_offset
+                ? search_->root_utility_offsets_[index] *
+                      std::max(0.0f, 1.0f - std::abs(node->GetQ(draw_score)))
+                : 0.0f;
         current_util[index] = q + m_evaluator.GetMUtility(child, q) + o;
       }
       const float fpu =

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -211,16 +211,36 @@ float TemperatureDecay(float temp, float endgame,
   return temp;
 }
 
+constexpr float kTemperatureOffsetDecayCuttoff = 3.0f;
+
+float UpdateTemperatureOffsetDecay(const Node* root, Move bestmove,
+                                   float draw_score) {
+  float best_q = -1.0f;
+  float selected_q = -1.0f;
+  if (root->GetN() <= 1) return 0.0f;
+  for (const auto& edge : root->Edges()) {
+    if (!edge.HasNode()) continue;
+    float q = edge.GetQ(0.0, draw_score);
+    best_q = std::max(best_q, q);
+    if (edge.GetMove(false) == bestmove) {
+      selected_q = q;
+    }
+  }
+  float div = 50.0f * 0.5f / kTemperatureOffsetDecayCuttoff;
+  return (best_q - selected_q) * div;
+}
+
 }  // namespace
 
-Search::Search(const NodeTree& tree, Backend* backend,
+Search::Search(SearchCachedState& state, const NodeTree& tree, Backend* backend,
                std::unique_ptr<UciResponder> uci_responder,
                const MoveList& searchmoves,
                std::chrono::steady_clock::time_point start_time,
                std::unique_ptr<classic::SearchStopper> stopper, bool infinite,
                bool ponder, const OptionsDict& options, TranspositionTable* tt,
                SyzygyTablebase* syzygy_tb)
-    : ok_to_respond_bestmove_(!infinite && !ponder),
+    : state_(state),
+      ok_to_respond_bestmove_(!infinite && !ponder),
       stopper_(std::move(stopper)),
       root_node_(tree.GetCurrentHead()),
       tt_(tt),
@@ -270,13 +290,16 @@ Search::Search(const NodeTree& tree, Backend* backend,
   }
 
   float root_deviation = params_.GetTemperatureUtilityDeviation();
-  float root_endgame_deviation = params_.GetTemperatureEndgameUtilityDeviation();
+  float root_endgame_deviation =
+      params_.GetTemperatureEndgameUtilityDeviation();
+  root_deviation =
+      std::max(0.0f, root_deviation - state_.temperature_offset_decay_);
   root_deviation = TemperatureDecay(root_deviation, root_endgame_deviation,
-                                   played_history_, params_);
+                                    played_history_, params_);
 
   if (root_deviation) {
     root_deviation /= 50.0f;
-    const float max_offset = root_deviation * 2.5f;
+    const float max_offset = root_deviation * kTemperatureOffsetDecayCuttoff;
     const float min_offset = -max_offset;
     std::normal_distribution<float> dist(0.0f, root_deviation);
     const int legal_moves =
@@ -746,6 +769,10 @@ void Search::MaybeTriggerStop(const classic::IterationStats& stats,
       !bestmove_is_sent_) {
     SendUciInfo(stats);
     EnsureBestMoveKnown();
+    auto bestmove = final_bestmove_;
+    if (played_history_.IsBlackToMove()) bestmove.Flip();
+    state_.temperature_offset_decay_ += UpdateTemperatureOffsetDecay(
+        root_node_, bestmove, GetDrawScore(played_history_.IsBlackToMove()));
     SendMovesStats();
     BestMoveInfo info(final_bestmove_, final_pondermove_);
     uci_responder_->OutputBestMove(&info);

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -211,12 +211,12 @@ float TemperatureDecay(float temp, float endgame,
   return temp;
 }
 
-constexpr float kTemperatureOffsetDecayCuttoff = 3.0f;
-
-float UpdateTemperatureOffsetDecay(const Node* root, Move bestmove,
-                                   float draw_score) {
+float UpdateTemperatureOffsetDecay(const Node* root, const SearchParams& params,
+                                   Move bestmove, float draw_score) {
   float best_q = -1.0f;
   float selected_q = -1.0f;
+  const float kTemperatureOffsetDecayCuttoff =
+      params.GetTemperatureUtilityMaximumOffset();
   if (root->GetN() <= 1) return 0.0f;
   for (const auto& edge : root->Edges()) {
     if (!edge.HasNode()) continue;
@@ -226,8 +226,40 @@ float UpdateTemperatureOffsetDecay(const Node* root, Move bestmove,
       selected_q = q;
     }
   }
-  float div = 50.0f * 0.5f / kTemperatureOffsetDecayCuttoff;
+  float div = 50.0f * 0.5f /
+              std::max(kTemperatureOffsetDecayCuttoff *
+                           (1.0f - std::abs(root->GetWL())),
+                       0.00001f);
   return (best_q - selected_q) * div;
+}
+
+void GenerateRootUtilityOffsets(const Node* root, const SearchParams& params,
+                                const SearchCachedState& state,
+                                const PositionHistory& history,
+                                std::vector<float>& offsets) {
+  if (!offsets.empty() || root->GetN() == 0) return;
+
+  float root_deviation = params.GetTemperatureUtilityDeviation();
+  float root_endgame_deviation = params.GetTemperatureEndgameUtilityDeviation();
+  root_deviation =
+      std::max(0.0f, root_deviation - state.GetTemperatureOffsetDecay());
+  root_deviation =
+      TemperatureDecay(root_deviation, root_endgame_deviation, history, params);
+
+  if (!root_deviation) return;
+  root_deviation /= 50.0f;
+  const float kTemperatureOffsetDecayCuttoff =
+      params.GetTemperatureUtilityMaximumOffset();
+  const float max_offset = root_deviation * kTemperatureOffsetDecayCuttoff;
+  const float min_offset = -max_offset;
+  std::normal_distribution<float> dist(0.0f, root_deviation);
+  const int legal_moves = root->GetNumEdges();
+  offsets.reserve(legal_moves);
+  auto& rng = Random::Get();
+  for (int i = 0; i < legal_moves; i++) {
+    float offset = std::clamp(dist(rng), min_offset, max_offset);
+    offsets.push_back(offset * (1.0f - std::abs(root->GetWL())));
+  }
 }
 
 }  // namespace
@@ -288,31 +320,8 @@ Search::Search(SearchCachedState& state, const NodeTree& tree, Backend* backend,
                            : ContemptMode::WHITE;
     }
   }
-
-  float root_deviation = params_.GetTemperatureUtilityDeviation();
-  float root_endgame_deviation =
-      params_.GetTemperatureEndgameUtilityDeviation();
-  root_deviation =
-      std::max(0.0f, root_deviation - state_.temperature_offset_decay_);
-  root_deviation = TemperatureDecay(root_deviation, root_endgame_deviation,
-                                    played_history_, params_);
-
-  if (root_deviation) {
-    root_deviation /= 50.0f;
-    const float max_offset = root_deviation * kTemperatureOffsetDecayCuttoff;
-    const float min_offset = -max_offset;
-    std::normal_distribution<float> dist(0.0f, root_deviation);
-    const int legal_moves =
-        root_node_->GetN() > 0
-            ? root_node_->GetNumEdges()
-            : played_history_.Last().GetBoard().GenerateLegalMoves().size();
-    root_utility_offsets_.reserve(legal_moves);
-    auto& rng = Random::Get();
-    for (int i = 0; i < legal_moves; i++) {
-      float offset = std::clamp(dist(rng), min_offset, max_offset);
-      root_utility_offsets_.push_back(offset);
-    }
-  }
+  GenerateRootUtilityOffsets(root_node_, params_, state_, played_history_,
+                             root_utility_offsets_);
 }
 
 namespace {
@@ -772,7 +781,8 @@ void Search::MaybeTriggerStop(const classic::IterationStats& stats,
     auto bestmove = final_bestmove_;
     if (played_history_.IsBlackToMove()) bestmove.Flip();
     state_.temperature_offset_decay_ += UpdateTemperatureOffsetDecay(
-        root_node_, bestmove, GetDrawScore(played_history_.IsBlackToMove()));
+        root_node_, params_, bestmove,
+        GetDrawScore(played_history_.IsBlackToMove()));
     SendMovesStats();
     BestMoveInfo info(final_bestmove_, final_pondermove_);
     uci_responder_->OutputBestMove(&info);
@@ -2242,6 +2252,9 @@ void SearchWorker::DoBackupUpdate() {
       work_done = true;
     }
   }
+  GenerateRootUtilityOffsets(search_->root_node_, params_, search_->state_,
+                             search_->played_history_,
+                             search_->root_utility_offsets_);
   if (!work_done) return;
   search_->total_batches_ += 1;
 }
@@ -2546,9 +2559,7 @@ void SearchWorker::UpdateCounters() {
   }
 }
 
-void SearchCachedState::UciNewGame() {
-  temperature_offset_decay_ = 0;
-}
+void SearchCachedState::UciNewGame() { temperature_offset_decay_ = 0; }
 
 }  // namespace dag_classic
 }  // namespace lczero

--- a/src/search/dag_classic/search.h
+++ b/src/search/dag_classic/search.h
@@ -208,6 +208,7 @@ class Search {
 
   std::unique_ptr<UciResponder> uci_responder_;
   ContemptMode contempt_mode_;
+  std::vector<float> root_utility_offsets_;
   friend class SearchWorker;
 };
 

--- a/src/search/dag_classic/search.h
+++ b/src/search/dag_classic/search.h
@@ -52,9 +52,11 @@ namespace dag_classic {
 // The tuple elements are (node, repetitons, moves left).
 typedef std::vector<std::tuple<Node*, int, int>> BackupPath;
 
+class SearchCachedState;
+
 class Search {
  public:
-  Search(const NodeTree& tree, Backend* backend,
+  Search(SearchCachedState& state, const NodeTree& tree, Backend* backend,
          std::unique_ptr<UciResponder> uci_responder,
          const MoveList& searchmoves,
          std::chrono::steady_clock::time_point start_time,
@@ -145,6 +147,7 @@ class Search {
   // Depth of a root node is 0 (even number).
   float GetDrawScore(bool is_odd_depth) const;
 
+  SearchCachedState& state_;
   mutable Mutex counters_mutex_ ACQUIRED_AFTER(nodes_mutex_);
   // Tells all threads to stop.
   std::atomic<bool> stop_{false};
@@ -510,6 +513,16 @@ class SearchWorker {
   std::vector<TaskWorkspace> task_workspaces_;
   TaskWorkspace main_workspace_;
   bool exiting_ = false;
+};
+
+class SearchCachedState {
+  public:
+    SearchCachedState() {}
+
+    friend class Search;
+    friend class SearchWorker;
+  private:
+    float temperature_offset_decay_ = 0.0f;
 };
 
 }  // namespace dag_classic

--- a/src/search/dag_classic/search.h
+++ b/src/search/dag_classic/search.h
@@ -519,6 +519,8 @@ class SearchCachedState {
   public:
     SearchCachedState() {}
 
+    void UciNewGame();
+
     friend class Search;
     friend class SearchWorker;
   private:

--- a/src/search/dag_classic/search.h
+++ b/src/search/dag_classic/search.h
@@ -521,6 +521,8 @@ class SearchCachedState {
 
     void UciNewGame();
 
+    float GetTemperatureOffsetDecay() const { return temperature_offset_decay_; }
+
     friend class Search;
     friend class SearchWorker;
   private:

--- a/src/search/dag_classic/wrapper.cc
+++ b/src/search/dag_classic/wrapper.cc
@@ -80,6 +80,7 @@ class DagClassicSearch : public SearchBase {
   std::unique_ptr<NodeTree> tree_;
   TranspositionTable tt_;
   std::optional<std::chrono::steady_clock::time_point> move_start_time_;
+  SearchCachedState search_cached_state_;
 };
 
 MoveList StringsToMovelist(const std::vector<std::string>& moves,
@@ -143,7 +144,7 @@ void DagClassicSearch::StartSearch(const GoParams& params) {
       params, tree_.get()->HeadPosition(), total_memory, kAvgNodeSize,
       tree_.get()->GetCurrentHead()->GetN());
   search_ = std::make_unique<Search>(
-      *tree_, backend_, std::move(forwarder),
+      search_cached_state_, *tree_, backend_, std::move(forwarder),
       StringsToMovelist(params.searchmoves, tree_->HeadPosition().GetBoard()),
       *move_start_time_, std::move(stopper), params.infinite, params.ponder,
       *options_, &tt_, syzygy_tb_);

--- a/src/search/dag_classic/wrapper.cc
+++ b/src/search/dag_classic/wrapper.cc
@@ -107,6 +107,7 @@ void DagClassicSearch::NewGame() {
   search_.reset();
   tt_.clear();
   tree_.reset();
+  search_cached_state_.UciNewGame();
   time_manager_ = classic::MakeTimeManager(*options_);
 }
 

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -144,6 +144,7 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
     }
   }
   // Do moves while not end of the game. (And while not abort_)
+  classic::SearchCachedState cached_state;
   while (!abort_) {
     game_result_ = tree_[0]->GetPositionHistory().ComputeGameResult();
 
@@ -170,7 +171,8 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
               options_[idx].best_move_callback, options_[idx].info_callback);
 
       search_ = std::make_unique<classic::Search>(
-          *tree_[idx], options_[idx].backend, std::move(responder),
+          cached_state, *tree_[idx], options_[idx].backend,
+          std::move(responder),
           /* searchmoves */ MoveList(), std::chrono::steady_clock::now(),
           std::move(stoppers), /* infinite */ false, /* ponder */ false,
           *options_[idx].uci_options, syzygy_tb);

--- a/src/tools/benchmark.cc
+++ b/src/tools/benchmark.cc
@@ -91,6 +91,7 @@ void Benchmark::Run(bool run_shorter_benchmark) {
     }
     std::vector<std::string> testing_positions(
         positions.cbegin(), positions.cbegin() + num_positions);
+    classic::SearchCachedState cached_state;
 
     for (std::string position : testing_positions) {
       std::cout << "\nPosition: " << cnt++ << "/" << testing_positions.size()
@@ -116,7 +117,7 @@ void Benchmark::Run(bool run_shorter_benchmark) {
 
       const auto start = std::chrono::steady_clock::now();
       auto search = std::make_unique<classic::Search>(
-          tree, backend.get(),
+          cached_state, tree, backend.get(),
           std::make_unique<CallbackUciResponder>(
               std::bind(&Benchmark::OnBestMove, this, std::placeholders::_1),
               std::bind(&Benchmark::OnInfo, this, std::placeholders::_1)),

--- a/src/utils/random.h
+++ b/src/utils/random.h
@@ -47,11 +47,20 @@ class Random {
   template <class RandomAccessIterator>
   void Shuffle(RandomAccessIterator s, RandomAccessIterator e);
 
+  using RandomEngine = std::mt19937;
+  using result_type = RandomEngine::result_type;
+  static constexpr result_type min() { return RandomEngine::min(); }
+  static constexpr result_type max() { return RandomEngine::max(); }
+  result_type operator()() {
+    Mutex::Lock lock(mutex_);
+    return gen_();
+  }
+
  private:
   Random();
 
   Mutex mutex_;
-  std::mt19937 gen_ GUARDED_BY(mutex_);
+  RandomEngine gen_ GUARDED_BY(mutex_);
 };
 
 template <class RandomAccessIterator>


### PR DESCRIPTION
Temperature implementation as post selection has bad interaction with smart prunning. Alternative idea is to implement randomization as utility offset for root moves. Offset allows search to refute temperature preferred moves.

I'm planning to backport this to odds bots if it looks resonable.