### PR TITLE
Add minimax value x_ to classic search nodes

### DIFF
--- a/src/search/classic/node.cc
+++ b/src/search/classic/node.cc
@@ -339,11 +339,11 @@ void Node::MakeNotTerminal() {
     // Recompute with current eval (instead of network's) and children's eval.
     wl_ /= n_;
     d_ /= n_;
-    x_ = std::numeric_limits<float>::lowest();
+    x_ = std::numeric_limits<float>::max();
     for (auto* child : VisitedNodes()) {
-      x_ = std::max(x_, -child->x_);
+      x_ = std::min(x_, -child->x_);
     }
-    if (x_ == std::numeric_limits<float>::lowest()) x_ = 0.0f;
+    if (x_ == std::numeric_limits<float>::max()) x_ = 0.0f;
   }
 }
 
@@ -402,20 +402,20 @@ bool Node::UpdateX(float child_old_x, float child_new_x) {
   float neg_old = -child_old_x;
   float neg_new = -child_new_x;
   if (x_ != neg_old) {
-    if (neg_new <= x_) return false;
+    if (neg_new >= x_) return false;
     x_ = neg_new;
     return true;
   }
-  if (neg_new >= x_) {
+  if (neg_new <= x_) {
     if (neg_new == x_) return false;
     x_ = neg_new;
     return true;
   }
   // Best child worsened — rescan all visited children.
   float old_x = x_;
-  x_ = std::numeric_limits<float>::lowest();
+  x_ = std::numeric_limits<float>::max();
   for (auto* child : VisitedNodes()) {
-    x_ = std::max(x_, -child->x_);
+    x_ = std::min(x_, -child->x_);
   }
   return x_ != old_x;
 }

--- a/src/search/classic/node.cc
+++ b/src/search/classic/node.cc
@@ -31,6 +31,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstring>
+#include <limits>
 #include <iostream>
 #include <sstream>
 #include <thread>
@@ -314,6 +315,7 @@ void Node::MakeTerminal(GameResult result, float plies_left, Terminal type) {
     // comparable to another non-loss choice. Force this by clearing the policy.
     if (GetParent() != nullptr) GetOwnEdge()->SetP(0.0f);
   }
+  x_ = wl_;
 }
 
 void Node::MakeNotTerminal() {
@@ -337,6 +339,11 @@ void Node::MakeNotTerminal() {
     // Recompute with current eval (instead of network's) and children's eval.
     wl_ /= n_;
     d_ /= n_;
+    x_ = std::numeric_limits<float>::lowest();
+    for (auto* child : VisitedNodes()) {
+      x_ = std::max(x_, -child->x_);
+    }
+    if (x_ == std::numeric_limits<float>::lowest()) x_ = 0.0f;
   }
 }
 
@@ -389,6 +396,28 @@ void Node::RevertTerminalVisits(float v, float d, float m, int multivisit) {
     // Decrement N.
     n_ -= multivisit;
   }
+}
+
+bool Node::UpdateX(float child_old_x, float child_new_x) {
+  float neg_old = -child_old_x;
+  float neg_new = -child_new_x;
+  if (x_ != neg_old) {
+    if (neg_new <= x_) return false;
+    x_ = neg_new;
+    return true;
+  }
+  if (neg_new >= x_) {
+    if (neg_new == x_) return false;
+    x_ = neg_new;
+    return true;
+  }
+  // Best child worsened — rescan all visited children.
+  float old_x = x_;
+  x_ = std::numeric_limits<float>::lowest();
+  for (auto* child : VisitedNodes()) {
+    x_ = std::max(x_, -child->x_);
+  }
+  return x_ != old_x;
 }
 
 void Node::UpdateChildrenParents() {

--- a/src/search/classic/node.h
+++ b/src/search/classic/node.h
@@ -171,6 +171,11 @@ class Node {
   float GetWL() const { return wl_; }
   float GetD() const { return d_; }
   float GetM() const { return m_; }
+  float GetX() const { return x_; }
+  void SetX(float x) { x_ = x; }
+  // Updates minimax x_ given child's old and new x values.
+  // Returns true if x_ changed.
+  bool UpdateX(float child_old_x, float child_new_x);
 
   // Returns whether the node is known to be draw/lose/win.
   bool IsTerminal() const { return terminal_type_ != Terminal::NonTerminal; }
@@ -305,6 +310,8 @@ class Node {
   float d_ = 0.0f;
   // Estimated remaining plies.
   float m_ = 0.0f;
+  // Minimax value of the node.
+  float x_ = 0.0f;
   // How many completed visits this node had.
   uint32_t n_ = 0;
   // (AKA virtual loss.) How many threads currently process this node (started

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -507,9 +507,11 @@ std::vector<std::string> Search::GetVerboseStats(const Node* node) const {
       print(oss, "(D: ", d, ") ", 5, 3);
       print(oss, "(M: ", n->GetM(), ") ", 4, 1);
       print(oss, "(Q: ", wl + draw_score * d, ") ", 8, 5);
+      print(oss, "(X: ", sign * n->GetX(), ") ", 8, 5);
     } else {
       *oss << "(WL:  -.-----) (D: -.---) (M:  -.-) ";
       print(oss, "(Q: ", fpu, ") ", 8, 5);
+      *oss << "(X:  -.-----) ";
     }
   };
   auto print_tail = [&](auto* oss, const auto* n) {
@@ -2236,8 +2238,22 @@ void SearchWorker::DoBackupUpdateSingleNode(
   float m_delta = 0.0f;
   uint32_t solid_threshold =
       static_cast<uint32_t>(params_.GetSolidTreeThreshold());
+  float prev_old_x = 0, prev_new_x = 0;
+  bool x_changed = false;
   for (Node *n = node, *p; n != search_->root_node_->GetParent(); n = p) {
     p = n->GetParent();
+
+    // Update minimax x.
+    float old_x = n->GetX();
+    if (n == node) {
+      n->SetX(v);
+      x_changed = (old_x != v);
+    } else if (x_changed) {
+      x_changed = n->IsTerminal() ? false
+                                   : n->UpdateX(prev_old_x, prev_new_x);
+    }
+    prev_old_x = old_x;
+    prev_new_x = n->GetX();
 
     // Current node might have become terminal from some other descendant, so
     // backup the rest of the way with more accurate values.


### PR DESCRIPTION
Propagate a pure minimax value alongside the averaged Q during backpropagation. Efficiently updates by only rescanning children when the previously-best child worsens. Displayed in verbose stats.