### PR TITLE
valuehead: add fixed-depth minimax support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -931,7 +931,7 @@ endif
 if get_option('gtest')
   gtest = dependency('gtest', fallback: ['gtest', 'gtest_dep'])
   gmock = dependency('gmock', fallback: ['gtest', 'gmock_dep'])
-  lc0_lib = library('lc0_lib', common_files, include_directories: includes, dependencies: deps)
+  lc0_lib = static_library('lc0_lib', common_files, include_directories: includes, dependencies: deps)
 
   test('ChessBoard',
     executable('chessboard_test', 'src/chess/board_test.cc',
@@ -974,6 +974,13 @@ if get_option('gtest')
                'src/neural/memcache.cc', pb_files,
     include_directories: includes, link_with: lc0_lib, dependencies: [gtest, gmock]),
     args: '--gtest_output=xml:engine_test.xml', timeout: 90)
+
+  test('InstamoveTest',
+    executable('instamove_test', 'src/search/instamove/instamove_test.cc',
+               'src/search/instamove/instamove.cc', 'src/search/register.cc',
+               pb_files,
+    include_directories: includes, link_with: lc0_lib, dependencies: gtest),
+    args: '--gtest_output=xml:instamove_test.xml', timeout: 90)
 endif
 
 

--- a/src/search/instamove/instamove.cc
+++ b/src/search/instamove/instamove.cc
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <optional>
 #include <vector>
 
 #include "chess/gamestate.h"
@@ -35,16 +36,43 @@
 #include "neural/batchsplit.h"
 #include "search/register.h"
 #include "search/search.h"
