### PR TITLE
Cache piercing with backpropagation repair

### DIFF
--- a/src/search/classic/node.h
+++ b/src/search/classic/node.h
@@ -209,6 +209,10 @@ class Node {
   // * N (+=1)
   // * N-in-flight (-=1)
   void FinalizeScoreUpdate(float v, float d, float m, int multivisit);
+  // Sets wl/d/m from cached NN values without changing N or NInFlight.
+  void SetCachedValue(float v, float d, float m) { wl_ = v; d_ = d; m_ = m; }
+  // Converts a cached value (set by SetCachedValue) into a real visit (N=1).
+  void MakeCachedVisitReal() { n_ = 1; }
   // Like FinalizeScoreUpdate, but it updates n existing visits by delta amount.
   void AdjustForTerminal(float v, float d, float m, int multivisit);
   // Revert visits to a node which ended in a now reverted terminal.

--- a/src/search/classic/params.cc
+++ b/src/search/classic/params.cc
@@ -54,6 +54,14 @@ FillEmptyHistory EncodeHistoryFill(std::string history_fill) {
   return FillEmptyHistory::NO;
 }
 
+CachePiercingBackpropMode EncodeCachePiercingBackprop(const std::string& s) {
+  if (s == "accumulate") return CachePiercingBackpropMode::kAccumulate;
+  if (s == "node") return CachePiercingBackpropMode::kNode;
+  if (s == "blend") return CachePiercingBackpropMode::kBlend;
+  assert(s == "none");
+  return CachePiercingBackpropMode::kNone;
+}
+
 float GetContempt(std::string name, std::string contempt_str,
                   float uci_rating_adv) {
   float contempt = uci_rating_adv;
@@ -529,6 +537,13 @@ const OptionId BaseSearchParams::kCachePiercingId{
     "cache-piercing", "CachePiercing",
     "Maximum number of times per visit that a new node found in the cache "
     "is immediately created and the visit continued through it."};
+const OptionId BaseSearchParams::kCachePiercingBackpropId{
+    "cache-piercing-backprop", "CachePiercingBackprop",
+    "How cache-pierced intermediate nodes are handled during "
+    "backpropagation. \"none\": leaf value overwrites cached value. "
+    "\"accumulate\": cached value counts as extra visit, multivisit "
+    "increases. \"node\": propagate node's own cached value, ignore leaf. "
+    "\"blend\": 50/50 mix of propagated and cached value at each step."};
 const OptionId BaseSearchParams::kGarbageCollectionDelayId{
     "garbage-collection-delay", "GarbageCollectionDelay",
     "The percentage of expected move time until garbage collection start. "
@@ -635,6 +650,11 @@ void BaseSearchParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kUCIRatingAdvId, -10000.0f, 10000.0f) = 0.0f;
   options->Add<BoolOption>(kSearchSpinBackoffId) = false;
   options->Add<IntOption>(kCachePiercingId, 0, 450) = 0;
+  {
+    std::vector<std::string> cp_backprop = {"none", "accumulate", "node",
+                                            "blend"};
+    options->Add<ChoiceOption>(kCachePiercingBackpropId, cp_backprop) = "none";
+  }
   options->Add<FloatOption>(kGarbageCollectionDelayId, 0.0f, 100.0f) = 10.0f;
 }
 
@@ -672,6 +692,8 @@ BaseSearchParams::BaseSearchParams(const OptionsDict& options)
                           : options.Get<float>(kFpuValueAtRootId)),
       kCacheHistoryLength(options.Get<int>(kCacheHistoryLengthId)),
       kCachePiercing(options.Get<int>(kCachePiercingId)),
+      kCachePiercingBackprop(EncodeCachePiercingBackprop(
+          options.Get<std::string>(kCachePiercingBackpropId))),
       kPolicySoftmaxTemp(
           options.Get<float>(SharedBackendParams::kPolicySoftmaxTemp)),
       kMaxCollisionEvents(options.Get<int>(kMaxCollisionEventsId)),

