### PR TITLE
Add fixed-depth minimax to value-head search

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1001,6 +1001,13 @@ if get_option('gtest')
                'src/neural/memcache.cc', pb_files,
     include_directories: includes, link_with: lc0_lib, dependencies: [gtest, gmock]),
     args: '--gtest_output=xml:engine_test.xml', timeout: 90)
+
+  test('InstamoveTest',
+    executable('instamove_test', 'src/search/instamove/instamove_test.cc',
+               'src/search/instamove/instamove.cc', 'src/search/register.cc',
+               pb_files,
+    include_directories: includes, link_with: lc0_lib, dependencies: gtest),
+    args: '--gtest_output=xml:instamove_test.xml', timeout: 90)
 endif
 
 

--- a/src/search/instamove/instamove.cc
+++ b/src/search/instamove/instamove.cc
@@ -26,7 +26,14 @@
 */
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
 #include <vector>
 
 #include "chess/gamestate.h"
@@ -35,36 +42,95 @@
 #include "neural/batchsplit.h"
 #include "search/register.h"
 #include "search/search.h"
+#include "utils/logging.h"
+#include "utils/optionsparser.h"
 
 namespace lczero {
 namespace {
 
+const OptionId kValueHeadDepthId{
+    "valuehead-depth", "ValueHeadDepth",
+    "Number of full-width minimax plies for value-head search."};
+const OptionId kValueHeadMaxNodesId{
+    "valuehead-max-nodes", "ValueHeadMaxNodes",
+    "Maximum number of positions in a fixed-depth value-head search tree."};
+
+constexpr int kDefaultValueHeadDepth = 1;
+constexpr int kMaximumValueHeadDepth = 99;
+constexpr int kDefaultValueHeadMaxNodes = 10000;
+constexpr int kMaximumValueHeadMaxNodes = 100000000;
+
+bool IsCancellationRequested(const std::atomic<bool>& cancellation_requested) {
+  return cancellation_requested.load(std::memory_order_relaxed);
+}
+
 class InstamoveSearch : public SearchBase {
  public:
   using SearchBase::SearchBase;
+  ~InstamoveSearch() override { Shutdown(); }
 
  private:
-  virtual Move GetBestMove(const GameState& game_state) = 0;
+  virtual Move GetBestMove(const GameState& game_state,
+                           const GoParams& go_params,
+                           const std::atomic<bool>& cancellation_requested) = 0;
 
   void SetPosition(const GameState& game_state) final {
     game_state_ = game_state;
   }
 
   void StartSearch(const GoParams& go_params) final {
-    responded_bestmove_.store(false, std::memory_order_relaxed);
-    bestmove_ = GetBestMove(game_state_);
-    if (!go_params.infinite && !go_params.ponder) RespondBestMove();
-  }
-  void WaitSearch() final {
-    while (!responded_bestmove_.load()) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    if (worker_.joinable()) {
+      {
+        std::lock_guard<std::mutex> lock(response_mutex_);
+        cancellation_requested_.store(true, std::memory_order_relaxed);
+        responded_bestmove_.store(true, std::memory_order_relaxed);
+      }
+      worker_.join();
+    }
+
+    const MoveList legal_moves =
+        game_state_.CurrentPosition().GetBoard().GenerateLegalMoves();
+    {
+      std::lock_guard<std::mutex> lock(bestmove_mutex_);
+      bestmove_ = legal_moves.empty() ? Move{} : legal_moves.front();
+    }
+    {
+      std::lock_guard<std::mutex> lock(response_mutex_);
+      cancellation_requested_.store(false, std::memory_order_relaxed);
+      responded_bestmove_.store(false, std::memory_order_relaxed);
+    }
+    try {
+      worker_ = std::thread([this, go_params] { RunSearch(go_params); });
+    } catch (...) {
+      RespondBestMove();
+      throw;
     }
   }
-  void StopSearch() final { RespondBestMove(); }
-  void AbortSearch() final { responded_bestmove_.store(true); }
+  void WaitSearch() final {
+    if (worker_.joinable()) worker_.join();
+  }
+  void StopSearch() final {
+    std::lock_guard<std::mutex> lock(response_mutex_);
+    cancellation_requested_.store(true, std::memory_order_relaxed);
+    RespondBestMoveLocked();
+  }
+  void AbortSearch() final {
+    std::lock_guard<std::mutex> lock(response_mutex_);
+    cancellation_requested_.store(true, std::memory_order_relaxed);
+    responded_bestmove_.store(true, std::memory_order_relaxed);
+  }
   void RespondBestMove() {
+    std::lock_guard<std::mutex> lock(response_mutex_);
+    RespondBestMoveLocked();
+  }
+  void RespondBestMoveLocked() {
     if (responded_bestmove_.exchange(true)) return;
-    BestMoveInfo info{bestmove_};
+    Move bestmove;
+    {
+      std::lock_guard<std::mutex> lock(bestmove_mutex_);
+      bestmove = bestmove_;
+    }
+    BestMoveInfo info{bestmove};
     // TODO Remove this when move will be encoded from white perspective.
     if (game_state_.CurrentPosition().IsBlackToMove()) {
       info.bestmove.Flip();
@@ -74,14 +140,68 @@ class InstamoveSearch : public SearchBase {
     uci_responder_->OutputBestMove(&info);
   }
 
+  void RunSearch(const GoParams& go_params) noexcept {
+    try {
+      Move bestmove =
+          GetBestMove(game_state_, go_params, cancellation_requested_);
+      PublishBestMoveIfActive(bestmove);
+    } catch (const std::exception& exception) {
+      LOGFILE << "Instamove search failed: " << exception.what();
+    } catch (...) {
+      LOGFILE << "Instamove search failed with an unknown exception.";
+    }
+    if (!go_params.infinite && !go_params.ponder) {
+      RespondBestMove();
+    }
+  }
+
+  void PublishBestMoveIfActive(Move bestmove) {
+    std::lock_guard<std::mutex> response_lock(response_mutex_);
+    if (cancellation_requested_.load(std::memory_order_relaxed) ||
+        responded_bestmove_.load(std::memory_order_relaxed)) {
+      return;
+    }
+    std::lock_guard<std::mutex> bestmove_lock(bestmove_mutex_);
+    bestmove_ = bestmove;
+  }
+
   void SetBackend(Backend* backend) override {
     batchsplit_backend_ = CreateBatchSplitingBackend(backend);
     backend_ = batchsplit_backend_.get();
   }
   void StartClock() final {}
 
+ protected:
+  void Shutdown() {
+    {
+      std::lock_guard<std::mutex> lock(response_mutex_);
+      cancellation_requested_.store(true, std::memory_order_relaxed);
+      responded_bestmove_.store(true, std::memory_order_relaxed);
+    }
+    if (worker_.joinable()) worker_.join();
+  }
+
+  void PublishBestMoveAndOutputThinkingInfoIfActive(
+      Move bestmove, std::vector<ThinkingInfo>* infos) {
+    std::lock_guard<std::mutex> lock(response_mutex_);
+    if (cancellation_requested_.load(std::memory_order_relaxed) ||
+        responded_bestmove_.load(std::memory_order_relaxed)) {
+      return;
+    }
+    {
+      std::lock_guard<std::mutex> bestmove_lock(bestmove_mutex_);
+      bestmove_ = bestmove;
+    }
+    uci_responder_->OutputThinkingInfo(infos);
+  }
+
+ private:
   Move bestmove_;
-  std::atomic<bool> responded_bestmove_{false};
+  std::mutex bestmove_mutex_;
+  std::mutex response_mutex_;
+  std::thread worker_;
+  std::atomic<bool> cancellation_requested_{false};
+  std::atomic<bool> responded_bestmove_{true};
   std::unique_ptr<Backend> batchsplit_backend_;
   GameState game_state_;
 };
@@ -89,12 +209,16 @@ class InstamoveSearch : public SearchBase {
 class PolicyHeadSearch : public InstamoveSearch {
  public:
   using InstamoveSearch::InstamoveSearch;
+  ~PolicyHeadSearch() override { Shutdown(); }
 
-  Move GetBestMove(const GameState& game_state) final {
+  Move GetBestMove(const GameState& game_state, const GoParams&,
+                   const std::atomic<bool>& cancellation_requested) final {
+    if (IsCancellationRequested(cancellation_requested)) return Move{};
     const std::vector<Position> positions = game_state.GetPositions();
     MoveList legal_moves = positions.back().GetBoard().GenerateLegalMoves();
     std::vector<EvalResult> res = backend_->EvaluateBatch(
         std::vector<EvalPosition>{EvalPosition{positions, legal_moves}});
+    if (IsCancellationRequested(cancellation_requested)) return Move{};
     const size_t best_move_idx =
         std::max_element(res[0].p.begin(), res[0].p.end()) - res[0].p.begin();
 
@@ -105,95 +229,251 @@ class PolicyHeadSearch : public InstamoveSearch {
         .score = 90 * std::tan(1.5637541897 * res[0].q),
         .wdl =
             ThinkingInfo::WDL{
-                static_cast<int>(std::round(
-                    500 * (1 + res[0].q - res[0].d))),
+                static_cast<int>(std::round(500 * (1 + res[0].q - res[0].d))),
                 static_cast<int>(std::round(1000 * res[0].d)),
-                static_cast<int>(std::round(
-                    500 * (1 - res[0].q - res[0].d)))},
+                static_cast<int>(std::round(500 * (1 - res[0].q - res[0].d)))},
     }};
-    uci_responder_->OutputThinkingInfo(&infos);
-
     Move best_move = legal_moves[best_move_idx];
+    PublishBestMoveAndOutputThinkingInfoIfActive(best_move, &infos);
     return best_move;
   }
 };
 
 class ValueHeadSearch : public InstamoveSearch {
  public:
-  using InstamoveSearch::InstamoveSearch;
-  Move GetBestMove(const GameState& game_state) final {
-    std::unique_ptr<BackendComputation> computation =
-        backend_->CreateComputation();
+  ValueHeadSearch(UciResponder* responder, const OptionsDict* options)
+      : InstamoveSearch(responder), options_(options) {}
+  ~ValueHeadSearch() override { Shutdown(); }
 
-    PositionHistory history(game_state.GetPositions());
-    const ChessBoard& board = history.Last().GetBoard();
-    const std::vector<Move> legal_moves = board.GenerateLegalMoves();
+  Move GetBestMove(const GameState& game_state, const GoParams& go_params,
+                   const std::atomic<bool>& cancellation_requested) final {
+    if (IsCancellationRequested(cancellation_requested)) return Move{};
+    const int requested_depth = std::clamp(
+        go_params.depth.value_or(options_->Get<int>(kValueHeadDepthId)), 1,
+        kMaximumValueHeadDepth);
+    const int64_t max_nodes = options_->Get<int>(kValueHeadMaxNodesId);
 
-    struct Score {
-      float negative_q;  // Negative because NN evaluates from opponent's
-                         // perspective.
-      float d;
-      std::optional<int> mate;
-
-      bool operator<(const Score& other) const {
-        // Mate always beats non-mate
-        if (mate && !other.mate) return true;
-        if (!mate && other.mate) return false;
-        // Both mates: shorter is better
-        if (mate && other.mate) return *mate < *other.mate;
-        // Neither mate: lower negative_q is better
-        return negative_q < other.negative_q;
-      }
-    };
-
-    std::vector<Score> results(legal_moves.size());
-
-    for (size_t i = 0; i < legal_moves.size(); i++) {
-      Move move = legal_moves[i];
-      history.Append(move);
-      switch (history.ComputeGameResult()) {
-        case GameResult::UNDECIDED:
-          computation->AddInput(
-              EvalPosition{history.GetPositions(), {}},
-              EvalResultPtr{.q = &results[i].negative_q, .d = &results[i].d});
-          break;
-        case GameResult::DRAW:
-          results[i] = {.negative_q = 0, .d = 1, .mate = std::nullopt};
-          break;
-        default:
-          // A legal move to a non-drawn terminal without tablebases must be a
-          // win.
-          results[i] = {.negative_q = -1, .d = 0, .mate = 1};
-      }
-      history.Pop();
+    std::unique_ptr<SearchTree> tree;
+    // Build candidate trees without queuing NN inputs. A rejected tree must
+    // not trigger evaluation through the batch-splitting backend.
+    for (int depth = 1; depth <= requested_depth; ++depth) {
+      if (IsCancellationRequested(cancellation_requested)) return Move{};
+      auto candidate = std::make_unique<SearchTree>();
+      candidate->depth = depth;
+      PositionHistory history(game_state.GetPositions());
+      const BuildResult result = BuildTree(
+          &history, &candidate->root, depth, 1, max_nodes, &candidate->nodes,
+          &candidate->seldepth, cancellation_requested);
+      if (result == BuildResult::kCancelled) return Move{};
+      if (result == BuildResult::kNodeLimit) break;
+      tree = std::move(candidate);
     }
 
-    computation->ComputeBlocking();
+    if (!tree) {
+      if (IsCancellationRequested(cancellation_requested)) return Move{};
+      const MoveList legal_moves =
+          game_state.CurrentPosition().GetBoard().GenerateLegalMoves();
+      std::vector<ThinkingInfo> infos = {
+          {.depth = 1, .seldepth = 0, .nodes = 0}};
+      const Move bestmove = legal_moves.empty() ? Move{} : legal_moves.front();
+      PublishBestMoveAndOutputThinkingInfoIfActive(bestmove, &infos);
+      return bestmove;
+    }
 
-    const size_t best_idx =
-        std::min_element(results.begin(), results.end()) - results.begin();
+    if (tree->root.children.empty()) return Move{};
 
-    const Score& r = results[best_idx];
+    std::unique_ptr<BackendComputation> computation =
+        backend_->CreateComputation();
+    PositionHistory history(game_state.GetPositions());
+    size_t evaluations = 0;
+    if (!QueueEvaluations(&history, &tree->root, computation.get(),
+                          &evaluations, cancellation_requested)) {
+      return Move{};
+    }
+    if (IsCancellationRequested(cancellation_requested)) return Move{};
+    if (evaluations != 0) {
+      computation->ComputeBlocking();
+      if (IsCancellationRequested(cancellation_requested)) return Move{};
+    }
+
+    if (!ResolveScore(&tree->root, cancellation_requested)) return Move{};
+    SearchNode* best_child = tree->root.children.front().get();
+    Score best_score = FlipScore(best_child->score);
+    for (size_t i = 1; i < tree->root.children.size(); ++i) {
+      if (IsCancellationRequested(cancellation_requested)) return Move{};
+      Score candidate = FlipScore(tree->root.children[i]->score);
+      if (IsBetter(candidate, best_score)) {
+        best_child = tree->root.children[i].get();
+        best_score = candidate;
+      }
+    }
+
     auto to_int = [](double x) { return static_cast<int>(std::round(x)); };
+    std::optional<int> mate;
+    if (best_score.mate) {
+      mate = best_score.mate->winning ? (best_score.mate->plies + 1) / 2
+                                      : -(best_score.mate->plies / 2);
+    }
+    if (IsCancellationRequested(cancellation_requested)) return Move{};
     std::vector<ThinkingInfo> infos{
-        {.depth = 1,
-         .seldepth = 1,
-         .nodes = static_cast<int64_t>(legal_moves.size()),
-         .mate = r.mate,
-         .score = r.mate ? std::nullopt
-                         : std::make_optional<int>(
-                               -90 * std::tan(1.5637541897 * r.negative_q)),
-         .wdl = r.mate
-                    ? std::nullopt
-                    : std::make_optional<ThinkingInfo::WDL>(ThinkingInfo::WDL{
-                          .w = to_int(500 * (1 - r.negative_q - r.d)),
-                          .d = to_int(1000 * r.d),
-                          .l = to_int(500 * (1 + r.negative_q - r.d)),
-                      })}};
-    uci_responder_->OutputThinkingInfo(&infos);
-    Move best_move = legal_moves[best_idx];
-    return best_move;
+        {.depth = tree->depth,
+         .seldepth = tree->seldepth,
+         .nodes = tree->nodes,
+         .mate = mate,
+         .score = mate ? std::nullopt
+                       : std::make_optional<int>(to_int(
+                             90 * std::tan(1.5637541897 * best_score.q))),
+         .wdl = mate ? std::nullopt
+                     : std::make_optional<ThinkingInfo::WDL>(ThinkingInfo::WDL{
+                           .w = to_int(500 * (1 + best_score.q - best_score.d)),
+                           .d = to_int(1000 * best_score.d),
+                           .l = to_int(500 * (1 - best_score.q - best_score.d)),
+                       })}};
+    PublishBestMoveAndOutputThinkingInfoIfActive(best_child->move, &infos);
+    return best_child->move;
   }
+
+ private:
+  struct MateScore {
+    bool winning;
+    int plies;
+  };
+
+  struct Score {
+    float q = 0.0f;
+    float d = 0.0f;
+    std::optional<MateScore> mate;
+  };
+
+  struct SearchNode {
+    Score score;
+    Move move;
+    bool needs_evaluation = false;
+    std::vector<std::unique_ptr<SearchNode>> children;
+  };
+
+  struct SearchTree {
+    SearchNode root;
+    int depth = 0;
+    int seldepth = 0;
+    int64_t nodes = 0;
+  };
+
+  enum class BuildResult { kComplete, kNodeLimit, kCancelled };
+
+  static bool IsBetter(const Score& score, const Score& other) {
+    if (score.mate && other.mate) {
+      if (score.mate->winning != other.mate->winning) {
+        return score.mate->winning;
+      }
+      return score.mate->winning ? score.mate->plies < other.mate->plies
+                                 : score.mate->plies > other.mate->plies;
+    }
+    if (score.mate) return score.mate->winning;
+    if (other.mate) return !other.mate->winning;
+    return score.q > other.q;
+  }
+
+  static Score FlipScore(const Score& score) {
+    Score flipped{.q = -score.q, .d = score.d};
+    if (score.mate) {
+      flipped.mate = MateScore{.winning = !score.mate->winning,
+                               .plies = score.mate->plies + 1};
+    }
+    return flipped;
+  }
+
+  static bool ResolveScore(SearchNode* node,
+                           const std::atomic<bool>& cancellation_requested) {
+    if (IsCancellationRequested(cancellation_requested)) return false;
+    if (node->children.empty()) return true;
+    if (!ResolveScore(node->children.front().get(), cancellation_requested)) {
+      return false;
+    }
+    node->score = FlipScore(node->children.front()->score);
+    for (size_t i = 1; i < node->children.size(); ++i) {
+      if (IsCancellationRequested(cancellation_requested)) return false;
+      if (!ResolveScore(node->children[i].get(), cancellation_requested)) {
+        return false;
+      }
+      Score candidate = FlipScore(node->children[i]->score);
+      if (IsBetter(candidate, node->score)) node->score = candidate;
+    }
+    return true;
+  }
+
+  static BuildResult BuildTree(
+      PositionHistory* history, SearchNode* node, int remaining_depth, int ply,
+      int64_t max_nodes, int64_t* nodes, int* seldepth,
+      const std::atomic<bool>& cancellation_requested) {
+    if (IsCancellationRequested(cancellation_requested)) {
+      return BuildResult::kCancelled;
+    }
+    const std::vector<Move> legal_moves =
+        history->Last().GetBoard().GenerateLegalMoves();
+    node->children.reserve(legal_moves.size());
+    for (const Move& move : legal_moves) {
+      if (IsCancellationRequested(cancellation_requested)) {
+        return BuildResult::kCancelled;
+      }
+      if (*nodes >= max_nodes) return BuildResult::kNodeLimit;
+      ++*nodes;
+      auto child = std::make_unique<SearchNode>();
+      child->move = move;
+      history->Append(move);
+      *seldepth = std::max(*seldepth, ply);
+      switch (history->ComputeGameResult()) {
+        case GameResult::UNDECIDED:
+          if (remaining_depth == 1) {
+            child->needs_evaluation = true;
+          } else {
+            const BuildResult result =
+                BuildTree(history, child.get(), remaining_depth - 1, ply + 1,
+                          max_nodes, nodes, seldepth, cancellation_requested);
+            if (result != BuildResult::kComplete) return result;
+          }
+          break;
+        case GameResult::DRAW:
+          child->score = {.q = 0.0f, .d = 1.0f};
+          break;
+        default:
+          child->score = {
+              .q = -1.0f,
+              .d = 0.0f,
+              .mate = MateScore{.winning = false, .plies = 0},
+          };
+      }
+      history->Pop();
+      node->children.push_back(std::move(child));
+    }
+    return BuildResult::kComplete;
+  }
+
+  static bool QueueEvaluations(
+      PositionHistory* history, SearchNode* node,
+      BackendComputation* computation, size_t* evaluations,
+      const std::atomic<bool>& cancellation_requested) {
+    if (IsCancellationRequested(cancellation_requested)) return false;
+    for (const auto& child : node->children) {
+      if (IsCancellationRequested(cancellation_requested)) return false;
+      history->Append(child->move);
+      if (child->needs_evaluation) {
+        computation->AddInput(
+            EvalPosition{history->GetPositions(), {}},
+            EvalResultPtr{.q = &child->score.q, .d = &child->score.d});
+        ++*evaluations;
+      } else if (!child->children.empty()) {
+        if (!QueueEvaluations(history, child.get(), computation, evaluations,
+                              cancellation_requested)) {
+          return false;
+        }
+      }
+      history->Pop();
+    }
+    return true;
+  }
+
+  const OptionsDict* options_;
 };
 
 class PolicyHeadFactory : public SearchFactory {
@@ -206,9 +486,16 @@ class PolicyHeadFactory : public SearchFactory {
 
 class ValueHeadFactory : public SearchFactory {
   std::string_view GetName() const override { return "valuehead"; }
-  std::unique_ptr<SearchBase> CreateSearch(UciResponder* responder,
-                                           const OptionsDict*) const override {
-    return std::make_unique<ValueHeadSearch>(responder);
+  void PopulateParams(OptionsParser* options) const override {
+    options->Add<IntOption>(kValueHeadDepthId, 1, kMaximumValueHeadDepth) =
+        kDefaultValueHeadDepth;
+    options->Add<IntOption>(kValueHeadMaxNodesId, 1,
+                            kMaximumValueHeadMaxNodes) =
+        kDefaultValueHeadMaxNodes;
+  }
+  std::unique_ptr<SearchBase> CreateSearch(
+      UciResponder* responder, const OptionsDict* options) const override {
+    return std::make_unique<ValueHeadSearch>(responder, options);
   }
 };
 

--- a/src/search/instamove/instamove_test.cc
+++ b/src/search/instamove/instamove_test.cc
@@ -1,0 +1,614 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2026 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "chess/board.h"
+#include "chess/callbacks.h"
+#include "chess/gamestate.h"
+#include "chess/position.h"
+#include "chess/uciloop.h"
+#include "gtest/gtest.h"
+#include "neural/backend.h"
+#include "search/register.h"
+#include "search/search.h"
+#include "utils/optionsparser.h"
+
+namespace lczero {
+namespace {
+
+using EvaluationFunction = std::function<EvalResult(std::span<const Position>)>;
+
+class CapturingResponder : public UciResponder {
+ public:
+  void OutputBestMove(BestMoveInfo* info) override {
+    bestmove_ = info->bestmove;
+    ++bestmove_count_;
+  }
+  void OutputThinkingInfo(std::vector<ThinkingInfo>* infos) override {
+    infos_ = *infos;
+  }
+
+  const Move& bestmove() const { return bestmove_; }
+  size_t bestmove_count() const { return bestmove_count_; }
+  const std::vector<ThinkingInfo>& infos() const { return infos_; }
+
+ private:
+  Move bestmove_;
+  size_t bestmove_count_ = 0;
+  std::vector<ThinkingInfo> infos_;
+};
+
+class FunctionBackendComputation : public BackendComputation {
+ public:
+  FunctionBackendComputation(const EvaluationFunction* evaluator,
+                             size_t* evaluations, size_t* computations)
+      : evaluator_(evaluator),
+        evaluations_(evaluations),
+        computations_(computations) {}
+
+  size_t UsedBatchSize() const override { return entries_.size(); }
+
+  AddInputResult AddInput(const EvalPosition& pos,
+                          EvalResultPtr result) override {
+    entries_.push_back(
+        {std::vector<Position>(pos.pos.begin(), pos.pos.end()), result});
+    return ENQUEUED_FOR_EVAL;
+  }
+
+  void ComputeBlocking() override {
+    ++*computations_;
+    for (const auto& entry : entries_) {
+      const EvalResult eval = (*evaluator_)(entry.positions);
+      if (entry.result.q) *entry.result.q = eval.q;
+      if (entry.result.d) *entry.result.d = eval.d;
+      if (entry.result.m) *entry.result.m = eval.m;
+      ++*evaluations_;
+    }
+  }
+
+ private:
+  struct Entry {
+    std::vector<Position> positions;
+    EvalResultPtr result;
+  };
+
+  const EvaluationFunction* evaluator_;
+  size_t* evaluations_;
+  size_t* computations_;
+  std::vector<Entry> entries_;
+};
+
+class FunctionBackend : public Backend {
+ public:
+  explicit FunctionBackend(EvaluationFunction evaluator,
+                           int maximum_batch_size = 20000)
+      : evaluator_(std::move(evaluator)),
+        maximum_batch_size_(maximum_batch_size) {}
+
+  BackendAttributes GetAttributes() const override {
+    return BackendAttributes{
+        .has_mlh = false,
+        .has_wdl = true,
+        .runs_on_cpu = true,
+        .suggested_num_search_threads = 1,
+        .recommended_batch_size = 256,
+        .maximum_batch_size = maximum_batch_size_,
+    };
+  }
+
+  std::unique_ptr<BackendComputation> CreateComputation() override {
+    return std::make_unique<FunctionBackendComputation>(
+        &evaluator_, &evaluations_, &computations_);
+  }
+
+  size_t evaluations() const { return evaluations_; }
+  size_t computations() const { return computations_; }
+
+ private:
+  EvaluationFunction evaluator_;
+  int maximum_batch_size_;
+  size_t evaluations_ = 0;
+  size_t computations_ = 0;
+};
+
+class BlockingEvaluation {
+ public:
+  EvalResult Evaluate() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (!entered_) {
+      entered_ = true;
+      entered_cv_.notify_one();
+      release_cv_.wait_for(lock, std::chrono::seconds(1),
+                           [&] { return released_; });
+    }
+    return EvalResult{.q = 0.0f, .d = 1.0f, .m = 0.0f};
+  }
+
+  bool WaitUntilEntered() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return entered_cv_.wait_for(lock, std::chrono::seconds(2),
+                                [&] { return entered_; });
+  }
+
+  void Release() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    released_ = true;
+    release_cv_.notify_one();
+  }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable entered_cv_;
+  std::condition_variable release_cv_;
+  bool entered_ = false;
+  bool released_ = false;
+};
+
+class BlockingInfoResponder : public UciResponder {
+ public:
+  void OutputBestMove(BestMoveInfo* info) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    bestmove_ = info->bestmove;
+    events_.push_back("bestmove");
+    bestmove_cv_.notify_one();
+  }
+
+  void OutputThinkingInfo(std::vector<ThinkingInfo>*) override {
+    std::unique_lock<std::mutex> lock(mutex_);
+    info_entered_ = true;
+    info_entered_cv_.notify_one();
+    release_info_cv_.wait(lock, [&] { return release_info_; });
+    events_.push_back("info");
+  }
+
+  bool WaitUntilInfoEntered() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return info_entered_cv_.wait_for(lock, std::chrono::seconds(2),
+                                     [&] { return info_entered_; });
+  }
+
+  bool WaitForBestMove(std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return bestmove_cv_.wait_for(lock, timeout, [&] {
+      return std::find(events_.begin(), events_.end(), "bestmove") !=
+             events_.end();
+    });
+  }
+
+  void ReleaseInfo() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    release_info_ = true;
+    release_info_cv_.notify_one();
+  }
+
+  std::vector<std::string> events() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return events_;
+  }
+
+  Move bestmove() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return bestmove_;
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  std::condition_variable info_entered_cv_;
+  std::condition_variable release_info_cv_;
+  std::condition_variable bestmove_cv_;
+  bool info_entered_ = false;
+  bool release_info_ = false;
+  Move bestmove_;
+  std::vector<std::string> events_;
+};
+
+GameState MakeGameState(const std::string& fen,
+                        const std::vector<std::string>& moves) {
+  GameState state;
+  state.startpos = Position::FromFen(fen);
+  Position position = state.startpos;
+  state.moves.reserve(moves.size());
+  for (const auto& move : moves) {
+    const Move parsed_move = position.GetBoard().ParseMove(move);
+    state.moves.push_back(parsed_move);
+    position = Position(position, parsed_move);
+  }
+  return state;
+}
+
+std::string FenAfterMoves(const std::string& fen,
+                          const std::vector<std::string>& moves) {
+  return PositionToFen(MakeGameState(fen, moves).CurrentPosition());
+}
+
+struct SearchResult {
+  std::string bestmove;
+  std::vector<ThinkingInfo> infos;
+  size_t evaluations;
+  size_t computations;
+};
+
+SearchResult RunValueHeadSearch(
+    const std::string& fen, EvaluationFunction evaluator,
+    std::optional<int> configured_depth = std::nullopt,
+    std::optional<int> go_depth = std::nullopt, int max_nodes = 10000) {
+  SearchFactory* factory = SearchManager::Get()->GetFactoryByName("valuehead");
+  EXPECT_NE(factory, nullptr);
+
+  OptionsParser parser;
+  factory->PopulateParams(&parser);
+  if (configured_depth) {
+    parser.SetUciOption("ValueHeadDepth", std::to_string(*configured_depth));
+  }
+  parser.SetUciOption("ValueHeadMaxNodes", std::to_string(max_nodes));
+  const OptionsDict& options = parser.GetOptionsDict();
+
+  FunctionBackend backend(std::move(evaluator));
+  CapturingResponder responder;
+  std::unique_ptr<SearchBase> search =
+      factory->CreateSearch(&responder, &options);
+  search->SetBackend(&backend);
+  search->SetPosition(MakeGameState(fen, {}));
+
+  GoParams params;
+  params.depth = go_depth;
+  search->StartSearch(params);
+  search->WaitSearch();
+
+  return SearchResult{
+      .bestmove = responder.bestmove().ToString(false),
+      .infos = responder.infos(),
+      .evaluations = backend.evaluations(),
+      .computations = backend.computations(),
+  };
+}
+
+TEST(ValueHeadSearch, PreservesDepthOneAsDefault) {
+  const std::string e4_fen = FenAfterMoves(ChessBoard::kStartposFen, {"e2e4"});
+  const std::string d4_fen = FenAfterMoves(ChessBoard::kStartposFen, {"d2d4"});
+  const SearchResult result = RunValueHeadSearch(
+      ChessBoard::kStartposFen, [=](std::span<const Position> positions) {
+        const std::string fen = PositionToFen(positions.back());
+        const float q = fen == e4_fen ? -0.5f : fen == d4_fen ? -0.2f : 0.0f;
+        return EvalResult{.q = q, .d = 0.2f, .m = 0.0f};
+      });
+
+  EXPECT_EQ(result.bestmove, "e2e4");
+  ASSERT_EQ(result.infos.size(), 1u);
+  EXPECT_EQ(result.infos.front().depth, 1);
+  EXPECT_EQ(result.infos.front().seldepth, 1);
+  EXPECT_EQ(result.infos.front().nodes, 20);
+  EXPECT_EQ(result.evaluations, 20u);
+  EXPECT_EQ(result.computations, 1u);
+}
+
+TEST(ValueHeadSearch, GoDepthRunsFixedDepthMinimax) {
+  const std::string e4_fen = FenAfterMoves(ChessBoard::kStartposFen, {"e2e4"});
+  const std::string d4_fen = FenAfterMoves(ChessBoard::kStartposFen, {"d2d4"});
+  const std::string e4_e5_fen =
+      FenAfterMoves(ChessBoard::kStartposFen, {"e2e4", "e7e5"});
+  const SearchResult result = RunValueHeadSearch(
+      ChessBoard::kStartposFen,
+      [=](std::span<const Position> positions) {
+        const std::string root_child_fen = PositionToFen(positions[1]);
+        const std::string leaf_fen = PositionToFen(positions.back());
+        const float q = root_child_fen == e4_fen
+                            ? (leaf_fen == e4_e5_fen ? -0.9f : 0.8f)
+                        : root_child_fen == d4_fen ? -0.2f
+                                                   : -0.8f;
+        return EvalResult{.q = q, .d = 0.1f, .m = 0.0f};
+      },
+      1, 2);
+
+  EXPECT_EQ(result.bestmove, "d2d4");
+  ASSERT_EQ(result.infos.size(), 1u);
+  EXPECT_EQ(result.infos.front().depth, 2);
+  EXPECT_EQ(result.infos.front().seldepth, 2);
+  EXPECT_EQ(result.infos.front().nodes, 420);
+  EXPECT_EQ(result.evaluations, 400u);
+  EXPECT_EQ(result.computations, 1u);
+}
+
+TEST(ValueHeadSearch, UsesConfiguredDepthWithoutGoDepth) {
+  const SearchResult result = RunValueHeadSearch(
+      ChessBoard::kStartposFen,
+      [](std::span<const Position>) {
+        return EvalResult{.q = 0.0f, .d = 1.0f, .m = 0.0f};
+      },
+      2);
+
+  ASSERT_EQ(result.infos.size(), 1u);
+  EXPECT_EQ(result.infos.front().depth, 2);
+  EXPECT_EQ(result.infos.front().nodes, 420);
+  EXPECT_EQ(result.evaluations, 400u);
+}
+
+TEST(ValueHeadSearch, PrefersCheckmateWithoutEvaluatingIt) {
+  const std::string fen = "7k/5Q2/6K1/8/8/8/8/8 w - - 0 1";
+  const SearchResult result =
+      RunValueHeadSearch(fen, [](std::span<const Position>) {
+        return EvalResult{.q = 1.0f, .d = 0.0f, .m = 0.0f};
+      });
+
+  const GameState state = MakeGameState(fen, {result.bestmove});
+  const std::vector<Position> positions = state.GetPositions();
+  const PositionHistory history(positions);
+  EXPECT_NE(history.ComputeGameResult(), GameResult::UNDECIDED);
+  EXPECT_NE(history.ComputeGameResult(), GameResult::DRAW);
+  ASSERT_EQ(result.infos.size(), 1u);
+  ASSERT_TRUE(result.infos.front().mate.has_value());
+  EXPECT_EQ(*result.infos.front().mate, 1);
+}
+
+TEST(ValueHeadSearch, ReportsRuleFiftyDrawWithoutNeuralEvaluation) {
+  const std::string fen = "7k/8/8/8/8/8/R7/K7 w - - 99 1";
+  const SearchResult result =
+      RunValueHeadSearch(fen, [](std::span<const Position>) {
+        return EvalResult{.q = 0.8f, .d = 0.0f, .m = 0.0f};
+      });
+
+  ASSERT_EQ(result.infos.size(), 1u);
+  ASSERT_TRUE(result.infos.front().wdl.has_value());
+  EXPECT_EQ(result.infos.front().wdl->w, 0);
+  EXPECT_EQ(result.infos.front().wdl->d, 1000);
+  EXPECT_EQ(result.infos.front().wdl->l, 0);
+  EXPECT_EQ(result.evaluations, 0u);
+}
+
+TEST(ValueHeadSearch, ReturnsMoveFromBlackPerspective) {
+  const std::string fen =
+      "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1";
+  const std::string e5_fen = FenAfterMoves(fen, {"e7e5"});
+  const SearchResult result =
+      RunValueHeadSearch(fen, [=](std::span<const Position> positions) {
+        const float q =
+            PositionToFen(positions.back()) == e5_fen ? -0.8f : 0.0f;
+        return EvalResult{.q = q, .d = 0.1f, .m = 0.0f};
+      });
+
+  EXPECT_EQ(result.bestmove, "e7e5");
+}
+
+TEST(ValueHeadSearch, ReducesDepthToFitNodeLimit) {
+  const SearchResult result = RunValueHeadSearch(
+      ChessBoard::kStartposFen,
+      [](std::span<const Position>) {
+        return EvalResult{.q = 0.0f, .d = 1.0f, .m = 0.0f};
+      },
+      4, std::nullopt, 10000);
+
+  ASSERT_EQ(result.infos.size(), 1u);
+  EXPECT_EQ(result.infos.front().depth, 3);
+  EXPECT_EQ(result.infos.front().nodes, 9322);
+  EXPECT_EQ(result.evaluations, 8902u);
+  EXPECT_EQ(result.computations, 1u);
+}
+
+TEST(ValueHeadSearch, NormalizesOutOfRangeGoDepth) {
+  const auto evaluator = [](std::span<const Position>) {
+    return EvalResult{.q = 0.0f, .d = 1.0f, .m = 0.0f};
+  };
+  const SearchResult zero_depth =
+      RunValueHeadSearch(ChessBoard::kStartposFen, evaluator, 1, 0, 100);
+  const SearchResult excessive_depth =
+      RunValueHeadSearch(ChessBoard::kStartposFen, evaluator, 1, 100, 100);
+
+  ASSERT_EQ(zero_depth.infos.size(), 1u);
+  EXPECT_EQ(zero_depth.infos.front().depth, 1);
+  ASSERT_EQ(excessive_depth.infos.size(), 1u);
+  EXPECT_EQ(excessive_depth.infos.front().depth, 1);
+  EXPECT_EQ(excessive_depth.evaluations, 20u);
+  EXPECT_EQ(excessive_depth.computations, 1u);
+}
+
+TEST(ValueHeadSearch, ReturnsLegalMoveWhenDepthOneExceedsLimit) {
+  const SearchResult result = RunValueHeadSearch(
+      ChessBoard::kStartposFen,
+      [](std::span<const Position>) {
+        return EvalResult{.q = 0.0f, .d = 1.0f, .m = 0.0f};
+      },
+      2, std::nullopt, 1);
+
+  const ChessBoard& board =
+      Position::FromFen(ChessBoard::kStartposFen).GetBoard();
+  const Move move = board.ParseMove(result.bestmove);
+  const MoveList legal_moves = board.GenerateLegalMoves();
+  EXPECT_NE(std::find(legal_moves.begin(), legal_moves.end(), move),
+            legal_moves.end());
+  ASSERT_EQ(result.infos.size(), 1u);
+  EXPECT_EQ(result.infos.front().depth, 1);
+  EXPECT_EQ(result.infos.front().nodes, 0);
+  EXPECT_EQ(result.evaluations, 0u);
+  EXPECT_EQ(result.computations, 0u);
+}
+
+TEST(ValueHeadSearch, DoesNotOutputInfoAfterBestMoveWhenStopRaces) {
+  SearchFactory* factory = SearchManager::Get()->GetFactoryByName("valuehead");
+  ASSERT_NE(factory, nullptr);
+
+  OptionsParser parser;
+  factory->PopulateParams(&parser);
+  const OptionsDict& options = parser.GetOptionsDict();
+  const std::string e4_fen = FenAfterMoves(ChessBoard::kStartposFen, {"e2e4"});
+  FunctionBackend backend([=](std::span<const Position> positions) {
+    const float q = PositionToFen(positions.back()) == e4_fen ? -0.8f : 0.0f;
+    return EvalResult{.q = q, .d = 0.1f, .m = 0.0f};
+  });
+  BlockingInfoResponder responder;
+  std::unique_ptr<SearchBase> search =
+      factory->CreateSearch(&responder, &options);
+  search->SetBackend(&backend);
+  search->SetPosition(MakeGameState(ChessBoard::kStartposFen, {}));
+
+  search->StartSearch(GoParams{});
+  ASSERT_TRUE(responder.WaitUntilInfoEntered());
+  std::thread stopper([&] { search->StopSearch(); });
+  EXPECT_FALSE(responder.WaitForBestMove(std::chrono::milliseconds(100)));
+
+  responder.ReleaseInfo();
+  stopper.join();
+  search->WaitSearch();
+  EXPECT_EQ(responder.events(), (std::vector<std::string>{"info", "bestmove"}));
+  EXPECT_EQ(responder.bestmove().ToString(false), "e2e4");
+}
+
+TEST(ValueHeadSearch, StartIsNonBlockingAndStopCancelsEvaluation) {
+  SearchFactory* factory = SearchManager::Get()->GetFactoryByName("valuehead");
+  ASSERT_NE(factory, nullptr);
+
+  OptionsParser parser;
+  factory->PopulateParams(&parser);
+  const OptionsDict& options = parser.GetOptionsDict();
+  BlockingEvaluation blocking_evaluation;
+  FunctionBackend backend(
+      [&](std::span<const Position>) { return blocking_evaluation.Evaluate(); },
+      1);
+  CapturingResponder responder;
+  std::unique_ptr<SearchBase> search =
+      factory->CreateSearch(&responder, &options);
+  search->SetBackend(&backend);
+  search->SetPosition(MakeGameState(ChessBoard::kStartposFen, {}));
+
+  const auto start = std::chrono::steady_clock::now();
+  search->StartSearch(GoParams{});
+  const auto start_duration = std::chrono::steady_clock::now() - start;
+  ASSERT_TRUE(blocking_evaluation.WaitUntilEntered());
+  EXPECT_LT(start_duration, std::chrono::milliseconds(500));
+
+  search->StopSearch();
+  EXPECT_EQ(responder.bestmove_count(), 1u);
+  blocking_evaluation.Release();
+  search->WaitSearch();
+
+  EXPECT_EQ(backend.evaluations(), 1u);
+  search->StopSearch();
+  EXPECT_EQ(responder.bestmove_count(), 1u);
+}
+
+TEST(ValueHeadSearch, AbortCancelsWithoutResponding) {
+  SearchFactory* factory = SearchManager::Get()->GetFactoryByName("valuehead");
+  ASSERT_NE(factory, nullptr);
+
+  OptionsParser parser;
+  factory->PopulateParams(&parser);
+  const OptionsDict& options = parser.GetOptionsDict();
+  BlockingEvaluation blocking_evaluation;
+  FunctionBackend backend(
+      [&](std::span<const Position>) { return blocking_evaluation.Evaluate(); },
+      1);
+  CapturingResponder responder;
+  std::unique_ptr<SearchBase> search =
+      factory->CreateSearch(&responder, &options);
+  search->SetBackend(&backend);
+  search->SetPosition(MakeGameState(ChessBoard::kStartposFen, {}));
+
+  search->StartSearch(GoParams{});
+  ASSERT_TRUE(blocking_evaluation.WaitUntilEntered());
+  search->AbortSearch();
+  blocking_evaluation.Release();
+  search->WaitSearch();
+
+  EXPECT_EQ(backend.evaluations(), 1u);
+  EXPECT_EQ(responder.bestmove_count(), 0u);
+}
+
+TEST(ValueHeadSearch, BackendFailureReturnsLegalMoveOnlyOnce) {
+  SearchFactory* factory = SearchManager::Get()->GetFactoryByName("valuehead");
+  ASSERT_NE(factory, nullptr);
+
+  OptionsParser parser;
+  factory->PopulateParams(&parser);
+  const OptionsDict& options = parser.GetOptionsDict();
+  FunctionBackend backend([](std::span<const Position>) -> EvalResult {
+    throw Exception("Expected backend failure.");
+  });
+  CapturingResponder responder;
+  std::unique_ptr<SearchBase> search =
+      factory->CreateSearch(&responder, &options);
+  search->SetBackend(&backend);
+  search->SetPosition(MakeGameState(ChessBoard::kStartposFen, {}));
+
+  EXPECT_NO_THROW(search->StartSearch(GoParams{}));
+  search->WaitSearch();
+  EXPECT_EQ(responder.bestmove_count(), 1u);
+  const ChessBoard& board =
+      Position::FromFen(ChessBoard::kStartposFen).GetBoard();
+  const MoveList legal_moves = board.GenerateLegalMoves();
+  EXPECT_NE(
+      std::find(legal_moves.begin(), legal_moves.end(), responder.bestmove()),
+      legal_moves.end());
+
+  search->StopSearch();
+  EXPECT_EQ(responder.bestmove_count(), 1u);
+}
+
+TEST(ValueHeadSearch, BackendFailureDuringInfiniteWaitsForStop) {
+  SearchFactory* factory = SearchManager::Get()->GetFactoryByName("valuehead");
+  ASSERT_NE(factory, nullptr);
+
+  OptionsParser parser;
+  factory->PopulateParams(&parser);
+  const OptionsDict& options = parser.GetOptionsDict();
+  FunctionBackend backend([](std::span<const Position>) -> EvalResult {
+    throw Exception("Expected backend failure.");
+  });
+  CapturingResponder responder;
+  std::unique_ptr<SearchBase> search =
+      factory->CreateSearch(&responder, &options);
+  search->SetBackend(&backend);
+  search->SetPosition(MakeGameState(ChessBoard::kStartposFen, {}));
+
+  GoParams params;
+  params.infinite = true;
+  search->StartSearch(params);
+  search->WaitSearch();
+  EXPECT_EQ(responder.bestmove_count(), 0u);
+
+  search->StopSearch();
+  EXPECT_EQ(responder.bestmove_count(), 1u);
+}
+
+}  // namespace
+}  // namespace lczero
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  lczero::InitializeMagicBitboards();
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

- add configurable full-width fixed-depth minimax to `valuehead`
- preserve depth 1 as the default and let `go depth` override `ValueHeadDepth`
- reduce requests to the deepest complete tree that fits `ValueHeadMaxNodes`
- score checkmates, draws, repetitions, and the fifty-move rule without unnecessary NN evaluation
- run instamove searches asynchronously with stop/abort cancellation and serialized UCI output
- add focused regression tests for minimax, terminal scoring, safeguards, black-to-move handling, and response races

## Behavior and safeguards

`ValueHeadDepth` defaults to 1, so the existing default behavior is preserved. `ValueHeadMaxNodes` defaults to 10000. If a requested full-width tree exceeds that limit, the search uses the deepest complete depth that fits; if even depth 1 does not fit, it returns a legal fallback move without NN evaluation.

Instamove search now runs on a worker thread. Tree construction, evaluation queuing, and minimax resolution observe cancellation. `info` and `bestmove` output are serialized so no search info is emitted after the final move.

## Testing

- `ninja -C builddir`
- `meson test -C builddir --print-errorlogs` — 9/9 test targets passed
- `InstamoveTest` — 14/14 cases passed
- clang-format dry run and `git diff --check`
- UCI smoke test with `ValueHeadMaxNodes=300000`, `go depth 4`, and `stop` after 10 ms

The default depth remains unchanged, so this does not alter default value-head playing behavior

Related to #2176.