### PR TITLE
Geometric policy blending on cuda backend

### DIFF
--- a/src/neural/backend.cc
+++ b/src/neural/backend.cc
@@ -60,6 +60,10 @@ uint64_t Backend::ConfigurationHash(const OptionsDict& options) const {
                            SharedBackendParams::kWeightsId)));
   hash = HashCat(hash, std::hash<float>{}(options.Get<float>(
                            SharedBackendParams::kPolicySoftmaxTemp)));
+  hash = HashCat(hash, std::hash<float>{}(options.Get<float>(
+                           SharedBackendParams::kPolicyBlendOptimistic)));
+  hash = HashCat(hash, std::hash<float>{}(options.Get<float>(
+                           SharedBackendParams::kPolicyBlendSoft)));
   hash = HashCat(hash, std::hash<std::string>{}(options.Get<std::string>(
                            SharedBackendParams::kHistoryFill)));
   return hash;

--- a/src/neural/backends/cuda/common_kernels.cu
+++ b/src/neural/backends/cuda/common_kernels.cu
@@ -76,6 +76,33 @@ void addVectors(T* c, T* a, T* b, int size, int asize, int bsize,
 }
 
 template <typename T>
+__global__ void blendPolicyLogits_kernel(T* main, const T* opt, const T* soft,
+                                         float w_main, float w_opt,
+                                         float w_soft, int count) {
+  int i = threadIdx.x + blockDim.x * blockIdx.x;
+  if (i < count) {
+    float val = w_main * (float)main[i];
+    if (opt) val += w_opt * (float)opt[i];
+    if (soft) val += w_soft * (float)soft[i];
+    main[i] = (T)val;
+  }
+}
+
+// Pools the policy heads geometrically, which in log space is a weighted sum
+// of their logits.
+template <typename T>
+void blendPolicyLogits(T* main, const T* opt, const T* soft, float w_main,
+                       float w_opt, float w_soft, int count,
+                       cudaStream_t stream) {
+  const int kBlockSize = 256;
+  int blocks = DivUp(count, kBlockSize);
+
+  blendPolicyLogits_kernel<<<blocks, kBlockSize, 0, stream>>>(
+      main, opt, soft, w_main, w_opt, w_soft, count);
+  ReportCUDAErrors(cudaGetLastError());
+}
+
+template <typename T>
 __global__ void addVectorsHNC_NHC_kernel(T* a, T* b, int N, int H, int C) {
   int i = threadIdx.x + blockDim.x * blockIdx.x;
   if (i < N * H * C) {
@@ -1365,6 +1392,15 @@ template void addVectors<float>(float* c, float* a, float* b, int size,
 template void addVectors<half>(half* c, half* a, half* b, int size, int asize,
                                int bsize, ActivationFunction act,
                                cudaStream_t stream);
+
+template void blendPolicyLogits<float>(float* main, const float* opt,
+                                       const float* soft, float w_main,
+                                       float w_opt, float w_soft, int count,
+                                       cudaStream_t stream);
+template void blendPolicyLogits<half>(half* main, const half* opt,
+                                      const half* soft, float w_main,
+                                      float w_opt, float w_soft, int count,
+                                      cudaStream_t stream);
 
 template void addVectorsHNC_NHC<float>(float* a, float* b, int N, int H, int C,
                                        cudaStream_t stream);

--- a/src/neural/backends/cuda/inputs_outputs.h
+++ b/src/neural/backends/cuda/inputs_outputs.h
@@ -37,6 +37,18 @@
 namespace lczero {
 namespace cudnn_backend {
 
+enum ExtraPolicyHeadIndex {
+  kExtraPolicyOptimistic = 0,
+  kExtraPolicySoft = 1,
+  kNumExtraPolicyHeads = 2
+};
+
+// Subset of policyheads for geometric blending.
+struct ExtraPolicyHeads {
+  bool optimistic = false;
+  bool soft = false;
+};
+
 inline void ToType(float& dst, float src) { dst = src; }
 inline void ToType(half& dst, float src) {
   auto temp = FP32toFP16(src);
@@ -73,7 +85,8 @@ template <typename DataType>
 struct InputsOutputs {
   InputsOutputs(unsigned maxBatchSize, bool wdl, bool moves_left,
                 size_t tensor_mem_size = 0, size_t scratch_size = 0,
-                bool cublasDisableTensorCores = false) {
+                bool cublasDisableTensorCores = false,
+                ExtraPolicyHeads extra_policy_heads = {}) {
     ReportCUDAErrors(cudaHostAlloc(
         &input_masks_mem_, maxBatchSize * kInputPlanes * sizeof(uint64_t),
         cudaHostAllocMapped));
@@ -98,6 +111,19 @@ struct InputsOutputs {
     ReportCUDAErrors(cudaMalloc(
         &op_policy_mem_gpu_,
         maxBatchSize * kNumOutputPolicy * sizeof(op_policy_mem_[0])));
+
+    // Output of the extra policy heads. Device only: the blend folds them into
+    // the policy output before it is copied out, so their logits never leave
+    // the card.
+    const bool wanted[kNumExtraPolicyHeads] = {extra_policy_heads.optimistic,
+                                               extra_policy_heads.soft};
+    for (int i = 0; i < kNumExtraPolicyHeads; i++) {
+      if (!wanted[i]) continue;
+      ReportCUDAErrors(cudaMalloc(
+          &op_policy_extra_mem_gpu_[i],
+          maxBatchSize * kNumOutputPolicy * sizeof(op_policy_mem_[0])));
+    }
+
     ReportCUDAErrors(cudaHostAlloc(
         &op_value_mem_, maxBatchSize * (wdl ? 3 : 1) * sizeof(op_value_mem_[0]),
         cudaHostAllocMapped));
@@ -165,6 +191,9 @@ struct InputsOutputs {
     ReportCUDAErrors(cudaFree(input_val_mem_gpu_));
     ReportCUDAErrors(cudaFreeHost(op_policy_mem_));
     ReportCUDAErrors(cudaFree(op_policy_mem_gpu_));
+    for (auto mem : op_policy_extra_mem_gpu_) {
+      if (mem) ReportCUDAErrors(cudaFree(mem));
+    }
     ReportCUDAErrors(cudaFreeHost(op_value_mem_));
     ReportCUDAErrors(cudaFree(op_value_mem_gpu_));
     ReportCUDAErrors(cudaEventDestroy(upload_done_event_));
@@ -189,6 +218,9 @@ struct InputsOutputs {
       if (head_offset_pointers_) {
         ReportCUDAErrors(cudaFree(head_offset_pointers_));
       }
+      for (auto ptrs : extra_head_offset_pointers_) {
+        if (ptrs) ReportCUDAErrors(cudaFree(ptrs));
+      }
       ReportCUDAErrors(cudaStreamDestroy(compute_stream_));
       ReportCUDAErrors(cudaStreamDestroy(upload_stream_));
       ReportCUDAErrors(cudaStreamDestroy(download_stream_));
@@ -207,6 +239,8 @@ struct InputsOutputs {
   DataType* op_policy_mem_gpu_;
   DataType* op_value_mem_gpu_;
   DataType* op_moves_left_mem_gpu_ = nullptr;
+  // Indexed by ExtraPolicyHeadIndex; null for heads the network cannot make.
+  DataType* op_policy_extra_mem_gpu_[kNumExtraPolicyHeads] = {};
 
   std::unique_ptr<float[]> wdl_cpu_softmax_;
 
@@ -217,6 +251,9 @@ struct InputsOutputs {
   void* scratch_mem_;
   void** offset_pointers_ = nullptr;
   void** head_offset_pointers_ = nullptr;
+  // The extra heads keep their own, because their policy encoder blocks may
+  // differ in shape from the selected head's.
+  void** extra_head_offset_pointers_[kNumExtraPolicyHeads] = {};
 
   // cuda stream used to run the network
   cudaStream_t compute_stream_ = nullptr;

--- a/src/neural/backends/cuda/kernels.h
+++ b/src/neural/backends/cuda/kernels.h
@@ -39,6 +39,14 @@ template <typename T>
 void addVectors(T* c, T* a, T* b, int size, int asize, int bsize,
                 ActivationFunction activation, cudaStream_t stream);
 
+// Geometric pooling of the policy heads, as a weighted sum of their logits
+// written over the first vector. A null head pointer drops that term, which is
+// how a head that is not part of the blend is never even evaluated.
+template <typename T>
+void blendPolicyLogits(T* main, const T* opt, const T* soft, float w_main,
+                       float w_opt, float w_soft, int count,
+                       cudaStream_t stream);
+
 // Adds two vectors of equal size overwriting the first with the sum.
 // This specialisation performs a transposition of the first 2 indexes
 // of the second while performing the addition.

--- a/src/neural/backends/cuda/layers.cc
+++ b/src/neural/backends/cuda/layers.cc
@@ -1422,9 +1422,10 @@ template <typename DataType>
 AttentionPolicyHead<DataType>::AttentionPolicyHead(
     BaseLayer<DataType>* ip, const MultiHeadWeights::PolicyHead& weights,
     void* scratch, bool attention_body, ActivationFunction act,
-    int max_batch_size, bool use_gemm_ex)
+    int max_batch_size, bool use_gemm_ex, bool shared_embedding)
     : BaseLayer<DataType>(64 * 64 + 24 * 8, 1, 1, ip),
       attention_body_(attention_body),
+      shared_embedding_(shared_embedding),
       // Old networks without attention body (e.g. T79) use hardcoded SELU
       // activations.
       act_(attention_body ? act : ACTIVATION_SELU) {
@@ -1435,8 +1436,15 @@ AttentionPolicyHead<DataType>::AttentionPolicyHead(
   encoder_heads_ = weights.pol_encoder_head_count;
   policy_d_model_ = wq_op_size_;
 
-  allocAndUpload<DataType>(&ip_pol_w_, weights.ip_pol_w, scratch);
-  allocAndUpload<DataType>(&ip_pol_b_, weights.ip_pol_b, scratch);
+  if (shared_embedding_) {
+    // Another head owns the embedding weights and computes the embedding.
+    assert(weights.pol_encoder.empty());
+    ip_pol_w_ = nullptr;
+    ip_pol_b_ = nullptr;
+  } else {
+    allocAndUpload<DataType>(&ip_pol_w_, weights.ip_pol_w, scratch);
+    allocAndUpload<DataType>(&ip_pol_b_, weights.ip_pol_b, scratch);
+  }
 
   allocAndUpload<DataType>(&ip2_pol_w_, weights.ip2_pol_w, scratch);
   allocAndUpload<DataType>(&ip2_pol_b_, weights.ip2_pol_b, scratch);
@@ -1904,33 +1912,39 @@ void AttentionPolicyHead<DataType>::Eval(
   DataType* buffer1 = output + scratch_size / (2 * sizeof(DataType));
   DataType* buffer2 = input2_tensor + scratch_size / (2 * sizeof(DataType));
 
-  int inputC = this->input_->GetC();
-  bool input_nhwc = attention_body_ || this->input_->isNHWC();
-  if (!input_nhwc)
-    convertNCHWtoNHWC((DataType*)scratch, input, N, inputC, N, inputC, 8, 8,
-                      stream);
+  // Steps 1 and 2 produce the policy embedding in input2_tensor. A head
+  // sharing the embedding finds it already there and starts at step 3; note
+  // that steps 3 onwards only read input2_tensor, so several such heads can
+  // run off the same embedding.
+  if (!shared_embedding_) {
+    int inputC = this->input_->GetC();
+    bool input_nhwc = attention_body_ || this->input_->isNHWC();
+    if (!input_nhwc)
+      convertNCHWtoNHWC((DataType*)scratch, input, N, inputC, N, inputC, 8, 8,
+                        stream);
 
-  // 1. Policy embedding (fully connected layer)
-  // Input data in NHWC layout N*(64)*C, output is N*(64)*embedding_op_size_
-  DataType* pol_embedding = input2_tensor;
-  {
-    const int num_outputs = embedding_op_size_;
-    const int num_inputs = inputC;
-    const int batch = N * 64;
-    cublasXgemm<DataType>(cublas, CUBLAS_OP_T, CUBLAS_OP_N, num_outputs, batch,
-                          num_inputs, 1.0f, (const DataType*)ip_pol_w_,
-                          num_inputs,
-                          input_nhwc ? input : (DataType*)scratch,
-                          num_inputs, 0.0f, pol_embedding, num_outputs);
-    addBiasBatched(pol_embedding, pol_embedding, ip_pol_b_, 1, batch,
-                   num_outputs, act_, stream);
+    // 1. Policy embedding (fully connected layer)
+    // Input data in NHWC layout N*(64)*C, output is N*(64)*embedding_op_size_
+    DataType* pol_embedding = input2_tensor;
+    {
+      const int num_outputs = embedding_op_size_;
+      const int num_inputs = inputC;
+      const int batch = N * 64;
+      cublasXgemm<DataType>(cublas, CUBLAS_OP_T, CUBLAS_OP_N, num_outputs,
+                            batch, num_inputs, 1.0f,
+                            (const DataType*)ip_pol_w_, num_inputs,
+                            input_nhwc ? input : (DataType*)scratch, num_inputs,
+                            0.0f, pol_embedding, num_outputs);
+      addBiasBatched(pol_embedding, pol_embedding, ip_pol_b_, 1, batch,
+                     num_outputs, act_, stream);
+    }
+
+    // 2. Encoder layers
+    for (const auto pEnc : encoder_weights_) {
+      pEnc->Eval(N, input2_tensor, (DataType*)scratch, buffer1, buffer2, cublas,
+                 stream, offset_pointers);
+    }  // End of encoder blocks
   }
-
-  // 2. Encoder layers
-  for (const auto pEnc : encoder_weights_) {
-    pEnc->Eval(N, input2_tensor, (DataType*)scratch, buffer1, buffer2, cublas,
-               stream, offset_pointers);
-  }  // End of encoder blocks
 
   DataType* wq;
   DataType* wk;

--- a/src/neural/backends/cuda/layers.h
+++ b/src/neural/backends/cuda/layers.h
@@ -413,11 +413,16 @@ class AttentionPolicyHead : public BaseLayer<DataType> {
   using BaseLayer<DataType>::use_gemm_ex_;
 
  public:
+  // With shared_embedding the head does not own the policy embedding: Eval
+  // expects input2 to already hold the embedding another head computed from
+  // the same body output, and only runs the query/key projections and the
+  // promotion logits on top of it. Requires a head without policy encoder
+  // blocks, since those would rewrite the embedding in place.
   AttentionPolicyHead(BaseLayer<DataType>* ip,
                       const MultiHeadWeights::PolicyHead& weights,
                       void* scratch, bool attention_body,
                       ActivationFunction act, int max_batch_size,
-                      bool use_gemm_ex);
+                      bool use_gemm_ex, bool shared_embedding = false);
   ~AttentionPolicyHead();
   void Eval(int N, DataType* output, const DataType* input,
             const DataType* input2, void* scratch, size_t scratch_size,
@@ -440,6 +445,8 @@ class AttentionPolicyHead : public BaseLayer<DataType> {
   int encoder_heads_;
   int policy_d_model_;
   bool attention_body_;
+  // The embedding is computed by another head and handed over in input2.
+  bool shared_embedding_;
   ActivationFunction act_;
 
   std::vector<EncoderBlock<DataType>*> encoder_weights_;

--- a/src/neural/backends/cuda/network_cuda.cc
+++ b/src/neural/backends/cuda/network_cuda.cc
@@ -57,6 +57,11 @@ using namespace cudnn_backend;
 template <typename DataType>
 class CudaNetwork;
 
+// Policy heads a multihead network carries besides the one the backend was
+// configured with, in ExtraPolicyHeadIndex order.
+static constexpr const char* kExtraPolicyHeadNames[kNumExtraPolicyHeads] = {
+    "optimistic", "soft"};
+
 static size_t getMaxAttentionHeadSize(
     const MultiHeadWeights::PolicyHead& weights, int N) {
   const size_t embedding_op_size = weights.ip_pol_b.size();
@@ -393,11 +398,83 @@ class CudaNetwork : public Network {
                       "' does not exist in this net.");
     }
 
+    // Pooling the policy heads here rather than anywhere downstream. Geometric
+    // pooling is a sum of logits, and the logits are exactly what this backend
+    // hands over, so the whole blend fits in the gap before the output is
+    // copied out -- and what leaves the backend is one policy vector,
+    // indistinguishable from an unblended one to everything downstream, which
+    // is why nothing outside this file has to know about it.
+    // The backend-opts lexer sorts `1` into the integer dictionary and `0.55`
+    // into the float one, so reading a weight as a float only would silently
+    // ignore any whole-number value. Both dictionaries are read and the float
+    // wins, which is also the precedence the UCI option needs: it is written
+    // as a float on top of whatever the backend options said. Reading both
+    // also leaves the key marked as read either way, and an unread key is a
+    // hard error.
+    auto blend_weight = [&options](const char* key) {
+      float weight = 0.0f;
+      if (options.Exists<int>(key)) weight = options.Get<int>(key);
+      if (options.Exists<float>(key)) weight = options.Get<float>(key);
+      return weight;
+    };
+    blend_w_extra_[kExtraPolicyOptimistic] =
+        blend_weight("policy_blend_optimistic");
+    blend_w_extra_[kExtraPolicySoft] = blend_weight("policy_blend_soft");
+    for (int i = 0; i < kNumExtraPolicyHeads; i++) {
+      if (blend_w_extra_[i] < 0.0f || blend_w_extra_[i] > 1.0f) {
+        throw Exception(std::string("The policy blend weight for the '") +
+                        kExtraPolicyHeadNames[i] +
+                        "' head must be between 0 and 1.");
+      }
+      if (blend_w_extra_[i] > 0.0f) blend_active_ = true;
+    }
+    if (blend_active_) {
+      if (!attn_policy_) {
+        throw Exception(
+            "The policy blend needs the extra policy heads, which only "
+            "attention policy networks have.");
+      }
+      if (policy_head != "vanilla") {
+        // A selected head is never built a second time as an extra head, so
+        // pooling on top of one would read a buffer nothing has written.
+        throw Exception(
+            "The policy blend pools the policy heads itself and needs "
+            "policy_head=vanilla, not '" +
+            policy_head + "'.");
+      }
+      // Weights past the simplex would scale every logit by the same factor,
+      // which is a temperature rather than a blend. Renormalize onto itself.
+      const float w_sum = blend_w_extra_[kExtraPolicyOptimistic] +
+                          blend_w_extra_[kExtraPolicySoft];
+      if (w_sum > 1.0f) {
+        for (int i = 0; i < kNumExtraPolicyHeads; i++) {
+          blend_w_extra_[i] /= w_sum;
+        }
+      }
+      blend_w_main_ =
+          std::max(0.0f, 1.0f - blend_w_extra_[kExtraPolicyOptimistic] -
+                             blend_w_extra_[kExtraPolicySoft]);
+      // A head stays in the blend however small its
+      // weight is, so that moving the weight cannot move the cost of a search
+      blend_heads_.optimistic = blend_w_extra_[kExtraPolicyOptimistic] > 0.0f;
+      blend_heads_.soft = blend_w_extra_[kExtraPolicySoft] > 0.0f;
+    }
+
     // Attention policy head or body may need more memory
-    const size_t attentionPolicySize =
+    size_t attentionPolicySize =
         getMaxAttentionHeadSize(weights.policy_heads.at(policy_head),
                                 max_batch_size_) *
         sizeof(DataType);
+    // The extra policy heads run over the same scratch allocation, so it has
+    // to fit the largest of them too.
+    for (const char* extra_head : kExtraPolicyHeadNames) {
+      if (!weights.policy_heads.contains(extra_head)) continue;
+      attentionPolicySize = std::max(
+          attentionPolicySize,
+          getMaxAttentionHeadSize(weights.policy_heads.at(extra_head),
+                                  max_batch_size_) *
+              sizeof(DataType));
+    }
 
     const size_t attentionBodySize =
         getMaxAttentionBodySize(weights, max_batch_size_) * sizeof(DataType);
@@ -561,6 +638,69 @@ class CudaNetwork : public Network {
       }
     }
 
+    // Extra policy heads, for the blend below. They read the same attention
+    // body output as the selected head, so they are kept out of network_
+    // (which forwardEval walks in order) and evaluated separately, after it.
+    if (attn_policy_ && attn_body_) {
+      // Reusing the selected head's policy embedding is what makes an extra
+      // head cheap. Turned off, every extra head recomputes its own
+      // Exposed so the two can be compared, and as a way out if a
+      // future net trips the detection below.
+      const bool allow_shared_embedding =
+          options.GetOrDefault<bool>("shared_policy_embedding", true);
+      const MultiHeadWeights::PolicyHead& main_head =
+          weights.policy_heads.at(policy_head);
+      for (int i = 0; i < kNumExtraPolicyHeads; i++) {
+        const char* name = kExtraPolicyHeadNames[i];
+        if (policy_head == name || !weights.policy_heads.contains(name)) {
+          continue;
+        }
+        if (blend_w_extra_[i] <= 0.0f) continue;
+        const MultiHeadWeights::PolicyHead& head =
+            weights.policy_heads.at(name);
+        // Multihead nets keep a single policy embedding for all heads: the
+        // weights loader binds every head's ip_pol_w to the same vector unless
+        // the head carries its own. When it is shared, the extra head can pick
+        // up the embedding the selected head already computed and pay only for
+        // its own query/key projections.
+        extra_policy_shares_embedding_[i] =
+            allow_shared_embedding && &head.ip_pol_w == &main_head.ip_pol_w &&
+            &head.ip_pol_b == &main_head.ip_pol_b && head.pol_encoder.empty() &&
+            main_head.pol_encoder.empty();
+        extra_policy_head_[i] = std::make_unique<AttentionPolicyHead<DataType>>(
+            encoder_last_, head, scratch_mem_, attn_body_, act, max_batch_size_,
+            use_gemm_ex, extra_policy_shares_embedding_[i]);
+        auto policymap = std::make_unique<PolicyMapLayer<DataType>>(
+            extra_policy_head_[i].get(), kNumOutputPolicy, 1, 1,
+            64 * 64 + 8 * 24, true);
+        policymap->LoadWeights(kAttnPolicyMap, scratch_mem_);
+        extra_policy_map_[i] = std::move(policymap);
+      }
+      available_extra_heads_.optimistic =
+          extra_policy_head_[kExtraPolicyOptimistic] != nullptr;
+      available_extra_heads_.soft =
+          extra_policy_head_[kExtraPolicySoft] != nullptr;
+    }
+
+    // Deliberately outside the block above: a net that never reaches it has no
+    // extra heads at all, which is the same failure as a net that reaches it
+    // and turns out not to carry the head asked for.
+    if (blend_active_) {
+      for (int i = 0; i < kNumExtraPolicyHeads; i++) {
+        if (blend_w_extra_[i] > 0.0f && !extra_policy_head_[i]) {
+          throw Exception(std::string("The policy blend was given weight on "
+                                      "the '") +
+                          kExtraPolicyHeadNames[i] +
+                          "' head, which this network does not have.");
+        }
+      }
+      CERR << "GPU policy blend: w_v=" << blend_w_main_
+           << " w_o=" << blend_w_extra_[kExtraPolicyOptimistic]
+           << " w_s=" << blend_w_extra_[kExtraPolicySoft]
+           << " (geometric/logit-space, pre-softmax); extra policy heads are "
+              "consumed internally.";
+    }
+
     // Value heads.
     {
       const MultiHeadWeights::ValueHead& head =
@@ -615,6 +755,13 @@ class CudaNetwork : public Network {
     // take max size of all layers
     for (auto& layer : network_) {
       maxSize = std::max(maxSize, layer->GetOutputSize(max_batch_size_));
+    }
+    for (int i = 0; i < kNumExtraPolicyHeads; i++) {
+      if (!extra_policy_head_[i]) continue;
+      maxSize = std::max(maxSize,
+                         extra_policy_head_[i]->GetOutputSize(max_batch_size_));
+      maxSize = std::max(maxSize,
+                         extra_policy_map_[i]->GetOutputSize(max_batch_size_));
     }
 
     if ((attn_policy_ || use_res_block_winograd_fuse_opt_ || attn_body_) &&
@@ -724,6 +871,7 @@ class CudaNetwork : public Network {
     void* scratch_mem;
     DataType*** offset_pointers;
     DataType*** head_offset_pointers;
+    void*** extra_head_offset_pointers;
     cudaStream_t compute_stream, upload_stream, download_stream;
     cublasHandle_t cublas;
     if (multi_stream_) {
@@ -733,6 +881,7 @@ class CudaNetwork : public Network {
       scratch_mem = io->scratch_mem_;
       offset_pointers = (DataType***)&io->offset_pointers_;
       head_offset_pointers = (DataType***)&io->head_offset_pointers_;
+      extra_head_offset_pointers = io->extra_head_offset_pointers_;
       compute_stream = io->compute_stream_;
       upload_stream = io->upload_stream_;
       download_stream = io->download_stream_;
@@ -742,6 +891,7 @@ class CudaNetwork : public Network {
       scratch_mem = scratch_mem_;
       offset_pointers = (DataType***)&offset_pointers_;
       head_offset_pointers = (DataType***)&head_offset_pointers_;
+      extra_head_offset_pointers = extra_head_offset_pointers_;
       compute_stream = compute_stream_;
       upload_stream = upload_stream_;
       download_stream = download_stream_;
@@ -882,6 +1032,54 @@ class CudaNetwork : public Network {
           batchSize, (DataType*)opPol, spare1, nullptr, scratch_mem,
           scratch_size_, nullptr, cublas,
           compute_stream);  // policy map layer  // POLICY output
+
+      if (blend_active_) {
+        // The pooled heads run over the same body output. spare1 and spare2 are
+        // free again now that the policy map has consumed them, and `flow` is
+        // untouched by the attention policy head, so each extra head is just
+        // its own query/key projections plus a policy map.
+        //
+        // One array decides both what is evaluated and what is pooled, so a
+        // head can never be computed and then dropped, or pooled from a buffer
+        // nothing wrote. The load-time guards make every entry here a head the
+        // network actually has.
+        const bool pooled[kNumExtraPolicyHeads] = {blend_heads_.optimistic,
+                                                   blend_heads_.soft};
+        // spare2 still holds the policy embedding the selected head computed.
+        // A head that has to recompute its own embedding overwrites it, so the
+        // heads that reuse it go first.
+        for (int pass = 0; pass < 2; pass++) {
+          const bool shared_pass = pass == 0;
+          for (int i = 0; i < kNumExtraPolicyHeads; i++) {
+            if (!pooled[i]) continue;
+            if (extra_policy_shares_embedding_[i] != shared_pass) continue;
+            extra_policy_head_[i]->Eval(
+                batchSize, spare1, flow, spare2, scratch_mem, scratch_size_,
+                nullptr, cublas, compute_stream,
+                (DataType***)&extra_head_offset_pointers[i]);
+            extra_policy_map_[i]->Eval(
+                batchSize, (DataType*)io->op_policy_extra_mem_gpu_[i], spare1,
+                nullptr, scratch_mem, scratch_size_, nullptr, cublas,
+                compute_stream);
+          }
+        }
+
+        // Folding the heads together here, before the policy output is copied
+        // out, is what keeps the rest of the engine on its vanilla path: one
+        // download, one softmax, one prior per position.
+        const DataType* blended[kNumExtraPolicyHeads] = {};
+        for (int i = 0; i < kNumExtraPolicyHeads; i++) {
+          if (pooled[i]) {
+            blended[i] = (const DataType*)io->op_policy_extra_mem_gpu_[i];
+          }
+        }
+        blendPolicyLogits<DataType>(
+            (DataType*)opPol, blended[kExtraPolicyOptimistic],
+            blended[kExtraPolicySoft], blend_w_main_,
+            blend_w_extra_[kExtraPolicyOptimistic],
+            blend_w_extra_[kExtraPolicySoft], batchSize * kNumOutputPolicy,
+            compute_stream);
+      }
 
     } else if (conv_policy_) {
       network_[l++]->Eval(batchSize, spare1, flow, nullptr, scratch_mem,
@@ -1026,6 +1224,9 @@ class CudaNetwork : public Network {
       if (offset_pointers_) ReportCUDAErrors(cudaFree(offset_pointers_));
       if (head_offset_pointers_)
         ReportCUDAErrors(cudaFree(head_offset_pointers_));
+      for (auto ptrs : extra_head_offset_pointers_) {
+        if (ptrs) ReportCUDAErrors(cudaFree(ptrs));
+      }
       ReportCUBLASErrors(cublasDestroy(cublas_));
       ReportCUDAErrors(cudaStreamDestroy(compute_stream_));
       ReportCUDAErrors(cudaStreamDestroy(upload_stream_));
@@ -1068,7 +1269,8 @@ class CudaNetwork : public Network {
     if (free_inputs_outputs_.empty()) {
       return std::make_unique<InputsOutputs<DataType>>(
           max_batch_size_, wdl_, moves_left_, tensor_mem_size_, scratch_size_,
-          !has_tensor_cores_ && std::is_same<half, DataType>::value);
+          !has_tensor_cores_ && std::is_same<half, DataType>::value,
+          available_extra_heads_);
     } else {
       std::unique_ptr<InputsOutputs<DataType>> resource =
           std::move(free_inputs_outputs_.front());
@@ -1118,6 +1320,21 @@ class CudaNetwork : public Network {
   std::vector<std::unique_ptr<BaseLayer<DataType>>> network_;
   BaseLayer<DataType>* getLastLayer() { return network_.back().get(); }
 
+  // Extra policy heads, indexed by ExtraPolicyHeadIndex. Null for a head the
+  // weights file does not have (or that is the selected head already).
+  ExtraPolicyHeads available_extra_heads_;
+  std::unique_ptr<BaseLayer<DataType>> extra_policy_head_[kNumExtraPolicyHeads];
+  std::unique_ptr<BaseLayer<DataType>> extra_policy_map_[kNumExtraPolicyHeads];
+  bool extra_policy_shares_embedding_[kNumExtraPolicyHeads] = {};
+
+  // Geometric pooling of the policy heads inside the backend. Fixed at load,
+  // which is what lets the captured cuda graphs bake the weights in: the heads
+  // to evaluate are the ones carrying weight, and the weights sum to one.
+  bool blend_active_ = false;
+  ExtraPolicyHeads blend_heads_;
+  float blend_w_main_ = 1.0f;
+  float blend_w_extra_[kNumExtraPolicyHeads] = {};
+
   BaseLayer<DataType>* resi_last_;
   BaseLayer<DataType>* encoder_last_;
 
@@ -1129,6 +1346,7 @@ class CudaNetwork : public Network {
   // this is only used when multi-stream is disabled
   void** offset_pointers_ = nullptr;
   void** head_offset_pointers_ = nullptr;
+  void** extra_head_offset_pointers_[kNumExtraPolicyHeads] = {};
 
   bool has_tensor_cores_;
 

--- a/src/neural/backends/cuda/network_cuda.cc
+++ b/src/neural/backends/cuda/network_cuda.cc
@@ -429,10 +429,11 @@ class CudaNetwork : public Network {
       if (blend_w_extra_[i] > 0.0f) blend_active_ = true;
     }
     if (blend_active_) {
-      if (!attn_policy_) {
+      if (!attn_policy_ || !attn_body_) {
         throw Exception(
-            "The policy blend needs the extra policy heads, which only "
-            "attention policy networks have.");
+            "The policy blend needs an attention policy network with an "
+            "attention body (multihead format)."
+            );
       }
       if (policy_head != "vanilla") {
         // A selected head is never built a second time as an extra head, so

--- a/src/neural/shared_params.cc
+++ b/src/neural/shared_params.cc
@@ -34,6 +34,22 @@ const OptionId SharedBackendParams::kPolicySoftmaxTemp{
     "policy-softmax-temp", "PolicyTemperature",
     "Policy softmax temperature. Higher values make priors of move candidates "
     "closer to each other, widening the search."};
+const OptionId SharedBackendParams::kPolicyBlendOptimistic{
+    {.long_flag = "backend-policy-blend-optimistic",
+     .uci_option = "BackendPolicyBlendOptimistic",
+     .help_text =
+         "Weight of the optimistic policy head where the backend pools the "
+         "policy heads itself, geometrically and before the softmax. Cuda "
+         "backends only.",
+     .visibility = OptionId::kProOnly}};
+const OptionId SharedBackendParams::kPolicyBlendSoft{
+    {.long_flag = "backend-policy-blend-soft",
+     .uci_option = "BackendPolicyBlendSoft",
+     .help_text =
+         "Weight of the soft policy head in the backend's own pooling of the "
+         "policy heads. If the two weights sum to more than one they are "
+         "scaled down to sum to one.",
+     .visibility = OptionId::kProOnly}};
 const OptionId SharedBackendParams::kHistoryFill{
     "history-fill", "HistoryFill",
     "Neural network uses 7 previous board positions in addition to the current "
@@ -67,6 +83,8 @@ const OptionId SharedBackendParams::kNNCacheSizeId{
 
 void SharedBackendParams::Populate(OptionsParser* options) {
   options->Add<FloatOption>(kPolicySoftmaxTemp, 0.1f, 10.0f) = 1.359f;
+  options->Add<FloatOption>(kPolicyBlendOptimistic, 0.0f, 1.0f) = 0.0f;
+  options->Add<FloatOption>(kPolicyBlendSoft, 0.0f, 1.0f) = 0.0f;
   std::vector<std::string> history_fill_opt{"no", "fen_only", "always"};
   options->Add<ChoiceOption>(kHistoryFill, history_fill_opt) = "fen_only";
 

--- a/src/neural/shared_params.h
+++ b/src/neural/shared_params.h
@@ -39,6 +39,8 @@ struct SharedBackendParams {
   static const constexpr char* kAutoDiscover = "<autodiscover>";
 
   static const OptionId kPolicySoftmaxTemp;
+  static const OptionId kPolicyBlendOptimistic;
+  static const OptionId kPolicyBlendSoft;
   static const OptionId kHistoryFill;
   static const OptionId kWeightsId;
   static const OptionId kBackendId;

--- a/src/neural/wrapper.cc
+++ b/src/neural/wrapper.cc
@@ -186,6 +186,17 @@ std::unique_ptr<Backend> NetworkAsBackendFactory::Create(
   OptionsDict network_options;
   network_options.AddSubdictFromString(backend_options);
 
+  const float blend_optimistic =
+      options.Get<float>(SharedBackendParams::kPolicyBlendOptimistic);
+  if (blend_optimistic > 0.0f) {
+    network_options.Set<float>("policy_blend_optimistic", blend_optimistic);
+  }
+  const float blend_soft =
+      options.Get<float>(SharedBackendParams::kPolicyBlendSoft);
+  if (blend_soft > 0.0f) {
+    network_options.Set<float>("policy_blend_soft", blend_soft);
+  }
+
   std::string net_path =
       options.Get<std::string>(SharedBackendParams::kWeightsId);
   std::optional<WeightsFile> weights = LoadWeights(net_path);


### PR DESCRIPTION
Geometric blending means a weighted sum of the heads' logits, taken before the softmax. It returns a single policy vector that nothing downstream can distinguish from an unblended one. PolicyTemperature is applied identically to every head, so it factors out of the mixture entirely and keeps its usual meaning.

Weights are set as backend options, and the heads that carry weight are decided once when the backend is built:

    --backend-opts=policy_blend_optimistic=0.55
    --backend-opts=policy_blend_optimistic=0.55,policy_blend_soft=0.1

The two also exist as pro-only UCI options (`BackendPolicyBlendOptimistic`, `BackendPolicyBlendSoft`) so a tuner can move them as ordinary parameters. They are hidden to pro options as the changes only can apply once the backend constructed. Weights are renormalised onto the simplex if they sum past one, so the blend stays a weighted mean rather than becoming a temperature. A network that lacks the requested head refuses to load, rather than silently not blending.

With no weight set, nothing changes: no extra head is built, no extra buffer is allocated, and the priors are bit-identical to master. That was checked against a build of this branch point over 100 positions, at defaults and under a tuned configuration, with identical bestmoves and no output of any kind. Cost ~0.5% fewer nodes per second with a 256x10 net when enabled. It iss the extra head's own projections plus the mixing kernel.

Tested at: https://bench-direct.lczero.org/test/1153/ Whether blending helps, and at what weights, depends on the net this is a capability rather than a general strength gain. On the net tested it was worth 20.2 +/- 3.1 Elo over 10000 games at 10+0.1 against the same net unblended.

Cuda backends only for now. The same graph would be three Mul and two Add nodes in the onnx converter, which would cover the onnx and xla backends and their execution providers without a kernel, if this turns out to be worth having.

Developed with the help of Claude agents for research, implementation and verification; all design decisions, testing and review are my own.