### PR TITLE
Use OpenCL cl_khr_command_buffer extension when available

### DIFF
--- a/src/neural/backends/opencl/OpenCL.cc
+++ b/src/neural/backends/opencl/OpenCL.cc
@@ -296,6 +296,9 @@ void OpenCL::initialize(const int channels, const OpenCLParams& params) {
       this_score += 1000 * (this_vendor.find("nvidia") != std::string::npos);
       this_score += 500 * (this_vendor.find("intel") != std::string::npos);
       this_score += 100 * (d.getInfo<CL_DEVICE_TYPE>() == CL_DEVICE_TYPE_GPU);
+      this_score += 10 * (d.getInfo<CL_DEVICE_EXTENSIONS>().find(
+                              "cl_khr_command_buffer") != std::string::npos);
+
       this_score += opencl_version * 10;
       CERR << "Device score:   " << this_score;
 
@@ -376,6 +379,15 @@ void OpenCL::initialize(const int channels, const OpenCLParams& params) {
 
   m_max_workgroup_size = best_device.getInfo<CL_DEVICE_MAX_WORK_GROUP_SIZE>();
   m_max_workgroup_dims = best_device.getInfo<CL_DEVICE_MAX_WORK_ITEM_SIZES>();
+
+  m_graph_capture_enabled = params.graph_capture;  // defaults to true
+  if (m_graph_capture_enabled) {
+    // If requested by user also check for device support for extension
+    std::string extensions = best_device.getInfo<CL_DEVICE_EXTENSIONS>();
+    m_graph_capture_enabled =
+        extensions.find("cl_khr_command_buffer") != std::string::npos;
+  }
+  CERR << "Graph Capture enabled: " << m_graph_capture_enabled;
 
   CERR << "Max workgroup size: " << m_max_workgroup_size;
   std::ostringstream ss;

--- a/src/neural/backends/opencl/OpenCL.h
+++ b/src/neural/backends/opencl/OpenCL.h
@@ -36,6 +36,7 @@ using net_t = float;
 #include <string>
 #include <vector>
 
+#define CL_ENABLE_BETA_EXTENSIONS
 #if __has_include("CL/opencl.hpp")
 #include "CL/opencl.hpp"
 #elif __has_include("OpenCL/opencl.hpp")
@@ -244,6 +245,8 @@ class OpenCL {
   void initialize(const int channels, const OpenCLParams& params);
   std::string get_device_name();
 
+  bool graph_capture_enabled() const { return m_graph_capture_enabled; }
+
   std::vector<size_t> get_sgemm_tuners(void);
 
   cl::Device m_device;
@@ -265,6 +268,7 @@ class OpenCL {
   size_t m_wavefront_size{0};
   size_t m_max_workgroup_size{0};
   std::vector<size_t> m_max_workgroup_dims;
+  bool m_graph_capture_enabled{false};
   bool m_init_ok{false};
 };
 

--- a/src/neural/backends/opencl/OpenCLBuffers.cc
+++ b/src/neural/backends/opencl/OpenCLBuffers.cc
@@ -128,20 +128,20 @@ OpenCLBuffers::OpenCLBuffers(const OpenCL_Network& opencl_net)
   m_pool_buffer =
       cl::Buffer(m_opencl.m_context, CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS,
                  alloc_pool_size);
+
+  if (m_opencl.m_graph_capture_enabled) {
+    std::vector<cl::CommandQueue> queues{m_commandqueue};
+    for (unsigned i = 0; i < max_batch_size; i++) {
+      m_commandbuffers.emplace_back(queues);
+    }
+  }
 }
 
-void OpenCLBuffers::forward(const std::vector<net_t>& input,
-                            std::vector<net_t>& output_pol,
-                            std::vector<net_t>& output_val,
-                            std::vector<net_t>& output_mov,
-                            const int batch_size) {
+void OpenCLBuffers::forward_kernels(const int batch_size,
+                                    const bool capture_kernels) {
   auto& layers = m_opencl_net.m_layers;
-
-  const auto inSize = sizeof(net_t) * input.size();
-  m_commandqueue.enqueueWriteBuffer(m_inBuffer, CL_FALSE, 0, inSize,
-                                    input.data());
-
   auto skip_in_trans = false;
+
   for (auto iter = cbegin(layers); iter != cend(layers); iter++) {
     const auto& layer = *iter;
     const auto niter = std::next(iter);
@@ -156,7 +156,8 @@ void OpenCLBuffers::forward(const std::vector<net_t>& input,
       }
       convolve3(layer.channels, layer.outputs, m_inBuffer, m_inBuffer,
                 m_VBuffer, m_MBuffer, conv_weights, nullptr, conv_biases,
-                skip_in_trans, skip_next_in_trans, true, true, batch_size);
+                skip_in_trans, skip_next_in_trans, true, true, batch_size,
+                capture_kernels);
       skip_in_trans = skip_next_in_trans;
     } else if (layer.is_residual_block) {
       assert(layer.channels == layer.outputs);
@@ -166,20 +167,21 @@ void OpenCLBuffers::forward(const std::vector<net_t>& input,
       auto conv2_weights = begin(layer.weights) + 2;
       auto conv2_biases = begin(layer.weights) + 3;
 
-      convolve3(layer.channels,  // channels
-                layer.outputs,   // outputs
-                m_inBuffer,      // bufferIn
-                m_inBuffer2,     // bufferOut
-                m_VBuffer,       // bufferV
-                m_MBuffer,       // bufferM
-                conv1_weights,   // weights
-                nullptr,         // bufferResidual
-                conv1_biases,    // biases
-                skip_in_trans,   // skip_in_transform
-                true,            // fuse_in_transform
-                false,           // store_inout
-                true,            // relu
-                batch_size);     // batch_size
+      convolve3(layer.channels,    // channels
+                layer.outputs,     // outputs
+                m_inBuffer,        // bufferIn
+                m_inBuffer2,       // bufferOut
+                m_VBuffer,         // bufferV
+                m_MBuffer,         // bufferM
+                conv1_weights,     // weights
+                nullptr,           // bufferResidual
+                conv1_biases,      // biases
+                skip_in_trans,     // skip_in_transform
+                true,              // fuse_in_transform
+                false,             // store_inout
+                true,              // relu
+                batch_size,        // batch_size
+                capture_kernels);  // capture_kernels
 
       auto skip_next_in_trans = false;
       if (niter->is_residual_block) {
@@ -209,7 +211,8 @@ void OpenCLBuffers::forward(const std::vector<net_t>& input,
                 skip_next_in_trans,  // fuse_in_transform
                 store_inout,         // store_inout
                 relu,                // relu
-                batch_size);         // batch_size
+                batch_size,          // batch_size
+                capture_kernels);    // capture_kernels
       skip_in_trans = skip_next_in_trans;
     } else if (layer.is_se_unit) {
       // inBuffer: residual connection from start of the residual block
@@ -224,7 +227,8 @@ void OpenCLBuffers::forward(const std::vector<net_t>& input,
                          m_MBuffer,            // bufferTemp2
                          se_weights,           // weights
                          m_inBuffer,           // residual
-                         batch_size);          // batch_size
+                         batch_size,           // batch_size
+                         capture_kernels);     // capture_kernels
     } else if (layer.is_conv_policy) {
       assert(niter != cend(layers));
       auto conv1_weights = begin(layer.weights);
@@ -233,39 +237,42 @@ void OpenCLBuffers::forward(const std::vector<net_t>& input,
       auto conv2_biases = begin(layer.weights) + 3;
       auto indices = begin(layer.weights) + 4;
 
-      convolve3(layer.channels,  // channels
-                layer.channels,  // outputs
-                m_inBuffer,      // bufferIn
-                m_inBuffer2,     // bufferOut
-                m_VBuffer,       // bufferV
-                m_MBuffer,       // bufferM
-                conv1_weights,   // weights
-                nullptr,         // bufferResidual
-                conv1_biases,    // biases
-                skip_in_trans,   // skip_in_transform
-                true,            // fuse_in_transform
-                false,           // store_inout
-                true,            // relu
-                batch_size);     // batch_size
+      convolve3(layer.channels,    // channels
+                layer.channels,    // outputs
+                m_inBuffer,        // bufferIn
+                m_inBuffer2,       // bufferOut
+                m_VBuffer,         // bufferV
+                m_MBuffer,         // bufferM
+                conv1_weights,     // weights
+                nullptr,           // bufferResidual
+                conv1_biases,      // biases
+                skip_in_trans,     // skip_in_transform
+                true,              // fuse_in_transform
+                false,             // store_inout
+                true,              // relu
+                batch_size,        // batch_size
+                capture_kernels);  // capture_kernels
 
       // m_inBuffer needs to be preserved for value head
-      convolve3(layer.channels,  // channels
-                layer.outputs,   // outputs
-                m_inBuffer2,     // bufferIn
-                m_inBuffer2,     // bufferOut
-                m_VBuffer,       // bufferV
-                m_MBuffer,       // bufferM
-                conv2_weights,   // weights
-                nullptr,         // bufferResidual
-                conv2_biases,    // biases
-                true,            // skip_in_transform
-                false,           // fuse_in_transform
-                false,           // store_inout
-                false,           // relu
-                batch_size);     // batch_size
+      convolve3(layer.channels,    // channels
+                layer.outputs,     // outputs
+                m_inBuffer2,       // bufferIn
+                m_inBuffer2,       // bufferOut
+                m_VBuffer,         // bufferV
+                m_MBuffer,         // bufferM
+                conv2_weights,     // weights
+                nullptr,           // bufferResidual
+                conv2_biases,      // biases
+                true,              // skip_in_transform
+                false,             // fuse_in_transform
+                false,             // store_inout
+                false,             // relu
+                batch_size,        // batch_size
+                capture_kernels);  // capture_kernels
 
       policymap(batch_size, m_inBuffer2, m_pinnedOutBuffer_pol, indices[0],
-                layer.outputs * 8 * 8, layer.ip_in_size, layer.ip_out_size);
+                layer.outputs * 8 * 8, layer.ip_in_size, layer.ip_out_size,
+                capture_kernels);
 
     } else {
       assert(layer.is_value || layer.is_policy || layer.is_moves_left);
@@ -285,11 +292,31 @@ void OpenCLBuffers::forward(const std::vector<net_t>& input,
       auto ip_b = begin(layer.weights) + 3;
 
       convolve1(layer.channels, layer.outputs, m_inBuffer, m_inBuffer2,
-                m_VBuffer, conv_weights, conv_biases, batch_size);
+                m_VBuffer, conv_weights, conv_biases, batch_size,
+                capture_kernels);
 
       innerproduct(m_inBuffer2, ip_w, ip_b, out_buffer, layer.ip_in_size,
-                   layer.ip_out_size, layer.is_value, batch_size);
+                   layer.ip_out_size, layer.is_value, batch_size,
+                   capture_kernels);
     }
+  }
+}
+
+void OpenCLBuffers::forward(const std::vector<net_t>& input,
+                            std::vector<net_t>& output_pol,
+                            std::vector<net_t>& output_val,
+                            std::vector<net_t>& output_mov,
+                            const int batch_size) {
+  const auto inSize = sizeof(net_t) * input.size();
+  m_commandqueue.enqueueWriteBuffer(m_inBuffer, CL_FALSE, 0, inSize,
+                                    input.data());
+  // If we have defined a graph already execute that
+  if (m_graph_finalized) {
+    std::vector<cl::CommandQueue> queues{m_commandqueue};
+    auto& command_buffer = m_commandbuffers[batch_size - 1];
+    command_buffer.enqueueCommandBuffer({queues});
+  } else {
+    forward_kernels(batch_size, false);
   }
 
   auto pinnedOutBufferHost_pol = m_commandqueue.enqueueMapBuffer(
@@ -331,7 +358,8 @@ void OpenCLBuffers::convolve3(int channels, int outputs, cl::Buffer& bufferIn,
                               cl::Buffer& bufferM, weight_slice_t weights,
                               cl::Buffer* bufferResidual, weight_slice_t biases,
                               bool skip_in_transform, bool fuse_in_transform,
-                              bool store_inout, bool relu, int batch_size) {
+                              bool store_inout, bool relu, int batch_size,
+                              bool capture_kernels) {
   auto mwg = m_opencl.m_sgemm_tuners.mwg;
   auto nwg = m_opencl.m_sgemm_tuners.nwg;
   auto kwg = m_opencl.m_sgemm_tuners.kwg;
@@ -367,9 +395,16 @@ void OpenCLBuffers::convolve3(int channels, int outputs, cl::Buffer& bufferIn,
       m_in_transform_kernel.setArg(3, k_ceil);
       m_in_transform_kernel.setArg(4, n_ceil);
 
-      m_commandqueue.enqueueNDRangeKernel(
-          m_in_transform_kernel, cl::NullRange,
-          cl::NDRange(wgs, channels, batch_size));
+      if (capture_kernels) {
+        auto& command_buffer = m_commandbuffers[batch_size - 1];
+        command_buffer.commandNDRangeKernel(
+            {}, m_in_transform_kernel, cl::NullRange,
+            cl::NDRange(wgs, channels, batch_size));
+      } else {
+        m_commandqueue.enqueueNDRangeKernel(
+            m_in_transform_kernel, cl::NullRange,
+            cl::NDRange(wgs, channels, batch_size));
+      }
     } catch (const cl::Error& e) {
       CERR << "Error in convolve3/in: " << e.what() << ": " << e.err()
            << std::endl;
@@ -390,8 +425,14 @@ void OpenCLBuffers::convolve3(int channels, int outputs, cl::Buffer& bufferIn,
     cl::NDRange size_sgemm = {(m_ceil * mdimc) / mwg, (n_ceil * ndimc) / nwg,
                               (cl::size_type)WINOGRAD_TILE};
 
-    m_commandqueue.enqueueNDRangeKernel(m_sgemm_kernel, cl::NullRange,
-                                        size_sgemm, local_sgemm);
+    if (capture_kernels) {
+      auto& command_buffer = m_commandbuffers[batch_size - 1];
+      command_buffer.commandNDRangeKernel({}, m_sgemm_kernel, cl::NullRange,
+                                          size_sgemm, local_sgemm);
+    } else {
+      m_commandqueue.enqueueNDRangeKernel(m_sgemm_kernel, cl::NullRange,
+                                          size_sgemm, local_sgemm);
+    }
   } catch (const cl::Error& e) {
     CERR << "Error in convolve3/sgemm: " << e.what() << ": " << e.err()
          << std::endl;
@@ -426,9 +467,18 @@ void OpenCLBuffers::convolve3(int channels, int outputs, cl::Buffer& bufferIn,
       m_out_transform_bn_in_kernel.setArg(
           9, cl::Local(dim_size * width * height * sizeof(float)));
 
-      m_commandqueue.enqueueNDRangeKernel(
-          m_out_transform_bn_in_kernel, cl::NullRange,
-          cl::NDRange(outputs, wgs, batch_size), cl::NDRange(dim_size, wgs, 1));
+      if (capture_kernels) {
+        auto& command_buffer = m_commandbuffers[batch_size - 1];
+        command_buffer.commandNDRangeKernel(
+            {}, m_out_transform_bn_in_kernel, cl::NullRange,
+            cl::NDRange(outputs, wgs, batch_size),
+            cl::NDRange(dim_size, wgs, 1));
+      } else {
+        m_commandqueue.enqueueNDRangeKernel(
+            m_out_transform_bn_in_kernel, cl::NullRange,
+            cl::NDRange(outputs, wgs, batch_size),
+            cl::NDRange(dim_size, wgs, 1));
+      }
     } else {
       m_out_transform_bn_kernel.setArg(0, bufferM);
       m_out_transform_bn_kernel.setArg(1, bufferOut);
@@ -443,9 +493,16 @@ void OpenCLBuffers::convolve3(int channels, int outputs, cl::Buffer& bufferIn,
       }
       m_out_transform_bn_kernel.setArg(7, biases[0]);
 
-      m_commandqueue.enqueueNDRangeKernel(
-          m_out_transform_bn_kernel, cl::NullRange,
-          cl::NDRange(outputs, wgs, batch_size));
+      if (capture_kernels) {
+        auto& command_buffer = m_commandbuffers[batch_size - 1];
+        command_buffer.commandNDRangeKernel(
+            {}, m_out_transform_bn_kernel, cl::NullRange,
+            cl::NDRange(outputs, wgs, batch_size));
+      } else {
+        m_commandqueue.enqueueNDRangeKernel(
+            m_out_transform_bn_kernel, cl::NullRange,
+            cl::NDRange(outputs, wgs, batch_size));
+      }
     }
   } catch (const cl::Error& e) {
     CERR << "Error in convolve3/out: " << e.what() << ": " << e.err()
@@ -457,7 +514,7 @@ void OpenCLBuffers::convolve3(int channels, int outputs, cl::Buffer& bufferIn,
 void OpenCLBuffers::squeeze_excitation(
     int channels, int fc_outputs, cl::Buffer& bufferIn, cl::Buffer& bufferTemp1,
     cl::Buffer& bufferTemp2, weight_slice_t weights, cl::Buffer& bufferResidual,
-    int batch_size) {
+    int batch_size, bool capture_kernels) {
   constexpr int width = 8;
 
   try {
@@ -465,9 +522,16 @@ void OpenCLBuffers::squeeze_excitation(
     m_global_avg_pooling_kernel.setArg(1, bufferIn);
     m_global_avg_pooling_kernel.setArg(2, bufferTemp1);
 
-    m_commandqueue.enqueueNDRangeKernel(
-        m_global_avg_pooling_kernel, cl::NullRange,
-        cl::NDRange(width, batch_size * channels), cl::NDRange(width, 1));
+    if (capture_kernels) {
+      auto& command_buffer = m_commandbuffers[batch_size - 1];
+      command_buffer.commandNDRangeKernel(
+          {}, m_global_avg_pooling_kernel, cl::NullRange,
+          cl::NDRange(width, batch_size * channels), cl::NDRange(width, 1));
+    } else {
+      m_commandqueue.enqueueNDRangeKernel(
+          m_global_avg_pooling_kernel, cl::NullRange,
+          cl::NDRange(width, batch_size * channels), cl::NDRange(width, 1));
+    }
   } catch (const cl::Error& e) {
     CERR << "Error in squeeze_excitation/pooling: " << e.what() << ": "
          << e.err() << std::endl;
@@ -475,10 +539,10 @@ void OpenCLBuffers::squeeze_excitation(
   }
 
   innerproduct(bufferTemp1, weights, weights + 1, bufferTemp2, channels,
-               fc_outputs, true, batch_size);
+               fc_outputs, true, batch_size, capture_kernels);
 
   innerproduct(bufferTemp2, weights + 2, weights + 3, bufferTemp1, fc_outputs,
-               2 * channels, false, batch_size);
+               2 * channels, false, batch_size, capture_kernels);
 
   try {
     m_apply_se_kernel.setArg(0, channels);
@@ -487,9 +551,16 @@ void OpenCLBuffers::squeeze_excitation(
     m_apply_se_kernel.setArg(3, bufferResidual);
     m_apply_se_kernel.setArg(4, bufferTemp1);
 
-    m_commandqueue.enqueueNDRangeKernel(
-        m_apply_se_kernel, cl::NullRange,
-        cl::NDRange(width, batch_size * channels));
+    if (capture_kernels) {
+      auto& command_buffer = m_commandbuffers[batch_size - 1];
+      command_buffer.commandNDRangeKernel(
+          {}, m_apply_se_kernel, cl::NullRange,
+          cl::NDRange(width, batch_size * channels));
+    } else {
+      m_commandqueue.enqueueNDRangeKernel(
+          m_apply_se_kernel, cl::NullRange,
+          cl::NDRange(width, batch_size * channels));
+    }
   } catch (const cl::Error& e) {
     CERR << "Error in squeeze_excitation/apply_se: " << e.what() << ": "
          << e.err() << std::endl;
@@ -501,7 +572,8 @@ void OpenCLBuffers::convolve1(int channels, int outputs,
                               cl::Buffer& bufferInput, cl::Buffer& bufferOutput,
                               cl::Buffer& bufferMerge,
                               weight_slice_t conv_weights,
-                              weight_slice_t conv_biases, int batch_size) {
+                              weight_slice_t conv_biases, int batch_size,
+                              bool capture_kernels) {
   // fixed for 8x8.
   constexpr int width = 8;
   constexpr int height = 8;
@@ -538,10 +610,18 @@ void OpenCLBuffers::convolve1(int channels, int outputs,
                               cl::Local(stripSize * channelGroup * rowGroup));
     m_convolve1_kernel.setArg(4, cl::Local(rowSize));
 
-    m_commandqueue.enqueueNDRangeKernel(
-        m_convolve1_kernel, cl::NullRange,
-        cl::NDRange(channels, outputs, batch_size * rowTiles),
-        cl::NDRange(channelGroup, outputGroup, rowGroup));
+    if (capture_kernels) {
+      auto& command_buffer = m_commandbuffers[batch_size - 1];
+      command_buffer.commandNDRangeKernel(
+          {}, m_convolve1_kernel, cl::NullRange,
+          cl::NDRange(channels, outputs, batch_size * rowTiles),
+          cl::NDRange(channelGroup, outputGroup, rowGroup));
+    } else {
+      m_commandqueue.enqueueNDRangeKernel(
+          m_convolve1_kernel, cl::NullRange,
+          cl::NDRange(channels, outputs, batch_size * rowTiles),
+          cl::NDRange(channelGroup, outputGroup, rowGroup));
+    }
   } catch (const cl::Error& e) {
     CERR << "Error in convolve1: " << e.what() << ": " << e.err() << std::endl;
     throw;
@@ -555,10 +635,18 @@ void OpenCLBuffers::convolve1(int channels, int outputs,
     m_merge_kernel.setArg(2, channels >> channelShift);
     m_merge_kernel.setArg(3, conv_biases[0]);
 
-    m_commandqueue.enqueueNDRangeKernel(
-        m_merge_kernel, cl::NullRange,
-        cl::NDRange(outputs, boardsize, batch_size),
-        cl::NDRange(std::min(8, outputs), 8, 1));
+    if (capture_kernels) {
+      auto& command_buffer = m_commandbuffers[batch_size - 1];
+      command_buffer.commandNDRangeKernel(
+          {}, m_merge_kernel, cl::NullRange,
+          cl::NDRange(outputs, boardsize, batch_size),
+          cl::NDRange(std::min(8, outputs), 8, 1));
+    } else {
+      m_commandqueue.enqueueNDRangeKernel(
+          m_merge_kernel, cl::NullRange,
+          cl::NDRange(outputs, boardsize, batch_size),
+          cl::NDRange(std::min(8, outputs), 8, 1));
+    }
   } catch (const cl::Error& e) {
     CERR << "Error in merge: " << e.what() << ": " << e.err() << std::endl;
     throw;
@@ -568,7 +656,8 @@ void OpenCLBuffers::convolve1(int channels, int outputs,
 void OpenCLBuffers::innerproduct(cl::Buffer& input, weight_slice_t weights,
                                  weight_slice_t biases, cl::Buffer& output,
                                  const int inputs, const int outputs,
-                                 const int relu, int batch_size) {
+                                 const int relu, int batch_size,
+                                 bool capture_kernels) {
   // TODO: Tune these.
   size_t wgs1 = 64;
   size_t wpt1 = 1;
@@ -591,9 +680,16 @@ void OpenCLBuffers::innerproduct(cl::Buffer& input, weight_slice_t weights,
     m_sgemv_kernel.setArg(9, biases[0]);
     m_sgemv_kernel.setArg(10, static_cast<int>(relu));
 
-    m_commandqueue.enqueueNDRangeKernel(m_sgemv_kernel, cl::NullRange,
-                                        cl::NDRange(global_size, batch_size),
-                                        cl::NDRange(local_size, 1));
+    if (capture_kernels) {
+      auto& command_buffer = m_commandbuffers[batch_size - 1];
+      command_buffer.commandNDRangeKernel({}, m_sgemv_kernel, cl::NullRange,
+                                          cl::NDRange(global_size, batch_size),
+                                          cl::NDRange(local_size, 1));
+    } else {
+      m_commandqueue.enqueueNDRangeKernel(m_sgemv_kernel, cl::NullRange,
+                                          cl::NDRange(global_size, batch_size),
+                                          cl::NDRange(local_size, 1));
+    }
   } catch (const cl::Error& e) {
     CERR << "Error in innerproduct: " << e.what() << ": " << e.err()
          << std::endl;
@@ -603,7 +699,8 @@ void OpenCLBuffers::innerproduct(cl::Buffer& input, weight_slice_t weights,
 
 void OpenCLBuffers::policymap(int N, const cl::Buffer& input,
                               cl::Buffer& output, const cl::Buffer& indices,
-                              int inputSize, int usedSize, int outputSize) {
+                              int inputSize, int usedSize, int outputSize,
+                              bool capture_kernels) {
   try {
     m_policymap_kernel.setArg(0, input);
     m_policymap_kernel.setArg(1, output);
@@ -613,10 +710,24 @@ void OpenCLBuffers::policymap(int N, const cl::Buffer& input,
     m_policymap_kernel.setArg(5, usedSize);
     m_policymap_kernel.setArg(6, outputSize);
 
-    m_commandqueue.enqueueNDRangeKernel(m_policymap_kernel, cl::NullRange,
-                                        cl::NDRange(N * usedSize));
+    if (capture_kernels) {
+      auto& command_buffer = m_commandbuffers[N - 1];
+      command_buffer.commandNDRangeKernel({}, m_policymap_kernel, cl::NullRange,
+                                          cl::NDRange(N * usedSize));
+    } else {
+      m_commandqueue.enqueueNDRangeKernel(m_policymap_kernel, cl::NullRange,
+                                          cl::NDRange(N * usedSize));
+    }
   } catch (const cl::Error& e) {
     CERR << "Error in policymap: " << e.what() << ": " << e.err() << std::endl;
     throw;
   }
+}
+
+void OpenCLBuffers::finalizeGraph() {
+  for (auto& cb : m_commandbuffers) {
+    cb.finalizeCommandBuffer();
+  }
+
+  m_graph_finalized = true;
 }

--- a/src/neural/backends/opencl/OpenCLBuffers.h
+++ b/src/neural/backends/opencl/OpenCLBuffers.h
@@ -34,6 +34,7 @@
 #include <string>
 #include <thread>
 
+#define CL_ENABLE_BETA_EXTENSIONS
 #include "neural/backends/opencl/OpenCL.h"
 #include "neural/backends/opencl/OpenCLParams.h"
 #include "neural/backends/opencl/OpenCLTuner.h"
@@ -49,9 +50,13 @@ class OpenCLBuffers {
  public:
   OpenCLBuffers(const OpenCL_Network& opencl_net);
 
+  void forward_kernels(const int batch_size, const bool capture_graph);
+
   void forward(const std::vector<net_t>& input, std::vector<net_t>& output_pol,
                std::vector<net_t>& output_val, std::vector<net_t>& output_mov,
                const int batch_size);
+
+  void finalizeGraph();
 
  private:
   using weight_slice_t = std::vector<cl::Buffer>::const_iterator;
@@ -61,28 +66,32 @@ class OpenCLBuffers {
                  cl::Buffer& bufferM, weight_slice_t weights,
                  cl::Buffer* bufferResidual, weight_slice_t biases,
                  bool skip_in_transform, bool fuse_in_transform,
-                 bool store_inout, bool relu, int batch_size);
+                 bool store_inout, bool relu, int batch_size,
+                 bool capture_kernels);
 
   void convolve1(int channels, int outputs, cl::Buffer& bufferInput,
                  cl::Buffer& bufferOutput, cl::Buffer& bufferMerge,
-                 weight_slice_t weights, weight_slice_t biases, int batch_size);
+                 weight_slice_t weights, weight_slice_t biases, int batch_size,
+                 bool capture_kernels);
 
   void innerproduct(cl::Buffer& input, weight_slice_t weights,
                     weight_slice_t biases, cl::Buffer& output, const int inputs,
-                    const int outputs, const int relu, int batch_size);
+                    const int outputs, const int relu, int batch_size,
+                    bool capture_kernels);
 
   void squeeze_excitation(int channels, int fc_outputs, cl::Buffer& bufferIn,
                           cl::Buffer& bufferTemp1, cl::Buffer& bufferTemp2,
                           weight_slice_t weights, cl::Buffer& bufferResidual,
-                          int batch_size);
+                          int batch_size, bool capture_kernels);
 
   void policymap(int N, const cl::Buffer& input, cl::Buffer& output,
                  const cl::Buffer& indices, int inputSize, int usedSize,
-                 int outputSize);
+                 int outputSize, bool capture_kernels);
 
   const OpenCL_Network& m_opencl_net;
   const OpenCL& m_opencl;
 
+  std::vector<cl::CommandBufferKhr> m_commandbuffers;
   cl::CommandQueue m_commandqueue;
   cl::Kernel m_convolve1_kernel;
   cl::Kernel m_merge_kernel;
@@ -105,4 +114,6 @@ class OpenCLBuffers {
   size_t m_finalSize_pol;
   size_t m_finalSize_val;
   size_t m_finalSize_mov;
+  bool m_enable_graph_capture;
+  bool m_graph_finalized{false};
 };

--- a/src/neural/backends/opencl/OpenCLParams.h
+++ b/src/neural/backends/opencl/OpenCLParams.h
@@ -27,6 +27,7 @@ struct OpenCLParams {
   bool tune_only = false;
   bool force_tune = false;
   bool tune_exhaustive = false;
+  bool graph_capture = false;
   int tune_batch_size = 1;
   std::string tuner_file;
 };

--- a/src/neural/backends/opencl/network_opencl.cc
+++ b/src/neural/backends/opencl/network_opencl.cc
@@ -83,6 +83,21 @@ class OpenCLComputation : public NetworkComputation {
   // Adds a sample to the batch.
   void AddInput(InputPlanes&& input) override { planes_.emplace_back(input); }
 
+  // Makes the command-buffers executable
+  void FinalizeGraph() { buffers_->finalizeGraph(); }
+
+  // Captures a command-buffer for each batch-size
+  void CaptureGraph() {
+    const auto plane_count = planes_.size();
+    const auto max_batch_size = opencl_net_.getMaxMatchSize();
+    const auto largest_batch_size = std::min(max_batch_size, plane_count);
+
+    for (size_t i = 0; i < plane_count; i += largest_batch_size) {
+      const auto batch_size = std::min(plane_count - i, largest_batch_size);
+      buffers_->forward_kernels(batch_size, true);
+    }
+  }
+
   // Do the computation.
   void ComputeBlocking() override {
     // Determine the largest batch for allocations.
@@ -247,6 +262,7 @@ class OpenCLNetwork : public Network {
     params_.tune_only = options.GetOrDefault<bool>("tune_only", false);
     params_.tune_exhaustive =
         options.GetOrDefault<bool>("tune_exhaustive", false);
+    params_.graph_capture = options.GetOrDefault<bool>("graph_capture", true);
     if (options.Exists<std::string>("tuner_file")) {
       params_.tuner_file = options.Get<std::string>("tuner_file");
     } else {
@@ -404,6 +420,25 @@ class OpenCLNetwork : public Network {
     }
 
     opencl_net_.setMaxMatchSize(max_batch_size_);
+
+    if (opencl_.graph_capture_enabled()) {
+      // pre-allocate 2 command-buffers as the default number of search threads.
+      // A user may manually specify more search threads, and the extra threads
+      // will use the eager submission path.
+      auto allocateGraph = [&](OpenCLComputation* comp) {
+        for (unsigned i = 0; i < max_batch_size_; i++) {
+          comp->AddInput(InputPlanes{(size_t)kInputPlanes});
+          comp->CaptureGraph();
+        }
+        comp->FinalizeGraph();
+      };
+      OpenCLComputation comp1(opencl_net_, weights_, wdl_, moves_left_);
+      OpenCLComputation comp2(opencl_net_, weights_, wdl_, moves_left_);
+
+      std::thread t2(allocateGraph, &comp1);
+      allocateGraph(&comp2);
+      t2.join();
+    }
   }
 
   std::unique_ptr<NetworkComputation> NewComputation() override {

--- a/third_party/opencl.hpp
+++ b/third_party/opencl.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2008-2024 The Khronos Group Inc.
+// Copyright (c) 2008-2026 The Khronos Group Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -173,6 +173,11 @@
  *   Enable exceptions for use in the C++ bindings header. This is the
  *   preferred error handling mechanism but is not required.
  *
+ * - CL_HPP_CUSTOM_EXCEPTION_TYPE
+ *
+ *   Specify the type which should be used for exceptions. This type
+ *   must have a constructor accepting an int and a const char*.
+ *
  * - CL_HPP_ENABLE_SIZE_T_COMPATIBILITY
  *
  *   Backward compatibility option to support cl.hpp-style size_t
@@ -205,6 +210,11 @@
  * - CL_HPP_USE_IL_KHR
  *
  *   Enable the cl_khr_il_program extension.
+ *
+ * - CL_HPP_OPENCL_API_WRAPPER
+ *
+ *   A macro which is used to wrap all OpenCL API symbols. This can be
+ *   used e.g. to load the OpenCL library dynamically with dlopen()/dlsym().
  *
  *
  * \section example Example
@@ -391,6 +401,12 @@
  */
 #ifndef CL_HPP_
 #define CL_HPP_
+
+#ifdef CL_HPP_OPENCL_API_WRAPPER
+#define CL_(name) CL_HPP_OPENCL_API_WRAPPER(name)
+#else
+#define CL_(name) ::name
+#endif
 
 /* Handle deprecated preprocessor definitions. In each case, we only check for
  * the old name if the new name is not defined, so that user code can define
@@ -703,15 +719,15 @@ namespace cl {
 #define CL_HPP_CREATE_CL_EXT_FCN_PTR_ALIAS_(name) \
     using PFN_##name = name##_fn
 
-#define CL_HPP_INIT_CL_EXT_FCN_PTR_(name)                               \
-    if (!pfn_##name) {                                                  \
-        pfn_##name = (PFN_##name)clGetExtensionFunctionAddress(#name);  \
+#define CL_HPP_INIT_CL_EXT_FCN_PTR_(name)                                    \
+    if (!pfn_##name) {                                                       \
+        pfn_##name = (PFN_##name)CL_(clGetExtensionFunctionAddress)(#name);  \
     }
 
-#define CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_(platform, name)            \
-    if (!pfn_##name) {                                                  \
-        pfn_##name = (PFN_##name)                                       \
-            clGetExtensionFunctionAddressForPlatform(platform, #name);  \
+#define CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_(platform, name)                 \
+    if (!pfn_##name) {                                                       \
+        pfn_##name = (PFN_##name)                                            \
+            CL_(clGetExtensionFunctionAddressForPlatform)(platform, #name);  \
     }
 
 #ifdef cl_khr_external_memory
@@ -737,6 +753,7 @@ namespace cl {
 #endif // cl_khr_command_buffer
 
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
+#if !defined(CL_HPP_CUSTOM_EXCEPTION_TYPE)
     /*! \brief Exception class 
      * 
      *  This may be thrown by API functions when CL_HPP_ENABLE_EXCEPTIONS is defined.
@@ -779,6 +796,9 @@ namespace cl {
          */
         cl_int err(void) const { return err_; }
     };
+#else
+  using Error = CL_HPP_CUSTOM_EXCEPTION_TYPE;
+#endif
 #define CL_HPP_ERR_STR_(x) #x
 #else
 #define CL_HPP_ERR_STR_(x) nullptr
@@ -1611,6 +1631,19 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
 #define CL_HPP_PARAM_NAME_CL_IMAGE_REQUIREMENTS_SLICE_PITCH_ALIGNMENT_EXT(F) \
     F(cl_image_requirements_info_ext, CL_IMAGE_REQUIREMENTS_SLICE_PITCH_ALIGNMENT_EXT, size_type) \
 
+#define CL_HPP_PARAM_NAME_CL_INTEL_COMMAND_QUEUE_FAMILIES_(F) \
+    F(cl_device_info, CL_DEVICE_QUEUE_FAMILY_PROPERTIES_INTEL, cl::vector<cl_queue_family_properties_intel>) \
+    \
+    F(cl_command_queue_info, CL_QUEUE_FAMILY_INTEL, cl_uint) \
+    F(cl_command_queue_info, CL_QUEUE_INDEX_INTEL, cl_uint)
+
+#define CL_HPP_PARAM_NAME_CL_INTEL_UNIFIED_SHARED_MEMORY_(F) \
+    F(cl_device_info, CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL, cl_device_unified_shared_memory_capabilities_intel ) \
+    F(cl_device_info, CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL, cl_device_unified_shared_memory_capabilities_intel ) \
+    F(cl_device_info, CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL, cl_device_unified_shared_memory_capabilities_intel ) \
+    F(cl_device_info, CL_DEVICE_CROSS_DEVICE_SHARED_MEM_CAPABILITIES_INTEL, cl_device_unified_shared_memory_capabilities_intel ) \
+    F(cl_device_info, CL_DEVICE_SHARED_SYSTEM_MEM_CAPABILITIES_INTEL, cl_device_unified_shared_memory_capabilities_intel )
+
 template <typename enum_type, cl_int Name>
 struct param_traits {};
 
@@ -1849,7 +1882,12 @@ CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_INTEGRATED_MEMORY_NV, cl_
 
 #if defined(cl_khr_command_buffer)
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR, cl_device_command_buffer_capabilities_khr)
-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR, cl_command_buffer_properties_khr)
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 5)
+CL_HPP_DECLARE_PARAM_TRAITS_(
+    cl_device_info, CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR,
+    cl_command_queue_properties)
+#endif
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR, cl_command_queue_properties)
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_command_buffer_info_khr, CL_COMMAND_BUFFER_QUEUES_KHR, cl::vector<CommandQueue>)
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_command_buffer_info_khr, CL_COMMAND_BUFFER_NUM_QUEUES_KHR, cl_uint)
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_command_buffer_info_khr, CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR, cl_uint)
@@ -1861,7 +1899,12 @@ CL_HPP_DECLARE_PARAM_TRAITS_(cl_command_buffer_info_khr, CL_COMMAND_BUFFER_PROPE
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_mutable_command_info_khr, CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR, CommandQueue)
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_mutable_command_info_khr, CL_MUTABLE_COMMAND_COMMAND_BUFFER_KHR, CommandBufferKhr)
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_mutable_command_info_khr, CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR, cl_command_type)
+
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 2)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_mutable_command_info_khr, CL_MUTABLE_COMMAND_PROPERTIES_ARRAY_KHR, cl::vector<cl_command_properties_khr>)
+#else
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_mutable_command_info_khr, CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR, cl::vector<cl_ndrange_kernel_command_properties_khr>)
+#endif
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_mutable_command_info_khr, CL_MUTABLE_DISPATCH_KERNEL_KHR, cl_kernel)
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_mutable_command_info_khr, CL_MUTABLE_DISPATCH_DIMENSIONS_KHR, cl_uint)
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_mutable_command_info_khr, CL_MUTABLE_DISPATCH_GLOBAL_WORK_OFFSET_KHR, cl::vector<size_type>)
@@ -1872,6 +1915,41 @@ CL_HPP_DECLARE_PARAM_TRAITS_(cl_mutable_command_info_khr, CL_MUTABLE_DISPATCH_LO
 #if defined(cl_khr_kernel_clock)
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_KERNEL_CLOCK_CAPABILITIES_KHR, cl_device_kernel_clock_capabilities_khr)
 #endif /* cl_khr_kernel_clock */
