### PR TITLE
fix(chess): defensively handle multi-checks and non-standard checking FENs

### DIFF
--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -862,11 +862,6 @@ KingAttackInfo ChessBoard::GenerateKingAttackInfo() const {
   king_attack_info.attack_lines_ =
       king_attack_info.attack_lines_ | attacking_pawns;
 
-  if (attacking_pawns.as_int()) {
-    // No more than one pawn can give check.
-    num_king_attackers++;
-  }
-
   // Check knights.
   const BitBoard attacking_knights =
       kKnightAttacks[our_king_.as_idx()] &
@@ -874,13 +869,9 @@ KingAttackInfo ChessBoard::GenerateKingAttackInfo() const {
   king_attack_info.attack_lines_ =
       king_attack_info.attack_lines_ | attacking_knights;
 
-  if (attacking_knights.as_int()) {
-    // No more than one knight can give check.
-    num_king_attackers++;
-  }
+  num_king_attackers += (attacking_knights | attacking_pawns).count();
 
-  assert(num_king_attackers <= 2);
-  king_attack_info.double_check_ = (num_king_attackers == 2);
+  king_attack_info.double_check_ = (num_king_attackers >= 2);
 
   return king_attack_info;
 }

--- a/src/chess/board_test.cc
+++ b/src/chess/board_test.cc
@@ -2250,6 +2250,43 @@ TEST(ChessBoard, QueenMoveFromEnPassantFlagBug) {
   EXPECT_EQ(board.GenerateLegalMoves(), legal_moves);
 }
 
+// Multi-check positions (triple check, dual pawns, dual knights) must only
+// generate king evasions and not allow non-king pieces to capture one attacker.
+TEST(ChessBoard, MultiCheckDefensiveHandling) {
+  // Triple check: White king on c3 attacked by b1 knight, b2 bishop, e3 queen.
+  {
+    ChessBoard board;
+    board.SetFromFen("4k3/8/PP1p1n2/R1prP3/N3p3/pPK1q3/pbp1p3/Qn4B1 w - - 0 1");
+    auto legal_moves = board.GenerateLegalMoves();
+    EXPECT_FALSE(legal_moves.empty());
+    for (const auto& m : legal_moves) {
+      EXPECT_EQ(BitBoard::FromSquare(m.from()), board.kings() & board.ours());
+    }
+  }
+
+  // Dual pawn check: White king on e4 attacked by d5 and f5 pawns.
+  {
+    ChessBoard board;
+    board.SetFromFen("Q7/8/8/3p1p2/4K3/8/8/7k w - - 0 1");
+    auto legal_moves = board.GenerateLegalMoves();
+    EXPECT_FALSE(legal_moves.empty());
+    for (const auto& m : legal_moves) {
+      EXPECT_EQ(BitBoard::FromSquare(m.from()), board.kings() & board.ours());
+    }
+  }
+
+  // Dual knight check: White king on e4 attacked by d6 and f6 knights.
+  {
+    ChessBoard board;
+    board.SetFromFen("Q7/8/3n1n2/8/4K3/8/8/7k w - - 0 1");
+    auto legal_moves = board.GenerateLegalMoves();
+    EXPECT_FALSE(legal_moves.empty());
+    for (const auto& m : legal_moves) {
+      EXPECT_EQ(BitBoard::FromSquare(m.from()), board.kings() & board.ours());
+    }
+  }
+}
+
 }  // namespace lczero
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Defensively count attacking pawns and knights via bitboard `.count()` and classify multi-checks using `num_king_attackers >= 2` in `src/chess/board.cc`.

This ensures that non-standard, corrupted, or test FENs containing multiple simultaneous checks (such as triple checks or simultaneous checks by multiple pawns/knights) only generate king evasions and do not fall through to single-check evasion logic.

Includes unit tests in `src/chess/board_test.cc`.

Fixes #2450
