### PR TITLE
Fix rescorer crash when tablebase fails to load

### DIFF
--- a/src/trainingdata/rescorer.cc
+++ b/src/trainingdata/rescorer.cc
@@ -929,7 +929,8 @@ void ApplyDTZCorrections(FileData<FrameType>& data, SyzygyTablebase* tablebase) 
     history.Append(data.moves[i]);
     const auto& board = history.Last().GetBoard();
     if (board.castlings().no_legal_castle() &&
-        (board.ours() | board.theirs()).count() <= 3 && board.pawns().empty()) {
+        (board.ours() | board.theirs()).count() <= 3 && board.pawns().empty() &&
+        (board.ours() | board.theirs()).count() <= tablebase->max_cardinality()) {
       ProbeState state;
       WDLScore wdl = tablebase->probe_wdl(history.Last(), &state);
       // Only fail state means the WDL is wrong, probe_wdl may produce


### PR DESCRIPTION
I had a typo in my syzygy path in chuck rescorer configuration. This only gives a warning and continues training process. But rescorer will crash in DTZ correction because tablebase implementation is nullptr. Checking cardinality avoids calling nullptr implementation.