+#include "utils/optionsparser.h"
 
 namespace lczero {
 namespace {
+
+const OptionId kValueHeadDepthId{
+    {.long_flag = "valuehead-depth",
+     .uci_option = "ValueHeadDepth",
+     .help_text = "Fixed minimax depth in plies for valuehead search. The "
+                  "standard `go depth` command overrides this value.",
+     .visibility = OptionId::kAlwaysVisible}};
+
+MoveList StringsToMovelist(const std::vector<std::string>& moves,
+                           const ChessBoard& board) {
+  MoveList legal_moves = board.GenerateLegalMoves();
+  if (moves.empty()) return legal_moves;
+
+  MoveList result;
+  result.reserve(moves.size());
+  for (const auto& move : moves) {
+    const Move parsed_move = board.ParseMove(move);
+    if (std::find(legal_moves.begin(), legal_moves.end(), parsed_move) !=
+        legal_moves.end()) {
+      result.emplace_back(parsed_move);
+    }
+  }
+  if (result.empty()) throw Exception("No legal searchmoves.");
+  return result;
+}
 
 class InstamoveSearch : public SearchBase {
  public:
   using SearchBase::SearchBase;
 
  private:
-  virtual Move GetBestMove(const GameState& game_state) = 0;
+  virtual Move GetBestMove(const GameState& game_state,
+                           const GoParams& go_params) = 0;
 
   void SetPosition(const GameState& game_state) final {
     game_state_ = game_state;
@@ -52,7 +80,7 @@ class InstamoveSearch : public SearchBase {
 
   void StartSearch(const GoParams& go_params) final {
     responded_bestmove_.store(false, std::memory_order_relaxed);
-    bestmove_ = GetBestMove(game_state_);
+    bestmove_ = GetBestMove(game_state_, go_params);
     if (!go_params.infinite && !go_params.ponder) RespondBestMove();
   }
   void WaitSearch() final {
@@ -90,9 +118,12 @@ class PolicyHeadSearch : public InstamoveSearch {
  public:
   using InstamoveSearch::InstamoveSearch;
 
-  Move GetBestMove(const GameState& game_state) final {
+  Move GetBestMove(const GameState& game_state,
+                   const GoParams& go_params) final {
     const std::vector<Position> positions = game_state.GetPositions();
-    MoveList legal_moves = positions.back().GetBoard().GenerateLegalMoves();
+    MoveList legal_moves =
+        StringsToMovelist(go_params.searchmoves, positions.back().GetBoard());
+    if (legal_moves.empty()) return Move{};
     std::vector<EvalResult> res = backend_->EvaluateBatch(
         std::vector<EvalPosition>{EvalPosition{positions, legal_moves}});
     const size_t best_move_idx =
@@ -102,7 +133,8 @@ class PolicyHeadSearch : public InstamoveSearch {
         .depth = 1,
         .seldepth = 1,
         .nodes = 1,
-        .score = 90 * std::tan(1.5637541897 * res[0].q),
+        .score = static_cast<int>(
+            std::round(90 * std::tan(1.5637541897 * res[0].q))),
         .wdl =
             ThinkingInfo::WDL{
                 static_cast<int>(std::round(
@@ -120,80 +152,189 @@ class PolicyHeadSearch : public InstamoveSearch {
 
 class ValueHeadSearch : public InstamoveSearch {
  public:
-  using InstamoveSearch::InstamoveSearch;
-  Move GetBestMove(const GameState& game_state) final {
-    std::unique_ptr<BackendComputation> computation =
-        backend_->CreateComputation();
+  ValueHeadSearch(UciResponder* responder, const OptionsDict* options)
+      : InstamoveSearch(responder), options_(options) {}
 
-    PositionHistory history(game_state.GetPositions());
-    const ChessBoard& board = history.Last().GetBoard();
-    const std::vector<Move> legal_moves = board.GenerateLegalMoves();
+ private:
+  struct MateScore {
+    bool winning;
+    int plies;
+  };
 
-    struct Score {
-      float negative_q;  // Negative because NN evaluates from opponent's
-                         // perspective.
-      float d;
-      std::optional<int> mate;
+  struct Score {
+    float q = 0.0f;
+    float d = 0.0f;
+    std::optional<MateScore> mate;
+  };
 
-      bool operator<(const Score& other) const {
-        // Mate always beats non-mate
-        if (mate && !other.mate) return true;
-        if (!mate && other.mate) return false;
-        // Both mates: shorter is better
-        if (mate && other.mate) return *mate < *other.mate;
-        // Neither mate: lower negative_q is better
-        return negative_q < other.negative_q;
-      }
+  struct SearchStats {
+    int seldepth = 0;
+    int64_t nodes = 0;
+  };
+
+  static Score FlipScore(const Score& score) {
+    Score flipped{
+        .q = -score.q,
+        .d = score.d,
+        .mate = score.mate
+                    ? std::make_optional<MateScore>(
+                          MateScore{.winning = !score.mate->winning,
+                                    .plies = score.mate->plies + 1})
+                    : std::nullopt,
     };
+    return flipped;
+  }
 
-    std::vector<Score> results(legal_moves.size());
+  static bool IsBetterScore(const Score& lhs, const Score& rhs) {
+    if (lhs.mate || rhs.mate) {
+      if (!lhs.mate) return rhs.mate->winning ? false : true;
+      if (!rhs.mate) return lhs.mate->winning ? true : false;
+      if (lhs.mate->winning != rhs.mate->winning) return lhs.mate->winning;
+      if (lhs.mate->winning) return lhs.mate->plies < rhs.mate->plies;
+      return lhs.mate->plies > rhs.mate->plies;
+    }
+    return lhs.q > rhs.q;
+  }
 
-    for (size_t i = 0; i < legal_moves.size(); i++) {
-      Move move = legal_moves[i];
-      history.Append(move);
-      switch (history.ComputeGameResult()) {
-        case GameResult::UNDECIDED:
-          computation->AddInput(
-              EvalPosition{history.GetPositions(), {}},
-              EvalResultPtr{.q = &results[i].negative_q, .d = &results[i].d});
-          break;
-        case GameResult::DRAW:
-          results[i] = {.negative_q = 0, .d = 1, .mate = std::nullopt};
-          break;
-        default:
-          // A legal move to a non-drawn terminal without tablebases must be a
-          // win.
-          results[i] = {.negative_q = -1, .d = 0, .mate = 1};
-      }
-      history.Pop();
+  static int ToUciMate(const MateScore& mate) {
+    return mate.winning ? (mate.plies + 1) / 2 : -(mate.plies / 2);
+  }
+
+  int GetSearchDepth(const GoParams& go_params) const {
+    if (go_params.depth) return std::max(1, *go_params.depth);
+    return std::max(1, options_->Get<int>(kValueHeadDepthId));
+  }
+
+  Score EvaluatePosition(PositionHistory* history, SearchStats* stats,
+                         int ply_from_root) {
+    stats->seldepth = std::max(stats->seldepth, ply_from_root);
+    switch (history->ComputeGameResult()) {
+      case GameResult::DRAW:
+        return Score{.q = 0.0f, .d = 1.0f, .mate = std::nullopt};
+      case GameResult::UNDECIDED:
+        break;
+      default:
+        return Score{
+            .q = -1.0f,
+            .d = 0.0f,
+            .mate = MateScore{.winning = false, .plies = 0},
+        };
     }
 
-    computation->ComputeBlocking();
+    const EvalResult eval = backend_->EvaluateBatch(
+        std::vector<EvalPosition>{EvalPosition{history->GetPositions(), {}}})[0];
+    return Score{.q = eval.q, .d = eval.d, .mate = std::nullopt};
+  }
 
+  std::vector<Score> EvaluateMoves(PositionHistory* history,
+                                   const MoveList& legal_moves, int depth,
+                                   int ply_from_root, SearchStats* stats) {
+    std::vector<Score> results(legal_moves.size());
+    if (depth == 1) {
+      std::unique_ptr<BackendComputation> computation =
+          backend_->CreateComputation();
+      std::vector<size_t> pending_indices;
+      pending_indices.reserve(legal_moves.size());
+      for (size_t i = 0; i < legal_moves.size(); ++i) {
+        history->Append(legal_moves[i]);
+        ++stats->nodes;
+        stats->seldepth = std::max(stats->seldepth, ply_from_root + 1);
+        switch (history->ComputeGameResult()) {
+          case GameResult::UNDECIDED:
+            computation->AddInput(
+                EvalPosition{history->GetPositions(), {}},
+                EvalResultPtr{.q = &results[i].q, .d = &results[i].d});
+            pending_indices.emplace_back(i);
+            break;
+          case GameResult::DRAW:
+            results[i] = Score{.q = 0.0f, .d = 1.0f, .mate = std::nullopt};
+            break;
+          default:
+            results[i] = Score{
+                .q = 1.0f,
+                .d = 0.0f,
+                .mate = MateScore{.winning = true, .plies = 1},
+            };
+            break;
+        }
+        history->Pop();
+      }
+      computation->ComputeBlocking();
+      for (const size_t idx : pending_indices) {
+        results[idx] = FlipScore(results[idx]);
+      }
+      return results;
+    }
+
+    for (size_t i = 0; i < legal_moves.size(); ++i) {
+      history->Append(legal_moves[i]);
+      ++stats->nodes;
+      results[i] =
+          FlipScore(EvaluateNode(history, depth - 1, ply_from_root + 1, stats));
+      history->Pop();
+    }
+    return results;
+  }
+
+  Score EvaluateNode(PositionHistory* history, int depth, int ply_from_root,
+                     SearchStats* stats) {
+    if (depth <= 0) return EvaluatePosition(history, stats, ply_from_root);
+    const MoveList legal_moves = history->Last().GetBoard().GenerateLegalMoves();
+    if (legal_moves.empty()) {
+      return EvaluatePosition(history, stats, ply_from_root);
+    }
+
+    const std::vector<Score> results =
+        EvaluateMoves(history, legal_moves, depth, ply_from_root, stats);
+    return *std::max_element(results.begin(), results.end(),
+                             [](const Score& lhs, const Score& rhs) {
+                               return IsBetterScore(rhs, lhs);
+                             });
+  }
+
+  Move GetBestMove(const GameState& game_state,
+                   const GoParams& go_params) final {
+    PositionHistory history(game_state.GetPositions());
+    const MoveList legal_moves =
+        StringsToMovelist(go_params.searchmoves, history.Last().GetBoard());
+    if (legal_moves.empty()) return Move{};
+
+    SearchStats stats;
+    const int search_depth = GetSearchDepth(go_params);
+    const std::vector<Score> results =
+        EvaluateMoves(&history, legal_moves, search_depth, 0, &stats);
     const size_t best_idx =
-        std::min_element(results.begin(), results.end()) - results.begin();
+        std::max_element(results.begin(), results.end(),
+                         [](const Score& lhs, const Score& rhs) {
+                           return IsBetterScore(rhs, lhs);
+                         }) -
+        results.begin();
 
     const Score& r = results[best_idx];
     auto to_int = [](double x) { return static_cast<int>(std::round(x)); };
     std::vector<ThinkingInfo> infos{
-        {.depth = 1,
-         .seldepth = 1,
-         .nodes = static_cast<int64_t>(legal_moves.size()),
-         .mate = r.mate,
+        {.depth = search_depth,
+         .seldepth = stats.seldepth,
+         .nodes = stats.nodes,
+         .mate = r.mate ? std::make_optional(ToUciMate(*r.mate))
+                        : std::nullopt,
          .score = r.mate ? std::nullopt
                          : std::make_optional<int>(
-                               -90 * std::tan(1.5637541897 * r.negative_q)),
+                               static_cast<int>(
+                                   std::round(90 * std::tan(1.5637541897 *
+                                                            r.q)))),
          .wdl = r.mate
                     ? std::nullopt
                     : std::make_optional<ThinkingInfo::WDL>(ThinkingInfo::WDL{
-                          .w = to_int(500 * (1 - r.negative_q - r.d)),
+                          .w = to_int(500 * (1 + r.q - r.d)),
                           .d = to_int(1000 * r.d),
-                          .l = to_int(500 * (1 + r.negative_q - r.d)),
+                          .l = to_int(500 * (1 - r.q - r.d)),
                       })}};
     uci_responder_->OutputThinkingInfo(&infos);
-    Move best_move = legal_moves[best_idx];
-    return best_move;
+    return legal_moves[best_idx];
   }
+
+  const OptionsDict* options_;
 };
 
 class PolicyHeadFactory : public SearchFactory {
@@ -207,8 +348,12 @@ class PolicyHeadFactory : public SearchFactory {
 class ValueHeadFactory : public SearchFactory {
   std::string_view GetName() const override { return "valuehead"; }
   std::unique_ptr<SearchBase> CreateSearch(UciResponder* responder,
-                                           const OptionsDict*) const override {
-    return std::make_unique<ValueHeadSearch>(responder);
+                                           const OptionsDict* options)
+      const override {
+    return std::make_unique<ValueHeadSearch>(responder, options);
+  }
+  void PopulateParams(OptionsParser* parser) const override {
+    parser->Add<IntOption>(kValueHeadDepthId, 1, 99) = 1;
   }
 };
 

--- a/src/search/instamove/instamove_test.cc
+++ b/src/search/instamove/instamove_test.cc
@@ -1,0 +1,216 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2026 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#include "gtest/gtest.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "chess/board.h"
+#include "chess/callbacks.h"
+#include "chess/gamestate.h"
+#include "chess/position.h"
+#include "chess/uciloop.h"
+#include "neural/backend.h"
+#include "search/register.h"
+#include "search/search.h"
+#include "utils/optionsparser.h"
+
+namespace lczero {
+namespace {
+
+class CapturingResponder : public UciResponder {
+ public:
+  void OutputBestMove(BestMoveInfo* info) override {
+    bestmove_ = info->bestmove;
+  }
+  void OutputThinkingInfo(std::vector<ThinkingInfo>* infos) override {
+    infos_ = *infos;
+  }
+
+  const Move& bestmove() const { return bestmove_; }
+  const std::vector<ThinkingInfo>& infos() const { return infos_; }
+
+ private:
+  Move bestmove_;
+  std::vector<ThinkingInfo> infos_;
+};
+
+class MapBackendComputation : public BackendComputation {
+ public:
+  MapBackendComputation(const std::unordered_map<std::string, EvalResult>* evals,
+                        EvalResult fallback)
+      : evals_(evals), fallback_(std::move(fallback)) {}
+
+  size_t UsedBatchSize() const override { return entries_.size(); }
+
+  AddInputResult AddInput(const EvalPosition& pos,
+                          EvalResultPtr result) override {
+    entries_.push_back({PositionToFen(pos.pos.back()), result});
+    return ENQUEUED_FOR_EVAL;
+  }
+
+  void ComputeBlocking() override {
+    for (const auto& entry : entries_) {
+      const auto it = evals_->find(entry.fen);
+      const EvalResult& eval = it == evals_->end() ? fallback_ : it->second;
+      if (entry.result.q) *entry.result.q = eval.q;
+      if (entry.result.d) *entry.result.d = eval.d;
+      if (entry.result.m) *entry.result.m = eval.m;
+    }
+  }
+
+ private:
+  struct Entry {
+    std::string fen;
+    EvalResultPtr result;
+  };
+
+  const std::unordered_map<std::string, EvalResult>* evals_;
+  EvalResult fallback_;
+  std::vector<Entry> entries_;
+};
+
+class MapBackend : public Backend {
+ public:
+  explicit MapBackend(std::unordered_map<std::string, EvalResult> evals,
+                      EvalResult fallback)
+      : evals_(std::move(evals)), fallback_(std::move(fallback)) {}
+
+  BackendAttributes GetAttributes() const override {
+    return BackendAttributes{
+        .has_mlh = false,
+        .has_wdl = true,
+        .runs_on_cpu = true,
+        .suggested_num_search_threads = 1,
+        .recommended_batch_size = 16,
+        .maximum_batch_size = 16,
+    };
+  }
+
+  std::unique_ptr<BackendComputation> CreateComputation() override {
+    return std::make_unique<MapBackendComputation>(&evals_, fallback_);
+  }
+
+ private:
+  std::unordered_map<std::string, EvalResult> evals_;
+  EvalResult fallback_;
+};
+
+GameState MakeGameState(const std::string& fen,
+                        const std::vector<std::string>& moves) {
+  GameState state;
+  state.startpos = Position::FromFen(fen);
+  ChessBoard board = state.startpos.GetBoard();
+  state.moves.reserve(moves.size());
+  for (const auto& move : moves) {
+    const Move parsed_move = board.ParseMove(move);
+    state.moves.push_back(parsed_move);
+    board.ApplyMove(parsed_move);
+    board.Mirror();
+  }
+  return state;
+}
+
+std::string FenAfterMoves(const std::vector<std::string>& moves) {
+  return PositionToFen(
+      MakeGameState(ChessBoard::kStartposFen, moves).CurrentPosition());
+}
+
+struct SearchResult {
+  std::string bestmove;
+  std::vector<ThinkingInfo> infos;
+};
+
+SearchResult RunValueHeadSearch(int configured_depth,
+                                std::optional<int> go_depth) {
+  auto* factory = SearchManager::Get()->GetFactoryByName("valuehead");
+  EXPECT_NE(factory, nullptr);
+
+  OptionsParser parser;
+  factory->PopulateParams(&parser);
+  parser.SetUciOption("ValueHeadDepth", std::to_string(configured_depth));
+  const OptionsDict& options = parser.GetOptionsDict();
+
+  const std::unordered_map<std::string, EvalResult> evals = {
+      {FenAfterMoves({"e2e4"}), EvalResult{.q = -0.3f, .d = 0.2f, .m = 0.0f}},
+      {FenAfterMoves({"d2d4"}), EvalResult{.q = -0.2f, .d = 0.2f, .m = 0.0f}},
+      {FenAfterMoves({"e2e4", "e7e5"}),
+       EvalResult{.q = -0.9f, .d = 0.1f, .m = 0.0f}},
+      {FenAfterMoves({"d2d4", "d7d5"}),
+       EvalResult{.q = -0.2f, .d = 0.2f, .m = 0.0f}},
+  };
+  MapBackend backend(evals, EvalResult{.q = -0.1f, .d = 0.2f, .m = 0.0f});
+  CapturingResponder responder;
+
+  std::unique_ptr<SearchBase> search =
+      factory->CreateSearch(&responder, &options);
+  search->SetBackend(&backend);
+  search->SetPosition(MakeGameState(ChessBoard::kStartposFen, {}));
+
+  GoParams params;
+  params.searchmoves = {"e2e4", "d2d4"};
+  params.depth = go_depth;
+  search->StartSearch(params);
+  search->WaitSearch();
+
+  return SearchResult{
+      .bestmove = responder.bestmove().ToString(false),
+      .infos = responder.infos(),
+  };
+}
+
+TEST(ValueHeadSearch, UsesConfiguredDepthWhenGoDepthIsAbsent) {
+  const SearchResult depth_one = RunValueHeadSearch(1, std::nullopt);
+  EXPECT_EQ(depth_one.bestmove, "e2e4");
+  ASSERT_EQ(depth_one.infos.size(), 1u);
+  EXPECT_EQ(depth_one.infos.front().depth, 1);
+
+  const SearchResult depth_two = RunValueHeadSearch(2, std::nullopt);
+  EXPECT_EQ(depth_two.bestmove, "d2d4");
+  ASSERT_EQ(depth_two.infos.size(), 1u);
+  EXPECT_EQ(depth_two.infos.front().depth, 2);
+}
+
+TEST(ValueHeadSearch, GoDepthOverridesConfiguredDepth) {
+  const SearchResult result = RunValueHeadSearch(1, 2);
+  EXPECT_EQ(result.bestmove, "d2d4");
+  ASSERT_EQ(result.infos.size(), 1u);
+  EXPECT_EQ(result.infos.front().depth, 2);
+}
+
+}  // namespace
+}  // namespace lczero
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  lczero::InitializeMagicBitboards();
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

This addresses the fixed-depth minimax part of #2176.

The current `valuehead` search only scores root moves with a depth-1 sweep. This PR adds configurable fixed-depth minimax support while preserving the current default behavior.

- add a `ValueHeadDepth` option for the `valuehead` search
- honor `go depth` as an override for `valuehead`
- run a full-width fixed-depth minimax search instead of stopping at depth 1 when requested
- keep `valuehead` depth at `1` by default, so normal behavior stays unchanged unless explicitly requested
- support `searchmoves` in the `instamove` searches at the root
- add an `InstamoveTest` covering both the configured-depth path and the `go depth` override

To test:

- `py -m mesonbuild.mesonmain test -C build\\debug InstamoveTest --print-errorlogs`
