### PR TITLE
Add Support for RMSNorm and optional QKV Biases to Onnx backends

### DIFF
--- a/src/neural/backends/onnx/network_onnx.cc
+++ b/src/neural/backends/onnx/network_onnx.cc
@@ -932,6 +932,11 @@ std::unique_ptr<Network> MakeOnnxNetwork(const std::optional<WeightsFile>& w,
   } else {
     WeightsToOnnxConverterOptions converter_options;
     converter_options.ir = opts.GetOrDefault<int>("ir", -1);
+    converter_options.opset = opts.GetOrDefault<int>(
+        "opset", converter_options.data_type ==
+                         WeightsToOnnxConverterOptions::DataType::kBFloat16
+                     ? 22
+                     : 17);
     converter_options.alt_mish = opts.GetOrDefault<bool>(
         "alt_mish",
         kProvider == OnnxProvider::CPU || kProvider == OnnxProvider::COREML
@@ -944,6 +949,10 @@ std::unique_ptr<Network> MakeOnnxNetwork(const std::optional<WeightsFile>& w,
                     pblczero::NetworkFormat::ACTIVATION_RELU_2
             ? true
             : false);
+    converter_options.alt_rmsnorm = opts.GetOrDefault<bool>(
+        "alt_rmsnorm",
+        kProvider != OnnxProvider::CPU || converter_options.opset < 23 ? true
+                                                                       : false);
     converter_options.no_shape = opts.GetOrDefault<bool>("no_shape", false);
     converter_options.policy_head =
         opts.GetOrDefault<std::string>("policy_head", "vanilla");
@@ -971,11 +980,6 @@ std::unique_ptr<Network> MakeOnnxNetwork(const std::optional<WeightsFile>& w,
     }
     converter_options.data_type =
         WeightsToOnnxConverterOptions::StringToDataType(datatype);
-    converter_options.opset = opts.GetOrDefault<int>(
-        "opset", converter_options.data_type ==
-                         WeightsToOnnxConverterOptions::DataType::kBFloat16
-                     ? 22
-                     : 17);
 
     auto converted = ConvertWeightsToOnnx(*w, converter_options);
     return std::make_unique<OnnxNetwork>(converted, opts, kProvider, true);

--- a/src/neural/onnx/builder.cc
+++ b/src/neural/onnx/builder.cc
@@ -394,6 +394,19 @@ std::string OnnxBuilder::LayerNormalization(const std::string& name,
   return out;
 }
 
+// Only supported since opset 23
+std::string OnnxBuilder::RMSNormalization(const std::string& name,
+                                         const std::string& input,
+                                         const OnnxConst& scale, int axis,
+                                         float epsilon) {
+  auto* node = model_.mutable_graph()->add_node();
+  auto out = PopulateStdNodeFields(node, name, input, "RMSNormalization");
+  node->add_input(AddInitializer(name + "/w/scale", scale));
+  AddIntAttribute(node, "axis", axis);
+  AddFloatAttribute(node, "epsilon", epsilon);
+  return out;
+}
+
 std::string OnnxBuilder::Expand(const std::string& name,
                                 const std::string& input,
                                 const std::string& shape) {

--- a/src/neural/onnx/builder.cc
+++ b/src/neural/onnx/builder.cc
@@ -36,15 +36,16 @@
 namespace lczero {
 
 OnnxBuilder::OnnxBuilder(int opset, int ir) : opset_(opset) {
-  if (opset < 7 || opset > 22) {
-    throw Exception("Only ONNX opsets between 7 and 22 are supported.");
+  if (opset < 7 || opset > 23) {
+    throw Exception("Only ONNX opsets between 7 and 23 are supported.");
   }
   // Map of latest opset corresponding to IR version.
   std::map<int, int> opset_to_ir = {{8, 3},  {9, 4},   {10, 5},
                                     {11, 6}, {14, 7},  {18, 8},
-                                    {20, 9}, {22, 10}, {99, 11}};
+                                    {20, 9}, {22, 10}, {23, 11},
+                                    {24, 12}, {25, 13}};
   if (ir < 0) ir = opset_to_ir.upper_bound(opset - 1)->second;
-  if (ir < 3 || ir > 10) {
+  if (ir < 3 || ir > 11) {
     throw Exception("Only ONNX IR between 3 and 10 is supported.");
   }
   model_.set_ir_version(ir);

--- a/src/neural/onnx/builder.h
+++ b/src/neural/onnx/builder.h
@@ -105,6 +105,10 @@ class OnnxBuilder {
                     std::initializer_list<int> ends);
   std::string Concat(const std::string& name,
                      const std::vector<std::string>& input, int axis);
+  std::string RMSNormalization(const std::string& name,
+                               const std::string& input,
+                               const OnnxConst& scale, int axis,
+                               float epsilon = 1e-6);
   std::string LayerNormalization(const std::string& name,
                                  const std::string& input,
                                  const OnnxConst& scale, const OnnxConst& bias,

--- a/src/neural/onnx/converter.cc
+++ b/src/neural/onnx/converter.cc
@@ -558,7 +558,13 @@ std::string Converter::MakeEncoderLayer(
     OnnxBuilder* builder, const MultiHeadWeights::EncoderLayer& layer,
     int embedding_size, int heads, const std::string& encoder_in,
     const std::string& name, ActivationFunction activation, float alpha) {
-  const int d_model = layer.mha.q_b.size();
+  // Q/K/V biases are optional in newer weight files.  The projection width is
+  // normally available from q_b, but must be inferred from q_w when it is
+  // omitted.  ONNX's MatMul does not need a bias input, so simply skip the
+  // corresponding Add in that case.
+  const int d_model = layer.mha.q_b.empty()
+                          ? layer.mha.q_w.size() / embedding_size
+                          : layer.mha.q_b.size();
   const int depth = d_model / heads;
 
   auto mha_shape =
@@ -567,22 +573,28 @@ std::string Converter::MakeEncoderLayer(
   auto flow = builder->MatMul(
       name + "/mha/Q/w", encoder_in,
       *GetWeghtsConverter(layer.mha.q_w, {embedding_size, d_model}, {1, 0}));
-  flow = builder->Add(name + "/mha/Q/b", flow,
-                      *GetWeghtsConverter(layer.mha.q_b, {d_model}));
+  if (!layer.mha.q_b.empty()) {
+    flow = builder->Add(name + "/mha/Q/b", flow,
+                        *GetWeghtsConverter(layer.mha.q_b, {d_model}));
+  }
   flow = builder->Reshape(name + "/mha/Q/reshape", flow, mha_shape);
   auto Q = builder->Transpose(name + "/mha/Q/transpose", flow, {0, 2, 1, 3});
   flow = builder->MatMul(
       name + "/mha/K/w", encoder_in,
       *GetWeghtsConverter(layer.mha.k_w, {embedding_size, d_model}, {1, 0}));
-  flow = builder->Add(name + "/mha/K/b", flow,
-                      *GetWeghtsConverter(layer.mha.k_b, {d_model}));
+  if (!layer.mha.k_b.empty()) {
+    flow = builder->Add(name + "/mha/K/b", flow,
+                        *GetWeghtsConverter(layer.mha.k_b, {d_model}));
+  }
   flow = builder->Reshape(name + "/mha/K/reshape", flow, mha_shape);
   auto K = builder->Transpose(name + "/mha/K/transpose", flow, {0, 2, 3, 1});
   flow = builder->MatMul(
       name + "/mha/V/w", encoder_in,
       *GetWeghtsConverter(layer.mha.v_w, {embedding_size, d_model}, {1, 0}));
-  flow = builder->Add(name + "/mha/V/b", flow,
-                      *GetWeghtsConverter(layer.mha.v_b, {d_model}));
+  if (!layer.mha.v_b.empty()) {
+    flow = builder->Add(name + "/mha/V/b", flow,
+                        *GetWeghtsConverter(layer.mha.v_b, {d_model}));
+  }
   flow = builder->Reshape(name + "/mha/V/reshape", flow, mha_shape);
   auto V = builder->Transpose(name + "/mha/V/transpose", flow, {0, 2, 1, 3});
   flow = builder->MatMul(name + "/mha/QK/matmul", Q, K);

--- a/src/neural/onnx/converter.cc
+++ b/src/neural/onnx/converter.cc
@@ -128,6 +128,10 @@ class Converter {
                           const std::string& encoder_in,
                           const std::string& name);
 
+  std::string MakeRMSNorm(OnnxBuilder* builder, const std::string& input,
+                          const std::string& name,
+                          const lczero::OnnxConst& gammas, float eps = 1e-6);
+
   std::string MakeLayerNorm(OnnxBuilder* builder, const std::string& input,
                             const std::string& name,
                             const lczero::OnnxConst& gammas,
@@ -466,12 +470,23 @@ std::string Converter::MakeSmolgen(OnnxBuilder* builder,
   return flow;
 }
 
+std::string Converter::MakeRMSNorm(OnnxBuilder* builder,
+    const std::string& input,
+    const std::string& name,
+    const lczero::OnnxConst& gammas, float eps) {
+  auto in = input;
+  return builder->RMSNormalization(name, in, gammas, 1, eps);
+}
+
 std::string Converter::MakeLayerNorm(OnnxBuilder* builder,
                                      const std::string& input,
                                      const std::string& name,
                                      const lczero::OnnxConst& gammas,
                                      const lczero::OnnxConst& betas,
                                      float eps) {
+  if (betas.GetRawData().empty()) {
+    return MakeRMSNorm(builder, input, name, gammas, eps);
+  }
   if (!options_.alt_layernorm) {
     return builder->LayerNormalization(name, input, gammas, betas, 1, eps);
   }

--- a/src/neural/onnx/converter.cc
+++ b/src/neural/onnx/converter.cc
@@ -475,7 +475,25 @@ std::string Converter::MakeRMSNorm(OnnxBuilder* builder,
     const std::string& name,
     const lczero::OnnxConst& gammas, float eps) {
   auto in = input;
-  return builder->RMSNormalization(name, in, gammas, 1, eps);
+  if (!options_.alt_rmsnorm) {
+    return builder->RMSNormalization(name, in, gammas, 1, eps);
+  }
+  if (GetDataType() != pblczero::TensorProto::FLOAT) {
+    in = builder->Cast(name + "/to_float", in, pblczero::TensorProto::FLOAT);
+  }
+  auto flow = builder->Mul(name + "/squared", in, in);
+  flow = builder->ReduceMean(name + "/mean", flow, {1});
+  flow =
+      builder->Add(name + "/mean_eps", flow,
+                   static_cast<const OnnxConst&>(FloatOnnxConst({eps}, {1})));
+  flow = builder->Sqrt(name + "/rms", flow);
+  flow = builder->Reciprocal(name + "/inv_rms", flow);
+  flow = builder->Mul(name + "/normalized", in, flow);
+  if (GetDataType() != pblczero::TensorProto::FLOAT) {
+    flow = builder->Cast(name + "/to_data_type", flow, GetDataType());
+  }
+  flow = builder->Mul(name + "/gammas", flow, gammas);
+  return flow;
 }
 
 std::string Converter::MakeLayerNorm(OnnxBuilder* builder,

--- a/src/neural/onnx/converter.h
+++ b/src/neural/onnx/converter.h
@@ -50,6 +50,7 @@ struct WeightsToOnnxConverterOptions {
   bool real_mish = true;       // Use "Mish" operator (opset 18+ and !alt_mish).
   bool alt_layernorm = false;  // Discrete "LayerNormalization" implementation.
   bool alt_selu = false;       // Use discrete "Selu" implementation.
+  bool alt_rmsnorm = true;     // Discrete "RMSNormalization" implementation.
   bool no_shape = false;       // Avoid use of "Shape" operator.
   bool no_wdl_softmax = false; // Skip wdl softmax.
   std::string policy_head = "vanilla";


### PR DESCRIPTION
Add ONNX conversion support for attention networks that use RMSNorm and omit
Q/K/V projection biases.

By Menkib:
- Detect empty LayerNorm beta tensors and export RMSNorm instead.
- Add an `alt_rmsnorm` fallback that expresses RMSNorm using standard ONNX nodes, keeping it compatible with runtimes that do not support the native `RMSNormalization` operator.
- Add native `RMSNormalization` export support for opset 23.
- Select the RMSNorm fallback by default where native RMSNormalization is not expected to be supported.

By me:
- Infer encoder projection width from `q_w` when `q_b` is absent, and omit Q/K/V bias-add nodes for missing bias tensors.

Planned follow up PR: Updating TensorRT version to support native RMSNorm node

This has been tested locally on test networks.