+
+#if defined(cl_khr_spirv_queries)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_SPIRV_EXTENDED_INSTRUCTION_SETS_KHR, cl::vector<const char*>)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_SPIRV_EXTENSIONS_KHR, cl::vector<const char*>)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_SPIRV_CAPABILITIES_KHR, cl::vector<cl_uint>)
+#endif /* cl_khr_spirv_queries */
+
+#if defined(cl_ext_float_atomics)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT, cl_device_fp_atomic_capabilities_ext)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT, cl_device_fp_atomic_capabilities_ext)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT, cl_device_fp_atomic_capabilities_ext)
+#endif /* cl_ext_float_atomics */
+
+#if defined(cl_intel_command_queue_families)
+CL_HPP_PARAM_NAME_CL_INTEL_COMMAND_QUEUE_FAMILIES_(CL_HPP_DECLARE_PARAM_TRAITS_)
+#endif // cl_intel_command_queue_families
+
+#if defined(cl_intel_device_attribute_query)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_IP_VERSION_INTEL, cl_uint)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_ID_INTEL, cl_uint)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_NUM_SLICES_INTEL, cl_uint)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_NUM_SUB_SLICES_PER_SLICE_INTEL, cl_uint)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_NUM_EUS_PER_SUB_SLICE_INTEL, cl_uint)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_NUM_THREADS_PER_EU_INTEL, cl_uint)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_FEATURE_CAPABILITIES_INTEL, cl_device_feature_capabilities_intel)
+#endif // cl_intel_device_attribute_query
+
+#if defined(cl_intel_required_subgroup_size)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_SUB_GROUP_SIZES_INTEL, cl::vector<size_type>)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_kernel_work_group_info, CL_KERNEL_SPILL_MEM_SIZE_INTEL, cl_ulong)
+#endif // cl_intel_required_subgroup_size
+
+#if defined(cl_intel_unified_shared_memory)
+CL_HPP_PARAM_NAME_CL_INTEL_UNIFIED_SHARED_MEMORY_(CL_HPP_DECLARE_PARAM_TRAITS_)
+#endif // cl_intel_unified_shared_memory
 
 // Convenience functions
 
