### PR TITLE
add Iluvatar CoreX (ivcore11) build support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -461,6 +461,10 @@ if get_option('build_backends')
   cu_blas = cc.find_library('cublas', dirs: cudnn_libdirs, required: false)
   cu_dnn = cc.find_library('cudnn', dirs: cudnn_libdirs, required: false)
   cu_dart = cc.find_library('cudart', dirs: cudnn_libdirs, required: false)
+  if get_option('corex') and get_option('nvcc')
+    error('The corex (Iluvatar CoreX) and nvcc CUDA backends are mutually ' +
+          'exclusive; build the CoreX backend with -Dcorex=true -Dnvcc=false.')
+  endif
   nvcc = find_program(nvcc_paths,
                       required: false)
   nvcc_ok = false
@@ -607,6 +611,58 @@ if get_option('build_backends')
       command : [nvcc, nvcc_extra_args, nvcc_arguments, nvcc_io_arguments]
     )
     has_backends = true
+  endif
+
+  ## ~~~~~~~~~~~~~~~~~
+  ## CoreX (ivcore11)
+  ## ~~~~~~~~~~~~~~~~~
+  # Iluvatar CoreX ships no nvcc; its CUDA frontend is clang++ (-x ivcore).
+  # A single fixed target needs no arch/std probing, so this block is
+  # self-contained and independent of the nvcc logic above.
+  if get_option('corex')
+    corex_root = get_option('corex_root')
+    corex_clang = find_program(corex_root / 'bin' / 'clang++', required : true)
+    corex_lib = corex_root / 'lib64'
+
+    cx_blas = cc.find_library('cublas', dirs : corex_lib, required : true)
+    cx_dart = cc.find_library('cudart', dirs : corex_lib, required : true)
+    cx_dnn = cc.find_library('cudnn', dirs : corex_lib, required : false)
+
+    corex_args = ['-x', 'ivcore', '--cuda-path=' + corex_root,
+                  '--cuda-gpu-arch=ivcore11', '-Wno-unknown-cuda-version',
+                  '-fPIC', '-std=c++20',
+                  '-I', meson.current_source_dir() / 'src',
+                  '-I', corex_root / 'include']
+    corex_cmd = [corex_clang, corex_args, '-c', '@INPUT@', '-o', '@OUTPUT@']
+
+    deps += [cx_blas, cx_dart]
+    cuda_files = ['src/neural/backends/cuda/layers.cc']
+    if get_option('cudnn') and cx_dnn.found()
+      deps += cx_dnn
+      cuda_files += 'src/neural/backends/cuda/network_cudnn.cc'
+      cuda_files += 'src/neural/backends/cuda/network_cuda.cc'
+      add_project_arguments('-DUSE_CUDNN', language : 'cpp')
+    else
+      cuda_files += 'src/neural/backends/cuda/network_cuda.cc'
+    endif
+    includes += include_directories('src/neural/backends/cuda/')
+    includes += include_directories(corex_root / 'include', is_system : true)
+    files += cuda_files
+
+    files += custom_target('corex fp32 code',
+      input : 'src/neural/backends/cuda/common_kernels.cu',
+      output : '@BASENAME@.o',
+      depend_files : 'src/neural/backends/cuda/winograd_helper.inc',
+      command : corex_cmd)
+
+    files += custom_target('corex fp16 code',
+      input : 'src/neural/backends/cuda/fp16_kernels.cu',
+      output : '@BASENAME@.o',
+      depend_files : 'src/neural/backends/cuda/winograd_helper.inc',
+      command : corex_cmd)
+
+    has_backends = true
+    message('CoreX (ivcore11): building CUDA backend with clang++ -x ivcore')
   endif
 
   ## ~~~~~~~~

--- a/meson.build
+++ b/meson.build
@@ -461,10 +461,6 @@ if get_option('build_backends')
   cu_blas = cc.find_library('cublas', dirs: cudnn_libdirs, required: false)
   cu_dnn = cc.find_library('cudnn', dirs: cudnn_libdirs, required: false)
   cu_dart = cc.find_library('cudart', dirs: cudnn_libdirs, required: false)
-  if get_option('corex') and get_option('nvcc')
-    error('The corex (Iluvatar CoreX) and nvcc CUDA backends are mutually ' +
-          'exclusive; build the CoreX backend with -Dcorex=true -Dnvcc=false.')
-  endif
   nvcc = find_program(nvcc_paths,
                       required: false)
   nvcc_ok = false
@@ -620,13 +616,16 @@ if get_option('build_backends')
   # A single fixed target needs no arch/std probing, so this block is
   # self-contained and independent of the nvcc logic above.
   if get_option('corex')
+    if get_option('nvcc')
+      error('The corex (Iluvatar CoreX) and nvcc CUDA backends are mutually ' +
+            'exclusive; build the CoreX backend with -Dcorex=true -Dnvcc=false.')
+    endif
     corex_root = get_option('corex_root')
     corex_clang = find_program(corex_root / 'bin' / 'clang++', required : true)
     corex_lib = corex_root / 'lib64'
 
     cx_blas = cc.find_library('cublas', dirs : corex_lib, required : true)
     cx_dart = cc.find_library('cudart', dirs : corex_lib, required : true)
