### PR TITLE
Replace WDL_mu fallback with thresholds.

### DIFF
--- a/src/search/classic/params.cc
+++ b/src/search/classic/params.cc
@@ -592,7 +592,7 @@ void BaseSearchParams::Populate(OptionsParser* options) {
                                          "Q",
                                          "W-L",
                                          "WDL_mu"};
-  options->Add<ChoiceOption>(kScoreTypeId, score_type) = "WDL_mu";
+  options->Add<ChoiceOption>(kScoreTypeId, score_type) = "centipawn";
   std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};
   options->Add<FloatOption>(kMovesLeftMaxEffectId, 0.0f, 1.0f) = 0.0345f;
   options->Add<FloatOption>(kMovesLeftThresholdId, 0.0f, 1.0f) = 0.8f;

--- a/src/search/classic/params.cc
+++ b/src/search/classic/params.cc
@@ -592,7 +592,7 @@ void BaseSearchParams::Populate(OptionsParser* options) {
                                          "Q",
                                          "W-L",
                                          "WDL_mu"};
-  options->Add<ChoiceOption>(kScoreTypeId, score_type) = "centipawn";
+  options->Add<ChoiceOption>(kScoreTypeId, score_type) = "WDL_mu";
   std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};
   options->Add<FloatOption>(kMovesLeftMaxEffectId, 0.0f, 1.0f) = 0.0345f;
   options->Add<FloatOption>(kMovesLeftThresholdId, 0.0f, 1.0f) = 0.8f;

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -320,6 +320,8 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
       uci_info.score = 90 * tan(1.5637541897 * q);
     } else if (score_type == "centipawn") {
       uci_info.score = 100.79055 * tan(1.56292199291664 * wl);
+    } else if (score_type == "centipawn_2020") {
+      uci_info.score = 90 * tan(1.5637541897 * wl);
     } else if (score_type == "centipawn_2019") {
       uci_info.score = 295 * wl / (1 - 0.976953126 * std::pow(wl, 14));
     } else if (score_type == "centipawn_2018") {

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -234,11 +234,11 @@ inline double WDLRescale(float& v, float& d, float wdl_rescale_ratio,
     // Keep centipawn scores within resonable limits when l or d becomes close
     // to zero.
     const float wl_threshold = 0.006f;
-    const float d_threshold = 0.000492143f;
+    const float d_threshold = 0.0004875f;
     w = std::max(w, wl_threshold);
     l = std::max(l, wl_threshold);
-    float d_copy = std::max(d, d_threshold);
-    const float scale = 1.0f / (w + l + d_copy);
+    d = std::max(d, d_threshold);
+    const float scale = 1.0f / (w + l + d);
     w *= scale;
     l *= scale;
   }

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -223,13 +223,25 @@ namespace {
 // WDL conversion formula based on random walk model.
 inline double WDLRescale(float& v, float& d, float wdl_rescale_ratio,
                          float wdl_rescale_diff, float sign, bool invert,
-                         float max_reasonable_s) {
+                         float max_reasonable_s, bool use_threshold = false) {
   if (invert) {
     wdl_rescale_diff = -wdl_rescale_diff;
     wdl_rescale_ratio = 1.0f / wdl_rescale_ratio;
   }
   auto w = (1 + v - d) / 2;
   auto l = (1 - v - d) / 2;
+  if (use_threshold) {
+    // Keep centipawn scores within resonable limits when l or d becomes close
+    // to zero.
+    const float wl_threshold = 0.006f;
+    const float d_threshold = 0.000492143f;
+    w = std::max(w, wl_threshold);
+    l = std::max(l, wl_threshold);
+    float d_copy = std::max(d, d_threshold);
+    const float scale = 1.0f / (w + l + d_copy);
+    w *= scale;
+    l *= scale;
+  }
   // Safeguard against numerical issues; skip WDL transformation if WDL is too
   // extreme.
   const float eps = 0.0001f;
@@ -309,7 +321,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
           contempt_mode_ == ContemptMode::NONE
               ? 0
               : params_.GetWDLRescaleDiff() * params_.GetWDLEvalObjectivity(),
-          sign, true, params_.GetWDLMaxS());
+          sign, true, params_.GetWDLMaxS(), true);
     }
     const auto q = edge.GetQ(default_q, draw_score);
     if (edge.IsTerminal() && wl != 0.0f) {
@@ -333,17 +345,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
     } else if (score_type == "W-L") {
       uci_info.score = wl * 10000;
     } else if (score_type == "WDL_mu") {
-      // Reports the WDL mu value whenever it is reasonable, and defaults to
-      // centipawn otherwise.
-      const float centipawn_fallback_threshold = 0.996f;
-      float centipawn_score = 45 * tan(1.56728071628 * wl);
-      uci_info.score =
-          backend_attributes_.has_wdl && mu_uci != 0.0f &&
-                  std::abs(wl) + d < centipawn_fallback_threshold &&
-                  (std::abs(mu_uci) < 1.0f ||
-                   std::abs(centipawn_score) < std::abs(100 * mu_uci))
-              ? 100 * mu_uci
-              : centipawn_score;
+      uci_info.score = 100 * mu_uci;
     }
 
     auto wdl_w =

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -319,7 +319,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
     } else if (score_type == "centipawn_with_drawscore") {
       uci_info.score = 90 * tan(1.5637541897 * q);
     } else if (score_type == "centipawn") {
-      uci_info.score = 90 * tan(1.5637541897 * wl);
+      uci_info.score = 100.79055 * tan(1.56292199291664 * wl);
     } else if (score_type == "centipawn_2019") {
       uci_info.score = 295 * wl / (1 - 0.976953126 * std::pow(wl, 14));
     } else if (score_type == "centipawn_2018") {

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -316,12 +316,22 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
                    played_history_.IsBlackToMove())
                       ? 1.0f
                       : -1.0f;