@@ -1938,7 +2016,7 @@ struct ReferenceHandler<cl_device_id>
      *   CL_OUT_OF_HOST_MEMORY
      */
     static cl_int retain(cl_device_id device)
-    { return ::clRetainDevice(device); }
+    { return CL_(clRetainDevice)(device); }
     /**
      * Retain the device.
      * \param device A valid device created using createSubDevices
@@ -1949,7 +2027,7 @@ struct ReferenceHandler<cl_device_id>
      *   CL_OUT_OF_HOST_MEMORY
      */
     static cl_int release(cl_device_id device)
-    { return ::clReleaseDevice(device); }
+    { return CL_(clReleaseDevice)(device); }
 };
 #else // CL_HPP_TARGET_OPENCL_VERSION >= 120
 /**
@@ -1982,63 +2060,63 @@ template <>
 struct ReferenceHandler<cl_context>
 {
     static cl_int retain(cl_context context)
-    { return ::clRetainContext(context); }
+    { return CL_(clRetainContext)(context); }
     static cl_int release(cl_context context)
-    { return ::clReleaseContext(context); }
+    { return CL_(clReleaseContext)(context); }
 };
 
 template <>
 struct ReferenceHandler<cl_command_queue>
 {
     static cl_int retain(cl_command_queue queue)
-    { return ::clRetainCommandQueue(queue); }
+    { return CL_(clRetainCommandQueue)(queue); }
     static cl_int release(cl_command_queue queue)
-    { return ::clReleaseCommandQueue(queue); }
+    { return CL_(clReleaseCommandQueue)(queue); }
 };
 
 template <>
 struct ReferenceHandler<cl_mem>
 {
     static cl_int retain(cl_mem memory)
-    { return ::clRetainMemObject(memory); }
+    { return CL_(clRetainMemObject)(memory); }
     static cl_int release(cl_mem memory)
-    { return ::clReleaseMemObject(memory); }
+    { return CL_(clReleaseMemObject)(memory); }
 };
 
 template <>
 struct ReferenceHandler<cl_sampler>
 {
     static cl_int retain(cl_sampler sampler)
-    { return ::clRetainSampler(sampler); }
+    { return CL_(clRetainSampler)(sampler); }
     static cl_int release(cl_sampler sampler)
-    { return ::clReleaseSampler(sampler); }
+    { return CL_(clReleaseSampler)(sampler); }
 };
 
 template <>
 struct ReferenceHandler<cl_program>
 {
     static cl_int retain(cl_program program)
-    { return ::clRetainProgram(program); }
+    { return CL_(clRetainProgram)(program); }
     static cl_int release(cl_program program)
-    { return ::clReleaseProgram(program); }
+    { return CL_(clReleaseProgram)(program); }
 };
 
 template <>
 struct ReferenceHandler<cl_kernel>
 {
     static cl_int retain(cl_kernel kernel)
-    { return ::clRetainKernel(kernel); }
+    { return CL_(clRetainKernel)(kernel); }
     static cl_int release(cl_kernel kernel)
-    { return ::clReleaseKernel(kernel); }
+    { return CL_(clReleaseKernel)(kernel); }
 };
 
 template <>
 struct ReferenceHandler<cl_event>
 {
     static cl_int retain(cl_event event)
-    { return ::clRetainEvent(event); }
+    { return CL_(clRetainEvent)(event); }
     static cl_int release(cl_event event)
-    { return ::clReleaseEvent(event); }
+    { return CL_(clReleaseEvent)(event); }
 };
 
 #ifdef cl_khr_semaphore
@@ -2123,17 +2201,17 @@ static cl_uint getVersion(const vector<char> &versionInfo)
 static cl_uint getPlatformVersion(cl_platform_id platform)
 {
     size_type size = 0;
-    clGetPlatformInfo(platform, CL_PLATFORM_VERSION, 0, nullptr, &size);
+    CL_(clGetPlatformInfo)(platform, CL_PLATFORM_VERSION, 0, nullptr, &size);
 
     vector<char> versionInfo(size);
-    clGetPlatformInfo(platform, CL_PLATFORM_VERSION, size, versionInfo.data(), &size);
+    CL_(clGetPlatformInfo)(platform, CL_PLATFORM_VERSION, size, versionInfo.data(), &size);
     return getVersion(versionInfo);
 }
 
 static cl_uint getDevicePlatformVersion(cl_device_id device)
 {
     cl_platform_id platform;
-    clGetDeviceInfo(device, CL_DEVICE_PLATFORM, sizeof(platform), &platform, nullptr);
+    CL_(clGetDeviceInfo)(device, CL_DEVICE_PLATFORM, sizeof(platform), &platform, nullptr);
     return getPlatformVersion(platform);
 }
 
@@ -2142,11 +2220,11 @@ static cl_uint getContextPlatformVersion(cl_context context)
     // The platform cannot be queried directly, so we first have to grab a
     // device and obtain its context
     size_type size = 0;
-    clGetContextInfo(context, CL_CONTEXT_DEVICES, 0, nullptr, &size);
+    CL_(clGetContextInfo)(context, CL_CONTEXT_DEVICES, 0, nullptr, &size);
     if (size == 0)
         return 0;
     vector<cl_device_id> devices(size/sizeof(cl_device_id));
-    clGetContextInfo(context, CL_CONTEXT_DEVICES, size, devices.data(), nullptr);
+    CL_(clGetContextInfo)(context, CL_CONTEXT_DEVICES, size, devices.data(), nullptr);
     return getDevicePlatformVersion(devices[0]);
 }
 #endif // CL_HPP_TARGET_OPENCL_VERSION && CL_HPP_MINIMUM_OPENCL_VERSION
@@ -2521,7 +2599,7 @@ public:
     cl_int getInfo(cl_device_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetDeviceInfo, object_, name, param),
+            detail::getInfo(CL_(clGetDeviceInfo), object_, name, param),
             __GET_DEVICE_INFO_ERR);
     }
 
@@ -2531,7 +2609,7 @@ public:
     getInfo(cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_device_info, name>::param_type param;
+            detail::cl_device_info, name>::param_type param{};
         cl_int result = getInfo(name, &param);
         if (err != nullptr) {
             *err = result;
@@ -2550,7 +2628,7 @@ public:
     {
         cl_ulong retVal = 0;
         cl_int err = 
-            clGetHostTimer(this->get(), &retVal);
+            CL_(clGetHostTimer)(this->get(), &retVal);
         detail::errHandler(
             err,
             __GET_HOST_TIMER_ERR);
@@ -2574,7 +2652,7 @@ public:
     {
         std::pair<cl_ulong, cl_ulong> retVal;
         cl_int err =
-            clGetDeviceAndHostTimer(this->get(), &(retVal.first), &(retVal.second));
+            CL_(clGetDeviceAndHostTimer)(this->get(), &(retVal.first), &(retVal.second));
         detail::errHandler(
             err,
             __GET_DEVICE_AND_HOST_TIMER_ERR);
@@ -2679,7 +2757,7 @@ private:
             // Otherwise set it
             cl_uint n = 0;
 
-            cl_int err = ::clGetPlatformIDs(0, nullptr, &n);
+            cl_int err = CL_(clGetPlatformIDs)(0, nullptr, &n);
             if (err != CL_SUCCESS) {
                 default_error_ = err;
                 return;
@@ -2690,7 +2768,7 @@ private:
             }
 
             vector<cl_platform_id> ids(n);
-            err = ::clGetPlatformIDs(n, ids.data(), nullptr);
+            err = CL_(clGetPlatformIDs)(n, ids.data(), nullptr);
             if (err != CL_SUCCESS) {
                 default_error_ = err;
                 return;
@@ -2780,7 +2858,7 @@ public:
     cl_int getInfo(cl_platform_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetPlatformInfo, object_, name, param),
+            detail::getInfo(CL_(clGetPlatformInfo), object_, name, param),
             __GET_PLATFORM_INFO_ERR);
     }
 
@@ -2790,7 +2868,7 @@ public:
     getInfo(cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_platform_info, name>::param_type param;
+            detail::cl_platform_info, name>::param_type param{};
         cl_int result = getInfo(name, &param);
         if (err != nullptr) {
             *err = result;
@@ -2804,20 +2882,17 @@ public:
      */
     cl_int getDevices(
         cl_device_type type,
-        vector<Device>* devices) const
+        vector<Device>& devices) const
     {
         cl_uint n = 0;
-        if( devices == nullptr ) {
-            return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
-        }
-        cl_int err = ::clGetDeviceIDs(object_, type, 0, nullptr, &n);
+        cl_int err = CL_(clGetDeviceIDs)(object_, type, 0, nullptr, &n);
         if (err != CL_SUCCESS  && err != CL_DEVICE_NOT_FOUND) {
             return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
         }
 
         vector<cl_device_id> ids(n);
         if (n>0) {
-            err = ::clGetDeviceIDs(object_, type, n, ids.data(), nullptr);
+            err = CL_(clGetDeviceIDs)(object_, type, n, ids.data(), nullptr);
             if (err != CL_SUCCESS) {
                 return detail::errHandler(err, __GET_DEVICE_IDS_ERR);
             }
@@ -2827,16 +2902,29 @@ public:
         // with safe construction
         // We must retain things we obtain from the API to avoid releasing
         // API-owned objects.
-        if (devices) {
-            devices->resize(ids.size());
+        devices.resize(ids.size());
 
-            // Assign to param, constructing with retain behaviour
-            // to correctly capture each underlying CL object
-            for (size_type i = 0; i < ids.size(); i++) {
-                (*devices)[i] = Device(ids[i], true);
-            }
+        // Assign to param, constructing with retain behaviour
+        // to correctly capture each underlying CL object
+        for (size_type i = 0; i < ids.size(); i++) {
+            devices[i] = Device(ids[i], true);
         }
         return CL_SUCCESS;
+    }
+
+    /*! \brief Gets a list of devices for this platform.
+     *
+     *  Pointer overload for backwards compatibility.
+     */
+    cl_int getDevices(
+        cl_device_type type,
+        vector<Device>* devices) const
+    {
+        if( devices == nullptr ) {
+            return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
+        }
+
+        return getDevices(type, *devices);
     }
 
 #if defined(CL_HPP_USE_DX_INTEROP)
@@ -2867,7 +2955,7 @@ public:
         cl_d3d10_device_source_khr d3d_device_source,
         void *                     d3d_object,
         cl_d3d10_device_set_khr    d3d_device_set,
-        vector<Device>* devices) const
+        vector<Device>& devices) const
     {
         typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clGetDeviceIDsFromD3D10KHR)(
             cl_platform_id platform, 
@@ -2877,10 +2965,6 @@ public:
             cl_uint num_entries,
             cl_device_id * devices,
             cl_uint* num_devices);
-
-        if( devices == nullptr ) {
-            return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
-        }
 
         static PFN_clGetDeviceIDsFromD3D10KHR pfn_clGetDeviceIDsFromD3D10KHR = nullptr;
 #if CL_HPP_TARGET_OPENCL_VERSION >= 120
@@ -2920,16 +3004,31 @@ public:
         // with safe construction
         // We must retain things we obtain from the API to avoid releasing
         // API-owned objects.
-        if (devices) {
-            devices->resize(ids.size());
+        devices.resize(ids.size());
 
-            // Assign to param, constructing with retain behaviour
-            // to correctly capture each underlying CL object
-            for (size_type i = 0; i < ids.size(); i++) {
-                (*devices)[i] = Device(ids[i], true);
-            }
+        // Assign to param, constructing with retain behaviour
+        // to correctly capture each underlying CL object
+        for (size_type i = 0; i < ids.size(); i++) {
+            devices[i] = Device(ids[i], true);
         }
         return CL_SUCCESS;
+    }
+
+   /*! \brief Get the list of available D3D10 devices.
+     *
+     *  Pointer overload for backwards compatibility.
+     */
+    cl_int getDevices(
+        cl_d3d10_device_source_khr d3d_device_source,
+        void *                     d3d_object,
+        cl_d3d10_device_set_khr    d3d_device_set,
+        vector<Device>* devices) const
+    {
+        if( devices == nullptr ) {
+            return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_DEVICE_IDS_ERR);
+        }
+
+        return getDevices(d3d_device_source, d3d_object, d3d_device_set, *devices);
     }
 #endif
 
@@ -2938,34 +3037,42 @@ public:
      *  Wraps clGetPlatformIDs().
      */
     static cl_int get(
-        vector<Platform>* platforms)
+        vector<Platform>& platforms)
     {
         cl_uint n = 0;
 
-        if( platforms == nullptr ) {
-            return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_PLATFORM_IDS_ERR);
-        }
-
-        cl_int err = ::clGetPlatformIDs(0, nullptr, &n);
+        cl_int err = CL_(clGetPlatformIDs)(0, nullptr, &n);
         if (err != CL_SUCCESS) {
             return detail::errHandler(err, __GET_PLATFORM_IDS_ERR);
         }
 
         vector<cl_platform_id> ids(n);
-        err = ::clGetPlatformIDs(n, ids.data(), nullptr);
+        err = CL_(clGetPlatformIDs)(n, ids.data(), nullptr);
         if (err != CL_SUCCESS) {
             return detail::errHandler(err, __GET_PLATFORM_IDS_ERR);
         }
 
-        if (platforms) {
-            platforms->resize(ids.size());
+        platforms.resize(ids.size());
 
-            // Platforms don't reference count
-            for (size_type i = 0; i < ids.size(); i++) {
-                (*platforms)[i] = Platform(ids[i]);
-            }
+        // Platforms don't reference count
+        for (size_type i = 0; i < ids.size(); i++) {
+            platforms[i] = Platform(ids[i]);
         }
         return CL_SUCCESS;
+    }
+
+    /*! \brief Gets a list of available platforms.
+     *
+     *  Pointer overload for backwards compatibility.
+     */
+    static cl_int get(
+        vector<Platform>* platforms)
+    {
+        if( platforms == nullptr ) {
+            return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_PLATFORM_IDS_ERR);
+        }
+
+        return get(*platforms);
     }
 
     /*! \brief Gets the first available platform.
@@ -3007,7 +3114,7 @@ public:
     cl_int
     unloadCompiler()
     {
-        return ::clUnloadPlatformCompiler(object_);
+        return CL_(clUnloadPlatformCompiler)(object_);
     }
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 120
 }; // class Platform
@@ -3018,14 +3125,14 @@ inline cl_int Device::createSubDevices(const cl_device_partition_property* prope
                          vector<Device>* devices)
 {
     cl_uint n = 0;
-    cl_int err = clCreateSubDevices(object_, properties, 0, nullptr, &n);
+    cl_int err = CL_(clCreateSubDevices)(object_, properties, 0, nullptr, &n);
     if (err != CL_SUCCESS)
     {
         return detail::errHandler(err, __CREATE_SUB_DEVICES_ERR);
     }
 
     vector<cl_device_id> ids(n);
-    err = clCreateSubDevices(object_, properties, n, ids.data(), nullptr);
+    err = CL_(clCreateSubDevices)(object_, properties, n, ids.data(), nullptr);
     if (err != CL_SUCCESS)
     {
         return detail::errHandler(err, __CREATE_SUB_DEVICES_ERR);
@@ -3117,7 +3224,7 @@ UnloadCompiler() CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 inline cl_int
 UnloadCompiler()
 {
-    return ::clUnloadCompiler();
+    return CL_(clUnloadCompiler)();
 }
 #endif // #if defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
 
@@ -3285,9 +3392,10 @@ public:
             deviceIDs[deviceIndex] = (devices[deviceIndex])();
         }
 
-        object_ = ::clCreateContext(
-            properties, (cl_uint) numDevices,
-            deviceIDs.data(),
+        object_ = CL_(clCreateContext)(
+            properties,
+            (cl_uint)deviceIDs.size(),
+            deviceIDs.empty() ? nullptr : deviceIDs.data(),
             notifyFptr, data, &error);
 
         detail::errHandler(error, __CREATE_CONTEXT_ERR);
@@ -3315,7 +3423,7 @@ public:
 
         cl_device_id deviceID = device();
 
-        object_ = ::clCreateContext(
+        object_ = CL_(clCreateContext)(
             properties, 1,
             &deviceID,
             notifyFptr, data, &error);
@@ -3404,7 +3512,7 @@ public:
             properties = &prop[0];
         }
 #endif
-        object_ = ::clCreateContextFromType(
+        object_ = CL_(clCreateContextFromType)(
             properties, type, notifyFptr, data, &error);
 
         detail::errHandler(error, __CREATE_CONTEXT_FROM_TYPE_ERR);
@@ -3469,7 +3577,7 @@ public:
     cl_int getInfo(cl_context_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetContextInfo, object_, name, param),
+            detail::getInfo(CL_(clGetContextInfo), object_, name, param),
             __GET_CONTEXT_INFO_ERR);
     }
 
@@ -3479,7 +3587,7 @@ public:
     getInfo(cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_context_info, name>::param_type param;
+            detail::cl_context_info, name>::param_type param{};
         cl_int result = getInfo(name, &param);
         if (err != nullptr) {
             *err = result;
@@ -3494,15 +3602,11 @@ public:
     cl_int getSupportedImageFormats(
         cl_mem_flags flags,
         cl_mem_object_type type,
-        vector<ImageFormat>* formats) const
+        vector<ImageFormat>& formats) const
     {
         cl_uint numEntries;
-        
-        if (!formats) {
-            return CL_SUCCESS;
-        }
 
-        cl_int err = ::clGetSupportedImageFormats(
+        cl_int err = CL_(clGetSupportedImageFormats)(
            object_, 
            flags,
            type, 
@@ -3515,7 +3619,7 @@ public:
 
         if (numEntries > 0) {
             vector<ImageFormat> value(numEntries);
-            err = ::clGetSupportedImageFormats(
+            err = CL_(clGetSupportedImageFormats)(
                 object_,
                 flags,
                 type,
@@ -3526,14 +3630,29 @@ public:
                 return detail::errHandler(err, __GET_SUPPORTED_IMAGE_FORMATS_ERR);
             }
 
-            formats->assign(value.begin(), value.end());
+            formats.assign(value.begin(), value.end());
         }
         else {
             // If no values are being returned, ensure an empty vector comes back
-            formats->clear();
+            formats.clear();
         }
 
         return CL_SUCCESS;
+    }
+
+    /*! \brief Gets a list of supported image formats.
+     *
+     *  Pointer overload for backwards compatibility.
+     */
+    cl_int getSupportedImageFormats(
+        cl_mem_flags flags,
+        cl_mem_object_type type,
+        vector<ImageFormat>* formats) const
+    {
+        if( formats == nullptr ) {
+            return detail::errHandler(CL_INVALID_ARG_VALUE, __GET_SUPPORTED_IMAGE_FORMATS_ERR);
+        }
+        return getSupportedImageFormats(flags, type, *formats);
     }
 
 #if defined(cl_ext_image_requirements_info)
