### PR TITLE
Fix PGN parsing for piece moves to en-passant target squares

### DIFF
--- a/src/chess/pgn.h
+++ b/src/chess/pgn.h
@@ -291,7 +291,7 @@ class PgnReader {
         }
         Square to(File::FromIdx(c2), Rank::FromIdx(sr2));
         Move move_to_find = promotion ? Move::WhitePromotion(sq, to, *promotion)
-                            : enpassant && *enpassant == to
+                            : p == 0 && enpassant && *enpassant == to
                                 ? Move::WhiteEnPassant(sq, to)
                                 : Move::White(sq, to);
         if (std::find(plm.begin(), plm.end(), move_to_find) == plm.end()) {
@@ -324,8 +324,9 @@ class PgnReader {
     Square from(File::FromIdx(c1), Rank::FromIdx(r1));
     Square to(File::FromIdx(c2), Rank::FromIdx(r2));
     Move m = promotion ? Move::WhitePromotion(from, to, *promotion)
-             : enpassant && *enpassant == to ? Move::WhiteEnPassant(from, to)
-                                             : Move::White(from, to);
+             : p == 0 && enpassant && *enpassant == to
+                 ? Move::WhiteEnPassant(from, to)
+                 : Move::White(from, to);
     if (board.flipped()) m.Flip();
     return m;
   }


### PR DESCRIPTION
Fixes a PGN reader bug where a non-pawn SAN move landing on the current en-passant target square could be encoded as an en-passant move.


This happened when a double pawn push created an en-passant target, and the following move was a piece move to that same square, such as ...Nb3 after b4. The SAN parser now only creates an en-passant move when the parsed move is a pawn move, leaving normal piece moves encoded normally.

Example PGN that exposes the bug:

```
1. Nf3 d5 2. c4 dxc4 3. e3 b6 4. Rg1 Ba6 5. g4 Nc6 6. a3 Na5 7. b4 Nb3 *
```
AI Disclosure:
I encountered this bug, Codex-GPT5.5 found the issue, I verified that its solution was correct and tested it manually. 