+      auto wl_copy = wl, d_copy = d;
       mu_uci = WDLRescale(
-          wl, d, params_.GetWDLRescaleRatio(),
+          wl_copy, d_copy, params_.GetWDLRescaleRatio(),
+
           contempt_mode_ == ContemptMode::NONE
               ? 0
               : params_.GetWDLRescaleDiff() * params_.GetWDLEvalObjectivity(),
           sign, true, params_.GetWDLMaxS(), true);
+      if (params_.GetWDLRescaleDiff() != 0.0f &&
+          contempt_mode_ != ContemptMode::NONE &&
+          params_.GetWDLEvalObjectivity() != 0.0f) {
+        WDLRescale(
+            wl, d, params_.GetWDLRescaleRatio(),
+            params_.GetWDLRescaleDiff() * params_.GetWDLEvalObjectivity(), sign,
+            true, params_.GetWDLMaxS());
+      }
     }
     const auto q = edge.GetQ(default_q, draw_score);
     if (edge.IsTerminal() && wl != 0.0f) {

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -273,13 +273,25 @@ namespace {
 // WDL conversion formula based on random walk model.
 inline double WDLRescale(float& v, float& d, float wdl_rescale_ratio,
                          float wdl_rescale_diff, float sign, bool invert,
-                         float max_reasonable_s) {
+                         float max_reasonable_s, bool use_threshold = false) {
   if (invert) {
     wdl_rescale_diff = -wdl_rescale_diff;
     wdl_rescale_ratio = 1.0f / wdl_rescale_ratio;
   }
   auto w = (1 + v - d) / 2;
   auto l = (1 - v - d) / 2;
+  if (use_threshold) {
+    // Keep centipawn scores within resonable limits when l or d becomes close
+    // to zero.
+    const float wl_threshold = 0.006f;
+    const float d_threshold = 0.000492143f;
+    w = std::max(w, wl_threshold);
+    l = std::max(l, wl_threshold);
+    float d_copy = std::max(d, d_threshold);
+    const float scale = 1.0f / (w + l + d_copy);
+    w *= scale;
+    l *= scale;
+  }
   // Safeguard against numerical issues; skip WDL transformation if WDL is too
   // extreme.
   const float eps = 0.0001f;
@@ -357,7 +369,7 @@ void Search::SendUciInfo(const classic::IterationStats& stats)
           contempt_mode_ == ContemptMode::NONE
               ? 0
               : params_.GetWDLRescaleDiff() * params_.GetWDLEvalObjectivity(),
-          sign, true, params_.GetWDLMaxS());
+          sign, true, params_.GetWDLMaxS(), true);
     }
     const auto q = edge.GetQ(default_q, draw_score);
     if (edge.IsTerminal() && wl != 0.0f) {
@@ -381,17 +393,7 @@ void Search::SendUciInfo(const classic::IterationStats& stats)
     } else if (score_type == "W-L") {
       uci_info.score = wl * 10000;
     } else if (score_type == "WDL_mu") {
-      // Reports the WDL mu value whenever it is reasonable, and defaults to
-      // centipawn otherwise.
-      const float centipawn_fallback_threshold = 0.996f;
-      float centipawn_score = 45 * tan(1.56728071628 * wl);
-      uci_info.score =
-          backend_attributes_.has_wdl && mu_uci != 0.0f &&
-                  std::abs(wl) + d < centipawn_fallback_threshold &&
-                  (std::abs(mu_uci) < 1.0f ||
-                   std::abs(centipawn_score) < std::abs(100 * mu_uci))
-              ? 100 * mu_uci
-              : centipawn_score;
+      uci_info.score = 100 * mu_uci;
     }
 
     auto wdl_w =

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -364,12 +364,21 @@ void Search::SendUciInfo(const classic::IterationStats& stats)
                    played_history_.IsBlackToMove())
                       ? 1.0f
                       : -1.0f;