@@ -3562,7 +3681,7 @@ public:
             cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-        detail::cl_image_requirements_info_ext, type>::param_type param;
+        detail::cl_image_requirements_info_ext, type>::param_type param{};
         cl_int result = getImageRequirementsInfoExt(type, &param, flags, properties, image_format, image_desc);
         if (err != nullptr) {
             *err = result;
@@ -3587,7 +3706,7 @@ public:
         void * user_data = nullptr)
     {
         return detail::errHandler(
-            ::clSetContextDestructorCallback(
+            CL_(clSetContextDestructorCallback)(
                 object_,
                 pfn_notify,
                 user_data),
@@ -3670,7 +3789,7 @@ public:
     cl_int getInfo(cl_event_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetEventInfo, object_, name, param),
+            detail::getInfo(CL_(clGetEventInfo), object_, name, param),
             __GET_EVENT_INFO_ERR);
     }
 
@@ -3680,7 +3799,7 @@ public:
     getInfo(cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_event_info, name>::param_type param;
+            detail::cl_event_info, name>::param_type param{};
         cl_int result = getInfo(name, &param);
         if (err != nullptr) {
             *err = result;
@@ -3693,7 +3812,7 @@ public:
     cl_int getProfilingInfo(cl_profiling_info name, T* param) const
     {
         return detail::errHandler(detail::getInfo(
-            &::clGetEventProfilingInfo, object_, name, param),
+            CL_(clGetEventProfilingInfo), object_, name, param),
             __GET_EVENT_PROFILE_INFO_ERR);
     }
 
@@ -3703,7 +3822,7 @@ public:
     getProfilingInfo(cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_profiling_info, name>::param_type param;
+            detail::cl_profiling_info, name>::param_type param{};
         cl_int result = getProfilingInfo(name, &param);
         if (err != nullptr) {
             *err = result;
@@ -3718,7 +3837,7 @@ public:
     cl_int wait() const
     {
         return detail::errHandler(
-            ::clWaitForEvents(1, &object_),
+            CL_(clWaitForEvents)(1, &object_),
             __WAIT_FOR_EVENTS_ERR);
     }
 
@@ -3733,7 +3852,7 @@ public:
         void * user_data = nullptr)
     {
         return detail::errHandler(
-            ::clSetEventCallback(
+            CL_(clSetEventCallback)(
                 object_,
                 type,
                 pfn_notify,
@@ -3753,8 +3872,8 @@ public:
         "Size of cl::Event must be equal to size of cl_event");
 
         return detail::errHandler(
-            ::clWaitForEvents(
-                (cl_uint) events.size(), (events.size() > 0) ? (cl_event*)&events.front() : nullptr),
+            CL_(clWaitForEvents)(
+                (cl_uint) events.size(), (events.size() > 0) ? (const cl_event*)&events.front() : nullptr),
             __WAIT_FOR_EVENTS_ERR);
     }
 };
@@ -3776,7 +3895,7 @@ public:
         cl_int * err = nullptr)
     {
         cl_int error;
-        object_ = ::clCreateUserEvent(
+        object_ = CL_(clCreateUserEvent)(
             context(),
             &error);
 
@@ -3796,7 +3915,7 @@ public:
     cl_int setStatus(cl_int status)
     {
         return detail::errHandler(
-            ::clSetUserEventStatus(object_,status), 
+            CL_(clSetUserEventStatus)(object_,status),
             __SET_USER_EVENT_STATUS_ERR);
     }
 };
@@ -3810,8 +3929,8 @@ inline static cl_int
 WaitForEvents(const vector<Event>& events)
 {
     return detail::errHandler(
-        ::clWaitForEvents(
-            (cl_uint) events.size(), (events.size() > 0) ? (cl_event*)&events.front() : nullptr),
+        CL_(clWaitForEvents)(
+            (cl_uint) events.size(), (events.size() > 0) ? (const cl_event*)&events.front() : nullptr),
         __WAIT_FOR_EVENTS_ERR);
 }
 
@@ -3859,7 +3978,7 @@ public:
     cl_int getInfo(cl_mem_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetMemObjectInfo, object_, name, param),
+            detail::getInfo(CL_(clGetMemObjectInfo), object_, name, param),
             __GET_MEM_OBJECT_INFO_ERR);
     }
 
@@ -3869,7 +3988,7 @@ public:
     getInfo(cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_mem_info, name>::param_type param;
+            detail::cl_mem_info, name>::param_type param{};
         cl_int result = getInfo(name, &param);
         if (err != nullptr) {
             *err = result;
@@ -3896,7 +4015,7 @@ public:
         void * user_data = nullptr)
     {
         return detail::errHandler(
-            ::clSetMemObjectDestructorCallback(
+            CL_(clSetMemObjectDestructorCallback)(
                 object_,
                 pfn_notify,
                 user_data), 
@@ -4091,7 +4210,7 @@ public:
     {
         // Allocate memory with default alignment matching the size of the type
         void* voidPointer =
-            clSVMAlloc(
+            CL_(clSVMAlloc)(
             context_(),
             SVMTrait::getSVMMemFlags(),
             size*sizeof(T),
@@ -4109,7 +4228,7 @@ public:
         if (map && !(SVMTrait::getSVMMemFlags() & CL_MEM_SVM_FINE_GRAIN_BUFFER)) {
             cl_int err = enqueueMapSVM(retValue, CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, size*sizeof(T));
             if (err != CL_SUCCESS) {
-                clSVMFree(context_(), retValue);
+                CL_(clSVMFree)(context_(), retValue);
                 retValue = nullptr;
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
                 std::bad_alloc excep;
@@ -4124,7 +4243,7 @@ public:
 
     void deallocate(pointer p, size_type)
     {
-        clSVMFree(context_(), p);
+        CL_(clSVMFree)(context_(), p);
     }
 
     /**
@@ -4229,10 +4348,18 @@ cl::pointer<T, detail::Deleter<Alloc>> allocate_pointer(const Alloc &alloc_, Arg
 
     T* tmp = std::allocator_traits<Alloc>::allocate(alloc, copies);
     if (!tmp) {
+#if defined(CL_HPP_ENABLE_EXCEPTIONS)
         std::bad_alloc excep;
         throw excep;
+#else
+        return nullptr;
+#endif
     }
-    try {
+
+#if defined(CL_HPP_ENABLE_EXCEPTIONS)
+    try
+#endif
+    {
         std::allocator_traits<Alloc>::construct(
             alloc,
             std::addressof(*tmp),
@@ -4240,11 +4367,13 @@ cl::pointer<T, detail::Deleter<Alloc>> allocate_pointer(const Alloc &alloc_, Arg
 
         return cl::pointer<T, detail::Deleter<Alloc>>(tmp, detail::Deleter<Alloc>{alloc, copies});
     }
+#if defined(CL_HPP_ENABLE_EXCEPTIONS)
     catch (std::bad_alloc&)
     {
         std::allocator_traits<Alloc>::deallocate(alloc, tmp, copies);
         throw;
     }
+#endif
 }
 
 template< class T, class SVMTrait, class... Args >
@@ -4308,7 +4437,7 @@ public:
         cl_int* err = nullptr)
     {
         cl_int error;
-        object_ = ::clCreateBuffer(context(), flags, size, host_ptr, &error);
+        object_ = CL_(clCreateBuffer)(context(), flags, size, host_ptr, &error);
 
         detail::errHandler(error, __CREATE_BUFFER_ERR);
         if (err != nullptr) {
@@ -4337,14 +4466,10 @@ public:
     {
         cl_int error;
 
-        if (properties.empty()) {
-            object_ = ::clCreateBufferWithProperties(context(), nullptr, flags,
-                                                     size, host_ptr, &error);
-        }
-        else {
-            object_ = ::clCreateBufferWithProperties(
-                context(), properties.data(), flags, size, host_ptr, &error);
-        }
+        object_ = CL_(clCreateBufferWithProperties)(
+            context(),
+            properties.empty() ? nullptr : properties.data(),
+            flags, size, host_ptr, &error);
 
         detail::errHandler(error, __CREATE_BUFFER_ERR);
         if (err != nullptr) {
@@ -4421,9 +4546,9 @@ public:
         Context context = Context::getDefault(err);
 
         if( useHostPtr ) {
-            object_ = ::clCreateBuffer(context(), flags, size, const_cast<DataType*>(&*startIterator), &error);
+            object_ = CL_(clCreateBuffer)(context(), flags, size, const_cast<DataType*>(&*startIterator), &error);
         } else {
-            object_ = ::clCreateBuffer(context(), flags, size, 0, &error);
+            object_ = CL_(clCreateBuffer)(context(), flags, size, 0, &error);
         }
 
         detail::errHandler(error, __CREATE_BUFFER_ERR);
@@ -4494,7 +4619,7 @@ public:
     {
         Buffer result;
         cl_int error;
-        result.object_ = ::clCreateSubBuffer(
+        result.object_ = CL_(clCreateSubBuffer)(
             object_, 
             flags, 
             buffer_create_type, 
@@ -4616,7 +4741,7 @@ public:
         cl_int * err = nullptr)
     {
         cl_int error;
-        object_ = ::clCreateFromGLBuffer(
+        object_ = CL_(clCreateFromGLBuffer)(
             context(),
             flags,
             bufobj,
@@ -4658,7 +4783,7 @@ public:
         cl_GLuint * gl_object_name)
     {
         return detail::errHandler(
-            ::clGetGLObjectInfo(object_,type,gl_object_name),
+            CL_(clGetGLObjectInfo)(object_,type,gl_object_name),
             __GET_GL_OBJECT_INFO_ERR);
     }
 };
@@ -4686,7 +4811,7 @@ public:
         cl_int * err = nullptr)
     {
         cl_int error;
-        object_ = ::clCreateFromGLRenderbuffer(
+        object_ = CL_(clCreateFromGLRenderbuffer)(
             context(),
             flags,
             bufobj,
@@ -4728,7 +4853,7 @@ public:
         cl_GLuint * gl_object_name)
     {
         return detail::errHandler(
-            ::clGetGLObjectInfo(object_,type,gl_object_name),
+            CL_(clGetGLObjectInfo)(object_,type,gl_object_name),
             __GET_GL_OBJECT_INFO_ERR);
     }
 };
@@ -4772,7 +4897,7 @@ public:
     cl_int getImageInfo(cl_image_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetImageInfo, object_, name, param),
+            detail::getInfo(CL_(clGetImageInfo), object_, name, param),
             __GET_IMAGE_INFO_ERR);
     }
     
@@ -4782,7 +4907,7 @@ public:
     getImageInfo(cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_image_info, name>::param_type param;
+            detail::cl_image_info, name>::param_type param{};
         cl_int result = getImageInfo(name, &param);
         if (err != nullptr) {
             *err = result;
@@ -4819,7 +4944,7 @@ public:
         desc.image_type = CL_MEM_OBJECT_IMAGE1D;
         desc.image_width = width;
 
-        object_ = ::clCreateImage(
+        object_ = CL_(clCreateImage)(
             context(), 
             flags, 
             &format, 
@@ -4835,6 +4960,39 @@ public:
 
     //! \brief Default constructor - initializes to nullptr.
     Image1D() { }
+
+#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+    /*! \brief Constructs a Image1D with specified properties.
+     *
+     *  Wraps clCreateImageWithProperties().
+     *
+     *  \param properties Optional list of properties for the image object and
+     *                    their corresponding values. The non-empty list must
+     *                    end with 0.
+     *  \param host_ptr Storage to be used if the CL_MEM_USE_HOST_PTR flag was
+     *                  specified. Note alignment & exclusivity requirements.
+     */
+    Image1D(const Context &context, const vector<cl_mem_properties> &properties,
+            cl_mem_flags flags, ImageFormat format, size_type width,
+            void *host_ptr = nullptr, cl_int *err = nullptr)
+    {
+        cl_int error;
+
+        cl_image_desc desc = {};
+        desc.image_type = CL_MEM_OBJECT_IMAGE1D;
+        desc.image_width = width;
+
+        object_ = CL_(clCreateImageWithProperties)(
+            context(),
+            properties.empty() ? nullptr : properties.data(),
+            flags, &format, &desc, host_ptr, &error);
+
+        detail::errHandler(error, __CREATE_IMAGE_ERR);
+        if (err != nullptr) {
+            *err = error;
+        }
+    }
+#endif //#if CL_HPP_TARGET_OPENCL_VERSION >= 300
 
     /*! \brief Constructor from cl_mem - takes ownership.
      *
@@ -4880,7 +5038,7 @@ public:
         desc.image_width = width;
         desc.buffer = buffer();
 
-        object_ = ::clCreateImage(
+        object_ = CL_(clCreateImage)(
             context(), 
             flags, 
             &format, 
@@ -4895,6 +5053,40 @@ public:
     }
 
     Image1DBuffer() { }
+
+#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+    /*! \brief Constructs a Image1DBuffer with specified properties.
+     *
+     *  Wraps clCreateImageWithProperties().
+     *
+     *  \param properties Optional list of properties for the image object and
+     *                    their corresponding values. The non-empty list must
+     *                    end with 0.
+     *  \param buffer Refer to a valid buffer or image memory object.
+     */
+    Image1DBuffer(const Context &context,
+                  const vector<cl_mem_properties> &properties,
+                  cl_mem_flags flags, ImageFormat format, size_type width,
+                  const Buffer &buffer, cl_int *err = nullptr)
+    {
+        cl_int error;
+
+        cl_image_desc desc = {};
+        desc.image_type = CL_MEM_OBJECT_IMAGE1D_BUFFER;
+        desc.image_width = width;
+        desc.buffer = buffer();
+
+        object_ = CL_(clCreateImageWithProperties)(
+            context(),
+            properties.empty() ? nullptr : properties.data(),
+            flags, &format, &desc, nullptr, &error);
+
+        detail::errHandler(error, __CREATE_IMAGE_ERR);
+        if (err != nullptr) {
+            *err = error;
+        }
+    }
+#endif //#if CL_HPP_TARGET_OPENCL_VERSION >= 300
 
     /*! \brief Constructor from cl_mem - takes ownership.
      *
@@ -4911,9 +5103,6 @@ public:
         Image::operator=(rhs);
         return *this;
     }
-
-
-
 };
 
 /*! \class Image1DArray
@@ -4940,7 +5129,7 @@ public:
         desc.image_array_size = arraySize;
         desc.image_row_pitch = rowPitch;
 
-        object_ = ::clCreateImage(
+        object_ = CL_(clCreateImage)(
             context(), 
             flags, 
             &format, 
@@ -4955,7 +5144,44 @@ public:
     }
 
     Image1DArray() { }
-  
+
+#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+    /*! \brief Constructs a Image1DArray with specified properties.
+     *
+     *  Wraps clCreateImageWithProperties().
+     *
+     *  \param properties Optional list of properties for the image object and
+     *                    their corresponding values. The non-empty list must
+     *                    end with 0.
+     *  \param host_ptr Storage to be used if the CL_MEM_USE_HOST_PTR flag was
+     *                  specified. Note alignment & exclusivity requirements.
+     */
+    Image1DArray(const Context &context,
+                 const vector<cl_mem_properties> &properties,
+                 cl_mem_flags flags, ImageFormat format, size_type arraySize,
+                 size_type width, size_type rowPitch = 0,
+                 void *host_ptr = nullptr, cl_int *err = nullptr)
+    {
+        cl_int error;
+
+        cl_image_desc desc = {};
+        desc.image_type = CL_MEM_OBJECT_IMAGE1D_ARRAY;
+        desc.image_width = width;
+        desc.image_array_size = arraySize;
+        desc.image_row_pitch = rowPitch;
+
+        object_ = CL_(clCreateImageWithProperties)(
+            context(),
+            properties.empty() ? nullptr : properties.data(),
+            flags, &format, &desc, host_ptr, &error);
+
+        detail::errHandler(error, __CREATE_IMAGE_ERR);
+        if (err != nullptr) {
+            *err = error;
+        }
+    }
+#endif //#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+
     /*! \brief Constructor from cl_mem - takes ownership.
      *
      * \param retainObject will cause the constructor to retain its cl object.
@@ -5025,7 +5251,7 @@ public:
             desc.image_height = height;
             desc.image_row_pitch = row_pitch;
 
-            object_ = ::clCreateImage(
+            object_ = CL_(clCreateImage)(
                 context(),
                 flags,
                 &format,
@@ -5042,7 +5268,7 @@ public:
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 120
         if (!useCreateImage)
         {
-            object_ = ::clCreateImage2D(
+            object_ = CL_(clCreateImage2D)(
                 context(), flags,&format, width, height, row_pitch, host_ptr, &error);
 
             detail::errHandler(error, __CREATE_IMAGE2D_ERR);
@@ -5080,7 +5306,7 @@ public:
         desc.image_row_pitch = row_pitch;
         desc.buffer = sourceBuffer();
 
-        object_ = ::clCreateImage(
+        object_ = CL_(clCreateImage)(
             context(),
             0, // flags inherited from buffer
             &format,
@@ -5143,7 +5369,7 @@ public:
         desc.num_samples = sourceNumSamples;
         desc.buffer = sourceImage();
 
-        object_ = ::clCreateImage(
+        object_ = CL_(clCreateImage)(
             context(),
             0, // flags should be inherited from mem_object
             &sourceFormat,
@@ -5157,6 +5383,77 @@ public:
         }
     }
 #endif //#if CL_HPP_TARGET_OPENCL_VERSION >= 200
+
+#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+    /*! \brief Constructs a Image2D with specified properties.
+     *
+     *  Wraps clCreateImageWithProperties().
+     *
+     *  \param properties Optional list of properties for the image object and
+     *                    their corresponding values. The non-empty list must
+     *                    end with 0.
+     *  \param host_ptr Storage to be used if the CL_MEM_USE_HOST_PTR flag was
+     *                  specified. Note alignment & exclusivity requirements.
+     */
+    Image2D(const Context &context, const vector<cl_mem_properties> &properties,
+            cl_mem_flags flags, ImageFormat format, size_type width,
+            size_type height, size_type row_pitch = 0, void *host_ptr = nullptr,
+            cl_int *err = nullptr)
+    {
+        cl_int error;
+
+        cl_image_desc desc = {};
+        desc.image_type = CL_MEM_OBJECT_IMAGE2D;
+        desc.image_width = width;
+        desc.image_height = height;
+        desc.image_row_pitch = row_pitch;
+
+        object_ = CL_(clCreateImageWithProperties)(
+            context(),
+            properties.empty() ? nullptr : properties.data(),
+            flags, &format, &desc, host_ptr, &error);
+
+        detail::errHandler(error, __CREATE_IMAGE_ERR);
+        if (err != nullptr) {
+            *err = error;
+        }
+    }
+
+    /*! \brief Constructs a Image2D with specified properties.
+     *
+     *  Wraps clCreateImageWithProperties().
+     *
+     *  \param properties Optional list of properties for the image object and
+     *                    their corresponding values. The non-empty list must
+     *                    end with 0.
+     *  \param buffer Refer to a valid buffer or image memory object.
+     */
+    Image2D(const Context &context, const vector<cl_mem_properties> &properties,
+            cl_mem_flags flags, ImageFormat format, const Buffer &buffer,
+            size_type width, size_type height, size_type row_pitch = 0,
+            cl_int *err = nullptr)
+    {
+        cl_int error;
+
+        cl_image_desc desc = {};
+        desc.image_type = CL_MEM_OBJECT_IMAGE2D;
+        desc.image_width = width;
+        desc.image_height = height;
+        desc.image_row_pitch = row_pitch;
+        desc.buffer = buffer();
+
+        object_ = CL_(clCreateImageWithProperties)(
+            context(),
+            properties.empty() ? nullptr : properties.data(),
+            flags, &format, &desc, nullptr, &error);
+
+        detail::errHandler(error, __CREATE_IMAGE_ERR);
+        if (err != nullptr) {
+            *err = error;
+        }
+    }
+
+#endif //#if CL_HPP_TARGET_OPENCL_VERSION >= 300
 
     //! \brief Default constructor - initializes to nullptr.
     Image2D() { }
@@ -5180,10 +5477,6 @@ public:
         Image::operator=(rhs);
         return *this;
     }
-
-
-
-
 };
 
 
@@ -5214,7 +5507,7 @@ public:
         cl_int * err = nullptr)
     {
         cl_int error;
-        object_ = ::clCreateFromGLTexture2D(
+        object_ = CL_(clCreateFromGLTexture2D)(
             context(),
             flags,
             target,
@@ -5286,7 +5579,7 @@ public:
         desc.image_row_pitch = rowPitch;
         desc.image_slice_pitch = slicePitch;
 
-        object_ = ::clCreateImage(
+        object_ = CL_(clCreateImage)(
             context(), 
             flags, 
             &format, 
@@ -5299,6 +5592,46 @@ public:
             *err = error;
         }
     }
+
+#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+    /*! \brief Constructs a Image2DArray with specified properties.
+     *
+     *  Wraps clCreateImageWithProperties().
+     *
+     *  \param properties Optional list of properties for the image object and
+     *                    their corresponding values. The non-empty list must
+     *                    end with 0.
+     *  \param host_ptr Storage to be used if the CL_MEM_USE_HOST_PTR flag was
+     *                  specified. Note alignment & exclusivity requirements.
+     */
+    Image2DArray(const Context &context,
+                 const vector<cl_mem_properties> &properties,
+                 cl_mem_flags flags, ImageFormat format, size_type arraySize,
+                 size_type width, size_type height, size_type rowPitch = 0,
+                 size_type slicePitch = 0, void *host_ptr = nullptr,
+                 cl_int *err = nullptr)
+    {
+        cl_int error;
+
+        cl_image_desc desc = {};
+        desc.image_type = CL_MEM_OBJECT_IMAGE2D_ARRAY;
+        desc.image_width = width;
+        desc.image_height = height;
+        desc.image_array_size = arraySize;
+        desc.image_row_pitch = rowPitch;
+        desc.image_slice_pitch = slicePitch;
+
+        object_ = CL_(clCreateImageWithProperties)(
+            context(),
+            properties.empty() ? nullptr : properties.data(),
+            flags, &format, &desc, host_ptr, &error);
+
+        detail::errHandler(error, __CREATE_IMAGE_ERR);
+        if (err != nullptr) {
+            *err = error;
+        }
+    }
+#endif //#if CL_HPP_TARGET_OPENCL_VERSION >= 300
 
     Image2DArray() { }
     
@@ -5371,7 +5704,7 @@ public:
             desc.image_row_pitch = row_pitch;
             desc.image_slice_pitch = slice_pitch;
 
-            object_ = ::clCreateImage(
+            object_ = CL_(clCreateImage)(
                 context(), 
                 flags, 
                 &format, 
@@ -5388,7 +5721,7 @@ public:
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 120
         if (!useCreateImage)
         {
-            object_ = ::clCreateImage3D(
+            object_ = CL_(clCreateImage3D)(
                 context(), flags, &format, width, height, depth, row_pitch,
                 slice_pitch, host_ptr, &error);
 
@@ -5399,6 +5732,45 @@ public:
         }
 #endif // CL_HPP_MINIMUM_OPENCL_VERSION < 120
     }
+
+#if CL_HPP_TARGET_OPENCL_VERSION >= 300
+    /*! \brief Constructs a Image3D with specified properties.
+     *
+     *  Wraps clCreateImageWithProperties().
+     *
+     *  \param properties Optional list of properties for the image object and
+     *                    their corresponding values. The non-empty list must
+     *                    end with 0.
+     *  \param host_ptr Storage to be used if the CL_MEM_USE_HOST_PTR flag was
+     *                  specified. Note alignment & exclusivity requirements.
+     */
+    Image3D(const Context &context, const vector<cl_mem_properties> &properties,
+            cl_mem_flags flags, ImageFormat format, size_type width,
+            size_type height, size_type depth, size_type row_pitch = 0,
+            size_type slice_pitch = 0, void *host_ptr = nullptr,
+            cl_int *err = nullptr)
+    {
+        cl_int error;
+
+        cl_image_desc desc = {};
+        desc.image_type = CL_MEM_OBJECT_IMAGE3D;
+        desc.image_width = width;
+        desc.image_height = height;
+        desc.image_depth = depth;
+        desc.image_row_pitch = row_pitch;
+        desc.image_slice_pitch = slice_pitch;
+
+        object_ = CL_(clCreateImageWithProperties)(
+            context(),
+            properties.empty() ? nullptr : properties.data(),
+            flags, &format, &desc, host_ptr, &error);
+
+        detail::errHandler(error, __CREATE_IMAGE_ERR);
+        if (err != nullptr) {
+            *err = error;
+        }
+    }
+#endif //#if CL_HPP_TARGET_OPENCL_VERSION >= 300
 
     //! \brief Default constructor - initializes to nullptr.
     Image3D() : Image() { }
@@ -5451,7 +5823,7 @@ public:
         cl_int * err = nullptr)
     {
         cl_int error;
-        object_ = ::clCreateFromGLTexture3D(
+        object_ = CL_(clCreateFromGLTexture3D)(
             context(),
             flags,
             target,
@@ -5510,7 +5882,7 @@ public:
         cl_int * err = nullptr)
     {
         cl_int error;
-        object_ = ::clCreateFromGLTexture(
+        object_ = CL_(clCreateFromGLTexture)(
             context(), 
             flags, 
             target,
@@ -5576,7 +5948,7 @@ public:
         cl_int error;
 
         cl_mem_flags flags = CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS;
-        object_ = ::clCreatePipe(context(), flags, packet_size, max_packets, nullptr, &error);
+        object_ = CL_(clCreatePipe)(context(), flags, packet_size, max_packets, nullptr, &error);
 
         detail::errHandler(error, __CREATE_PIPE_ERR);
         if (err != nullptr) {
@@ -5602,7 +5974,7 @@ public:
         Context context = Context::getDefault(err);
 
         cl_mem_flags flags = CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS;
-        object_ = ::clCreatePipe(context(), flags, packet_size, max_packets, nullptr, &error);
+        object_ = CL_(clCreatePipe)(context(), flags, packet_size, max_packets, nullptr, &error);
 
         detail::errHandler(error, __CREATE_PIPE_ERR);
         if (err != nullptr) {
@@ -5640,7 +6012,7 @@ public:
     cl_int getInfo(cl_pipe_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetPipeInfo, object_, name, param),
+            detail::getInfo(CL_(clGetPipeInfo), object_, name, param),
             __GET_PIPE_INFO_ERR);
     }
 
@@ -5650,7 +6022,7 @@ public:
         getInfo(cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_pipe_info, name>::param_type param;
+            detail::cl_pipe_info, name>::param_type param{};
         cl_int result = getInfo(name, &param);
         if (err != nullptr) {
             *err = result;
@@ -5694,7 +6066,7 @@ public:
             CL_SAMPLER_ADDRESSING_MODE, addressing_mode,
             CL_SAMPLER_FILTER_MODE, filter_mode,
             0 };
-        object_ = ::clCreateSamplerWithProperties(
+        object_ = CL_(clCreateSamplerWithProperties)(
             context(),
             sampler_properties,
             &error);
@@ -5704,7 +6076,7 @@ public:
             *err = error;
         }
 #else
-        object_ = ::clCreateSampler(
+        object_ = CL_(clCreateSampler)(
             context(),
             normalized_coords,
             addressing_mode,
@@ -5747,7 +6119,7 @@ public:
     cl_int getInfo(cl_sampler_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetSamplerInfo, object_, name, param),
+            detail::getInfo(CL_(clGetSamplerInfo), object_, name, param),
             __GET_SAMPLER_INFO_ERR);
     }
 
@@ -5757,7 +6129,7 @@ public:
     getInfo(cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_sampler_info, name>::param_type param;
+            detail::cl_sampler_info, name>::param_type param{};
         cl_int result = getInfo(name, &param);
         if (err != nullptr) {
             *err = result;
@@ -5956,7 +6328,7 @@ public:
     cl_int getInfo(cl_kernel_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetKernelInfo, object_, name, param),
+            detail::getInfo(CL_(clGetKernelInfo), object_, name, param),
             __GET_KERNEL_INFO_ERR);
     }
 
@@ -5965,7 +6337,7 @@ public:
     getInfo(cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_kernel_info, name>::param_type param;
+            detail::cl_kernel_info, name>::param_type param{};
         cl_int result = getInfo(name, &param);
         if (err != nullptr) {
             *err = result;
@@ -5978,7 +6350,7 @@ public:
     cl_int getArgInfo(cl_uint argIndex, cl_kernel_arg_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetKernelArgInfo, object_, argIndex, name, param),
+            detail::getInfo(CL_(clGetKernelArgInfo), object_, argIndex, name, param),
             __GET_KERNEL_ARG_INFO_ERR);
     }
 
@@ -5987,7 +6359,7 @@ public:
     getArgInfo(cl_uint argIndex, cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_kernel_arg_info, name>::param_type param;
+            detail::cl_kernel_arg_info, name>::param_type param{};
         cl_int result = getArgInfo(argIndex, name, &param);
         if (err != nullptr) {
             *err = result;
@@ -6002,7 +6374,7 @@ public:
     {
         return detail::errHandler(
             detail::getInfo(
-                &::clGetKernelWorkGroupInfo, object_, device(), name, param),
+                CL_(clGetKernelWorkGroupInfo), object_, device(), name, param),
                 __GET_KERNEL_WORK_GROUP_INFO_ERR);
     }
 
@@ -6011,7 +6383,7 @@ public:
         getWorkGroupInfo(const Device& device, cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-        detail::cl_kernel_work_group_info, name>::param_type param;
+        detail::cl_kernel_work_group_info, name>::param_type param{};
         cl_int result = getWorkGroupInfo(device, name, &param);
         if (err != nullptr) {
             *err = result;
@@ -6025,7 +6397,7 @@ public:
 #if CL_HPP_TARGET_OPENCL_VERSION >= 210
 
         return detail::errHandler(
-            clGetKernelSubGroupInfo(object_, dev(), name, range.size(), range.get(), sizeof(size_type), param, nullptr),
+            CL_(clGetKernelSubGroupInfo)(object_, dev(), name, range.size(), range.get(), sizeof(size_type), param, nullptr),
             __GET_KERNEL_SUB_GROUP_INFO_ERR);
 
 #else // #if CL_HPP_TARGET_OPENCL_VERSION >= 210
@@ -6060,17 +6432,18 @@ public:
     cl_int setArg(cl_uint index, const cl::pointer<T, D> &argPtr)
     {
         return detail::errHandler(
-            ::clSetKernelArgSVMPointer(object_, index, argPtr.get()),
+            CL_(clSetKernelArgSVMPointer)(object_, index, argPtr.get()),
             __SET_KERNEL_ARGS_ERR);
     }
 
     /*! \brief setArg overload taking a vector type.
      */
     template<typename T, class Alloc>
-    cl_int setArg(cl_uint index, const cl::vector<T, Alloc> &argPtr)
+    cl_int setArg(cl_uint index, const cl::vector<T, Alloc> &arg)
     {
         return detail::errHandler(
-            ::clSetKernelArgSVMPointer(object_, index, argPtr.data()),
+            CL_(clSetKernelArgSVMPointer)(object_, index,
+                arg.empty() ? nullptr : arg.data()),
             __SET_KERNEL_ARGS_ERR);
     }
 
@@ -6081,7 +6454,7 @@ public:
         setArg(cl_uint index, const T argPtr)
     {
         return detail::errHandler(
-            ::clSetKernelArgSVMPointer(object_, index, argPtr),
+            CL_(clSetKernelArgSVMPointer)(object_, index, argPtr),
             __SET_KERNEL_ARGS_ERR);
     }
 #endif // #if CL_HPP_TARGET_OPENCL_VERSION >= 200
@@ -6093,7 +6466,7 @@ public:
         setArg(cl_uint index, const T &value)
     {
         return detail::errHandler(
-            ::clSetKernelArg(
+            CL_(clSetKernelArg)(
                 object_,
                 index,
                 detail::KernelArgumentHandler<T>::size(value),
@@ -6104,7 +6477,7 @@ public:
     cl_int setArg(cl_uint index, size_type size, const void* argPtr)
     {
         return detail::errHandler(
-            ::clSetKernelArg(object_, index, size, argPtr),
+            CL_(clSetKernelArg)(object_, index, size, argPtr),
             __SET_KERNEL_ARGS_ERR);
     }
 
@@ -6116,11 +6489,11 @@ public:
     cl_int setSVMPointers(const vector<void*> &pointerList)
     {
         return detail::errHandler(
-            ::clSetKernelExecInfo(
+            CL_(clSetKernelExecInfo)(
                 object_,
                 CL_KERNEL_EXEC_INFO_SVM_PTRS,
-                sizeof(void*)*pointerList.size(),
-                pointerList.data()));
+                sizeof(void*) * pointerList.size(),
+                pointerList.empty() ? nullptr : pointerList.data()));
     }
 
     /*!
@@ -6131,11 +6504,11 @@ public:
     cl_int setSVMPointers(const std::array<void*, ArrayLength> &pointerList)
     {
         return detail::errHandler(
-            ::clSetKernelExecInfo(
+            CL_(clSetKernelExecInfo)(
                 object_,
                 CL_KERNEL_EXEC_INFO_SVM_PTRS,
-                sizeof(void*)*pointerList.size(),
-                pointerList.data()));
+                sizeof(void*) * pointerList.size(),
+                pointerList.empty() ? nullptr : pointerList.data()));
     }
 
     /*! \brief Enable fine-grained system SVM.
@@ -6153,7 +6526,7 @@ public:
     {
         cl_bool svmEnabled_ = svmEnabled ? CL_TRUE : CL_FALSE;
         return detail::errHandler(
-            ::clSetKernelExecInfo(
+            CL_(clSetKernelExecInfo)(
                 object_,
                 CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM,
                 sizeof(cl_bool),
@@ -6198,10 +6571,10 @@ public:
 
         setSVMPointersHelper<0, 1 + sizeof...(Ts)>(pointerList, t0, ts...);
         return detail::errHandler(
-            ::clSetKernelExecInfo(
+            CL_(clSetKernelExecInfo)(
             object_,
             CL_KERNEL_EXEC_INFO_SVM_PTRS,
-            sizeof(void*)*(1 + sizeof...(Ts)),
+            sizeof(void*) * (1 + sizeof...(Ts)),
             pointerList.data()));
     }
 
@@ -6209,7 +6582,7 @@ public:
     cl_int setExecInfo(cl_kernel_exec_info param_name, const T& val)
     {
         return detail::errHandler(
-            ::clSetKernelExecInfo(
+            CL_(clSetKernelExecInfo)(
             object_,
             param_name,
             sizeof(T),
@@ -6232,7 +6605,7 @@ public:
     Kernel clone()
     {
         cl_int error;
-        Kernel retValue(clCloneKernel(this->get(), &error));
+        Kernel retValue(CL_(clCloneKernel)(this->get(), &error));
 
         detail::errHandler(error, __CLONE_KERNEL_ERR);
         return retValue;
@@ -6266,14 +6639,14 @@ public:
 
         Context context = Context::getDefault(err);
 
-        object_ = ::clCreateProgramWithSource(
+        object_ = CL_(clCreateProgramWithSource)(
             context(), (cl_uint)1, &strings, &length, &error);
 
         detail::errHandler(error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
 
         if (error == CL_SUCCESS && build) {
 
-            error = ::clBuildProgram(
+            error = CL_(clBuildProgram)(
                 object_,
                 0,
                 nullptr,
@@ -6304,13 +6677,13 @@ public:
         const char * strings = source.c_str();
         const size_type length  = source.size();
 
-        object_ = ::clCreateProgramWithSource(
+        object_ = CL_(clCreateProgramWithSource)(
             context(), (cl_uint)1, &strings, &length, &error);
 
         detail::errHandler(error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
 
         if (error == CL_SUCCESS && build) {
-            error = ::clBuildProgram(
+            error = CL_(clBuildProgram)(
                 object_,
                 0,
                 nullptr,
@@ -6356,8 +6729,11 @@ public:
 #endif // #if !defined(CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY)
         }
 
-        object_ = ::clCreateProgramWithSource(
-            context(), (cl_uint)n, strings.data(), lengths.data(), &error);
+        object_ = CL_(clCreateProgramWithSource)(
+            context(), (cl_uint)n,
+            strings.empty() ? nullptr : strings.data(),
+            lengths.empty() ? nullptr : lengths.data(),
+            &error);
 
         detail::errHandler(error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
         if (err != nullptr) {
@@ -6391,8 +6767,11 @@ public:
 #endif // #if !defined(CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY)
         }
 
-        object_ = ::clCreateProgramWithSource(
-            context(), (cl_uint)n, strings.data(), lengths.data(), &error);
+        object_ = CL_(clCreateProgramWithSource)(
+            context(), (cl_uint)n,
+            strings.empty() ? nullptr : strings.data(),
+            lengths.empty() ? nullptr : lengths.data(),
+            &error);
 
         detail::errHandler(error, __CREATE_PROGRAM_WITH_SOURCE_ERR);
         if (err != nullptr) {
@@ -6417,7 +6796,7 @@ public:
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 210
 
-        object_ = ::clCreateProgramWithIL(
+        object_ = CL_(clCreateProgramWithIL)(
             context(), static_cast<const void*>(IL.data()), IL.size(), &error);
 
 #else // #if CL_HPP_TARGET_OPENCL_VERSION >= 210
@@ -6435,7 +6814,7 @@ public:
 
         if (error == CL_SUCCESS && build) {
 
-            error = ::clBuildProgram(
+            error = CL_(clBuildProgram)(
                 object_,
                 0,
                 nullptr,
@@ -6471,7 +6850,7 @@ public:
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 210
 
-        object_ = ::clCreateProgramWithIL(
+        object_ = CL_(clCreateProgramWithIL)(
             context(), static_cast<const void*>(IL.data()), IL.size(), &error);
 
 #else // #if CL_HPP_TARGET_OPENCL_VERSION >= 210
@@ -6488,7 +6867,7 @@ public:
         detail::errHandler(error, __CREATE_PROGRAM_WITH_IL_ERR);
 
         if (error == CL_SUCCESS && build) {
-            error = ::clBuildProgram(
+            error = CL_(clBuildProgram)(
                 object_,
                 0,
                 nullptr,
@@ -6572,12 +6951,16 @@ public:
             binaryStatus->resize(numDevices);
         }
 
-        object_ = ::clCreateProgramWithBinary(
-            context(), (cl_uint) devices.size(),
-            deviceIDs.data(),
-            lengths.data(), images.data(), (binaryStatus != nullptr && numDevices > 0)
+        object_ = CL_(clCreateProgramWithBinary)(
+            context(),
+            (cl_uint)deviceIDs.size(),
+            deviceIDs.empty() ? nullptr : deviceIDs.data(),
+            lengths.empty() ? nullptr : lengths.data(),
+            images.empty() ? nullptr : images.data(),
+            (binaryStatus != nullptr && numDevices > 0)
                ? &binaryStatus->front()
-               : nullptr, &error);
+               : nullptr,
+            &error);
 
         detail::errHandler(error, __CREATE_PROGRAM_WITH_BINARY_ERR);
         if (err != nullptr) {
@@ -6599,17 +6982,16 @@ public:
     {
         cl_int error;
 
-
         size_type numDevices = devices.size();
         vector<cl_device_id> deviceIDs(numDevices);
         for( size_type deviceIndex = 0; deviceIndex < numDevices; ++deviceIndex ) {
             deviceIDs[deviceIndex] = (devices[deviceIndex])();
         }
         
-        object_ = ::clCreateProgramWithBuiltInKernels(
+        object_ = CL_(clCreateProgramWithBuiltInKernels)(
             context(), 
-            (cl_uint) devices.size(),
-            deviceIDs.data(),
+            (cl_uint)deviceIDs.size(),
+            deviceIDs.empty() ? nullptr : deviceIDs.data(),
             kernelNames.c_str(), 
             &error);
 
@@ -6660,11 +7042,10 @@ public:
             deviceIDs[deviceIndex] = (devices[deviceIndex])();
         }
 
-        cl_int buildError = ::clBuildProgram(
+        cl_int buildError = CL_(clBuildProgram)(
             object_,
-            (cl_uint)
-            devices.size(),
-            deviceIDs.data(),
+            (cl_uint)deviceIDs.size(),
+            deviceIDs.empty() ? nullptr : deviceIDs.data(),
             options,
             notifyFptr,
             data);
@@ -6689,7 +7070,7 @@ public:
     {
         cl_device_id deviceID = device();
 
-        cl_int buildError = ::clBuildProgram(
+        cl_int buildError = CL_(clBuildProgram)(
             object_,
             1,
             &deviceID,
@@ -6715,7 +7096,7 @@ public:
         void (CL_CALLBACK * notifyFptr)(cl_program, void *) = nullptr,
         void* data = nullptr) const
     {
-        cl_int buildError = ::clBuildProgram(
+        cl_int buildError = CL_(clBuildProgram)(
             object_,
             0,
             nullptr,
@@ -6740,7 +7121,7 @@ public:
         void (CL_CALLBACK * notifyFptr)(cl_program, void *) = nullptr,
         void* data = nullptr) const
     {
-        cl_int error = ::clCompileProgram(
+        cl_int error = CL_(clCompileProgram)(
             object_,
             0,
             nullptr,
@@ -6772,18 +7153,20 @@ public:
     {
         static_assert(sizeof(cl::Program) == sizeof(cl_program),
             "Size of cl::Program must be equal to size of cl_program");
+
         vector<const char*> headerIncludeNamesCStr;
         for(const string& name: headerIncludeNames) {
             headerIncludeNamesCStr.push_back(name.c_str());
         }
-        cl_int error = ::clCompileProgram(
+
+        cl_int error = CL_(clCompileProgram)(
             object_,
             0,
             nullptr,
             options,
             static_cast<cl_uint>(inputHeaders.size()),
-            reinterpret_cast<const cl_program*>(inputHeaders.data()),
-            reinterpret_cast<const char**>(headerIncludeNamesCStr.data()),
+            reinterpret_cast<const cl_program*>(inputHeaders.empty() ? nullptr : inputHeaders.data()),
+            reinterpret_cast<const char**>(headerIncludeNamesCStr.empty() ? nullptr : headerIncludeNamesCStr.data()),
             notifyFptr,
             data);
         return detail::buildErrHandler(error, __COMPILE_PROGRAM_ERR, getBuildInfo<CL_PROGRAM_BUILD_LOG>());
@@ -6802,7 +7185,7 @@ public:
 
     cl_int compile(
         const char* options,
-        const vector<Device>& deviceList,
+        const vector<Device>& devices,
         const vector<Program>& inputHeaders = vector<Program>(),
         const vector<string>& headerIncludeNames = vector<string>(),
         void (CL_CALLBACK * notifyFptr)(cl_program, void *) = nullptr,
@@ -6810,22 +7193,25 @@ public:
     {
         static_assert(sizeof(cl::Program) == sizeof(cl_program),
             "Size of cl::Program must be equal to size of cl_program");
+
+        vector<cl_device_id> deviceIDs;
+        for(const Device& device: devices) {
+            deviceIDs.push_back(device());
+        }
+
         vector<const char*> headerIncludeNamesCStr;
         for(const string& name: headerIncludeNames) {
             headerIncludeNamesCStr.push_back(name.c_str());
         }
-        vector<cl_device_id> deviceIDList;
-        for(const Device& device: deviceList) {
-            deviceIDList.push_back(device());
-        }
-        cl_int error = ::clCompileProgram(
+
+        cl_int error = CL_(clCompileProgram)(
             object_,
-            static_cast<cl_uint>(deviceList.size()),
-            reinterpret_cast<const cl_device_id*>(deviceIDList.data()),
+            static_cast<cl_uint>(deviceIDs.size()),
+            reinterpret_cast<const cl_device_id*>(deviceIDs.empty() ? nullptr : deviceIDs.data()),
             options,
             static_cast<cl_uint>(inputHeaders.size()),
-            reinterpret_cast<const cl_program*>(inputHeaders.data()),
-            reinterpret_cast<const char**>(headerIncludeNamesCStr.data()),
+            reinterpret_cast<const cl_program*>(inputHeaders.empty() ? nullptr : inputHeaders.data()),
+            reinterpret_cast<const char**>(headerIncludeNamesCStr.empty() ? nullptr : headerIncludeNamesCStr.data()),
             notifyFptr,
             data);
         return detail::buildErrHandler(error, __COMPILE_PROGRAM_ERR, getBuildInfo<CL_PROGRAM_BUILD_LOG>());
@@ -6836,7 +7222,7 @@ public:
     cl_int getInfo(cl_program_info name, T* param) const
     {
         return detail::errHandler(
-            detail::getInfo(&::clGetProgramInfo, object_, name, param),
+            detail::getInfo(CL_(clGetProgramInfo), object_, name, param),
             __GET_PROGRAM_INFO_ERR);
     }
 
@@ -6845,7 +7231,7 @@ public:
     getInfo(cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_program_info, name>::param_type param;
+            detail::cl_program_info, name>::param_type param{};
         cl_int result = getInfo(name, &param);
         if (err != nullptr) {
             *err = result;
@@ -6859,7 +7245,7 @@ public:
     {
         return detail::errHandler(
             detail::getInfo(
-                &::clGetProgramBuildInfo, object_, device(), name, param),
+                CL_(clGetProgramBuildInfo), object_, device(), name, param),
                 __GET_PROGRAM_BUILD_INFO_ERR);
     }
 
@@ -6868,7 +7254,7 @@ public:
     getBuildInfo(const Device& device, cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_program_build_info, name>::param_type param;
+            detail::cl_program_build_info, name>::param_type param{};
         cl_int result = getBuildInfo(device, name, &param);
         if (err != nullptr) {
             *err = result;
@@ -6901,7 +7287,7 @@ public:
 
         for (const cl::Device &d : devs) {
             typename detail::param_traits<
-                detail::cl_program_build_info, name>::param_type param;
+                detail::cl_program_build_info, name>::param_type param{};
             result = getBuildInfo(d, name, &param);
             devInfo.push_back(
                 std::pair<cl::Device, typename detail::param_traits<detail::cl_program_build_info, name>::param_type>
@@ -6923,15 +7309,17 @@ public:
     cl_int createKernels(vector<Kernel>* kernels)
     {
         cl_uint numKernels;
-        cl_int err = ::clCreateKernelsInProgram(object_, 0, nullptr, &numKernels);
+        cl_int err = CL_(clCreateKernelsInProgram)(object_, 0, nullptr, &numKernels);
         if (err != CL_SUCCESS) {
             return detail::errHandler(err, __CREATE_KERNELS_IN_PROGRAM_ERR);
         }
 
         vector<cl_kernel> value(numKernels);
-        
-        err = ::clCreateKernelsInProgram(
-            object_, numKernels, value.data(), nullptr);
+        err = CL_(clCreateKernelsInProgram)(
+            object_,
+            numKernels,
+            value.empty() ? nullptr : value.data(),
+            nullptr);
         if (err != CL_SUCCESS) {
             return detail::errHandler(err, __CREATE_KERNELS_IN_PROGRAM_ERR);
         }
@@ -6967,7 +7355,7 @@ public:
         void * user_data = nullptr) CL_API_SUFFIX__VERSION_2_2_DEPRECATED
     {
         return detail::errHandler(
-            ::clSetProgramReleaseCallback(
+            CL_(clSetProgramReleaseCallback)(
                 object_,
                 pfn_notify,
                 user_data),
@@ -6984,7 +7372,7 @@ public:
         setSpecializationConstant(cl_uint index, const T &value)
     {
         return detail::errHandler(
-            ::clSetProgramSpecializationConstant(
+            CL_(clSetProgramSpecializationConstant)(
                 object_,
                 index,
                 sizeof(value),
@@ -6999,7 +7387,7 @@ public:
     cl_int setSpecializationConstant(cl_uint index, size_type size, const void* value)
     {
         return detail::errHandler(
-            ::clSetProgramSpecializationConstant(
+            CL_(clSetProgramSpecializationConstant)(
                 object_,
                 index,
                 size,
@@ -7026,7 +7414,7 @@ inline Program linkProgram(
         detail::errHandler(error_local, __LINK_PROGRAM_ERR);
     }
 
-    cl_program prog = ::clLinkProgram(
+    cl_program prog = CL_(clLinkProgram)(
         ctx(),
         0,
         nullptr,
@@ -7076,13 +7464,13 @@ inline Program linkProgram(
         }
     }
 
-    cl_program prog = ::clLinkProgram(
+    cl_program prog = CL_(clLinkProgram)(
         ctx(),
         0,
         nullptr,
         options,
         static_cast<cl_uint>(inputPrograms.size()),
-        reinterpret_cast<const cl_program *>(inputPrograms.data()),
+        reinterpret_cast<const cl_program *>(inputPrograms.empty() ? nullptr : inputPrograms.data()),
         notifyFptr,
         data,
         &error_local);
@@ -7127,7 +7515,7 @@ inline cl_int cl::Program::getInfo(cl_program_info name, vector<vector<unsigned 
         }
 
         return detail::errHandler(
-            detail::getInfo(&::clGetProgramInfo, object_, name, param),
+            detail::getInfo(CL_(clGetProgramInfo), object_, name, param),
             __GET_PROGRAM_INFO_ERR);
     }
 
@@ -7153,7 +7541,7 @@ inline cl_int cl::Program::setSpecializationConstant(cl_uint index, const bool &
 {
     cl_uchar ucValue = value ? CL_UCHAR_MAX : 0;
     return detail::errHandler(
-        ::clSetProgramSpecializationConstant(
+        CL_(clSetProgramSpecializationConstant)(
             object_,
             index,
             sizeof(ucValue),
@@ -7166,7 +7554,7 @@ inline Kernel::Kernel(const Program& program, const string& name, cl_int* err)
 {
     cl_int error;
 
-    object_ = ::clCreateKernel(program(), name.c_str(), &error);
+    object_ = CL_(clCreateKernel)(program(), name.c_str(), &error);
     detail::errHandler(error, __CREATE_KERNEL_ERR);
 
     if (err != nullptr) {
@@ -7178,7 +7566,7 @@ inline Kernel::Kernel(const Program& program, const char* name, cl_int* err)
 {
     cl_int error;
 
-    object_ = ::clCreateKernel(program(), name, &error);
+    object_ = CL_(clCreateKernel)(program(), name, &error);
     detail::errHandler(error, __CREATE_KERNEL_ERR);
 
     if (err != nullptr) {
@@ -7190,20 +7578,21 @@ inline Kernel::Kernel(const Program& program, const char* name, cl_int* err)
 enum class ExternalMemoryType : cl_external_memory_handle_type_khr
 {
     None = 0,
-
+#ifdef cl_khr_external_memory_android_hardware_buffer
+    AndroidHardwareBuffer = CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR,
+#endif // cl_khr_external_memory_android_hardware_buffer
+#ifdef cl_khr_external_memory_opaque_fd
     OpaqueFd = CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR,
+#endif // cl_khr_external_memory_opaque_fd
+#ifdef cl_khr_external_memory_win32
     OpaqueWin32 = CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR,
     OpaqueWin32Kmt = CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR,
-
-    D3D11Texture = CL_EXTERNAL_MEMORY_HANDLE_D3D11_TEXTURE_KHR,
-    D3D11TextureKmt = CL_EXTERNAL_MEMORY_HANDLE_D3D11_TEXTURE_KMT_KHR,
-
-    D3D12Heap = CL_EXTERNAL_MEMORY_HANDLE_D3D12_HEAP_KHR,
-    D3D12Resource = CL_EXTERNAL_MEMORY_HANDLE_D3D12_RESOURCE_KHR,
-
+#endif // cl_khr_external_memory_win32
+#ifdef cl_khr_external_memory_dma_buf
     DmaBuf = CL_EXTERNAL_MEMORY_HANDLE_DMA_BUF_KHR,
+#endif // cl_khr_external_memory_dma_buf
 };
-#endif
+#endif // cl_khr_external_memory
 
 enum class QueueProperties : cl_command_queue_properties
 {
@@ -7344,7 +7733,7 @@ public:
                 cl_queue_properties queue_properties[] = {
                     CL_QUEUE_PROPERTIES, properties, 0 };
                 if ((properties & CL_QUEUE_ON_DEVICE) == 0) {
-                    object_ = ::clCreateCommandQueueWithProperties(
+                    object_ = CL_(clCreateCommandQueueWithProperties)(
                         context(), device(), queue_properties, &error);
                 }
                 else {
@@ -7359,7 +7748,7 @@ public:
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 200
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 200
             if (!useWithProperties) {
-                object_ = ::clCreateCommandQueue(
+                object_ = CL_(clCreateCommandQueue)(
                     context(), device(), properties, &error);
 
                 detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
@@ -7410,7 +7799,7 @@ public:
                cl_queue_properties queue_properties[] = {
                    CL_QUEUE_PROPERTIES, static_cast<cl_queue_properties>(properties), 0 };
 
-               object_ = ::clCreateCommandQueueWithProperties(
+               object_ = CL_(clCreateCommandQueueWithProperties)(
                    context(), device(), queue_properties, &error);
 
                detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -7421,7 +7810,7 @@ public:
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 200
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 200
            if (!useWithProperties) {
-               object_ = ::clCreateCommandQueue(
+               object_ = CL_(clCreateCommandQueue)(
                    context(), device(), static_cast<cl_command_queue_properties>(properties), &error);
 
                detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
@@ -7475,7 +7864,7 @@ public:
             cl_queue_properties queue_properties[] = {
                 CL_QUEUE_PROPERTIES, properties, 0 };
             if ((properties & CL_QUEUE_ON_DEVICE) == 0) {
-                object_ = ::clCreateCommandQueueWithProperties(
+                object_ = CL_(clCreateCommandQueueWithProperties)(
                     context(), devices[0](), queue_properties, &error);
             }
             else {
@@ -7490,7 +7879,7 @@ public:
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 200
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 200
         if (!useWithProperties) {
-            object_ = ::clCreateCommandQueue(
+            object_ = CL_(clCreateCommandQueue)(
                 context(), devices[0](), properties, &error);
 
             detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
@@ -7541,7 +7930,7 @@ public:
         if (useWithProperties) {
             cl_queue_properties queue_properties[] = {
                 CL_QUEUE_PROPERTIES, static_cast<cl_queue_properties>(properties), 0 };
-            object_ = ::clCreateCommandQueueWithProperties(
+            object_ = CL_(clCreateCommandQueueWithProperties)(
                 context(), devices[0](), queue_properties, &error);
 
             detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -7552,7 +7941,7 @@ public:
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 200
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 200
         if (!useWithProperties) {
-            object_ = ::clCreateCommandQueue(
+            object_ = CL_(clCreateCommandQueue)(
                 context(), devices[0](), static_cast<cl_command_queue_properties>(properties), &error);
 
             detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
@@ -7592,7 +7981,7 @@ public:
         if (useWithProperties) {
             cl_queue_properties queue_properties[] = {
                 CL_QUEUE_PROPERTIES, properties, 0 };
-            object_ = ::clCreateCommandQueueWithProperties(
+            object_ = CL_(clCreateCommandQueueWithProperties)(
                 context(), device(), queue_properties, &error);
 
             detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -7603,7 +7992,7 @@ public:
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 200
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 200
         if (!useWithProperties) {
-            object_ = ::clCreateCommandQueue(
+            object_ = CL_(clCreateCommandQueue)(
                 context(), device(), properties, &error);
 
             detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
@@ -7643,7 +8032,7 @@ public:
         if (useWithProperties) {
             cl_queue_properties queue_properties[] = {
                 CL_QUEUE_PROPERTIES, static_cast<cl_queue_properties>(properties), 0 };
-            object_ = ::clCreateCommandQueueWithProperties(
+            object_ = CL_(clCreateCommandQueueWithProperties)(
                 context(), device(), queue_properties, &error);
 
             detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -7654,7 +8043,7 @@ public:
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 200
 #if CL_HPP_MINIMUM_OPENCL_VERSION < 200
         if (!useWithProperties) {
-            object_ = ::clCreateCommandQueue(
+            object_ = CL_(clCreateCommandQueue)(
                 context(), device(), static_cast<cl_command_queue_properties>(properties), &error);
 
             detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
@@ -7716,7 +8105,7 @@ public:
     {
         return detail::errHandler(
             detail::getInfo(
-                &::clGetCommandQueueInfo, object_, name, param),
+                CL_(clGetCommandQueueInfo), object_, name, param),
                 __GET_COMMAND_QUEUE_INFO_ERR);
     }
 
@@ -7725,7 +8114,7 @@ public:
     getInfo(cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_command_queue_info, name>::param_type param;
+            detail::cl_command_queue_info, name>::param_type param{};
         cl_int result = getInfo(name, &param);
         if (err != nullptr) {
             *err = result;
@@ -7744,11 +8133,11 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueReadBuffer(
+            CL_(clEnqueueReadBuffer)(
                 object_, buffer(), blocking, offset, size,
                 ptr,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_READ_BUFFER_ERR);
 
@@ -7769,11 +8158,11 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueWriteBuffer(
+            CL_(clEnqueueWriteBuffer)(
                 object_, buffer(), blocking, offset, size,
                 ptr,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
                 __ENQUEUE_WRITE_BUFFER_ERR);
 
@@ -7794,10 +8183,10 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueCopyBuffer(
+            CL_(clEnqueueCopyBuffer)(
                 object_, src(), dst(), src_offset, dst_offset, size,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
             __ENQEUE_COPY_BUFFER_ERR);
 
@@ -7823,7 +8212,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueReadBufferRect(
+            CL_(clEnqueueReadBufferRect)(
                 object_, 
                 buffer(), 
                 blocking,
@@ -7836,7 +8225,7 @@ public:
                 host_slice_pitch,
                 ptr,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
                 __ENQUEUE_READ_BUFFER_RECT_ERR);
 
@@ -7891,7 +8280,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueWriteBufferRect(
+            CL_(clEnqueueWriteBufferRect)(
                 object_, 
                 buffer(), 
                 blocking,
@@ -7904,7 +8293,7 @@ public:
                 host_slice_pitch,
                 ptr,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
                 __ENQUEUE_WRITE_BUFFER_RECT_ERR);
 
@@ -7958,7 +8347,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueCopyBufferRect(
+            CL_(clEnqueueCopyBufferRect)(
                 object_, 
                 src(), 
                 dst(), 
@@ -7970,7 +8359,7 @@ public:
                 dst_row_pitch,
                 dst_slice_pitch,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
             __ENQEUE_COPY_BUFFER_RECT_ERR);
 
@@ -8031,7 +8420,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueFillBuffer(
+            CL_(clEnqueueFillBuffer)(
                 object_, 
                 buffer(),
                 static_cast<void*>(&pattern),
@@ -8039,7 +8428,7 @@ public:
                 offset, 
                 size,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
                 __ENQUEUE_FILL_BUFFER_ERR);
 
@@ -8063,7 +8452,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueReadImage(
+            CL_(clEnqueueReadImage)(
                 object_, 
                 image(), 
                 blocking, 
@@ -8073,7 +8462,7 @@ public:
                 slice_pitch, 
                 ptr,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_READ_IMAGE_ERR);
 
@@ -8119,7 +8508,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueWriteImage(
+            CL_(clEnqueueWriteImage)(
                 object_, 
                 image(), 
                 blocking, 
@@ -8129,7 +8518,7 @@ public:
                 slice_pitch, 
                 ptr,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_WRITE_IMAGE_ERR);
 
@@ -8173,7 +8562,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueCopyImage(
+            CL_(clEnqueueCopyImage)(
                 object_, 
                 src(), 
                 dst(), 
@@ -8181,7 +8570,7 @@ public:
                 dst_origin.data(), 
                 region.data(),
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_COPY_IMAGE_ERR);
 
@@ -8233,14 +8622,14 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueFillImage(
+            CL_(clEnqueueFillImage)(
                 object_,
                 image(),
                 static_cast<void*>(&fillColor),
                 origin.data(),
                 region.data(),
                 (events != nullptr) ? (cl_uint)events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : NULL,
+                (events != nullptr && events->size() > 0) ? (const cl_event*)&events->front() : NULL,
                 (event != NULL) ? &tmp : nullptr),
             __ENQUEUE_FILL_IMAGE_ERR);
 
@@ -8290,7 +8679,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueCopyImageToBuffer(
+            CL_(clEnqueueCopyImageToBuffer)(
                 object_, 
                 src(), 
                 dst(), 
@@ -8298,7 +8687,7 @@ public:
                 region.data(), 
                 dst_offset,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_COPY_IMAGE_TO_BUFFER_ERR);
 
@@ -8338,7 +8727,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueCopyBufferToImage(
+            CL_(clEnqueueCopyBufferToImage)(
                 object_, 
                 src(), 
                 dst(), 
@@ -8346,7 +8735,7 @@ public:
                 dst_origin.data(), 
                 region.data(),
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_COPY_BUFFER_TO_IMAGE_ERR);
 
@@ -8387,10 +8776,10 @@ public:
     {
         cl_event tmp;
         cl_int error;
-        void * result = ::clEnqueueMapBuffer(
+        void * result = CL_(clEnqueueMapBuffer)(
             object_, buffer(), blocking, flags, offset, size,
             (events != nullptr) ? (cl_uint) events->size() : 0,
-            (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+            (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
             (event != nullptr) ? &tmp : nullptr,
             &error);
 
@@ -8418,13 +8807,13 @@ public:
     {
         cl_event tmp;
         cl_int error;
-        void * result = ::clEnqueueMapImage(
+        void * result = CL_(clEnqueueMapImage)(
             object_, image(), blocking, flags,
             origin.data(), 
             region.data(),
             row_pitch, slice_pitch,
             (events != nullptr) ? (cl_uint) events->size() : 0,
-            (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+            (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
             (event != nullptr) ? &tmp : nullptr,
             &error);
 
@@ -8470,10 +8859,10 @@ public:
             const vector<Event> *events = nullptr,
             Event *event = nullptr) const {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMemcpy(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMemcpy)(
                 object_, blocking, static_cast<void *>(dst_ptr), static_cast<const void *>(src_ptr), size,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event *) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event *) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr), __ENQUEUE_COPY_SVM_ERR);
 
         if (event != nullptr && err == CL_SUCCESS)
@@ -8495,11 +8884,11 @@ public:
             const vector<Event> *events = nullptr,
             Event *event = nullptr) const {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMemcpy(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMemcpy)(
                 object_, blocking, static_cast<void *>(dst_ptr.get()), static_cast<const void *>(src_ptr.get()),
                 size,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event *) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event *) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr), __ENQUEUE_COPY_SVM_ERR);
 
         if (event != nullptr && err == CL_SUCCESS)
@@ -8523,13 +8912,14 @@ public:
         if(src_container.size() != dst_container.size()){
             return detail::errHandler(CL_INVALID_VALUE,__ENQUEUE_COPY_SVM_ERR);
         }
-        cl_int err = detail::errHandler(::clEnqueueSVMMemcpy(
-                object_, blocking, static_cast<void *>(dst_container.data()),
-                static_cast<const void *>(src_container.data()),
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMemcpy)(
+                object_, blocking,
+                dst_container.empty() ? nullptr : dst_container.data(),
+                src_container.empty() ? nullptr : src_container.data(),
                 dst_container.size() * sizeof(T),
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event *) &events->front() : nullptr,
-                (event != NULL) ? &tmp : nullptr), __ENQUEUE_COPY_SVM_ERR);
+                (events != nullptr && events->size() > 0) ? (const cl_event *) &events->front() : nullptr,
+                (event != nullptr) ? &tmp : nullptr), __ENQUEUE_COPY_SVM_ERR);
 
         if (event != nullptr && err == CL_SUCCESS)
             *event = tmp;
@@ -8549,11 +8939,11 @@ public:
             const vector<Event> *events = nullptr,
             Event *event = nullptr) const {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMemFill(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMemFill)(
                 object_, static_cast<void *>(ptr), static_cast<void *>(&pattern),
                 sizeof(PatternType), size,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event *) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event *) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr), __ENQUEUE_FILL_SVM_ERR);
 
         if (event != nullptr && err == CL_SUCCESS)
@@ -8574,11 +8964,11 @@ public:
             const vector<Event> *events = nullptr,
             Event *event = nullptr) const {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMemFill(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMemFill)(
                 object_, static_cast<void *>(ptr.get()), static_cast<void *>(&pattern),
                 sizeof(PatternType), size,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event *) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event *) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr), __ENQUEUE_FILL_SVM_ERR);
 
         if (event != nullptr && err == CL_SUCCESS)
@@ -8599,11 +8989,14 @@ public:
             Event* event = nullptr) const
     {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMemFill(
-                object_, static_cast<void *>(container.data()), static_cast<void *>(&pattern),
-                sizeof(PatternType), container.size() * sizeof(T),
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMemFill)(
+                object_,
+                container.empty() ? nullptr : container.data(),
+                &pattern,
+                sizeof(PatternType),
+                container.size() * sizeof(T),
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event *) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event *) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : NULL), __ENQUEUE_FILL_SVM_ERR);
 
         if (event != nullptr && err == CL_SUCCESS)
@@ -8626,10 +9019,10 @@ public:
         Event* event = nullptr) const
     {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMap(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMap)(
             object_, blocking, flags, static_cast<void*>(ptr), size,
             (events != nullptr) ? (cl_uint)events->size() : 0,
-            (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
+            (events != nullptr && events->size() > 0) ? (const cl_event*)&events->front() : nullptr,
             (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_MAP_SVM_ERR);
 
@@ -8654,10 +9047,10 @@ public:
         Event* event = nullptr) const
     {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMap(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMap)(
             object_, blocking, flags, static_cast<void*>(ptr.get()), size,
             (events != nullptr) ? (cl_uint)events->size() : 0,
-            (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
+            (events != nullptr && events->size() > 0) ? (const cl_event*)&events->front() : nullptr,
             (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_MAP_SVM_ERR);
 
@@ -8680,10 +9073,12 @@ public:
         Event* event = nullptr) const
     {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMap(
-            object_, blocking, flags, static_cast<void*>(container.data()), container.size()*sizeof(T),
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMap)(
+            object_, blocking, flags,
+            container.empty() ? nullptr : container.data(),
+            container.size() * sizeof(T),
             (events != nullptr) ? (cl_uint)events->size() : 0,
-            (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
+            (events != nullptr && events->size() > 0) ? (const cl_event*)&events->front() : nullptr,
             (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_MAP_SVM_ERR);
 
@@ -8702,10 +9097,10 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueUnmapMemObject(
+            CL_(clEnqueueUnmapMemObject)(
                 object_, memory(), mapped_ptr,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
 
@@ -8729,10 +9124,10 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueSVMUnmap(
+            CL_(clEnqueueSVMUnmap)(
             object_, static_cast<void*>(ptr),
             (events != nullptr) ? (cl_uint)events->size() : 0,
-            (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
+            (events != nullptr && events->size() > 0) ? (const cl_event*)&events->front() : nullptr,
             (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_UNMAP_SVM_ERR);
 
@@ -8754,10 +9149,10 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueSVMUnmap(
+            CL_(clEnqueueSVMUnmap)(
             object_, static_cast<void*>(ptr.get()),
             (events != nullptr) ? (cl_uint)events->size() : 0,
-            (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
+            (events != nullptr && events->size() > 0) ? (const cl_event*)&events->front() : nullptr,
             (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_UNMAP_SVM_ERR);
 
@@ -8779,10 +9174,11 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueSVMUnmap(
-            object_, static_cast<void*>(container.data()),
+            CL_(clEnqueueSVMUnmap)(
+            object_,
+            container.empty() ? nullptr : container.data(),
             (events != nullptr) ? (cl_uint)events->size() : 0,
-            (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
+            (events != nullptr && events->size() > 0) ? (const cl_event*)&events->front() : nullptr,
             (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_UNMAP_SVM_ERR);
 
@@ -8811,10 +9207,10 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueMarkerWithWaitList(
+            CL_(clEnqueueMarkerWithWaitList)(
                 object_,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_MARKER_WAIT_LIST_ERR);
 
@@ -8841,10 +9237,10 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueBarrierWithWaitList(
+            CL_(clEnqueueBarrierWithWaitList)(
                 object_,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_BARRIER_WAIT_LIST_ERR);
 
@@ -8874,13 +9270,13 @@ public:
         }
         
         cl_int err = detail::errHandler(
-            ::clEnqueueMigrateMemObjects(
+            CL_(clEnqueueMigrateMemObjects)(
                 object_, 
                 (cl_uint)memObjects.size(), 
-                localMemObjects.data(),
+                localMemObjects.empty() ? nullptr : localMemObjects.data(),
                 flags,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
 
@@ -8907,13 +9303,14 @@ public:
         Event* event = nullptr) const
     {
         cl_event tmp;
-        cl_int err = detail::errHandler(::clEnqueueSVMMigrateMem(
+        cl_int err = detail::errHandler(CL_(clEnqueueSVMMigrateMem)(
             object_,
-            svmRawPointers.size(), static_cast<void**>(svmRawPointers.data()),
-            sizes.data(), // array of sizes not passed
+            svmRawPointers.size(),
+            svmRawPointers.empty() ? nullptr : svmRawPointers.data(),
+            sizes.empty() ? nullptr : sizes.data(),
             flags,
             (events != nullptr) ? (cl_uint)events->size() : 0,
-            (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
+            (events != nullptr && events->size() > 0) ? (const cl_event*)&events->front() : nullptr,
             (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_MIGRATE_SVM_ERR);
 
@@ -9023,13 +9420,13 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueNDRangeKernel(
+            CL_(clEnqueueNDRangeKernel)(
                 object_, kernel(), (cl_uint) global.dimensions(),
                 offset.dimensions() != 0 ? (const size_type*) offset : nullptr,
                 (const size_type*) global,
                 local.dimensions() != 0 ? (const size_type*) local : nullptr,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_NDRANGE_KERNEL_ERR);
 
@@ -9047,10 +9444,10 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueTask(
+            CL_(clEnqueueTask)(
                 object_, kernel(),
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_TASK_ERR);
 
@@ -9071,13 +9468,13 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueNativeKernel(
+            CL_(clEnqueueNativeKernel)(
                 object_, userFptr, args.first, args.second,
                 (mem_objects != nullptr) ? (cl_uint) mem_objects->size() : 0,
                 (mem_objects->size() > 0 ) ? reinterpret_cast<const cl_mem *>(mem_objects->data()) : nullptr,
-                (mem_locs != nullptr && mem_locs->size() > 0) ? (const void **) &mem_locs->front() : nullptr,
+                (mem_locs != nullptr && mem_locs->size() > 0) ? const_cast<const void**>(&mem_locs->front()) : nullptr,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_NATIVE_KERNEL);
 
@@ -9096,7 +9493,7 @@ public:
     {
         cl_event tmp;
         cl_int err = detail::errHandler(
-            ::clEnqueueMarker(
+            CL_(clEnqueueMarker)(
                 object_, 
                 (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_MARKER_ERR);
@@ -9111,7 +9508,7 @@ public:
     cl_int enqueueWaitForEvents(const vector<Event>& events) const CL_API_SUFFIX__VERSION_1_1_DEPRECATED
     {
         return detail::errHandler(
-            ::clEnqueueWaitForEvents(
+            CL_(clEnqueueWaitForEvents)(
                 object_,
                 (cl_uint) events.size(),
                 events.size() > 0 ? (const cl_event*) &events.front() : nullptr),
@@ -9126,12 +9523,12 @@ public:
      {
         cl_event tmp;
         cl_int err = detail::errHandler(
-             ::clEnqueueAcquireGLObjects(
+             CL_(clEnqueueAcquireGLObjects)(
                  object_,
                  (mem_objects != nullptr) ? (cl_uint) mem_objects->size() : 0,
                  (mem_objects != nullptr && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): nullptr,
                  (events != nullptr) ? (cl_uint) events->size() : 0,
-                 (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                 (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                  (event != nullptr) ? &tmp : nullptr),
              __ENQUEUE_ACQUIRE_GL_ERR);
 
@@ -9148,12 +9545,12 @@ public:
      {
         cl_event tmp;
         cl_int err = detail::errHandler(
-             ::clEnqueueReleaseGLObjects(
+             CL_(clEnqueueReleaseGLObjects)(
                  object_,
                  (mem_objects != nullptr) ? (cl_uint) mem_objects->size() : 0,
                  (mem_objects != nullptr && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): nullptr,
                  (events != nullptr) ? (cl_uint) events->size() : 0,
-                 (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                 (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                  (event != nullptr) ? &tmp : nullptr),
              __ENQUEUE_RELEASE_GL_ERR);
 
@@ -9196,7 +9593,7 @@ typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueReleaseD3D10ObjectsKHR)(
                  (mem_objects != nullptr) ? (cl_uint) mem_objects->size() : 0,
                  (mem_objects != nullptr && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): nullptr,
                  (events != nullptr) ? (cl_uint) events->size() : 0,
-                 (events != nullptr) ? (cl_event*) &events->front() : nullptr,
+                 (events != nullptr) ? (const cl_event*) &events->front() : nullptr,
                  (event != nullptr) ? &tmp : nullptr),
              __ENQUEUE_ACQUIRE_GL_ERR);
 
@@ -9229,7 +9626,7 @@ typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueReleaseD3D10ObjectsKHR)(
                 (mem_objects != nullptr) ? (cl_uint) mem_objects->size() : 0,
                 (mem_objects != nullptr && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): nullptr,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr),
             __ENQUEUE_RELEASE_GL_ERR);
 
@@ -9248,19 +9645,19 @@ typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueReleaseD3D10ObjectsKHR)(
     cl_int enqueueBarrier() const CL_API_SUFFIX__VERSION_1_1_DEPRECATED
     {
         return detail::errHandler(
-            ::clEnqueueBarrier(object_),
+            CL_(clEnqueueBarrier)(object_),
             __ENQUEUE_BARRIER_ERR);
     }
 #endif // CL_USE_DEPRECATED_OPENCL_1_1_APIS
 
     cl_int flush() const
     {
-        return detail::errHandler(::clFlush(object_), __FLUSH_ERR);
+        return detail::errHandler(CL_(clFlush)(object_), __FLUSH_ERR);
     }
 
     cl_int finish() const
     {
-        return detail::errHandler(::clFinish(object_), __FINISH_ERR);
+        return detail::errHandler(CL_(clFinish)(object_), __FINISH_ERR);
     }
 
 #ifdef cl_khr_external_memory
@@ -9279,7 +9676,7 @@ typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueReleaseD3D10ObjectsKHR)(
             err = pfn_clEnqueueAcquireExternalMemObjectsKHR(
                 object_,
                 static_cast<cl_uint>(mem_objects.size()),
-                (mem_objects.size() > 0) ? reinterpret_cast<const cl_mem *>(mem_objects.data()) : nullptr,
+                reinterpret_cast<const cl_mem *>(mem_objects.empty() ? nullptr : mem_objects.data()),
                 (events_wait != nullptr) ? static_cast<cl_uint>(events_wait->size()) : 0,
                 (events_wait != nullptr && events_wait->size() > 0) ? reinterpret_cast<const cl_event*>(events_wait->data()) : nullptr,
                 &tmp);
@@ -9308,7 +9705,7 @@ typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueReleaseD3D10ObjectsKHR)(
             err = pfn_clEnqueueReleaseExternalMemObjectsKHR(
                 object_,
                 static_cast<cl_uint>(mem_objects.size()),
-                (mem_objects.size() > 0) ? reinterpret_cast<const cl_mem *>(mem_objects.data()) : nullptr,
+                reinterpret_cast<const cl_mem *>(mem_objects.empty() ? nullptr : mem_objects.data()),
                 (events_wait != nullptr) ? static_cast<cl_uint>(events_wait->size()) : 0,
                 (events_wait != nullptr && events_wait->size() > 0) ? reinterpret_cast<const cl_event*>(events_wait->data()) : nullptr,
                 &tmp);
@@ -9385,7 +9782,7 @@ public:
 
         cl_queue_properties queue_properties[] = {
             CL_QUEUE_PROPERTIES, mergedProperties, 0 };
-        object_ = ::clCreateCommandQueueWithProperties(
+        object_ = CL_(clCreateCommandQueueWithProperties)(
             context(), device(), queue_properties, &error);
 
         detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -9409,7 +9806,7 @@ public:
             CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_ON_DEVICE | static_cast<cl_command_queue_properties>(properties);
         cl_queue_properties queue_properties[] = {
             CL_QUEUE_PROPERTIES, mergedProperties, 0 };
-        object_ = ::clCreateCommandQueueWithProperties(
+        object_ = CL_(clCreateCommandQueueWithProperties)(
             context(), device(), queue_properties, &error);
 
         detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -9436,7 +9833,7 @@ public:
             CL_QUEUE_PROPERTIES, mergedProperties,
             CL_QUEUE_SIZE, queueSize, 
             0 };
-        object_ = ::clCreateCommandQueueWithProperties(
+        object_ = CL_(clCreateCommandQueueWithProperties)(
             context(), device(), queue_properties, &error);
 
         detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -9465,7 +9862,7 @@ public:
     {
         return detail::errHandler(
             detail::getInfo(
-            &::clGetCommandQueueInfo, object_, name, param),
+            CL_(clGetCommandQueueInfo), object_, name, param),
             __GET_COMMAND_QUEUE_INFO_ERR);
     }
 
@@ -9474,7 +9871,7 @@ public:
         getInfo(cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_command_queue_info, name>::param_type param;
+            detail::cl_command_queue_info, name>::param_type param{};
         cl_int result = getInfo(name, &param);
         if (err != nullptr) {
             *err = result;
@@ -9501,7 +9898,7 @@ public:
             CL_QUEUE_PROPERTIES, properties,
             0 };
         DeviceCommandQueue deviceQueue(
-            ::clCreateCommandQueueWithProperties(
+            CL_(clCreateCommandQueueWithProperties)(
             context(), device(), queue_properties, &error));
 
         detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -9529,7 +9926,7 @@ public:
             CL_QUEUE_PROPERTIES, properties,
             0 };
         DeviceCommandQueue deviceQueue(
-            ::clCreateCommandQueueWithProperties(
+            CL_(clCreateCommandQueueWithProperties)(
             context(), device(), queue_properties, &error));
 
         detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -9558,7 +9955,7 @@ public:
             CL_QUEUE_SIZE, queueSize,
             0 };
         DeviceCommandQueue deviceQueue(
-            ::clCreateCommandQueueWithProperties(
+            CL_(clCreateCommandQueueWithProperties)(
                 context(), device(), queue_properties, &error));
 
         detail::errHandler(error, __CREATE_COMMAND_QUEUE_WITH_PROPERTIES_ERR);
@@ -9581,7 +9978,7 @@ public:
     static DeviceCommandQueue updateDefault(const Context &context, const Device &device, const DeviceCommandQueue &default_queue, cl_int *err = nullptr)
     {
         cl_int error;
-        error = clSetDefaultDeviceCommandQueue(context.get(), device.get(), default_queue.get());
+        error = CL_(clSetDefaultDeviceCommandQueue)(context.get(), device.get(), default_queue.get());
 
         detail::errHandler(error, __SET_DEFAULT_DEVICE_COMMAND_QUEUE_ERR);
         if (err != nullptr) {
@@ -9641,9 +10038,9 @@ Buffer::Buffer(
     size_type size = sizeof(DataType)*(endIterator - startIterator);
 
     if( useHostPtr ) {
-        object_ = ::clCreateBuffer(context(), flags, size, const_cast<DataType*>(&*startIterator), &error);
+        object_ = CL_(clCreateBuffer)(context(), flags, size, const_cast<DataType*>(&*startIterator), &error);
     } else {
-        object_ = ::clCreateBuffer(context(), flags, size, 0, &error);
+        object_ = CL_(clCreateBuffer)(context(), flags, size, 0, &error);
     }
 
     detail::errHandler(error, __CREATE_BUFFER_ERR);
@@ -9694,10 +10091,10 @@ Buffer::Buffer(
     Context context = queue.getInfo<CL_QUEUE_CONTEXT>();
 
     if (useHostPtr) {
-        object_ = ::clCreateBuffer(context(), flags, size, const_cast<DataType*>(&*startIterator), &error);
+        object_ = CL_(clCreateBuffer)(context(), flags, size, const_cast<DataType*>(&*startIterator), &error);
     }
     else {
-        object_ = ::clCreateBuffer(context(), flags, size, 0, &error);
+        object_ = CL_(clCreateBuffer)(context(), flags, size, 0, &error);
     }
 
     detail::errHandler(error, __CREATE_BUFFER_ERR);
@@ -9769,10 +10166,10 @@ inline void* enqueueMapBuffer(
         *err = error;
     }
 
-    void * result = ::clEnqueueMapBuffer(
+    void * result = CL_(clEnqueueMapBuffer)(
             queue(), buffer(), blocking, flags, offset, size,
             (events != nullptr) ? (cl_uint) events->size() : 0,
-            (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+            (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
             (cl_event*) event,
             &error);
 
@@ -9873,10 +10270,10 @@ inline cl_int enqueueUnmapMemObject(
 
     cl_event tmp;
     cl_int err = detail::errHandler(
-        ::clEnqueueUnmapMemObject(
+        CL_(clEnqueueUnmapMemObject)(
         queue(), memory(), mapped_ptr,
         (events != nullptr) ? (cl_uint)events->size() : 0,
-        (events != nullptr && events->size() > 0) ? (cl_event*)&events->front() : nullptr,
+        (events != nullptr && events->size() > 0) ? (const cl_event*)&events->front() : nullptr,
         (event != nullptr) ? &tmp : nullptr),
         __ENQUEUE_UNMAP_MEM_OBJECT_ERR);
 
@@ -10024,15 +10421,15 @@ inline cl_int copy( const CommandQueue &queue, IteratorType startIterator, Itera
     if( error != CL_SUCCESS ) {
         return error;
     }
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER < 1920
     std::copy(
-        startIterator, 
-        endIterator, 
+        startIterator,
+        endIterator,
         stdext::checked_array_iterator<DataType*>(
             pointer, length));
 #else
     std::copy(startIterator, endIterator, pointer);
-#endif
+#endif // defined(_MSC_VER) && _MSC_VER < 1920
     Event endEvent;
     error = queue.enqueueUnmapMemObject(buffer, pointer, 0, &endEvent);
     // if exceptions enabled, enqueueUnmapMemObject will throw
@@ -10908,13 +11305,13 @@ enum ExternalSemaphoreType : cl_external_semaphore_handle_type_khr
     None = 0,
 #ifdef cl_khr_external_semaphore_dx_fence
     D3D12Fence = CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR,
-#endif
+#endif // cl_khr_external_semaphore_dx_fence
 #ifdef cl_khr_external_semaphore_opaque_fd
     OpaqueFd = CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR,
-#endif
+#endif // cl_khr_external_semaphore_opaque_fd
 #ifdef cl_khr_external_semaphore_sync_fd
     SyncFd = CL_SEMAPHORE_HANDLE_SYNC_FD_KHR,
-#endif
+#endif // cl_khr_external_semaphore_sync_fd
 #ifdef cl_khr_external_semaphore_win32
     OpaqueWin32 = CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR,
     OpaqueWin32Kmt = CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR,
@@ -10940,7 +11337,7 @@ public:
         {
             object_ = pfn_clCreateSemaphoreWithPropertiesKHR(
                 context(),
-                sema_props.data(),
+                sema_props.empty() ? nullptr : sema_props.data(),
                 &error);
         }
           
@@ -10977,7 +11374,7 @@ public:
     getInfo(cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_semaphore_info_khr, name>::param_type param;
+            detail::cl_semaphore_info_khr, name>::param_type param{};
         cl_int result = getInfo(name, &param);
         if (err != nullptr) {
             *err = result;        
@@ -11097,7 +11494,7 @@ inline cl_int CommandQueue::enqueueWaitSemaphores(
                 (const cl_semaphore_khr *) &sema_objects.front(),
                 (sema_payloads.size() > 0) ? &sema_payloads.front() : nullptr,
                 (events_wait_list != nullptr) ? (cl_uint) events_wait_list->size() : 0,
-                (events_wait_list != nullptr && events_wait_list->size() > 0) ? (cl_event*) &events_wait_list->front() : nullptr,
+                (events_wait_list != nullptr && events_wait_list->size() > 0) ? (const cl_event*) &events_wait_list->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr);
     }
 
@@ -11125,7 +11522,7 @@ inline cl_int CommandQueue::enqueueSignalSemaphores(
                 (const cl_semaphore_khr*) &sema_objects.front(),
                 (sema_payloads.size() > 0) ? &sema_payloads.front() : nullptr,
                 (events_wait_list != nullptr) ? (cl_uint) events_wait_list->size() : 0,
-                (events_wait_list != nullptr && events_wait_list->size() > 0) ? (cl_event*) &events_wait_list->front() : nullptr,
+                (events_wait_list != nullptr && events_wait_list->size() > 0) ? (const cl_event*) &events_wait_list->front() : nullptr,
                 (event != nullptr) ? &tmp : nullptr);
     }
 
@@ -11167,7 +11564,7 @@ public:
         if (pfn_clCreateCommandBufferKHR)
         {
             object_ = pfn_clCreateCommandBufferKHR((cl_uint) queues.size(),
-                (cl_command_queue *) &queues.front(),
+                (const cl_command_queue *) &queues.front(),
                 command_buffer_properties,
                 &error);
         }
@@ -11204,7 +11601,7 @@ public:
         getInfo(cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_command_buffer_info_khr, name>::param_type param;
+            detail::cl_command_buffer_info_khr, name>::param_type param{};
         cl_int result = getInfo(name, &param);
         if (err != nullptr) {
             *err = result;
@@ -11214,7 +11611,10 @@ public:
 
     cl_int finalizeCommandBuffer() const
     {
-        return detail::errHandler(::clFinalizeCommandBufferKHR(object_), __FINALIZE_COMMAND_BUFFER_KHR_ERR);
+        if (pfn_clFinalizeCommandBufferKHR == nullptr) {
+            return detail::errHandler(CL_INVALID_OPERATION, __FINALIZE_COMMAND_BUFFER_KHR_ERR);
+        }
+        return detail::errHandler(pfn_clFinalizeCommandBufferKHR(object_), __FINALIZE_COMMAND_BUFFER_KHR_ERR);
     }
 
     cl_int enqueueCommandBuffer(vector<CommandQueue> &queues,
@@ -11233,7 +11633,7 @@ public:
                 (cl_command_queue *) &queues.front(),
                 object_,
                 (events != nullptr) ? (cl_uint) events->size() : 0,
-                (events != nullptr && events->size() > 0) ? (cl_event*) &events->front() : nullptr,
+                (events != nullptr && events->size() > 0) ? (const cl_event*) &events->front() : nullptr,
                 (cl_event*) event),
                 __ENQUEUE_COMMAND_BUFFER_KHR_ERR);
     }
@@ -11252,6 +11652,9 @@ public:
         cl_int error = detail::errHandler(
             pfn_clCommandBarrierWithWaitListKHR(object_,
                 (command_queue != nullptr) ? (*command_queue)() : nullptr,
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+                nullptr, // Properties
+#endif
                 (sync_points_vec != nullptr) ? (cl_uint) sync_points_vec->size() : 0,
                 (sync_points_vec != nullptr && sync_points_vec->size() > 0) ? &sync_points_vec->front() : nullptr,
                 (sync_point != nullptr) ? &tmp_sync_point : nullptr,
@@ -11283,6 +11686,9 @@ public:
         cl_int error = detail::errHandler(
             pfn_clCommandCopyBufferKHR(object_,
                 (command_queue != nullptr) ? (*command_queue)() : nullptr,
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+                nullptr, // Properties
+#endif
                 src(),
                 dst(),
                 src_offset,
@@ -11323,6 +11729,9 @@ public:
         cl_int error = detail::errHandler(
             pfn_clCommandCopyBufferRectKHR(object_,
                 (command_queue != nullptr) ? (*command_queue)() : nullptr,
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+                nullptr, // Properties
+#endif
                 src(),
                 dst(),
                 src_origin.data(),
@@ -11363,6 +11772,9 @@ public:
         cl_int error = detail::errHandler(
             pfn_clCommandCopyBufferToImageKHR(object_,
                 (command_queue != nullptr) ? (*command_queue)() : nullptr,
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+                nullptr, // Properties
+#endif
                 src(),
                 dst(),
                 src_offset,
@@ -11399,6 +11811,9 @@ public:
         cl_int error = detail::errHandler(
             pfn_clCommandCopyImageKHR(object_,
                 (command_queue != nullptr) ? (*command_queue)() : nullptr,
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+                nullptr, // Properties
+#endif
                 src(),
                 dst(),
                 src_origin.data(),
@@ -11435,6 +11850,9 @@ public:
         cl_int error = detail::errHandler(
             pfn_clCommandCopyImageToBufferKHR(object_,
                 (command_queue != nullptr) ? (*command_queue)() : nullptr,
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+                nullptr, // Properties
+#endif
                 src(),
                 dst(),
                 src_origin.data(),
@@ -11471,6 +11889,9 @@ public:
         cl_int error = detail::errHandler(
             pfn_clCommandFillBufferKHR(object_,
                 (command_queue != nullptr) ? (*command_queue)() : nullptr,
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+                nullptr, // Properties
+#endif
                 buffer(),
                 static_cast<void*>(&pattern),
                 sizeof(PatternType),
@@ -11506,8 +11927,11 @@ public:
         cl_int error = detail::errHandler(
             pfn_clCommandFillImageKHR(object_,
                 (command_queue != nullptr) ? (*command_queue)() : nullptr,
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+                nullptr, // Properties
+#endif
                 image(),
-                static_cast<void*>(&fillColor),
+                &fillColor,
                 origin.data(),
                 region.data(),
                 (sync_points_vec != nullptr) ? (cl_uint) sync_points_vec->size() : 0,
@@ -11522,7 +11946,12 @@ public:
         return error;
     }
 
-    cl_int commandNDRangeKernel(const cl::vector<cl_ndrange_kernel_command_properties_khr> &properties,
+    cl_int commandNDRangeKernel(
+#if CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION > CL_MAKE_VERSION(0, 9, 4)
+            const cl::vector<cl_command_properties_khr> &properties,
+#else
+            const cl::vector<cl_ndrange_kernel_command_properties_khr> &properties,
+#endif
         const Kernel& kernel,
         const NDRange& offset,
         const NDRange& global,
@@ -11541,7 +11970,7 @@ public:
         cl_int error = detail::errHandler(
             pfn_clCommandNDRangeKernelKHR(object_,
                 (command_queue != nullptr) ? (*command_queue)() : nullptr,
-                &properties[0],
+                properties.empty() ? nullptr : properties.data(),
                 kernel(),
                 (cl_uint) global.dimensions(),
                 offset.dimensions() != 0 ? (const size_type*) offset : nullptr,
@@ -11560,6 +11989,8 @@ public:
     }
 
 #if defined(cl_khr_command_buffer_mutable_dispatch)
+#if CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION <                 \
+    CL_MAKE_VERSION(0, 9, 2)
     cl_int updateMutableCommands(const cl_mutable_base_config_khr* mutable_config)
     {
         if (pfn_clUpdateMutableCommandsKHR == nullptr) {
@@ -11569,6 +12000,24 @@ public:
         return detail::errHandler(pfn_clUpdateMutableCommandsKHR(object_, mutable_config),
                         __UPDATE_MUTABLE_COMMANDS_KHR_ERR);
     }
+#else
+    template <int ArrayLength>
+    cl_int updateMutableCommands(std::array<cl_command_buffer_update_type_khr,
+                                            ArrayLength> &config_types,
+                                 std::array<const void *, ArrayLength> &configs) {
+        if (pfn_clUpdateMutableCommandsKHR == nullptr) {
+            return detail::errHandler(CL_INVALID_OPERATION,
+                                      __UPDATE_MUTABLE_COMMANDS_KHR_ERR);
+        }
+        return detail::errHandler(
+            pfn_clUpdateMutableCommandsKHR(
+                object_,
+                static_cast<cl_uint>(configs.size()),
+                config_types.empty() ? nullptr : config_types.data(),
+                configs.empty() ? nullptr : configs.data()),
+            __UPDATE_MUTABLE_COMMANDS_KHR_ERR);
+    }
+#endif /* CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_VERSION */
 #endif /* cl_khr_command_buffer_mutable_dispatch */
 
 private:
@@ -11682,7 +12131,7 @@ public:
         getInfo(cl_int* err = nullptr) const
     {
         typename detail::param_traits<
-            detail::cl_mutable_command_info_khr, name>::param_type param;
+            detail::cl_mutable_command_info_khr, name>::param_type param{};
         cl_int result = getInfo(name, &param);
         if (err != nullptr) {
             *err = result;
@@ -11832,6 +12281,8 @@ public:
 #undef CL_HPP_INIT_CL_EXT_FCN_PTR_PLATFORM_
 
 #undef CL_HPP_DEFINE_STATIC_MEMBER_
+
+#undef CL_
 
 } // namespace cl
 


### PR DESCRIPTION
This PR introduces a code path to the OpenCL backend when the [cl_khr_command_buffer extension](https://registry.khronos.org/OpenCL/specs/unified/html/OpenCL_API.html#cl_khr_command_buffer) is available, to first capture the net in a command-buffer for use in future computations. The caveat is that this extension has not yet been made final by the OpenCL WG, and so the `CL_ENABLE_BETA_EXTENSIONS` macro must be set to acknowledge that API breaking changes are possible (but unlikely).

This extension is the same conceptually as CUDA-Graph which is used in the CUDA backend where possible, and separates the creation of a graph of device commands graphs for submission, from the submission act itself.

### Summary 
*  Update OpenCL-HPP headers to tip, I can split this out as a separate PR to go in first if that's preferred.
*  Add a device selector weighting to OpenCL devices with `cl_khr_command_buffer` extension support
*  Added `graph_capture` backend option so that users can forcible set or unset to using command-buffer capture. Name is the same as CUDA backend.
* Refactors `OpenCLBuffers::forward` into `OpenCLBuffers::forward_kernels` so that command-buffer creation can easily just capture the layers of the network rather than data movement
* A command-buffer is created for each batch size up to the max batch size when the OpenCLNetwork is created by instantiating a temporary OpenCLNetwork object that sets up the command-buffers which live in an OpenCLBuffer object. 

### Performance Analysis

I don't have access to a GPU with driver support for cl_khr_command_buffer, where this change would be most effective. Instead I've had to test on CPU OpenCL drivers with cl_khr_command_buffer support where there's a marginal improvement in nodes/second but 

Using the backend benchmark with a single thread, which seems to be faster than multiple threads.

```sh
Platform version: OpenCL 3.0 LINUX
Platform profile: FULL_PROFILE
Platform name:    Intel(R) OpenCL
Platform vendor:  Intel(R) Corporation
Device ID:      1
Device name:    Intel(R) Core(TM) Ultra 7 155H
Device type:    CPU
Device vendor:  Intel(R) Corporation
Device driver:  2026.21.3.0.31_160000
Device speed:   0 MHZ
Device cores:   22 CU
Device score:   10530
Selected platform: Intel(R) OpenCL
Selected device: Intel(R) Core(TM) Ultra 7 155H
with OpenCL 3.0 capability.
Loaded existing SGEMM tuning for batch size 16.
Wavefront/Warp size: 128

Max workgroup size: 8192
Max workgroup dimensions: 8192 8192 8192
```

### Before

```sh
$ ./build/lc0 backendbench -w weights/T78    --backend=opencl --backend-opts=graph_capture=false -t 1 
```

```
size, mean nps, mean ms,   sdev,     cv, max nps,  median, min nps,
   1,        3,   326.3,11.8916, 0.0364,       3,       3,       3
   2,        6,   342.1, 5.3953, 0.0158,       6,       6,       6
   3,        9,   351.7,12.6837, 0.0361,       9,       8,       8
   4,       11,   371.9, 8.9808, 0.0241,      12,      11,      10
   5,        8,   651.3,15.5988, 0.0240,       8,       8,       7
   6,       10,   629.6,13.2493, 0.0210,      10,      10,       9
   7,       11,   634.9,13.7942, 0.0217,      12,      11,      10
   8,       12,   662.5,21.3337, 0.0322,      13,      12,      11
   9,       10,   870.4,10.7591, 0.0124,      11,      10,      10
  10,       11,   878.4,11.3638, 0.0129,      12,      11,      11
  11,       12,   889.8, 9.0988, 0.0102,      13,      12,      12
  12,       13,   902.5,11.6281, 0.0129,      14,      13,      12
  13,       11,    1151,17.8332, 0.0155,      12,      11,      11
  14,       12,    1152, 9.3498, 0.0081,      12,      12,      12
  15,       13,    1156, 9.3376, 0.0081,      13,      13,      13
  16,       14,    1169, 9.9273, 0.0085,      14,      14,      13
  17,       12,    1466,22.6842, 0.0155,      12,      12,      10
  18,       12,    1507,22.8419, 0.0152,      12,      12,      11
  19,       10,    1876,27.9158, 0.0149,      10,      10,      10
  20,       11,    1874,13.5521, 0.0072,      11,      11,      10
  21,       10,    2155,20.2816, 0.0094,      10,      10,       9
  22,       10,    2211,37.7708, 0.0171,      10,      10,      10
  23,       10,    2196,20.1761, 0.0092,      11,      10,      10
  24,       11,    2207,20.9169, 0.0095,      11,      11,      10
```

### After

```sh
$ ./build/lc0 backendbench -w weights/T78    --backend=opencl --backend-opts=graph_capture=true -t 1 
```

```
size, mean nps, mean ms,   sdev,     cv, max nps,  median, min nps,
   1,        3,   313.1, 8.0166, 0.0256,       3,       3,       3
   2,        6,   330.4,13.5229, 0.0409,       7,       6,       6
   3,        8,   358.7,10.7599, 0.0300,       9,       8,       8
   4,       10,   382.7, 7.6739, 0.0200,      11,      10,      10
   5,        8,     657,19.1287, 0.0291,       8,       8,       7
   6,        9,     648,20.5059, 0.0316,      10,       9,       9
   7,       11,   655.1,28.4095, 0.0434,      11,      11,      10
   8,       12,   676.9,24.2239, 0.0358,      13,      12,      11
   9,       10,   888.3,12.5438, 0.0141,      10,      10,      10
  10,       11,   882.4,11.3991, 0.0129,      12,      11,      11
  11,       12,   888.8, 8.1439, 0.0092,      13,      12,      12
  12,       13,   924.8,12.6045, 0.0136,      13,      13,      13
  13,       11,    1143,10.5167, 0.0092,      12,      11,      11
  14,       12,    1148, 9.4841, 0.0083,      12,      12,      12
  15,       13,    1184,15.6582, 0.0132,      13,      13,      12
  16,       14,    1180,19.4899, 0.0165,      14,      14,      12
  17,       11,    1496,23.5639, 0.0158,      12,      11,      11
  18,       12,    1497,15.8826, 0.0106,      12,      12,      12
  19,       12,    1548,29.2381, 0.0189,      13,      12,      11
  20,       13,    1541,11.4616, 0.0074,      13,      13,      13
  21,       12,    1821,23.8576, 0.0131,      12,      12,      11
  22,       12,    1812,25.8402, 0.0143,      12,      12,      12
  23,       13,    1822,25.0733, 0.0138,      13,      13,      12
  24,       13,    1847,24.0262, 0.0130,      13,      13,      13
```
