### PR TITLE
fix: prevent segfault in Python bindings when calling `Weights.filters()` on transformer networks

### DIFF
--- a/scripts/gen_py_bindings.py
+++ b/scripts/gen_py_bindings.py
@@ -55,7 +55,7 @@ weights.AddMethod('policy_format').AddRetVal(NumericRetVal('i'))
 weights.AddMethod('value_format').AddRetVal(NumericRetVal('i'))
 weights.AddMethod('moves_left_format').AddRetVal(NumericRetVal('i'))
 weights.AddMethod('blocks').AddRetVal(NumericRetVal('i'))
-weights.AddMethod('filters').AddRetVal(NumericRetVal('i'))
+weights.AddMethod('filters').AddRetVal(NumericRetVal('i')).AddEx(ex)
 
 # Input class
 input = mod.AddClass(Class('Input', cpp_name='lczero::python::Input'))

--- a/src/python/weights.h
+++ b/src/python/weights.h
@@ -71,6 +71,11 @@ class Weights {
   }
   int blocks() const { return weights_.weights().residual_size(); }
   int filters() const {
+    if (weights_.weights().residual_size() == 0) {
+      throw Exception(
+          "filters() is not available for this network architecture "
+          "(no residual blocks found — likely a transformer/T1 network).");
+    }
     return weights_.weights().residual(0).conv1().weights().params().size() /
            2304;
   }

--- a/src/python/weights.h
+++ b/src/python/weights.h
@@ -72,9 +72,7 @@ class Weights {
   int blocks() const { return weights_.weights().residual_size(); }
   int filters() const {
     if (weights_.weights().residual_size() == 0) {
-      throw Exception(
-          "filters() is not available for this network architecture "
-          "(no residual blocks found - likely a transformer/T1 network).");
+      throw Exception("This network does not use residual blocks. There are no filters.");
     }
     return weights_.weights().residual(0).conv1().weights().params().size() /
            2304;

--- a/src/python/weights.h
+++ b/src/python/weights.h
@@ -74,7 +74,7 @@ class Weights {
     if (weights_.weights().residual_size() == 0) {
       throw Exception(
           "filters() is not available for this network architecture "
-          "(no residual blocks found — likely a transformer/T1 network).");
+          "(no residual blocks found - likely a transformer/T1 network).");
     }
     return weights_.weights().residual(0).conv1().weights().params().size() /
            2304;


### PR DESCRIPTION
Calling `Weights.filters()` via the Python bindings on a T1/smolgen/transformer network causes a **segfault**, crashing the Python process with no recoverable error.

This happens because `filters()` unconditionally accesses `residual(0)` to compute the filter count, but transformer-based networks store their architecture differently and have `residual_size() == 0`. The out-of-bounds access on the empty repeated field causes undefined behavior (segfault on most platforms).

**Reproduction:**

```python
from lczero.backends import Weights

w = Weights("t1-512x15x8h-distilled-swa-3395000.pb.gz")
w.blocks()   # returns 0 (no crash, but misleading)
w.filters()  # segfault — process killed
```