### PR TITLE
classic: Calculate cpuct using started visits

### DIFF
--- a/src/search/classic/node.h
+++ b/src/search/classic/node.h
@@ -166,8 +166,8 @@ class Node {
     uint32_t n = GetNStarted();
     return n > 0 ? n - 1 : 0;
   }
-  // Returns n = n_if_flight.
-  int GetNStarted() const { return n_ + n_in_flight_; }
+  // Returns n + n_if_flight.
+  uint32_t GetNStarted() const { return n_ + n_in_flight_; }
   float GetQ(float draw_score) const { return wl_ + draw_score * d_; }
   // Returns node eval, i.e. average subtree V for non-terminal node and -1/0/1
   // for terminal nodes.
@@ -389,7 +389,7 @@ class EdgeAndNode {
   }
   // N-related getters, from Node (if exists).
   uint32_t GetN() const { return node_ ? node_->GetN() : 0; }
-  int GetNStarted() const { return node_ ? node_->GetNStarted() : 0; }
+  uint32_t GetNStarted() const { return node_ ? node_->GetNStarted() : 0; }
   uint32_t GetNInFlight() const { return node_ ? node_->GetNInFlight() : 0; }
 
   // Whether the node is known to be terminal.

--- a/src/search/classic/node.h
+++ b/src/search/classic/node.h
@@ -162,7 +162,10 @@ class Node {
   float GetVisitedPolicy() const;
   uint32_t GetN() const { return n_; }
   uint32_t GetNInFlight() const { return n_in_flight_; }
-  uint32_t GetChildrenVisits() const { return n_ > 0 ? n_ - 1 : 0; }
+  uint32_t GetChildrenVisits() const {
+    uint32_t n = GetNStarted();
+    return n > 0 ? n - 1 : 0;
+  }
   // Returns n = n_if_flight.
   int GetNStarted() const { return n_ + n_in_flight_; }
   float GetQ(float draw_score) const { return wl_ + draw_score * d_; }

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -464,7 +464,7 @@ std::vector<std::string> Search::GetVerboseStats(const Node* node) const {
   const bool is_black_to_move = (played_history_.IsBlackToMove() == is_root);
   const float draw_score = GetDrawScore(is_odd_depth);
   const float fpu = GetFpu(params_, node, is_root, draw_score);
-  const float cpuct = ComputeCpuct(params_, node->GetN(), is_root);
+  const float cpuct = ComputeCpuct(params_, node->GetNStarted(), is_root);
   const float U_coeff =
       cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
   std::vector<std::tuple<uint32_t, float, EdgeAndNode>> edges;
@@ -1715,7 +1715,7 @@ void SearchWorker::PickNodesToExtendTask(
         }
       }
 
-      const float cpuct = ComputeCpuct(params_, node->GetN(), is_root_node);
+      const float cpuct = ComputeCpuct(params_, node->GetNStarted(), is_root_node);
       const float puct_mult =
           cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
       int cache_filled_idx = -1;
@@ -2079,7 +2079,7 @@ int SearchWorker::PrefetchIntoCache(Node* node, int budget, bool is_odd_depth) {
   typedef std::pair<float, EdgeAndNode> ScoredEdge;
   std::vector<ScoredEdge> scores;
   const float cpuct =
-      ComputeCpuct(params_, node->GetN(), node == search_->root_node_);
+      ComputeCpuct(params_, node->GetNStarted(), node == search_->root_node_);
   const float puct_mult =
       cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
   const float fpu =

--- a/src/search/classic/search.cc
+++ b/src/search/classic/search.cc
@@ -1600,7 +1600,7 @@ void SearchWorker::PickNodesToExtendTask(
 
   // These 3 are 'filled on demand'.
   std::array<float, 256> current_score;
-  std::array<int, 256> current_nstarted;
+  std::array<uint32_t, 256> current_nstarted;
   auto& cur_iters = workspace->cur_iters;
 
   Node::Iterator best_edge;
@@ -1688,7 +1688,8 @@ void SearchWorker::PickNodesToExtendTask(
       // node to stay at 64 bytes).
       int max_needed = node->GetNumEdges();
       if (!is_root_node || root_move_filter.empty()) {
-        max_needed = std::min(max_needed, node->GetNStarted() + cur_limit + 2);
+        max_needed =
+            std::min<unsigned>(max_needed, node->GetNStarted() + cur_limit + 2);
       }
       node->CopyPolicy(max_needed, current_pol.data());
       for (int i = 0; i < max_needed; i++) {
@@ -1715,7 +1716,8 @@ void SearchWorker::PickNodesToExtendTask(
         }
       }
 
-      const float cpuct = ComputeCpuct(params_, node->GetNStarted(), is_root_node);
+      const float cpuct =
+          ComputeCpuct(params_, node->GetNStarted(), is_root_node);
       const float puct_mult =
           cpuct * std::sqrt(std::max(node->GetChildrenVisits(), 1u));
       int cache_filled_idx = -1;


### PR DESCRIPTION
I noticed that node picking is optimising slightly wrong S values when it uses visits instead of started visits. This means high policy low value children get 1-3 visits less than expected in an early search.

Generally difference is hard to notice. I was trying to make code which detects surprise value improvements for children and tries to allocate a few extra nodes to children based on this. The missing 1-3 visits looks the same like child having a major value gain in the last batch.

I check if dag could implement the same change. It won't be as simple so I'm leaving it as a future change.