### PR TITLE
few cuda cleanups

### DIFF
--- a/src/neural/backends/cuda/inputs_outputs.h
+++ b/src/neural/backends/cuda/inputs_outputs.h
@@ -83,7 +83,7 @@ template <typename DataType>
 struct InputsOutputs {
   InputsOutputs(unsigned maxBatchSize, bool wdl, bool moves_left,
                 size_t tensor_mem_size = 0, size_t scratch_size = 0,
-                bool cublasDisableTensorCores = false) {
+                [[maybe_unused]] bool cublasDisableTensorCores = false) {
     ReportCUDAErrors(cudaHostAlloc(
         &input_masks_mem_, maxBatchSize * kInputPlanes * sizeof(uint64_t),
         cudaHostAllocMapped));
@@ -160,14 +160,11 @@ struct InputsOutputs {
             cudaMemsetAsync(mem, 0, tensor_mem_size, compute_stream_));
       }
       ReportCUBLASErrors(cublasCreate(&cublas_));
-#if !defined(USE_HIP)
-      // No hipBLAS equivalent for the TF32/tensor-op math-mode toggle; hipBLAS
-      // picks its default precision (see network_cuda.cc constructor).
+#if !defined(USE_HIP) && CUDART_VERSION < 11010
+      // See CudaNetwork constructor in network_cuda.cc.
       ReportCUBLASErrors(cublasSetMathMode(
           cublas_, cublasDisableTensorCores ? CUBLAS_PEDANTIC_MATH
                                             : CUBLAS_TENSOR_OP_MATH));
-#else
-      (void)cublasDisableTensorCores;
 #endif
       ReportCUBLASErrors(cublasSetStream(cublas_, compute_stream_));
     } else {

--- a/src/neural/backends/cuda/layers.cc
+++ b/src/neural/backends/cuda/layers.cc
@@ -601,11 +601,11 @@ void SELayer<half>::Eval(int N, half* output, const half* input,
 template <>
 void SELayer<__nv_bfloat16>::Eval(int N, __nv_bfloat16* output,
                                   const __nv_bfloat16* input,
-                                  const __nv_bfloat16* input2, void* scratch,
-                                  size_t scratch_size, cudnnHandle_t /*cudnn*/,
+                                  const __nv_bfloat16* /*input2*/,
+                                  void* scratch, size_t scratch_size,
+                                  cudnnHandle_t /*cudnn*/,
                                   cublasHandle_t cublas, cudaStream_t stream,
                                   __nv_bfloat16***) {
-  assert(output == input2);
   __nv_bfloat16* op1 = (__nv_bfloat16*)scratch;
   __nv_bfloat16* op2 =
       (__nv_bfloat16*)scratch + scratch_size / sizeof(__nv_bfloat16) / 2;

--- a/src/neural/backends/cuda/network_cuda.cc
+++ b/src/neural/backends/cuda/network_cuda.cc
@@ -324,15 +324,15 @@ class CudaNetwork : public Network {
                                                 cudaEventDisableTiming));
       ReportCUBLASErrors(cublasCreate(&cublas_));
       ReportCUBLASErrors(cublasSetStream(cublas_, compute_stream_));
-#if !defined(USE_HIP)
-      // The CUBLAS_TENSOR_OP_MATH / CUBLAS_PEDANTIC_MATH enums (a NVIDIA
-      // TF32/tensor-op math-mode toggle and a TU11x workaround) have no hipBLAS
-      // equivalent; let hipBLAS pick its default precision.
+#if !defined(USE_HIP) && CUDART_VERSION < 11010
+      // CUBLAS_TENSOR_OP_MATH was deprecated in CUDA 11.0 while using
+      // CUBLAS_PEDANTIC_MATH was a workaround for a TU11x bug (apparently
+      // fixed in CUDA 11.1) and hipBLAS has no equivalent.
       if (has_tensor_cores_)
         ReportCUBLASErrors(cublasSetMathMode(
             cublas_,
             CUBLAS_TENSOR_OP_MATH));  // Deprecated on CUDA 11.0 and later
-      else if (fp16 || is_bf16)
+      else if (fp16)
         ReportCUBLASErrors(cublasSetMathMode(
             cublas_,
             CUBLAS_PEDANTIC_MATH));  // Explicitly set PEDANTIC_MATH mode to
@@ -388,8 +388,9 @@ class CudaNetwork : public Network {
     // ROCm; HIP always takes the cuBLAS attention fallback, so keep this false.
     if (deviceProp.major >= 8 && (fp16 || is_bf16)) {
       use_fused_mha = options.GetOrDefault<bool>(
-          "fused_mha", file.format().network_format().ffn_activation() !=
-                           pblczero::NetworkFormat::ACTIVATION_RELU_2);
+          "fused_mha",
+          is_bf16 || file.format().network_format().ffn_activation() !=
+                      pblczero::NetworkFormat::ACTIVATION_RELU_2);
     }
 #endif
 
@@ -1136,15 +1137,10 @@ class CudaNetwork : public Network {
   std::unique_ptr<InputsOutputs<DataType>> GetInputsOutputs() {
     std::lock_guard<std::mutex> lock(inputs_outputs_lock_);
     if (free_inputs_outputs_.empty()) {
-#if LC0_CUDA_BF16_SUPPORTED
-      constexpr bool is_16bit = std::is_same<half, DataType>::value ||
-                                std::is_same<__nv_bfloat16, DataType>::value;
-#else
-      constexpr bool is_16bit = std::is_same<half, DataType>::value;
-#endif
+      constexpr bool is_fp16 = std::is_same<half, DataType>::value;
       return std::make_unique<InputsOutputs<DataType>>(
           max_batch_size_, wdl_, moves_left_, tensor_mem_size_, scratch_size_,
-          !has_tensor_cores_ && is_16bit);
+          !has_tensor_cores_ && is_fp16);
     } else {
       std::unique_ptr<InputsOutputs<DataType>> resource =
           std::move(free_inputs_outputs_.front());


### PR DESCRIPTION
1. The fp16 bug that required `CUBLAS_PEDANTIC_MATH` as a workaround was reported fixed in cuda 11.1 and `CUBLAS_TENSOR_OP_MATH` was deprecated in cuda 11.0 so don't compile the relevant code for newer versions (or hip).
2. The `fused_mha` backend option defaulted to false for networks with ReLU^2 activation due to fp16 overflow risk, which is not applicable with bf16.
3. A warning fix.