### PR TITLE
cuda: tune fixed-size softmax launch

### DIFF
--- a/src/neural/backends/cuda/common_kernels.cu
+++ b/src/neural/backends/cuda/common_kernels.cu
@@ -820,8 +820,9 @@ __global__ void softmax_opt_64_kernel(T* output, const T* input,
   float Sum = warpReduce(threadSum);
   Sum = __shfl_sync(0xFFFFFFFF, Sum, 0);
 
-  ex[0] = ex[0] / Sum;
-  ex[1] = ex[1] / Sum;
+  const float inv_sum = 1.0f / Sum;
+  ex[0] = ex[0] * inv_sum;
+  ex[1] = ex[1] * inv_sum;
 
   // Store to memory
   if (fp16) {
@@ -889,7 +890,7 @@ void Softmax(int N, int C, T* output, const T* input, const T* input2,
              cudaStream_t stream) {
   if (C == 64) {
     int size = N * 32;  // Total no of threads needed
-    const int kBlockSize = 256;
+    const int kBlockSize = 128;  // Four independent softmax rows per block.
     int blocks = DivUp(size, kBlockSize);
     softmax_opt_64_kernel<T>
         <<<blocks, kBlockSize, 0, stream>>>(output, input, input2, size);


### PR DESCRIPTION
- Reduce the optimized 64-element softmax launch from 256 to 128 threads.
- Compute one exact reciprocal and reuse it for the two outputs handled by each thread.

## Performance:

On RTX 3090 Ti at batch 84:

- Current paired WSL Nsight trace: 18.372 us -> 18.454 us median, effectively neutral.
- Earlier cleaner isolated traces: 19.828 us -> 19.409 us, approximately 2.1% faster.

AI Acknowledgement: Written by Codex