-    cx_dnn = cc.find_library('cudnn', dirs : corex_lib, required : false)
 
     corex_args = ['-x', 'ivcore', '--cuda-path=' + corex_root,
                   '--cuda-gpu-arch=ivcore11', '-Wno-unknown-cuda-version',
@@ -636,18 +635,10 @@ if get_option('build_backends')
     corex_cmd = [corex_clang, corex_args, '-c', '@INPUT@', '-o', '@OUTPUT@']
 
     deps += [cx_blas, cx_dart]
-    cuda_files = ['src/neural/backends/cuda/layers.cc']
-    if get_option('cudnn') and cx_dnn.found()
-      deps += cx_dnn
-      cuda_files += 'src/neural/backends/cuda/network_cudnn.cc'
-      cuda_files += 'src/neural/backends/cuda/network_cuda.cc'
-      add_project_arguments('-DUSE_CUDNN', language : 'cpp')
-    else
-      cuda_files += 'src/neural/backends/cuda/network_cuda.cc'
-    endif
     includes += include_directories('src/neural/backends/cuda/')
     includes += include_directories(corex_root / 'include', is_system : true)
-    files += cuda_files
+    files += ['src/neural/backends/cuda/layers.cc',
+              'src/neural/backends/cuda/network_cuda.cc']
 
     files += custom_target('corex fp32 code',
       input : 'src/neural/backends/cuda/common_kernels.cu',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -269,3 +269,13 @@ option('nvcc',
        type: 'boolean',
        value: true,
        description: 'Use nvcc: required for cuda, optional for onnx')
+
+option('corex',
+       type: 'boolean',
+       value: false,
+       description: 'Build the CUDA backend for Iluvatar CoreX (ivcore11) via clang++ -x ivcore')
+
+option('corex_root',
+       type: 'string',
+       value: '/usr/local/corex',
+       description: 'Iluvatar CoreX SDK root (clang++, headers, libs)')

--- a/src/neural/backends/cuda/fp16_kernels.cu
+++ b/src/neural/backends/cuda/fp16_kernels.cu
@@ -30,7 +30,8 @@
 #include "utils/exception.h"
 
 // Allow building on an old architecture.
-#if __CUDA_ARCH__ < 530
+// CoreX/ivcore11: device __CUDA_ARCH__ reports 300.
+#if !defined(__ILUVATAR__) && (__CUDA_ARCH__ < 530)
 #define SKIP_FP16_BITS 1
 #endif
 #include "winograd_helper.inc"
@@ -57,7 +58,7 @@ __global__ void SE_Layer_NHWC(half* output, const half* skip, const half* input,
                               const half* w1, const half* b1, const half* w2,
                               const half* b2, const half* bPrev,
                               ActivationFunction activation) {
-#if __CUDA_ARCH__ >= 530
+#if defined(__ILUVATAR__) || (__CUDA_ARCH__ >= 530)
   const int elementsPerThread = 64;  // 8x8 board
   const int se_K = K;
 
@@ -228,7 +229,7 @@ __global__ __launch_bounds__(
                                                         const half* b1,
                                                         const half* w2,
                                                         const half* b2) {
-#if __CUDA_ARCH__ >= 530
+#if defined(__ILUVATAR__) || (__CUDA_ARCH__ >= 530)
   int k = threadIdx.x;
   int n = blockIdx.x;
 


### PR DESCRIPTION
Add an opt-in `corex` build for Iluvatar CoreX (ivcore11), whose SDK ships no nvcc and uses `clang++ -x ivcore --cuda-gpu-arch=ivcore11` as its CUDA frontend. Since ivcore11 is a single fixed target, no nvcc arch/std/`__CUDA_ARCH__` probing is needed, so this is a small self-contained block in meson.build that leaves the existing nvcc logic completely untouched.

- `meson_options.txt`: new `corex` (boolean, default false) and `corex_root` (string, default `/usr/local/corex`)
- `meson.build`: a dedicated `corex` block finds clang++/libs under `corex_root` and compiles the `.cu` files directly with `clang++ -x ivcore --cuda-gpu-arch=ivcore11 -fPIC -std=c++20`; it errors out if both `corex` and `nvcc` are set (mutually exclusive)
- `fp16_kernels.cu`: gate the fp16 kernels on `__ILUVATAR__` in addition to `__CUDA_ARCH__ >= 530`, because ivcore11 reports `__CUDA_ARCH__` 300 yet fully supports fp16 (`__ILUVATAR__` is predefined by the CoreX clang frontend)

Build with `-Dcorex=true -Dnvcc=false`. No effect on existing nvcc builds (option defaults to false). 
All 52 test cases have passed on Corex.

Iluvatar Corex: https://en.wikipedia.org/wiki/Iluvatar_CoreX
