### PR TITLE
Optimize local time printing using new formatters

### DIFF
--- a/src/utils/logging.cc
+++ b/src/utils/logging.cc
@@ -105,12 +105,25 @@ std::chrono::time_point<std::chrono::system_clock> SteadyClockToSystemClock(
              time - std::chrono::steady_clock::now());
 }
 
+namespace {
+#if __cpp_lib_format >= 201907L
+const std::chrono::time_zone* GetCurrentTimeZone() {
+  try {
+    return std::chrono::current_zone();
+  } catch (const std::runtime_error&) {
+    // If the current time zone cannot be determined, fall back to UTC.
+    return nullptr;
+  }
+}
+#endif
+}  // namespace
+
 std::string FormatTime(
     std::chrono::time_point<std::chrono::system_clock> time) {
-
 #if __cpp_lib_format >= 201907L
-  static auto* zone = std::chrono::current_zone();
-  return std::format("{0:%m%d %T}", zone->to_local(time));
+  static auto* zone = GetCurrentTimeZone();
+  return zone ? std::format("{0:%m%d %T}", zone->to_local(time))
+              : std::format("{0:%m%d %T}", time);
 #else
   static Mutex mutex;
 

--- a/src/utils/logging.cc
+++ b/src/utils/logging.cc
@@ -27,6 +27,11 @@
 
 #include "utils/logging.h"
 
+#include <version>
+#if __cpp_lib_format >= 201907L
+#include <chrono>
+#include <format>
+#endif
 #include <iomanip>
 #include <iostream>
 #include <thread>
@@ -102,6 +107,11 @@ std::chrono::time_point<std::chrono::system_clock> SteadyClockToSystemClock(
 
 std::string FormatTime(
     std::chrono::time_point<std::chrono::system_clock> time) {
+
+#if __cpp_lib_format >= 201907L
+  static auto* zone = std::chrono::current_zone();
+  return std::format("{0:%m%d %T}", zone->to_local(time));
+#else
   static Mutex mutex;
 
   std::ostringstream ss;
@@ -121,6 +131,7 @@ std::string FormatTime(
        << std::setfill('0') << std::setw(6) << us;
   }
   return ss.str();
+#endif
 }
 
 }  // namespace lczero


### PR DESCRIPTION
I noticed that FormatTime took about 20 µs which is called from `SearchWorker` thread when sending uci infos. I decided to check if it could be done faster. The new chrono and formatter based approach manages to reduce it to about 8 µs. The gain is mainly from caching `current_zone()` result which takes over 10 µs each time called.