### PR TITLE
Expose CoreML compute units as gpu device IDs in onnx-coreml backend

### DIFF
--- a/src/neural/backends/onnx/network_onnx.cc
+++ b/src/neural/backends/onnx/network_onnx.cc
@@ -209,7 +209,6 @@ class OnnxNetwork final : public Network {
   // The lower limit for variable batch size.
   int min_batch_size_;
   int gpu_;
-  std::string compute_units_;
   static constexpr int max_batch_size_ = 1024;
   // For conditional locking if running the DML/ROCM/TRT provider.
   OnnxProvider provider_;
@@ -663,9 +662,13 @@ Ort::SessionOptions OnnxNetwork::GetOptions(int threads, int batch_size,
       break;
     }
     case OnnxProvider::COREML: {
+      // gpu=0 (default)=CPUAndGPU, gpu=1=CPUAndNeuralEngine, other=ALL.
+      std::string compute_units = "ALL";
+      if (gpu_ == 0) compute_units = "CPUAndGPU";
+      else if (gpu_ == 1) compute_units = "CPUAndNeuralEngine";
       std::unordered_map<std::string, std::string> provider_options;
       provider_options["ModelFormat"] = "MLProgram";
-      provider_options["MLComputeUnits"] = compute_units_;
+      provider_options["MLComputeUnits"] = compute_units;
       provider_options["AllowLowPrecisionAccumulationOnGPU"] = "1";
       options.AppendExecutionProvider("CoreML", provider_options);
       break;
@@ -861,7 +864,6 @@ OnnxNetwork::OnnxNetwork(const WeightsFile& file, const OptionsDict& opts,
   batch_size_ = opts.GetOrDefault<int>("batch", default_batch);
   steps_ = opts.GetOrDefault<int>("steps", default_steps);
   min_batch_size_ = opts.GetOrDefault<int>("min_batch", default_min_batch);
-  compute_units_ = opts.GetOrDefault<std::string>("compute_units", "ALL");
 
   // Sanity checks.
   if (batch_size_ <= 0) {

--- a/src/neural/backends/onnx/network_onnx.cc
+++ b/src/neural/backends/onnx/network_onnx.cc
@@ -209,6 +209,7 @@ class OnnxNetwork final : public Network {
   // The lower limit for variable batch size.
   int min_batch_size_;
   int gpu_;
+  std::string compute_units_;
   static constexpr int max_batch_size_ = 1024;
   // For conditional locking if running the DML/ROCM/TRT provider.
   OnnxProvider provider_;
@@ -664,7 +665,7 @@ Ort::SessionOptions OnnxNetwork::GetOptions(int threads, int batch_size,
     case OnnxProvider::COREML: {
       std::unordered_map<std::string, std::string> provider_options;
       provider_options["ModelFormat"] = "MLProgram";
-      provider_options["ProfileComputePlan"] = "1";
+      provider_options["MLComputeUnits"] = compute_units_;
       provider_options["AllowLowPrecisionAccumulationOnGPU"] = "1";
       options.AppendExecutionProvider("CoreML", provider_options);
       break;
@@ -860,6 +861,7 @@ OnnxNetwork::OnnxNetwork(const WeightsFile& file, const OptionsDict& opts,
   batch_size_ = opts.GetOrDefault<int>("batch", default_batch);
   steps_ = opts.GetOrDefault<int>("steps", default_steps);
   min_batch_size_ = opts.GetOrDefault<int>("min_batch", default_min_batch);
+  compute_units_ = opts.GetOrDefault<std::string>("compute_units", "ALL");
 
   // Sanity checks.
   if (batch_size_ <= 0) {


### PR DESCRIPTION
## Summary

- Exposes CoreML compute unit selection through the standard `gpu` device ID parameter in the `onnx-coreml` backend, allowing users to control which Apple hardware accelerators CoreML uses for inference.
- Removes `ProfileComputePlan=1` from CoreML provider options (previously caused ~111 s warm session creation; without it warm startup is ~46 s — a ~58% improvement).

## Usage

The `gpu` parameter selects which CoreML compute units to use:
- `gpu=0` (default) — CPU + GPU (`CPUAndGPU`)
- `gpu=1` — CPU + Neural Engine (`CPUAndNeuralEngine`)
- `gpu=2` or higher — all available hardware (`ALL`: CPU, GPU, Neural Engine)

This is most useful with the `multiplexing` backend to run separate instances targeting different compute units simultaneously:

```
./lc0 backendbench -w <model> \
  -b multiplexing \
  -o "gpu(backend=onnx-coreml,gpu=0,threads=2,max_batch=64),npu(backend=onnx-coreml,gpu=1,threads=2,max_batch=64)" \
  --batch-step=16 --start-batch-size=16 --max-batch-size=64 -t 4
```

## Motivation

On Apple Silicon, the GPU and Neural Engine are separate hardware units that can run simultaneously. By running two `onnx-coreml` instances via the `multiplexing` backend — one targeting `gpu=0` (CPUAndGPU) and one targeting `gpu=1` (CPUAndNeuralEngine) — both accelerators can be kept busy in parallel, increasing overall inference throughput compared to a single instance.

Using the existing `gpu` parameter (instead of a custom `compute_units` string option) keeps the interface consistent with other backends like CUDA, where `gpu=N` selects a device.

## Test plan

- [x] Build on macOS with ONNX Runtime CoreML provider
- [x] Run `onnx-coreml` backend with `gpu=0` and `gpu=1` and verify inference produces valid results
- [x] Confirm session creation time is reduced compared to `ProfileComputePlan=1`
- [x] Verify error histogram between `gpu=0` and `gpu=1` shows acceptable numerical differences

🤖 Generated with [Claude Code](https://claude.com/claude-code)