+      auto wl_copy = wl, d_copy = d;
       mu_uci = WDLRescale(
-          wl, d, params_.GetWDLRescaleRatio(),
+          wl_copy, d_copy, params_.GetWDLRescaleRatio(),
           contempt_mode_ == ContemptMode::NONE
               ? 0
               : params_.GetWDLRescaleDiff() * params_.GetWDLEvalObjectivity(),
           sign, true, params_.GetWDLMaxS(), true);
+      if (params_.GetWDLRescaleDiff() != 0.0f &&
+          contempt_mode_ != ContemptMode::NONE &&
+          params_.GetWDLEvalObjectivity() != 0.0f) {
+        WDLRescale(
+            wl, d, params_.GetWDLRescaleRatio(),
+            params_.GetWDLRescaleDiff() * params_.GetWDLEvalObjectivity(), sign,
+            true, params_.GetWDLMaxS());
+      }
     }
     const auto q = edge.GetQ(default_q, draw_score);
     if (edge.IsTerminal() && wl != 0.0f) {

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -367,7 +367,7 @@ void Search::SendUciInfo(const classic::IterationStats& stats)
     } else if (score_type == "centipawn_with_drawscore") {
       uci_info.score = 90 * tan(1.5637541897 * q);
     } else if (score_type == "centipawn") {
-      uci_info.score = 90 * tan(1.5637541897 * wl);
+      uci_info.score = 100.79055 * tan(1.56292199291664 * wl);
     } else if (score_type == "centipawn_2019") {
       uci_info.score = 295 * wl / (1 - 0.976953126 * std::pow(wl, 14));
     } else if (score_type == "centipawn_2018") {

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -284,11 +284,11 @@ inline double WDLRescale(float& v, float& d, float wdl_rescale_ratio,
     // Keep centipawn scores within resonable limits when l or d becomes close
     // to zero.
     const float wl_threshold = 0.006f;
-    const float d_threshold = 0.000492143f;
+    const float d_threshold = 0.0004875f;
     w = std::max(w, wl_threshold);
     l = std::max(l, wl_threshold);
-    float d_copy = std::max(d, d_threshold);
-    const float scale = 1.0f / (w + l + d_copy);
+    d = std::max(d, d_threshold);
+    const float scale = 1.0f / (w + l + d);
     w *= scale;
     l *= scale;
   }

--- a/src/search/dag_classic/search.cc
+++ b/src/search/dag_classic/search.cc
@@ -368,6 +368,8 @@ void Search::SendUciInfo(const classic::IterationStats& stats)
       uci_info.score = 90 * tan(1.5637541897 * q);
     } else if (score_type == "centipawn") {
       uci_info.score = 100.79055 * tan(1.56292199291664 * wl);
+    } else if (score_type == "centipawn_2020") {
+      uci_info.score = 90 * tan(1.5637541897 * wl);
     } else if (score_type == "centipawn_2019") {
       uci_info.score = 295 * wl / (1 - 0.976953126 * std::pow(wl, 14));
     } else if (score_type == "centipawn_2018") {


### PR DESCRIPTION
This centipawn conversion formula has been fitted trought 3 fixed points. 75% expected score is 1.00 centipawns. 100% expected score is 128.0 centipawns. 50% expected score is 0.0 centipawns.

Default score type is changed to centipawn because WDL_mu doesn't match how search ranks moves.