--- a/src/search/classic/params.cc
+++ b/src/search/classic/params.cc
@@ -525,6 +525,10 @@ const OptionId BaseSearchParams::kUCIRatingAdvId{
 const OptionId BaseSearchParams::kSearchSpinBackoffId{
     "search-spin-backoff", "SearchSpinBackoff",
     "Enable backoff for the spin lock that acquires available searcher."};
+const OptionId BaseSearchParams::kCachePiercingId{
+    "cache-piercing", "CachePiercing",
+    "Maximum number of times per visit that a new node found in the cache "
+    "is immediately created and the visit continued through it."};
 const OptionId BaseSearchParams::kGarbageCollectionDelayId{
     "garbage-collection-delay", "GarbageCollectionDelay",
     "The percentage of expected move time until garbage collection start. "
@@ -630,6 +634,7 @@ void BaseSearchParams::Populate(OptionsParser* options) {
   options->Add<StringOption>(kUCIOpponentId);
   options->Add<FloatOption>(kUCIRatingAdvId, -10000.0f, 10000.0f) = 0.0f;
   options->Add<BoolOption>(kSearchSpinBackoffId) = false;
+  options->Add<IntOption>(kCachePiercingId, 0, 450) = 0;
   options->Add<FloatOption>(kGarbageCollectionDelayId, 0.0f, 100.0f) = 10.0f;
 }
 
@@ -666,6 +671,7 @@ BaseSearchParams::BaseSearchParams(const OptionsDict& options)
                           ? kFpuValue
                           : options.Get<float>(kFpuValueAtRootId)),
       kCacheHistoryLength(options.Get<int>(kCacheHistoryLengthId)),
+      kCachePiercing(options.Get<int>(kCachePiercingId)),
       kPolicySoftmaxTemp(
           options.Get<float>(SharedBackendParams::kPolicySoftmaxTemp)),
       kMaxCollisionEvents(options.Get<int>(kMaxCollisionEventsId)),

--- a/src/search/classic/params.h
+++ b/src/search/classic/params.h
@@ -35,6 +35,7 @@ namespace lczero {
 namespace classic {
 
 enum class ContemptMode { PLAY, WHITE, BLACK, NONE };
+enum class CachePiercingBackpropMode { kNone, kAccumulate, kNode, kBlend };
 
 class BaseSearchParams {
  public:
@@ -93,6 +94,9 @@ class BaseSearchParams {
   }
   int GetCacheHistoryLength() const { return kCacheHistoryLength; }
   int GetCachePiercing() const { return kCachePiercing; }
+  CachePiercingBackpropMode GetCachePiercingBackprop() const {
+    return kCachePiercingBackprop;
+  }
   float GetPolicySoftmaxTemp() const { return kPolicySoftmaxTemp; }
   int GetMaxCollisionEvents() const { return kMaxCollisionEvents; }
   int GetMaxCollisionVisits() const { return kMaxCollisionVisits; }
@@ -232,6 +236,7 @@ class BaseSearchParams {
   static const OptionId kUCIRatingAdvId;
   static const OptionId kSearchSpinBackoffId;
   static const OptionId kCachePiercingId;
+  static const OptionId kCachePiercingBackpropId;
   static const OptionId kGarbageCollectionDelayId;
 
  protected:
@@ -259,6 +264,7 @@ class BaseSearchParams {
   const float kFpuValueAtRoot;
   const int kCacheHistoryLength;
   const int kCachePiercing;
+  const CachePiercingBackpropMode kCachePiercingBackprop;
   const float kPolicySoftmaxTemp;
   const int kMaxCollisionEvents;
   const int kMaxCollisionVisits;

--- a/src/search/classic/params.h
+++ b/src/search/classic/params.h
@@ -92,6 +92,7 @@ class BaseSearchParams {
     return at_root ? kFpuValueAtRoot : kFpuValue;
   }
   int GetCacheHistoryLength() const { return kCacheHistoryLength; }
+  int GetCachePiercing() const { return kCachePiercing; }
   float GetPolicySoftmaxTemp() const { return kPolicySoftmaxTemp; }
   int GetMaxCollisionEvents() const { return kMaxCollisionEvents; }
   int GetMaxCollisionVisits() const { return kMaxCollisionVisits; }
@@ -230,6 +231,7 @@ class BaseSearchParams {
   static const OptionId kUCIOpponentId;
   static const OptionId kUCIRatingAdvId;
   static const OptionId kSearchSpinBackoffId;
+  static const OptionId kCachePiercingId;
   static const OptionId kGarbageCollectionDelayId;
 
  protected:
@@ -256,6 +258,7 @@ class BaseSearchParams {
   const bool kFpuAbsoluteAtRoot;
   const float kFpuValueAtRoot;
   const int kCacheHistoryLength;
+  const int kCachePiercing;
   const float kPolicySoftmaxTemp;
   const int kMaxCollisionEvents;
   const int kMaxCollisionVisits;

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -1492,7 +1492,8 @@ void SearchWorker::ProcessPickedTask(int start_idx, int end_idx,
       picked_node.is_cache_hit = false;
       node = child;
     }
-    if (params_.GetOutOfOrderEval() && picked_node.CanEvalOutOfOrder()) {
+    if (params_.GetOutOfOrderEval() && picked_node.CanEvalOutOfOrder() &&
+        !(params_.GetCachePiercing() > 0 && picked_node.is_cache_hit)) {
       // Perform out of order eval for the last entry in minibatch_.
       FetchSingleNodeResult(&picked_node);
       picked_node.ooo_completed = true;

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -2249,6 +2249,7 @@ void SearchWorker::DoBackupUpdateSingleNode(
   float m = node_to_process.eval->m;
   const int multivisit = node_to_process.multivisit;
   int extra_multivisit = 0;
+  const auto cp_backprop = params_.GetCachePiercingBackprop();
   int n_to_fix = 0;
   float v_delta = 0.0f;
   float d_delta = 0.0f;
@@ -2265,16 +2266,38 @@ void SearchWorker::DoBackupUpdateSingleNode(
       d = n->GetD();
       m = n->GetM();
     }
-    // Repair cache-pierced intermediate nodes: their cached value becomes a
-    // real visit, and the extra visit count propagates to all ancestors.
+    // Handle cache-pierced intermediate nodes according to backprop mode.
     if (n->GetN() == 0 && n != node) {
-      if (extra_multivisit > 0) n->IncrementNInFlight(extra_multivisit);
-      n->MakeCachedVisitReal();
-      n->FinalizeScoreUpdate(v, d, m, multivisit + extra_multivisit);
-      v = n->GetWL();
-      d = n->GetD();
-      m = n->GetM();
-      extra_multivisit++;
+      using M = CachePiercingBackpropMode;
+      switch (cp_backprop) {
+        case M::kNone:
+          n->FinalizeScoreUpdate(v, d, m, multivisit + extra_multivisit);
+          break;
+        case M::kAccumulate:
+          if (extra_multivisit > 0) n->IncrementNInFlight(extra_multivisit);
+          n->MakeCachedVisitReal();
+          n->FinalizeScoreUpdate(v, d, m, multivisit + extra_multivisit);
+          v = n->GetWL();
+          d = n->GetD();
+          m = n->GetM();
+          extra_multivisit++;
+          break;
+        case M::kNode:
+          v = n->GetWL();
+          d = n->GetD();
+          m = n->GetM();
+          n->MakeCachedVisitReal();
+          n->CancelScoreUpdate(multivisit);
+          break;
+        case M::kBlend:
+          v = 0.5f * v + 0.5f * static_cast<float>(n->GetWL());
+          d = 0.5f * d + 0.5f * n->GetD();
+          m = 0.5f * m + 0.5f * n->GetM();
+          n->SetCachedValue(v, d, m);
+          n->MakeCachedVisitReal();
+          n->CancelScoreUpdate(multivisit);
+          break;
+      }
     } else {
       if (extra_multivisit > 0) n->IncrementNInFlight(extra_multivisit);
       n->FinalizeScoreUpdate(v, d, m, multivisit + extra_multivisit);

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -1455,25 +1455,42 @@ void SearchWorker::ProcessPickedTask(int start_idx, int end_idx,
 
     // If node is already known as terminal (win/loss/draw according to rules
     // of the game), it means that we already visited this node before.
-    if (picked_node.IsExtendable()) {
-      // Node was never visited, extend it.
-      ExtendNode(node, picked_node.depth, picked_node.moves_to_visit, &history);
-      if (!node->IsTerminal()) {
-        picked_node.nn_queried = true;
-        MoveList legal_moves;
-        legal_moves.reserve(node->GetNumEdges());
-        std::transform(node->Edges().begin(), node->Edges().end(),
-                       std::back_inserter(legal_moves),
-                       [](const auto& edge) { return edge.GetMove(); });
-        picked_node.eval->p.resize(legal_moves.size());
-        picked_node.is_cache_hit = computation_->AddInput(
-                                       EvalPosition{
-                                           .pos = history.GetPositions(),
-                                           .legal_moves = legal_moves,
-                                       },
-                                       picked_node.eval->AsPtr()) ==
-                                   BackendComputation::FETCHED_IMMEDIATELY;
+    for (int cache_piercing_remaining = params_.GetCachePiercing();;) {
+      if (picked_node.IsExtendable()) {
+        // Node was never visited, extend it.
+        ExtendNode(node, picked_node.depth, picked_node.moves_to_visit,
+                   &history);
+        if (!node->IsTerminal()) {
+          picked_node.nn_queried = true;
+          MoveList legal_moves;
+          legal_moves.reserve(node->GetNumEdges());
+          std::transform(node->Edges().begin(), node->Edges().end(),
+                         std::back_inserter(legal_moves),
+                         [](const auto& edge) { return edge.GetMove(); });
+          picked_node.eval->p.resize(legal_moves.size());
+          picked_node.is_cache_hit = computation_->AddInput(
+                                         EvalPosition{
+                                             .pos = history.GetPositions(),
+                                             .legal_moves = legal_moves,
+                                         },
+                                         picked_node.eval->AsPtr()) ==
+                                     BackendComputation::FETCHED_IMMEDIATELY;
+        }
       }
+      if (!picked_node.is_cache_hit || cache_piercing_remaining-- <= 0) break;
+      // Cache piercing: materialize node from cache, continue deeper.
+      FetchSingleNodeResult(&picked_node);
+      node->SetCachedValue(picked_node.eval->q, picked_node.eval->d,
+                           picked_node.eval->m);
+      auto best_edge = node->Edges().begin();
+      Node* child = best_edge.GetOrSpawnNode(node);
+      child->TryStartScoreUpdate();
+      picked_node.moves_to_visit.push_back(best_edge.GetMove());
+      picked_node.depth++;
+      picked_node.node = child;
+      picked_node.nn_queried = false;
+      picked_node.is_cache_hit = false;
+      node = child;
     }
     if (params_.GetOutOfOrderEval() && picked_node.CanEvalOutOfOrder()) {
       // Perform out of order eval for the last entry in minibatch_.
@@ -2230,6 +2247,8 @@ void SearchWorker::DoBackupUpdateSingleNode(
   float v = node_to_process.eval->q;
   float d = node_to_process.eval->d;
   float m = node_to_process.eval->m;
+  const int multivisit = node_to_process.multivisit;
+  int extra_multivisit = 0;
   int n_to_fix = 0;
   float v_delta = 0.0f;
   float d_delta = 0.0f;
@@ -2246,7 +2265,20 @@ void SearchWorker::DoBackupUpdateSingleNode(
       d = n->GetD();
       m = n->GetM();
     }
-    n->FinalizeScoreUpdate(v, d, m, node_to_process.multivisit);
+    // Repair cache-pierced intermediate nodes: their cached value becomes a
+    // real visit, and the extra visit count propagates to all ancestors.
+    if (n->GetN() == 0 && n != node) {
+      if (extra_multivisit > 0) n->IncrementNInFlight(extra_multivisit);
+      n->MakeCachedVisitReal();
+      n->FinalizeScoreUpdate(v, d, m, multivisit + extra_multivisit);
+      v = n->GetWL();
+      d = n->GetD();
+      m = n->GetM();
+      extra_multivisit++;
+    } else {
+      if (extra_multivisit > 0) n->IncrementNInFlight(extra_multivisit);
+      n->FinalizeScoreUpdate(v, d, m, multivisit + extra_multivisit);
+    }
     if (n_to_fix > 0 && !n->IsTerminal()) {
       n->AdjustForTerminal(v_delta, d_delta, m_delta, n_to_fix);
     }
@@ -2291,11 +2323,11 @@ void SearchWorker::DoBackupUpdateSingleNode(
           search_->GetBestChildNoTemperature(search_->root_node_, 0);
     }
   }
-  search_->total_playouts_ += node_to_process.multivisit;
+  search_->total_playouts_ += multivisit + extra_multivisit;
   if (node_to_process.nn_queried && !node_to_process.is_cache_hit) {
     search_->network_evaluations_++;
   }
-  search_->cum_depth_ += node_to_process.depth * node_to_process.multivisit;
+  search_->cum_depth_ += node_to_process.depth * multivisit;
   search_->max_depth_ = std::max(search_->max_depth_, node_to_process.depth);
 }
 


### PR DESCRIPTION
When a visit encounters a node whose NN result is already in cache, instead of stopping and queuing it for batch evaluation, the visit materializes the node immediately and continues deeper through it. This is repeated up to --cache-piercing times per visit, allowing a single visit to traverse multiple cached layers before hitting an uncached position.

The intermediate nodes created this way have their evaluation set from cache but are left with N=0 (no completed visits). During backpropagation, these nodes are "repaired": the cached evaluation is promoted to a real visit (N=1), then the value returning from the leaf is folded in as a second update. The resulting averaged value — blending the node's own cached evaluation with the subtree result — is what propagates further toward the root. Each repaired node also increments the visit count seen by all ancestors, so the tree's visit statistics remain consistent.

The n-in-flight counters are temporarily inflated before each finalize call to compensate for the increased multivisit, keeping virtual loss accounting balanced under the backup write lock.

Vibe coded with Claude Code (Opus 4.6).